### PR TITLE
test(ui): add unit and e2e tests for project list page (story 1-10)

### DIFF
--- a/frontend/e2e/tests/project-list.spec.ts
+++ b/frontend/e2e/tests/project-list.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Project List Page', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock authenticated user
+    await page.route('**/api/v1/auth/me', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: '1',
+          email: 'test@test.com',
+          name: 'Test User',
+        }),
+      })
+    })
+  })
+
+  test('displays project list in DataTable when API returns projects', async ({ page }) => {
+    const projects = [
+      {
+        id: 'p1',
+        name: 'Alpha Project',
+        description: 'First project',
+        owner_id: 'u1',
+        created_at: '2026-02-10T10:00:00Z',
+        updated_at: '2026-02-10T10:00:00Z',
+      },
+      {
+        id: 'p2',
+        name: 'Beta Project',
+        description: 'Second project',
+        owner_id: 'u1',
+        created_at: '2026-02-12T10:00:00Z',
+        updated_at: '2026-02-12T10:00:00Z',
+      },
+    ]
+
+    await page.route('**/api/v1/projects*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: projects,
+          pagination: { total: 2, page: 1, per_page: 20 },
+        }),
+      })
+    })
+
+    await page.goto('/projects')
+
+    // Page header is visible
+    await expect(page.locator('h1')).toHaveText('Projects')
+
+    // DataTable rows are visible with project names
+    await expect(page.getByText('Alpha Project')).toBeVisible()
+    await expect(page.getByText('Beta Project')).toBeVisible()
+
+    // Column headers are visible
+    await expect(page.getByText('Name')).toBeVisible()
+    await expect(page.getByText('Description')).toBeVisible()
+    await expect(page.getByText('Created')).toBeVisible()
+  })
+
+  test('displays empty state when API returns no projects', async ({ page }) => {
+    await page.route('**/api/v1/projects*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [],
+          pagination: { total: 0, page: 1, per_page: 20 },
+        }),
+      })
+    })
+
+    await page.goto('/projects')
+
+    // Empty state is visible
+    await expect(page.getByText('No projects yet')).toBeVisible()
+    await expect(page.getByText('Create your first project')).toBeVisible()
+  })
+
+  test('navigates to project detail when clicking a row', async ({ page }) => {
+    const projects = [
+      {
+        id: 'p1',
+        name: 'Alpha Project',
+        description: 'First project',
+        owner_id: 'u1',
+        created_at: '2026-02-10T10:00:00Z',
+        updated_at: '2026-02-10T10:00:00Z',
+      },
+    ]
+
+    await page.route('**/api/v1/projects*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: projects,
+          pagination: { total: 1, page: 1, per_page: 20 },
+        }),
+      })
+    })
+
+    await page.goto('/projects')
+
+    // Click the project row
+    await page.getByText('Alpha Project').click()
+
+    // Should navigate to project detail
+    await expect(page).toHaveURL('/projects/p1')
+  })
+})

--- a/frontend/src/composables/__tests__/useProjects.spec.ts
+++ b/frontend/src/composables/__tests__/useProjects.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useProjects } from '../useProjects'
+
+const mockGet = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+  },
+}))
+
+describe('useProjects', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockGet.mockReset()
+  })
+
+  it('exposes reactive computed properties from the store', () => {
+    const { projects, pagination, isLoading, error } = useProjects()
+    expect(projects.value).toEqual([])
+    expect(pagination.value).toBeNull()
+    expect(isLoading.value).toBe(false)
+    expect(error.value).toBeNull()
+  })
+
+  it('fetches projects and updates reactive state', async () => {
+    const projectData = [
+      {
+        id: '1',
+        name: 'Project A',
+        owner_id: 'u1',
+        created_at: '2026-01-15T10:00:00Z',
+        updated_at: '2026-01-15T10:00:00Z',
+      },
+    ]
+    mockGet.mockResolvedValue({
+      data: { data: projectData, pagination: { total: 1, page: 1, per_page: 20 } },
+      error: undefined,
+    })
+
+    const { projects, pagination, isLoading, fetchProjects } = useProjects()
+    await fetchProjects({ page: 1, per_page: 20 })
+
+    expect(projects.value).toEqual(projectData)
+    expect(pagination.value).toEqual({ total: 1, page: 1, per_page: 20 })
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('exposes error state on fetch failure', async () => {
+    mockGet.mockResolvedValue({
+      data: undefined,
+      error: { error: { code: 'INTERNAL', message: 'Server error' } },
+    })
+
+    const { error, fetchProjects } = useProjects()
+    await fetchProjects()
+
+    expect(error.value).toBe('Failed to load projects')
+  })
+
+  it('retry re-fetches with the same params', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: [], pagination: { total: 0, page: 2, per_page: 10 } },
+      error: undefined,
+    })
+
+    const { fetchProjects, retry } = useProjects()
+    await fetchProjects({ page: 2, per_page: 10 })
+
+    expect(mockGet).toHaveBeenCalledTimes(1)
+    expect(mockGet).toHaveBeenCalledWith('/projects', {
+      params: { query: { page: 2, per_page: 10, sort_by: undefined } },
+    })
+
+    mockGet.mockClear()
+    await retry()
+
+    expect(mockGet).toHaveBeenCalledTimes(1)
+    expect(mockGet).toHaveBeenCalledWith('/projects', {
+      params: { query: { page: 2, per_page: 10, sort_by: undefined } },
+    })
+  })
+
+  it('retry uses default params when fetchProjects was called without params', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: [], pagination: { total: 0, page: 1, per_page: 20 } },
+      error: undefined,
+    })
+
+    const { fetchProjects, retry } = useProjects()
+    await fetchProjects()
+    mockGet.mockClear()
+
+    await retry()
+
+    expect(mockGet).toHaveBeenCalledWith('/projects', {
+      params: { query: { page: undefined, per_page: undefined, sort_by: undefined } },
+    })
+  })
+})

--- a/frontend/src/features/projects/__tests__/ProjectEmptyState.spec.ts
+++ b/frontend/src/features/projects/__tests__/ProjectEmptyState.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import ProjectEmptyState from '../ProjectEmptyState.vue'
+
+function mountComponent() {
+  return mount(ProjectEmptyState, {
+    global: {
+      plugins: [PrimeVue],
+    },
+  })
+}
+
+describe('ProjectEmptyState', () => {
+  it('renders the heading text', () => {
+    const wrapper = mountComponent()
+    expect(wrapper.text()).toContain('No projects yet')
+  })
+
+  it('renders the description text', () => {
+    const wrapper = mountComponent()
+    expect(wrapper.text()).toContain('Get started by creating your first project')
+  })
+
+  it('renders the CTA button with correct label', () => {
+    const wrapper = mountComponent()
+    const button = wrapper.find('button')
+    expect(button.exists()).toBe(true)
+    expect(button.text()).toContain('Create your first project')
+  })
+
+  it('emits "create" event when CTA button is clicked', async () => {
+    const wrapper = mountComponent()
+    const button = wrapper.find('button')
+    await button.trigger('click')
+    expect(wrapper.emitted('create')).toHaveLength(1)
+  })
+
+  it('renders a folder icon', () => {
+    const wrapper = mountComponent()
+    const icon = wrapper.find('.pi-folder-open')
+    expect(icon.exists()).toBe(true)
+  })
+})

--- a/frontend/src/features/projects/__tests__/ProjectListTable.spec.ts
+++ b/frontend/src/features/projects/__tests__/ProjectListTable.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import ProjectListTable from '../ProjectListTable.vue'
+import type { Project } from '@/stores/projects'
+
+vi.mock('@/utils/formatDate', () => ({
+  formatRelativeDate: (date: string) => `mocked-${date}`,
+}))
+
+const sampleProjects: Project[] = [
+  {
+    id: '1',
+    name: 'Alpha Project',
+    description: 'First project description',
+    owner_id: 'u1',
+    created_at: '2026-01-15T10:00:00Z',
+    updated_at: '2026-01-15T10:00:00Z',
+  },
+  {
+    id: '2',
+    name: 'Beta Project',
+    owner_id: 'u1',
+    created_at: '2026-02-01T08:00:00Z',
+    updated_at: '2026-02-01T08:00:00Z',
+  },
+]
+
+function mountComponent(props: Partial<InstanceType<typeof ProjectListTable>['$props']> = {}) {
+  return mount(ProjectListTable, {
+    props: {
+      projects: sampleProjects,
+      totalRecords: sampleProjects.length,
+      rows: 20,
+      loading: false,
+      first: 0,
+      ...props,
+    },
+    global: {
+      plugins: [PrimeVue],
+    },
+  })
+}
+
+describe('ProjectListTable', () => {
+  it('renders column headers', () => {
+    const wrapper = mountComponent()
+    const text = wrapper.text()
+    expect(text).toContain('Name')
+    expect(text).toContain('Description')
+    expect(text).toContain('Created')
+  })
+
+  it('renders project names in the table', () => {
+    const wrapper = mountComponent()
+    const text = wrapper.text()
+    expect(text).toContain('Alpha Project')
+    expect(text).toContain('Beta Project')
+  })
+
+  it('renders project descriptions', () => {
+    const wrapper = mountComponent()
+    const text = wrapper.text()
+    expect(text).toContain('First project description')
+  })
+
+  it('renders dash for missing description', () => {
+    const wrapper = mountComponent()
+    // Beta Project has no description, should show '-'
+    const text = wrapper.text()
+    expect(text).toContain('-')
+  })
+
+  it('renders formatted dates using formatRelativeDate', () => {
+    const wrapper = mountComponent()
+    const text = wrapper.text()
+    expect(text).toContain('mocked-2026-01-15T10:00:00Z')
+    expect(text).toContain('mocked-2026-02-01T08:00:00Z')
+  })
+
+  it('emits row-click with project data when a row is clicked', async () => {
+    const wrapper = mountComponent()
+    const rows = wrapper.findAll('tr[data-p-index]')
+    expect(rows.length).toBeGreaterThan(0)
+    await rows[0]!.trigger('click')
+    const emitted = wrapper.emitted('row-click')
+    expect(emitted).toBeDefined()
+    expect(emitted).toHaveLength(1)
+    expect(emitted![0]![0]).toEqual(sampleProjects[0])
+  })
+
+  it('shows loading state when loading prop is true', () => {
+    const wrapper = mountComponent({ loading: true })
+    // PrimeVue DataTable adds a loading overlay when loading is true
+    const loadingIcon = wrapper.find('[data-pc-section="loadingicon"]')
+    expect(loadingIcon.exists()).toBe(true)
+  })
+})

--- a/frontend/src/utils/__tests__/formatDate.spec.ts
+++ b/frontend/src/utils/__tests__/formatDate.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { formatRelativeDate, formatDate } from '../formatDate'
+
+describe('formatRelativeDate', () => {
+  it('returns a relative time string for a valid ISO date', () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+    const result = formatRelativeDate(oneHourAgo)
+    expect(result).toContain('ago')
+  })
+
+  it('includes "ago" suffix', () => {
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+    const result = formatRelativeDate(yesterday)
+    expect(result).toMatch(/ago$/)
+  })
+
+  it('returns "Invalid date" for unparseable input', () => {
+    expect(formatRelativeDate('not-a-date')).toBe('Invalid date')
+  })
+
+  it('returns "Invalid date" for empty string', () => {
+    expect(formatRelativeDate('')).toBe('Invalid date')
+  })
+})
+
+describe('formatDate', () => {
+  it('formats an ISO date string as "MMM d, yyyy"', () => {
+    expect(formatDate('2026-02-15T10:30:00Z')).toBe('Feb 15, 2026')
+  })
+
+  it('formats another date correctly', () => {
+    expect(formatDate('2025-12-01T00:00:00Z')).toBe('Dec 1, 2025')
+  })
+
+  it('returns "Invalid date" for unparseable input', () => {
+    expect(formatDate('garbage')).toBe('Invalid date')
+  })
+
+  it('returns "Invalid date" for empty string', () => {
+    expect(formatDate('')).toBe('Invalid date')
+  })
+})


### PR DESCRIPTION
## Summary
- Add unit tests for `useProjects` composable (reactive state, fetch, retry logic)
- Add unit tests for `formatDate` and `formatRelativeDate` utilities (valid/invalid date inputs)
- Add component tests for `ProjectEmptyState` (rendering, CTA button emit)
- Add component tests for `ProjectListTable` (column rendering, row-click emit, loading state)
- Add E2E Playwright test for the project list page (data display, empty state, row click navigation)

## Test plan
- [x] `npm run type-check` passes with no errors
- [x] `npm run lint` passes with no errors
- [x] `npm run test:unit -- --run` — all 48 tests pass (25 new)
- [ ] `npm run test:e2e` — E2E tests pass against running dev server (requires Playwright + browser)

Refs: S-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)