### PR TITLE
feat(agent): CLAUDE.md templates for agent scoping

### DIFF
--- a/agent/claude-md/README.md
+++ b/agent/claude-md/README.md
@@ -4,7 +4,7 @@ This directory contains modular CLAUDE.md templates that are composed at runtime
 
 ## Directory Structure
 
-```
+```text
 agent/claude-md/
 ├── README.md          # This file — composition rules
 ├── base.md            # Common: git, commits, quality, testing principles

--- a/agent/claude-md/backend.md
+++ b/agent/claude-md/backend.md
@@ -20,7 +20,7 @@ You are working exclusively in the `backend/` directory. **NEVER** modify files 
 
 ### Package Layout
 
-```
+```text
 backend/
 ├── cmd/api/
 │   ├── main.go              # Entry point
@@ -109,6 +109,7 @@ id := chi.URLParam(r, "id")
 ### Configuration
 
 `sqlc.yaml`:
+
 ```yaml
 version: "2"
 sql:
@@ -125,6 +126,7 @@ sql:
 ### Query Files
 
 Queries in `backend/queries/*.sql`:
+
 ```sql
 -- name: GetStoryByKey :one
 SELECT * FROM stories WHERE project_id = $1 AND key = $2 LIMIT 1;
@@ -248,6 +250,7 @@ log.LoggerFrom(ctx).Info("processing run",
 ### Structured Fields
 
 Always include relevant context:
+
 - `request_id` — from middleware
 - `user_id` — from auth context
 - `project_id` — from request scope
@@ -400,6 +403,7 @@ var AdapterSet = wire.NewSet(
 ### Wire File
 
 `cmd/api/wire.go`:
+
 ```go
 //go:build wireinject
 // +build wireinject
@@ -460,6 +464,7 @@ err := transactor.WithinTransaction(ctx, func(ctx context.Context) error {
 ### Generated Output
 
 oapi-codegen produces:
+
 - Server interface (chi-compatible)
 - Request/response types
 - Parameter types
@@ -497,7 +502,7 @@ func (h *StoryHandler) GetStory(w http.ResponseWriter, r *http.Request, id strin
 
 ## Go Module
 
-```
+```text
 module github.com/zakari/hopeitworks/backend
 ```
 

--- a/agent/claude-md/base.md
+++ b/agent/claude-md/base.md
@@ -6,8 +6,8 @@ You are an AI agent working on the **hopeitworks** platform. Follow these conven
 
 ### Branch Naming
 
-- Feature branches: `feat/S-{key}-{slug}` (e.g., `feat/S-01-setup-project`)
-- Fix branches: `fix/S-{key}-{slug}` (e.g., `fix/S-03-ci-poller`)
+- Feature branches: `feat/{story-key}-{slug}` (e.g., `feat/1-14-claude-md-files`)
+- Fix branches: `fix/{story-key}-{slug}` (e.g., `fix/1-3-ci-poller`)
 - The branch name is provided to you — always work on the assigned branch
 
 ### Conventional Commits

--- a/agent/claude-md/base.md
+++ b/agent/claude-md/base.md
@@ -6,8 +6,8 @@ You are an AI agent working on the **hopeitworks** platform. Follow these conven
 
 ### Branch Naming
 
-- Feature branches: `feat/{story-key}-{slug}` (e.g., `feat/1-14-claude-md-files`)
-- Fix branches: `fix/{story-key}-{slug}` (e.g., `fix/1-3-ci-poller`)
+- Feature branches: `feat/S-{key}-{slug}` (e.g., `feat/S-01-setup-project`)
+- Fix branches: `fix/S-{key}-{slug}` (e.g., `fix/S-03-ci-poller`)
 - The branch name is provided to you — always work on the assigned branch
 
 ### Conventional Commits
@@ -15,6 +15,7 @@ You are an AI agent working on the **hopeitworks** platform. Follow these conven
 Format: `type(scope): message`
 
 Types:
+
 - `feat` — new feature
 - `fix` — bug fix
 - `refactor` — code restructuring without behavior change
@@ -23,17 +24,20 @@ Types:
 - `chore` — build, CI, tooling changes
 
 Scope matches the domain area:
+
 - Backend: `pipeline`, `auth`, `api`, `dag`, `git`, `agent`, `event`, `cost`, `config`
 - Frontend: `ui`, `stories`, `runs`, `approvals`, `dag`, `editor`, `auth`
 - Shared: `api-spec`, `deploy`, `ci`
 
 Rules:
+
 - Message in imperative mood, lowercase, no period at end
 - Body is optional — explains WHY, not WHAT
 - One logical change per commit
 
 Examples:
-```
+
+```text
 feat(pipeline): add retry logic for failed steps
 fix(auth): handle token expiry on page refresh
 refactor(dag): extract cycle detection into helper
@@ -94,6 +98,7 @@ chore(deploy): update docker-compose health checks
 ## Documentation
 
 - README updated for public API changes
+- CHANGELOG.md follows Keep a Changelog format
 - Code comments explain WHY, not WHAT
 - Document non-obvious architectural decisions inline
 - Generated code should never be manually edited — regenerate from source
@@ -128,22 +133,70 @@ chore(deploy): update docker-compose health checks
 - Format: `{entity}.{action}` dot-notation (`run.started`, `step.completed`, `hitl.pending`)
 - Payload: JSON with `snake_case` fields
 
+## API Response Format
+
+### Success (single resource)
+
+Direct object, HTTP 200/201:
+
+```json
+{ "id": "...", "summary": "...", "status": "..." }
+```
+
+### Success (list)
+
+Array with pagination metadata, HTTP 200:
+
+```json
+{
+  "data": [...],
+  "pagination": { "total": 42, "page": 1, "per_page": 20 }
+}
+```
+
+### Error
+
+Consistent error envelope:
+
+```json
+{
+  "error": {
+    "code": "STORY_NOT_FOUND",
+    "message": "Story S-03 not found in project X",
+    "details": {}
+  }
+}
+```
+
+### Async Operations
+
+Async operations return 202 Accepted:
+
+```json
+{ "epic_run_id": "...", "status": "scheduling", "stories_count": 5 }
+```
+
 ## Error Handling Philosophy
 
 - Errors are values — handle them explicitly, never ignore
 - Wrap errors with context as they propagate up the call stack
-- API errors follow a consistent envelope format:
-  ```json
-  {
-    "error": {
-      "code": "STORY_NOT_FOUND",
-      "message": "Story S-03 not found in project X",
-      "details": {}
-    }
-  }
-  ```
 - Error codes are `UPPER_SNAKE_CASE`
 - Error messages are human-readable and actionable
+- See "API Response Format > Error" above for the standard error envelope
+
+## Code Generation Philosophy
+
+This project follows a **code-gen-first** approach. Never manually write code that should be generated from a spec.
+
+| Domain | Spec Source | Generator | Output |
+|--------|-----------|-----------|--------|
+| API handlers | `api/openapi.yaml` | oapi-codegen | chi server interfaces + types |
+| API client | `api/openapi.yaml` | openapi-typescript + openapi-fetch | TypeScript typed fetch client |
+| Database queries | `backend/queries/*.sql` | sqlc | type-safe Go functions |
+| DI wiring | `wire.go` provider sets | go-wire | `wire_gen.go` auto-generated |
+| Prompts | Handlebars templates | runtime rendering | agent prompts |
+
+Generated files (e.g., `wire_gen.go`, `db/` for sqlc, `frontend/src/api/generated/`) must NEVER be manually edited — always regenerate from source.
 
 ## Security
 
@@ -151,3 +204,29 @@ chore(deploy): update docker-compose health checks
 - Use environment variables for all sensitive configuration
 - Validate all external input at system boundaries
 - Agent containers have no host filesystem access
+
+## CI Pipeline
+
+### Backend CI
+
+```bash
+golangci-lint run ./...              # Lint
+go test ./... -short                 # Unit tests (fast, no containers)
+go test ./... -run Integration       # Integration tests (testcontainers)
+```
+
+### Frontend CI
+
+```bash
+npm run lint                         # ESLint
+npm run type-check                   # tsc --noEmit
+npm run test:unit                    # Vitest
+npm run test:e2e                     # Playwright (against docker-compose.test.yml)
+```
+
+## Infrastructure
+
+- **Docker Compose** in `deploy/` for local dev stack
+- Health checks: `GET /health` (liveness) and `GET /ready` (readiness: DB + Docker socket)
+- Config: `config.yaml` + env var override, resolved at startup
+- No hot-reload for MVP — restart to apply config changes

--- a/agent/claude-md/frontend.md
+++ b/agent/claude-md/frontend.md
@@ -127,6 +127,7 @@ export const HopeTheme = definePreset(Aura, {
 ### Use Tailwind ONLY for Layout
 
 Tailwind is for structural layout only:
+
 - `flex`, `grid`, `gap`, `p-*`, `m-*`, `w-*`, `h-*`
 - `items-center`, `justify-between`, `space-x-*`
 - Responsive breakpoints: `md:`, `lg:`
@@ -157,6 +158,7 @@ Tailwind is for structural layout only:
 - No `<style scoped>` blocks except for complex animations or SVG
 - No inline styles
 - CSS layer order in `assets/main.css`:
+
   ```css
   @layer tailwind-base, primevue, tailwind-utilities;
   ```
@@ -234,6 +236,7 @@ export const useStoriesStore = defineStore('stories', () => {
 ### Store Organization
 
 One store per domain:
+
 - `stores/auth.ts`
 - `stores/projects.ts`
 - `stores/stories.ts`
@@ -294,7 +297,7 @@ This generates TypeScript types and the typed `paths` interface. Never manually 
 
 ### Directory Structure
 
-```
+```text
 frontend/src/
 ├── ui/                          # Atomic layer (shared only)
 │   ├── primitives/              # PrimeVue wrappers, base components
@@ -365,7 +368,7 @@ frontend/src/
 
 Views are 1:1 with routes and compose feature components:
 
-```
+```text
 views/
 ├── LoginView.vue
 ├── DashboardView.vue
@@ -423,6 +426,7 @@ export function useSSE(projectId: string) {
 ### Loading States
 
 Every async operation uses `useAsyncAction` pattern:
+
 - `isLoading` — show PrimeVue `Skeleton` or `ProgressSpinner`
 - `error` — show inline `Message` for validation (400), `Toast` for transient errors (500)
 - `data` — render the actual content
@@ -482,7 +486,7 @@ Do NOT test that PrimeVue renders a button correctly — that is PrimeVue's resp
 
 Tests live co-located in `__tests__/` directories next to source files:
 
-```
+```text
 features/stories/
 ├── StoryBoard.vue
 ├── StoryDetail.vue

--- a/agent/claude-md/project.md
+++ b/agent/claude-md/project.md
@@ -11,7 +11,7 @@
 
 ## Project Structure
 
-```
+```text
 hopeitworks/
 ├── backend/                    # Go module — autonomous
 │   ├── cmd/api/                # Entry point + wire.go
@@ -98,11 +98,8 @@ Both sides generate types and clients from the same OpenAPI spec. Never manually
 ### Completed
 
 - Story 1-1: Go project scaffolding + docker-compose dev stack
-
-### In Progress (Wave 1)
-
-- Story 1-2: OpenAPI spec + code generation pipeline
-- Story 1-7: Vue scaffolding + PrimeVue + Tailwind setup
+- Story 1-2: OpenAPI 3.0 spec + code generation pipeline
+- Story 1-7: Vue 3 scaffolding + PrimeVue 4 + Tailwind CSS v4
 - Story 1-14: CLAUDE.md files for agent scoping
 
 ## Known Constraints
@@ -129,7 +126,7 @@ Both sides generate types and clients from the same OpenAPI spec. Never manually
 
 ## Architectural Boundaries
 
-```
+```text
 ┌─────────────┐     openapi.yaml      ┌──────────────┐
 │   Frontend   │◄────────────────────►│   Backend    │
 │   (Vue 3)    │   HTTP + SSE         │   (Go API)   │


### PR DESCRIPTION
## Summary

- Improves modular CLAUDE.md template system in `agent/claude-md/` for agent scoping
- Fixes branch naming convention to match architecture doc (`feat/S-{key}-{slug}`)
- Expands `base.md` with API response format, code generation philosophy, CI pipeline, and infrastructure sections (154 → 224 lines, within 200-300 target range)
- Adds CHANGELOG reference to documentation standards
- Updates `project.md` implementation status to reflect completed Wave 1 stories
- Fixes markdown lint issues across all template files (language tags on code blocks, blank lines around fences/lists)
- Cross-references all content against `architecture.md` for accuracy

### Files

| File | Purpose | Lines |
|------|---------|-------|
| `agent/claude-md/README.md` | Composition rules: base + (backend OR frontend) + project | 51 |
| `agent/claude-md/base.md` | Project-wide conventions (git, commits, quality, testing, naming, API format, code-gen, CI) | 224 |
| `agent/claude-md/backend.md` | Go-specific patterns (hexagonal, chi, sqlc, DomainError, slog, testing, wire, pgx) | 544 |
| `agent/claude-md/frontend.md` | Vue-specific patterns (Composition API, PrimeVue, Tailwind, Pinia, openapi-fetch, testing) | 565 |
| `agent/claude-md/project.md` | Current state (overview, key paths, API contract, status, constraints) | 149 |

### Acceptance Criteria

- [x] AC1: `base.md` documents git workflow, branch naming, conventional commits, quality standards
- [x] AC2: `backend.md` documents hexagonal architecture, chi, sqlc, DomainError, slog, testing patterns
- [x] AC3: `frontend.md` documents Composition API, PrimeVue first, Tailwind layout, useAsyncAction, Pinia patterns
- [x] AC4: `project.md` documents current state, key file paths, shared contract (api/openapi.yaml)
- [x] AC5: `README.md` specifies composition: base + (backend OR frontend) + project

## Test plan

- [x] Verify all 5 template files exist in `agent/claude-md/`
- [x] Validate markdown structure (markdownlint — only cosmetic MD013/MD060 remain)
- [x] Cross-reference patterns against `_bmad-output/planning-artifacts/architecture.md`
- [x] Confirm no contradictions between template files
- [x] Verify composition rule is clear in README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)