### PR TITLE
feat(frontend): app shell layout — header, sidebar, status bar

### DIFF
--- a/_bmad-output/implementation-artifacts/1-8-app-shell-layout-header-sidebar-status-bar.md
+++ b/_bmad-output/implementation-artifacts/1-8-app-shell-layout-header-sidebar-status-bar.md
@@ -275,20 +275,41 @@ Routes do not need to exist yet. Use `router-link` or `to` prop where applicable
 
 ### Agent Model Used
 
-_(empty — to be filled by implementing agent)_
+Claude Opus 4.6 (claude-opus-4-6)
 
 ### Debug Log References
 
-_(empty — to be filled by implementing agent)_
+- Build: `npm run build` — passes with 0 errors (252 modules transformed)
+- Lint: `npm run lint` — 0 warnings, 0 errors (oxlint + eslint)
 
 ### Completion Notes List
 
-_(empty — to be filled by implementing agent)_
+- Installed Pinia as a new dependency and registered it in `main.ts`
+- Created `useLayoutStore` Pinia store with `sidebarCollapsed` state persisted to localStorage
+- Created `useKeyboard` composable for keydown bindings with input/textarea guard
+- Created `useBreakpoint` composable using `matchMedia` for reactive `isMobile` ref
+- Created `AppHeader.vue` with PrimeVue Button for hamburger and user menu placeholder
+- Created `AppSidebar.vue` with collapsible desktop sidebar (240/48px) and mobile overlay drawer
+- Created `AppStatusBar.vue` with connection status indicator and version string
+- Created `AppShell.vue` wiring all components with skip-nav link, keyboard shortcut (`[`), responsive layout
+- Updated `App.vue` to use `AppShell` as the root layout wrapper
+- Added placeholder routes for `/projects`, `/runs`, `/settings` in router
+- All semantic HTML elements used: `<header>`, `<aside>`, `<nav>`, `<main>`, `<footer>`
+- Zero custom CSS — Tailwind utility classes only, PrimeVue components for interactivity
 
 ### File List
 
-_(empty — to be filled by implementing agent)_
+- `frontend/src/stores/layout.ts` — Pinia store for sidebar collapsed state
+- `frontend/src/composables/useKeyboard.ts` — Keyboard shortcut composable
+- `frontend/src/composables/useBreakpoint.ts` — Responsive breakpoint composable
+- `frontend/src/ui/layout/AppHeader.vue` — Header component (48px)
+- `frontend/src/ui/layout/AppSidebar.vue` — Sidebar component (240/48px collapsible)
+- `frontend/src/ui/layout/AppStatusBar.vue` — Status bar component (24px)
+- `frontend/src/ui/layout/AppShell.vue` — Root layout shell
+- `frontend/src/App.vue` — Updated to use AppShell
+- `frontend/src/router/index.ts` — Updated with placeholder routes
+- `frontend/src/main.ts` — Updated to register Pinia
 
 ## Change Log
 
-_(empty)_
+- 2026-02-16: Initial implementation of Story 1-8

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primevue/themes": "^4.5.4",
+        "pinia": "^3.0.4",
         "primeicons": "^7.0.0",
         "primevue": "^4.5.4",
         "vue": "^3.5.28",
@@ -6012,6 +6013,66 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/pinia": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
+      "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^7.7.7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.5.0",
+        "vue": "^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pinia/node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/pinia/node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/pinia/node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/pinia/node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
     },
     "node_modules/pkg-types": {
       "version": "2.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@primevue/themes": "^4.5.4",
+    "pinia": "^3.0.4",
     "primeicons": "^7.0.0",
     "primevue": "^4.5.4",
     "vue": "^3.5.28",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { RouterView } from 'vue-router'
+import AppShell from '@/ui/layout/AppShell.vue'
 </script>
 
 <template>
-  <RouterView />
+  <AppShell />
 </template>

--- a/frontend/src/composables/useBreakpoint.ts
+++ b/frontend/src/composables/useBreakpoint.ts
@@ -1,0 +1,20 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+
+export function useBreakpoint() {
+  const query = window.matchMedia('(max-width: 1023px)')
+  const isMobile = ref(query.matches)
+
+  function onChange(event: MediaQueryListEvent) {
+    isMobile.value = event.matches
+  }
+
+  onMounted(() => {
+    query.addEventListener('change', onChange)
+  })
+
+  onUnmounted(() => {
+    query.removeEventListener('change', onChange)
+  })
+
+  return { isMobile }
+}

--- a/frontend/src/composables/useBreakpoint.ts
+++ b/frontend/src/composables/useBreakpoint.ts
@@ -4,7 +4,7 @@ export function useBreakpoint() {
   const query = window.matchMedia('(max-width: 1023px)')
   const isMobile = ref(query.matches)
 
-  function onChange(event: MediaQueryListEvent) {
+  const onChange = (event: MediaQueryListEvent) => {
     isMobile.value = event.matches
   }
 

--- a/frontend/src/composables/useKeyboard.ts
+++ b/frontend/src/composables/useKeyboard.ts
@@ -1,0 +1,28 @@
+import { onMounted, onUnmounted } from 'vue'
+
+export function useKeyboard(bindings: Record<string, () => void>): void {
+  function handler(event: KeyboardEvent) {
+    const target = event.target as HTMLElement | null
+    if (
+      target &&
+      (target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable)
+    ) {
+      return
+    }
+
+    const fn = bindings[event.key]
+    if (fn) {
+      fn()
+    }
+  }
+
+  onMounted(() => {
+    window.addEventListener('keydown', handler)
+  })
+
+  onUnmounted(() => {
+    window.removeEventListener('keydown', handler)
+  })
+}

--- a/frontend/src/composables/useKeyboard.ts
+++ b/frontend/src/composables/useKeyboard.ts
@@ -1,7 +1,7 @@
 import { onMounted, onUnmounted } from 'vue'
 
 export function useKeyboard(bindings: Record<string, () => void>): void {
-  function handler(event: KeyboardEvent) {
+  const handler = (event: KeyboardEvent) => {
     const target = event.target as HTMLElement | null
     if (
       target &&

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,7 @@
 import './assets/main.css'
 
 import { createApp } from 'vue'
+import { createPinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import App from './App.vue'
 import router from './router'
@@ -8,6 +9,7 @@ import { HopeTheme } from '@/theme'
 
 const app = createApp(App)
 
+app.use(createPinia())
 app.use(router)
 app.use(PrimeVue, {
   theme: {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -6,7 +6,22 @@ const router = createRouter({
   routes: [
     {
       path: '/',
-      name: 'test',
+      name: 'dashboard',
+      component: TestView,
+    },
+    {
+      path: '/projects',
+      name: 'projects',
+      component: TestView,
+    },
+    {
+      path: '/runs',
+      name: 'runs',
+      component: TestView,
+    },
+    {
+      path: '/settings',
+      name: 'settings',
       component: TestView,
     },
   ],

--- a/frontend/src/stores/layout.ts
+++ b/frontend/src/stores/layout.ts
@@ -1,0 +1,18 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useLayoutStore = defineStore('layout', () => {
+  const sidebarCollapsed = ref(
+    localStorage.getItem('layout-sidebar-collapsed') === 'true',
+  )
+
+  function toggleSidebar() {
+    sidebarCollapsed.value = !sidebarCollapsed.value
+    localStorage.setItem(
+      'layout-sidebar-collapsed',
+      String(sidebarCollapsed.value),
+    )
+  }
+
+  return { sidebarCollapsed, toggleSidebar }
+})

--- a/frontend/src/stores/layout.ts
+++ b/frontend/src/stores/layout.ts
@@ -3,15 +3,18 @@ import { ref } from 'vue'
 
 export const useLayoutStore = defineStore('layout', () => {
   const sidebarCollapsed = ref(
-    localStorage.getItem('layout-sidebar-collapsed') === 'true',
+    typeof window !== 'undefined' &&
+      localStorage.getItem('layout-sidebar-collapsed') === 'true',
   )
 
   function toggleSidebar() {
     sidebarCollapsed.value = !sidebarCollapsed.value
-    localStorage.setItem(
-      'layout-sidebar-collapsed',
-      String(sidebarCollapsed.value),
-    )
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(
+        'layout-sidebar-collapsed',
+        String(sidebarCollapsed.value),
+      )
+    }
   }
 
   return { sidebarCollapsed, toggleSidebar }

--- a/frontend/src/ui/layout/AppHeader.vue
+++ b/frontend/src/ui/layout/AppHeader.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import Button from 'primevue/button'
+
+defineProps<{
+  showHamburger: boolean
+}>()
+
+const emit = defineEmits<{
+  'toggle-sidebar': []
+}>()
+</script>
+
+<template>
+  <header
+    class="flex h-12 items-center justify-between border-b border-surface-200 bg-surface-0 px-4"
+  >
+    <div class="flex items-center gap-2">
+      <Button
+        v-if="showHamburger"
+        icon="pi pi-bars"
+        text
+        rounded
+        aria-label="Toggle sidebar"
+        @click="emit('toggle-sidebar')"
+      />
+      <span class="text-lg font-semibold text-surface-700">Hope</span>
+    </div>
+    <div class="flex items-center gap-2">
+      <Button icon="pi pi-user" text rounded aria-label="User menu" />
+    </div>
+  </header>
+</template>

--- a/frontend/src/ui/layout/AppShell.vue
+++ b/frontend/src/ui/layout/AppShell.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import Button from 'primevue/button'
+import AppHeader from './AppHeader.vue'
+import AppSidebar from './AppSidebar.vue'
+import AppStatusBar from './AppStatusBar.vue'
+import { useLayoutStore } from '@/stores/layout'
+import { useKeyboard } from '@/composables/useKeyboard'
+import { useBreakpoint } from '@/composables/useBreakpoint'
+
+const layoutStore = useLayoutStore()
+const { isMobile } = useBreakpoint()
+const mobileSidebarOpen = ref(false)
+const router = useRouter()
+
+const mobileNavItems = [
+  { label: 'Dashboard', icon: 'pi pi-home', route: '/' },
+  { label: 'Projects', icon: 'pi pi-folder', route: '/projects' },
+  { label: 'Runs', icon: 'pi pi-play', route: '/runs' },
+  { label: 'Settings', icon: 'pi pi-cog', route: '/settings' },
+]
+
+useKeyboard({
+  '[': () => {
+    if (!isMobile.value) {
+      layoutStore.toggleSidebar()
+    }
+  },
+})
+
+// Close mobile sidebar when switching to desktop
+watch(isMobile, (mobile) => {
+  if (!mobile) {
+    mobileSidebarOpen.value = false
+  }
+})
+
+function toggleMobileSidebar() {
+  mobileSidebarOpen.value = !mobileSidebarOpen.value
+}
+</script>
+
+<template>
+  <div class="flex h-screen flex-col overflow-hidden">
+    <!-- Skip navigation link -->
+    <a
+      href="#main-content"
+      class="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:bg-primary focus:px-4 focus:py-2 focus:text-white"
+    >
+      Skip to main content
+    </a>
+
+    <AppHeader
+      :show-hamburger="isMobile"
+      @toggle-sidebar="toggleMobileSidebar"
+    />
+
+    <div class="flex min-h-0 flex-1">
+      <AppSidebar
+        :collapsed="layoutStore.sidebarCollapsed"
+        :mobile-open="mobileSidebarOpen"
+        @close="mobileSidebarOpen = false"
+      />
+
+      <main
+        id="main-content"
+        class="flex-1 overflow-auto bg-surface-100 p-4"
+      >
+        <router-view />
+      </main>
+    </div>
+
+    <!-- Mobile bottom nav -->
+    <nav
+      v-if="isMobile"
+      class="flex h-14 items-center justify-around border-t border-surface-200 bg-surface-0"
+      aria-label="Mobile navigation"
+    >
+      <Button
+        v-for="item in mobileNavItems"
+        :key="item.route"
+        :icon="item.icon"
+        :label="item.label"
+        text
+        class="flex flex-col items-center gap-0.5 text-xs"
+        @click="router.push(item.route)"
+      />
+    </nav>
+
+    <AppStatusBar v-if="!isMobile" />
+  </div>
+</template>

--- a/frontend/src/ui/layout/AppSidebar.vue
+++ b/frontend/src/ui/layout/AppSidebar.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import Button from 'primevue/button'
+
+const props = defineProps<{
+  collapsed: boolean
+  mobileOpen: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const router = useRouter()
+
+const navItems = [
+  { label: 'Dashboard', icon: 'pi pi-home', route: '/' },
+  { label: 'Projects', icon: 'pi pi-folder', route: '/projects' },
+  { label: 'Runs', icon: 'pi pi-play', route: '/runs' },
+  { label: 'Settings', icon: 'pi pi-cog', route: '/settings' },
+]
+
+const sidebarWidth = computed(() => (props.collapsed ? 'w-12' : 'w-60'))
+
+function navigate(route: string) {
+  router.push(route)
+  emit('close')
+}
+</script>
+
+<template>
+  <!-- Mobile overlay backdrop -->
+  <div
+    v-if="mobileOpen"
+    class="fixed inset-0 z-40 bg-black/50 lg:hidden"
+    @click="emit('close')"
+  />
+
+  <aside
+    :class="[
+      'flex flex-col border-r border-surface-200 bg-surface-50',
+      'transition-all duration-200 ease-in-out',
+      // Mobile: overlay drawer
+      mobileOpen
+        ? 'fixed inset-y-0 left-0 z-50 w-60 shadow-lg lg:relative lg:z-auto lg:shadow-none'
+        : 'hidden lg:flex',
+      // Desktop: collapsible width
+      !mobileOpen ? sidebarWidth : '',
+    ]"
+  >
+    <nav class="flex flex-1 flex-col gap-1 p-2" aria-label="Main navigation">
+      <Button
+        v-for="item in navItems"
+        :key="item.route"
+        :icon="item.icon"
+        :label="collapsed && !mobileOpen ? undefined : item.label"
+        text
+        :class="[
+          'justify-start',
+          collapsed && !mobileOpen ? '!px-0 justify-center' : '',
+        ]"
+        @click="navigate(item.route)"
+      />
+    </nav>
+  </aside>
+</template>

--- a/frontend/src/ui/layout/AppStatusBar.vue
+++ b/frontend/src/ui/layout/AppStatusBar.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts"></script>
+
+<template>
+  <footer
+    class="flex h-6 items-center justify-between border-t border-surface-200 bg-surface-0 px-4 text-xs text-surface-500"
+  >
+    <div class="flex items-center gap-1">
+      <i class="pi pi-circle-fill text-green-500" style="font-size: 0.5rem" />
+      <span>Connected</span>
+    </div>
+    <span>v0.0.0</span>
+  </footer>
+</template>

--- a/frontend/src/ui/layout/AppStatusBar.vue
+++ b/frontend/src/ui/layout/AppStatusBar.vue
@@ -5,7 +5,7 @@
     class="flex h-6 items-center justify-between border-t border-surface-200 bg-surface-0 px-4 text-xs text-surface-500"
   >
     <div class="flex items-center gap-1">
-      <i class="pi pi-circle-fill text-green-500" style="font-size: 0.5rem" />
+      <i class="pi pi-circle-fill text-[0.5rem] text-green-500" />
       <span>Connected</span>
     </div>
     <span>v0.0.0</span>


### PR DESCRIPTION
## Summary

- Implements Story 1-8: responsive app shell with header (48px), collapsible sidebar (240/48px), and status bar (24px)
- Adds Pinia `useLayoutStore` with localStorage persistence for sidebar collapsed state
- Creates `useKeyboard` and `useBreakpoint` composables for keyboard shortcut (`[` key) and responsive breakpoint detection
- Builds `AppHeader`, `AppSidebar`, `AppStatusBar`, and `AppShell` layout components with semantic HTML (`<header>`, `<aside>`, `<nav>`, `<main>`, `<footer>`) and skip navigation link
- Mobile responsive: hamburger menu, overlay drawer sidebar, bottom tab navigation (4 tabs)
- Zero custom CSS — Tailwind utility classes + PrimeVue components only

## Acceptance Criteria

- [x] AC1: Layout structure renders correctly (header 48px, sidebar 240px, status bar 24px)
- [x] AC2: Desktop sidebar toggle via `[` key (240px ↔ 48px icons only)
- [x] AC3: Mobile responsive layout (<1024px) — sidebar hidden, hamburger in header, bottom nav with 4 tabs
- [x] AC4: Semantic HTML and accessibility — `<nav>`, `<main>`, `<aside>`, skip navigation link

## Test plan

- [ ] `npm run build` passes with no TypeScript errors
- [ ] `npm run lint` passes with 0 warnings/errors
- [ ] Desktop: header, sidebar (240px), main content, and status bar render correctly
- [ ] Press `[` key — sidebar toggles to 48px (icons only), press again — back to 240px
- [ ] Refresh page — sidebar collapsed state persists via localStorage
- [ ] Resize to <1024px — sidebar hides, hamburger appears, bottom nav shows 4 tabs
- [ ] Click hamburger — sidebar overlay opens, click backdrop — dismisses
- [ ] Inspect HTML — semantic elements present (`<header>`, `<aside>`, `<nav>`, `<main>`, `<footer>`)
- [ ] Tab from top — skip navigation link becomes visible on focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)