### PR TITLE
feat(api): add user management admin CRUD endpoints

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -61,7 +61,12 @@ func run() error {
 	projectRepo := pgadapter.NewProjectRepo(queries)
 	projectService := service.NewProjectService(projectRepo)
 	projectHandler := handler.NewProjectHandler(projectService)
-	server := handler.NewServer(projectHandler)
+
+	// User service
+	userService := service.NewUserService(userRepo)
+	userHandler := handler.NewUserHandler(userService)
+
+	server := handler.NewServer(projectHandler, userHandler)
 
 	// Build router
 	r := chi.NewRouter()

--- a/backend/internal/adapter/postgres/user_repository.go
+++ b/backend/internal/adapter/postgres/user_repository.go
@@ -77,6 +77,11 @@ func (r *UserRepository) Update(ctx context.Context, user *model.User) (*model.U
 	return toDomainUser(row), nil
 }
 
+// Count returns the total number of active (non-deleted) users.
+func (r *UserRepository) Count(ctx context.Context) (int64, error) {
+	return r.q.CountUsers(ctx)
+}
+
 func (r *UserRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	return r.q.DeleteUser(ctx, id)
 }
@@ -90,5 +95,6 @@ func toDomainUser(u User) *model.User {
 		Role:         model.Role(u.Role),
 		CreatedAt:    u.CreatedAt,
 		UpdatedAt:    u.UpdatedAt,
+		DeletedAt:    u.DeletedAt,
 	}
 }

--- a/backend/internal/api/handler/auth_handler_test.go
+++ b/backend/internal/api/handler/auth_handler_test.go
@@ -62,6 +62,10 @@ func (m *mockRepo) List(ctx context.Context, limit, offset int32) ([]*model.User
 	return nil, nil
 }
 
+func (m *mockRepo) Count(ctx context.Context) (int64, error) {
+	return int64(len(m.users)), nil
+}
+
 func (m *mockRepo) Update(ctx context.Context, user *model.User) (*model.User, error) {
 	return nil, nil
 }

--- a/backend/internal/api/handler/helpers.go
+++ b/backend/internal/api/handler/helpers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
 	"github.com/zakari/hopeitworks/backend/pkg/errors"
 )
@@ -71,4 +72,16 @@ func toAPIProject(p *model.Project) Project {
 		proj.OwnerId = *p.OwnerID
 	}
 	return proj
+}
+
+// toAPIUser converts a domain User to the API User type.
+func toAPIUser(u *model.User) User {
+	return User{
+		Id:        u.ID,
+		Email:     openapi_types.Email(u.Email),
+		Name:      u.Name,
+		Role:      UserRole(u.Role),
+		CreatedAt: u.CreatedAt,
+		UpdatedAt: u.UpdatedAt,
+	}
 }

--- a/backend/internal/api/handler/server.go
+++ b/backend/internal/api/handler/server.go
@@ -3,16 +3,16 @@ package handler
 import "net/http"
 
 // Server implements the generated ServerInterface, delegating to specific handlers.
-// It embeds Unimplemented to satisfy methods that are not yet implemented
-// (auth/user endpoints from Story 1-3).
+// It embeds Unimplemented to satisfy methods that are not yet implemented.
 type Server struct {
 	Unimplemented
 	projects *ProjectHandler
+	users    *UserHandler
 }
 
 // NewServer creates a new Server with the given handlers.
-func NewServer(projects *ProjectHandler) *Server {
-	return &Server{projects: projects}
+func NewServer(projects *ProjectHandler, users *UserHandler) *Server {
+	return &Server{projects: projects, users: users}
 }
 
 // ListProjects delegates to ProjectHandler.
@@ -38,4 +38,24 @@ func (s *Server) UpdateProject(w http.ResponseWriter, r *http.Request, id IdPath
 // DeleteProject delegates to ProjectHandler.
 func (s *Server) DeleteProject(w http.ResponseWriter, r *http.Request, id IdPath) {
 	s.projects.DeleteProject(w, r, id)
+}
+
+// ListUsers delegates to UserHandler.
+func (s *Server) ListUsers(w http.ResponseWriter, r *http.Request, params ListUsersParams) {
+	s.users.ListUsers(w, r, params)
+}
+
+// GetUser delegates to UserHandler.
+func (s *Server) GetUser(w http.ResponseWriter, r *http.Request, id IdPath) {
+	s.users.GetUser(w, r, id)
+}
+
+// UpdateUser delegates to UserHandler.
+func (s *Server) UpdateUser(w http.ResponseWriter, r *http.Request, id IdPath) {
+	s.users.UpdateUser(w, r, id)
+}
+
+// DeleteUser delegates to UserHandler.
+func (s *Server) DeleteUser(w http.ResponseWriter, r *http.Request, id IdPath) {
+	s.users.DeleteUser(w, r, id)
 }

--- a/backend/internal/api/handler/user_handler.go
+++ b/backend/internal/api/handler/user_handler.go
@@ -1,0 +1,130 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/zakari/hopeitworks/backend/internal/api/middleware"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// UserHandler implements user management HTTP handlers.
+type UserHandler struct {
+	service *service.UserService
+}
+
+// NewUserHandler creates a new UserHandler.
+func NewUserHandler(svc *service.UserService) *UserHandler {
+	return &UserHandler{service: svc}
+}
+
+// ListUsers handles GET /users.
+// Only admin users can list users.
+func (h *UserHandler) ListUsers(w http.ResponseWriter, r *http.Request, params ListUsersParams) {
+	if !middleware.IsAdmin(r.Context()) {
+		writeErrorResponse(w, errors.NewForbidden("Admin access required"))
+		return
+	}
+
+	page := 1
+	perPage := 20
+	if params.Page != nil && *params.Page > 0 {
+		page = *params.Page
+	}
+	if params.PerPage != nil && *params.PerPage > 0 {
+		perPage = *params.PerPage
+	}
+
+	result, err := h.service.List(r.Context(), page, perPage)
+	if err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+
+	resp := UserList{
+		Data: make([]User, len(result.Users)),
+		Pagination: Pagination{
+			Total:   int(result.Total),
+			Page:    page,
+			PerPage: perPage,
+		},
+	}
+	for i, u := range result.Users {
+		resp.Data[i] = toAPIUser(u)
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// GetUser handles GET /users/{id}.
+// Only admin users can get user details.
+func (h *UserHandler) GetUser(w http.ResponseWriter, r *http.Request, id IdPath) {
+	if !middleware.IsAdmin(r.Context()) {
+		writeErrorResponse(w, errors.NewForbidden("Admin access required"))
+		return
+	}
+
+	user, err := h.service.GetByID(r.Context(), id)
+	if err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toAPIUser(user))
+}
+
+// UpdateUser handles PUT /users/{id}.
+// Only admin users can update users.
+func (h *UserHandler) UpdateUser(w http.ResponseWriter, r *http.Request, id IdPath) {
+	if !middleware.IsAdmin(r.Context()) {
+		writeErrorResponse(w, errors.NewForbidden("Admin access required"))
+		return
+	}
+
+	var req UpdateUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErrorResponse(w, errors.NewValidation("body", "invalid JSON"))
+		return
+	}
+
+	params := service.UpdateUserParams{
+		ID: id,
+	}
+	if req.Name != nil {
+		params.Name = req.Name
+	}
+	if req.Email != nil {
+		email := string(*req.Email)
+		params.Email = &email
+	}
+	if req.Role != nil {
+		role := model.Role(*req.Role)
+		params.Role = &role
+	}
+
+	user, err := h.service.Update(r.Context(), params)
+	if err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toAPIUser(user))
+}
+
+// DeleteUser handles DELETE /users/{id}.
+// Only admin users can delete users.
+func (h *UserHandler) DeleteUser(w http.ResponseWriter, r *http.Request, id IdPath) {
+	if !middleware.IsAdmin(r.Context()) {
+		writeErrorResponse(w, errors.NewForbidden("Admin access required"))
+		return
+	}
+
+	if err := h.service.Delete(r.Context(), id); err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/internal/api/handler/user_handler_test.go
+++ b/backend/internal/api/handler/user_handler_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -14,8 +15,6 @@ import (
 	"github.com/zakari/hopeitworks/backend/internal/domain/port"
 	"github.com/zakari/hopeitworks/backend/internal/domain/service"
 	"github.com/zakari/hopeitworks/backend/pkg/errors"
-
-	"context"
 )
 
 // mockUserRepo is a mock implementation of port.UserRepository for handler tests.

--- a/backend/internal/api/handler/user_handler_test.go
+++ b/backend/internal/api/handler/user_handler_test.go
@@ -1,0 +1,377 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/api/middleware"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+
+	"context"
+)
+
+// mockUserRepo is a mock implementation of port.UserRepository for handler tests.
+type mockUserRepo struct {
+	users map[uuid.UUID]*model.User
+}
+
+// Compile-time check that mockUserRepo implements port.UserRepository.
+var _ port.UserRepository = (*mockUserRepo)(nil)
+
+func newMockUserRepo() *mockUserRepo {
+	return &mockUserRepo{
+		users: make(map[uuid.UUID]*model.User),
+	}
+}
+
+func (m *mockUserRepo) Create(_ context.Context, user *model.User) (*model.User, error) {
+	user.ID = uuid.New()
+	user.CreatedAt = time.Now()
+	user.UpdatedAt = time.Now()
+	m.users[user.ID] = user
+	return user, nil
+}
+
+func (m *mockUserRepo) GetByEmail(_ context.Context, email string) (*model.User, error) {
+	for _, u := range m.users {
+		if u.Email == email {
+			return u, nil
+		}
+	}
+	return nil, errors.NewNotFound("user", email)
+}
+
+func (m *mockUserRepo) GetByID(_ context.Context, id uuid.UUID) (*model.User, error) {
+	u, ok := m.users[id]
+	if !ok {
+		return nil, errors.NewNotFound("user", id)
+	}
+	return u, nil
+}
+
+func (m *mockUserRepo) List(_ context.Context, limit, offset int32) ([]*model.User, error) {
+	result := make([]*model.User, 0)
+	i := int32(0)
+	for _, u := range m.users {
+		if i >= offset && i < offset+limit {
+			result = append(result, u)
+		}
+		i++
+	}
+	return result, nil
+}
+
+func (m *mockUserRepo) Count(_ context.Context) (int64, error) {
+	return int64(len(m.users)), nil
+}
+
+func (m *mockUserRepo) Update(_ context.Context, user *model.User) (*model.User, error) {
+	user.UpdatedAt = time.Now()
+	m.users[user.ID] = user
+	return user, nil
+}
+
+func (m *mockUserRepo) Delete(_ context.Context, id uuid.UUID) error {
+	delete(m.users, id)
+	return nil
+}
+
+func setupUserHandler() (*UserHandler, *mockUserRepo) {
+	repo := newMockUserRepo()
+	svc := service.NewUserService(repo)
+	h := NewUserHandler(svc)
+	return h, repo
+}
+
+func seedTestUser(repo *mockUserRepo, name, email string, role model.Role) *model.User {
+	id := uuid.New()
+	u := &model.User{
+		ID:        id,
+		Name:      name,
+		Email:     email,
+		Role:      role,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	repo.users[id] = u
+	return u
+}
+
+func TestListUsers_AdminOnly(t *testing.T) {
+	h, repo := setupUserHandler()
+
+	for i := 0; i < 3; i++ {
+		seedTestUser(repo, "User", "user"+string(rune('0'+i))+"@example.com", model.RoleUser)
+	}
+
+	tests := []struct {
+		name       string
+		role       model.Role
+		wantStatus int
+	}{
+		{
+			name:       "admin can list",
+			role:       model.RoleAdmin,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "non-admin gets 403",
+			role:       model.RoleUser,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "no role gets 403",
+			role:       "",
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+			if tt.role != "" {
+				ctx := middleware.SetUserContext(req.Context(), uuid.New(), tt.role)
+				req = req.WithContext(ctx)
+			}
+
+			rec := httptest.NewRecorder()
+			h.ListUsers(rec, req, ListUsersParams{})
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d. Body: %s", tt.wantStatus, rec.Code, rec.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				var resp UserList
+				if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if len(resp.Data) != 3 {
+					t.Errorf("expected 3 users, got %d", len(resp.Data))
+				}
+				if resp.Pagination.Total != 3 {
+					t.Errorf("expected total 3, got %d", resp.Pagination.Total)
+				}
+			}
+		})
+	}
+}
+
+func TestGetUser_AdminOnly(t *testing.T) {
+	h, repo := setupUserHandler()
+	user := seedTestUser(repo, "Alice", "alice@example.com", model.RoleUser)
+
+	tests := []struct {
+		name       string
+		role       model.Role
+		id         uuid.UUID
+		wantStatus int
+	}{
+		{
+			name:       "admin can get user",
+			role:       model.RoleAdmin,
+			id:         user.ID,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "non-admin gets 403",
+			role:       model.RoleUser,
+			id:         user.ID,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "admin gets 404 for non-existent",
+			role:       model.RoleAdmin,
+			id:         uuid.New(),
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/users/"+tt.id.String(), nil)
+			if tt.role != "" {
+				ctx := middleware.SetUserContext(req.Context(), uuid.New(), tt.role)
+				req = req.WithContext(ctx)
+			}
+
+			rec := httptest.NewRecorder()
+			h.GetUser(rec, req, tt.id)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d. Body: %s", tt.wantStatus, rec.Code, rec.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				var resp User
+				if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if string(resp.Role) != string(model.RoleUser) {
+					t.Errorf("expected role %q, got %q", model.RoleUser, resp.Role)
+				}
+				if resp.Name != "Alice" {
+					t.Errorf("expected name 'Alice', got %q", resp.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateUser_AdminOnly(t *testing.T) {
+	h, repo := setupUserHandler()
+	user := seedTestUser(repo, "Alice", "alice@example.com", model.RoleUser)
+
+	tests := []struct {
+		name       string
+		role       model.Role
+		id         uuid.UUID
+		body       string
+		wantStatus int
+	}{
+		{
+			name:       "admin can update role",
+			role:       model.RoleAdmin,
+			id:         user.ID,
+			body:       `{"role":"admin"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "admin can update name",
+			role:       model.RoleAdmin,
+			id:         user.ID,
+			body:       `{"name":"Alice Updated"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "non-admin gets 403",
+			role:       model.RoleUser,
+			id:         user.ID,
+			body:       `{"name":"Hacked"}`,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "invalid JSON returns 400",
+			role:       model.RoleAdmin,
+			id:         user.ID,
+			body:       `{invalid}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "not found returns 404",
+			role:       model.RoleAdmin,
+			id:         uuid.New(),
+			body:       `{"name":"Test"}`,
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/users/"+tt.id.String(),
+				bytes.NewBufferString(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+
+			if tt.role != "" {
+				ctx := middleware.SetUserContext(req.Context(), uuid.New(), tt.role)
+				req = req.WithContext(ctx)
+			}
+
+			rec := httptest.NewRecorder()
+			h.UpdateUser(rec, req, tt.id)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d. Body: %s", tt.wantStatus, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestUpdateUser_RoleChange(t *testing.T) {
+	h, repo := setupUserHandler()
+	user := seedTestUser(repo, "Alice", "alice@example.com", model.RoleUser)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/users/"+user.ID.String(),
+		bytes.NewBufferString(`{"role":"admin"}`))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleAdmin)
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	h.UpdateUser(rec, req, user.ID)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp User
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if string(resp.Role) != "admin" {
+		t.Errorf("expected role 'admin', got %q", resp.Role)
+	}
+}
+
+func TestDeleteUser_AdminOnly(t *testing.T) {
+	h, repo := setupUserHandler()
+
+	tests := []struct {
+		name       string
+		role       model.Role
+		seedUser   bool
+		wantStatus int
+	}{
+		{
+			name:       "admin can delete",
+			role:       model.RoleAdmin,
+			seedUser:   true,
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "non-admin gets 403",
+			role:       model.RoleUser,
+			seedUser:   true,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "admin gets 404 for non-existent",
+			role:       model.RoleAdmin,
+			seedUser:   false,
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var targetID uuid.UUID
+			if tt.seedUser {
+				u := seedTestUser(repo, "ToDelete", "delete@example.com", model.RoleUser)
+				targetID = u.ID
+			} else {
+				targetID = uuid.New()
+			}
+
+			req := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+targetID.String(), nil)
+			if tt.role != "" {
+				ctx := middleware.SetUserContext(req.Context(), uuid.New(), tt.role)
+				req = req.WithContext(ctx)
+			}
+
+			rec := httptest.NewRecorder()
+			h.DeleteUser(rec, req, targetID)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d. Body: %s", tt.wantStatus, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}

--- a/backend/internal/api/middleware/auth_test.go
+++ b/backend/internal/api/middleware/auth_test.go
@@ -34,6 +34,7 @@ func (r *noopRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.User, erro
 func (r *noopRepo) List(ctx context.Context, limit, offset int32) ([]*model.User, error) {
 	return nil, nil
 }
+func (r *noopRepo) Count(ctx context.Context) (int64, error) { return 0, nil }
 func (r *noopRepo) Update(ctx context.Context, user *model.User) (*model.User, error) {
 	return nil, nil
 }

--- a/backend/internal/domain/service/auth_service_test.go
+++ b/backend/internal/domain/service/auth_service_test.go
@@ -66,6 +66,10 @@ func (m *mockUserRepository) List(ctx context.Context, limit, offset int32) ([]*
 	return result, nil
 }
 
+func (m *mockUserRepository) Count(ctx context.Context) (int64, error) {
+	return int64(len(m.users)), nil
+}
+
 func (m *mockUserRepository) Update(ctx context.Context, user *model.User) (*model.User, error) {
 	existing, ok := m.users[user.ID.String()]
 	if !ok {

--- a/backend/internal/domain/service/user_service.go
+++ b/backend/internal/domain/service/user_service.go
@@ -1,0 +1,117 @@
+package service
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// UserService provides business logic for user management (admin CRUD).
+type UserService struct {
+	repo port.UserRepository
+}
+
+// NewUserService creates a new UserService.
+func NewUserService(repo port.UserRepository) *UserService {
+	return &UserService{repo: repo}
+}
+
+// UserListResult holds the result of a paginated user list operation.
+type UserListResult struct {
+	Users []*model.User
+	Total int64
+}
+
+// UpdateUserParams holds parameters for updating a user.
+type UpdateUserParams struct {
+	ID    uuid.UUID
+	Name  *string
+	Email *string
+	Role  *model.Role
+}
+
+// GetByID retrieves a user by ID.
+func (s *UserService) GetByID(ctx context.Context, id uuid.UUID) (*model.User, error) {
+	user, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, errors.NewNotFound("user", id)
+	}
+	return user, nil
+}
+
+// List retrieves a paginated list of users.
+func (s *UserService) List(ctx context.Context, page, perPage int) (*UserListResult, error) {
+	if page < 1 {
+		page = 1
+	}
+	if perPage < 1 {
+		perPage = 20
+	}
+	if perPage > 100 {
+		perPage = 100
+	}
+
+	offset := int32((page - 1) * perPage)
+	limit := int32(perPage)
+
+	users, err := s.repo.List(ctx, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+
+	total, err := s.repo.Count(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &UserListResult{
+		Users: users,
+		Total: total,
+	}, nil
+}
+
+// Update validates inputs and updates an existing user.
+func (s *UserService) Update(ctx context.Context, params UpdateUserParams) (*model.User, error) {
+	existing, err := s.repo.GetByID(ctx, params.ID)
+	if err != nil {
+		return nil, errors.NewNotFound("user", params.ID)
+	}
+
+	if params.Name != nil {
+		if *params.Name == "" {
+			return nil, errors.NewValidation("name", "must not be empty")
+		}
+		if len(*params.Name) > 255 {
+			return nil, errors.NewValidation("name", "must be 255 characters or less")
+		}
+		existing.Name = *params.Name
+	}
+
+	if params.Email != nil {
+		if *params.Email == "" {
+			return nil, errors.NewValidation("email", "must not be empty")
+		}
+		existing.Email = *params.Email
+	}
+
+	if params.Role != nil {
+		if !params.Role.IsValid() {
+			return nil, errors.NewValidation("role", "must be 'admin' or 'user'")
+		}
+		existing.Role = *params.Role
+	}
+
+	return s.repo.Update(ctx, existing)
+}
+
+// Delete soft-deletes a user by ID.
+func (s *UserService) Delete(ctx context.Context, id uuid.UUID) error {
+	_, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return errors.NewNotFound("user", id)
+	}
+	return s.repo.Delete(ctx, id)
+}

--- a/backend/internal/domain/service/user_service_test.go
+++ b/backend/internal/domain/service/user_service_test.go
@@ -1,0 +1,303 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// mockUserRepo is a mock implementation of port.UserRepository for testing.
+type mockUserRepo struct {
+	users    map[uuid.UUID]*model.User
+	createFn func(ctx context.Context, u *model.User) (*model.User, error)
+	updateFn func(ctx context.Context, u *model.User) (*model.User, error)
+	deleteFn func(ctx context.Context, id uuid.UUID) error
+}
+
+func newMockUserRepo() *mockUserRepo {
+	return &mockUserRepo{
+		users: make(map[uuid.UUID]*model.User),
+	}
+}
+
+func (m *mockUserRepo) Create(ctx context.Context, user *model.User) (*model.User, error) {
+	if m.createFn != nil {
+		return m.createFn(ctx, user)
+	}
+	user.ID = uuid.New()
+	user.CreatedAt = time.Now()
+	user.UpdatedAt = time.Now()
+	m.users[user.ID] = user
+	return user, nil
+}
+
+func (m *mockUserRepo) GetByEmail(ctx context.Context, email string) (*model.User, error) {
+	for _, u := range m.users {
+		if u.Email == email {
+			return u, nil
+		}
+	}
+	return nil, errors.NewNotFound("user", email)
+}
+
+func (m *mockUserRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.User, error) {
+	u, ok := m.users[id]
+	if !ok {
+		return nil, errors.NewNotFound("user", id)
+	}
+	return u, nil
+}
+
+func (m *mockUserRepo) List(ctx context.Context, limit, offset int32) ([]*model.User, error) {
+	result := make([]*model.User, 0)
+	i := int32(0)
+	for _, u := range m.users {
+		if i >= offset && i < offset+limit {
+			result = append(result, u)
+		}
+		i++
+	}
+	return result, nil
+}
+
+func (m *mockUserRepo) Count(ctx context.Context) (int64, error) {
+	return int64(len(m.users)), nil
+}
+
+func (m *mockUserRepo) Update(ctx context.Context, user *model.User) (*model.User, error) {
+	if m.updateFn != nil {
+		return m.updateFn(ctx, user)
+	}
+	user.UpdatedAt = time.Now()
+	m.users[user.ID] = user
+	return user, nil
+}
+
+func (m *mockUserRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	if m.deleteFn != nil {
+		return m.deleteFn(ctx, id)
+	}
+	delete(m.users, id)
+	return nil
+}
+
+func seedUser(repo *mockUserRepo, name, email string, role model.Role) *model.User {
+	id := uuid.New()
+	u := &model.User{
+		ID:        id,
+		Name:      name,
+		Email:     email,
+		Role:      role,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	repo.users[id] = u
+	return u
+}
+
+func TestUserService_GetByID(t *testing.T) {
+	repo := newMockUserRepo()
+	svc := NewUserService(repo)
+
+	user := seedUser(repo, "Alice", "alice@example.com", model.RoleUser)
+
+	tests := []struct {
+		name    string
+		id      uuid.UUID
+		wantErr bool
+		errCode string
+	}{
+		{
+			name:    "existing user",
+			id:      user.ID,
+			wantErr: false,
+		},
+		{
+			name:    "non-existent user",
+			id:      uuid.New(),
+			wantErr: true,
+			errCode: "USER_NOT_FOUND",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := svc.GetByID(context.Background(), tt.id)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				domainErr, ok := err.(*errors.DomainError)
+				if !ok {
+					t.Fatalf("expected DomainError, got %T", err)
+				}
+				if domainErr.Code != tt.errCode {
+					t.Errorf("expected error code %q, got %q", tt.errCode, domainErr.Code)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.ID != tt.id {
+				t.Errorf("expected ID %v, got %v", tt.id, result.ID)
+			}
+		})
+	}
+}
+
+func TestUserService_List(t *testing.T) {
+	repo := newMockUserRepo()
+	svc := NewUserService(repo)
+
+	for i := 0; i < 5; i++ {
+		seedUser(repo, "User", "user"+string(rune('0'+i))+"@example.com", model.RoleUser)
+	}
+
+	tests := []struct {
+		name      string
+		page      int
+		perPage   int
+		wantTotal int64
+	}{
+		{name: "default pagination", page: 1, perPage: 20, wantTotal: 5},
+		{name: "clamp page to 1", page: 0, perPage: 20, wantTotal: 5},
+		{name: "clamp perPage to 20", page: 1, perPage: 0, wantTotal: 5},
+		{name: "clamp perPage max to 100", page: 1, perPage: 200, wantTotal: 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := svc.List(context.Background(), tt.page, tt.perPage)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Total != tt.wantTotal {
+				t.Errorf("expected total %d, got %d", tt.wantTotal, result.Total)
+			}
+		})
+	}
+}
+
+func TestUserService_Update(t *testing.T) {
+	repo := newMockUserRepo()
+	svc := NewUserService(repo)
+
+	user := seedUser(repo, "Alice", "alice@example.com", model.RoleUser)
+
+	newName := "Alice Updated"
+	newEmail := "alice-new@example.com"
+	adminRole := model.RoleAdmin
+	invalidRole := model.Role("superadmin")
+	emptyName := ""
+	longName := string(make([]byte, 256))
+	emptyEmail := ""
+
+	tests := []struct {
+		name    string
+		params  UpdateUserParams
+		wantErr bool
+		errCode string
+	}{
+		{
+			name:    "update name",
+			params:  UpdateUserParams{ID: user.ID, Name: &newName},
+			wantErr: false,
+		},
+		{
+			name:    "update email",
+			params:  UpdateUserParams{ID: user.ID, Email: &newEmail},
+			wantErr: false,
+		},
+		{
+			name:    "update role to admin",
+			params:  UpdateUserParams{ID: user.ID, Role: &adminRole},
+			wantErr: false,
+		},
+		{
+			name:    "not found",
+			params:  UpdateUserParams{ID: uuid.New(), Name: &newName},
+			wantErr: true,
+			errCode: "USER_NOT_FOUND",
+		},
+		{
+			name:    "invalid role",
+			params:  UpdateUserParams{ID: user.ID, Role: &invalidRole},
+			wantErr: true,
+			errCode: "VALIDATION_ERROR",
+		},
+		{
+			name:    "empty name",
+			params:  UpdateUserParams{ID: user.ID, Name: &emptyName},
+			wantErr: true,
+			errCode: "VALIDATION_ERROR",
+		},
+		{
+			name:    "name too long",
+			params:  UpdateUserParams{ID: user.ID, Name: &longName},
+			wantErr: true,
+			errCode: "VALIDATION_ERROR",
+		},
+		{
+			name:    "empty email",
+			params:  UpdateUserParams{ID: user.ID, Email: &emptyEmail},
+			wantErr: true,
+			errCode: "VALIDATION_ERROR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := svc.Update(context.Background(), tt.params)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				domainErr, ok := err.(*errors.DomainError)
+				if !ok {
+					t.Fatalf("expected DomainError, got %T", err)
+				}
+				if domainErr.Code != tt.errCode {
+					t.Errorf("expected error code %q, got %q", tt.errCode, domainErr.Code)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+		})
+	}
+}
+
+func TestUserService_Delete(t *testing.T) {
+	repo := newMockUserRepo()
+	svc := NewUserService(repo)
+
+	user := seedUser(repo, "ToDelete", "delete@example.com", model.RoleUser)
+
+	// Delete existing user
+	err := svc.Delete(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Delete non-existent user
+	err = svc.Delete(context.Background(), uuid.New())
+	if err == nil {
+		t.Fatal("expected error for non-existent user, got nil")
+	}
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected DomainError, got %T", err)
+	}
+	if domainErr.Code != "USER_NOT_FOUND" {
+		t.Errorf("expected USER_NOT_FOUND, got %q", domainErr.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- Add admin-only user management CRUD endpoints: `GET /users`, `GET /users/{id}`, `PUT /users/{id}`, `DELETE /users/{id}`
- Implement `UserService` domain service with validation, pagination, and soft-delete semantics
- Implement `UserHandler` with admin-only RBAC checks via `middleware.IsAdmin()`
- Wire `UserHandler` into `Server` and `main.go`
- Add `Count` method to `UserRepository` postgres adapter, update `toDomainUser` to map `DeletedAt`
- Add `toAPIUser` helper for domain-to-API type conversion
- Add comprehensive unit tests for both `UserService` and `UserHandler`
- Fix existing test mocks to satisfy updated `port.UserRepository` interface (add `Count` method)

## Acceptance Criteria
- [x] AC1: Admin can list users with pagination (GET /users → 200 with data[] + pagination)
- [x] AC2: Non-admin cannot list users (GET /users → 403)
- [x] AC3: Admin can get a single user (GET /users/{id} → 200 with user including role)
- [x] AC4: Admin can update a user including role change (PUT /users/{id} → 200)
- [x] AC5: Non-admin cannot update other users (PUT /users/{id} → 403)
- [x] AC6: Admin can deactivate a user via soft-delete (DELETE /users/{id} → 204)
- [x] AC7: OpenAPI spec includes role field (already in place from prior work)

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go vet ./...` passes
- [x] `go test ./... -short` — all 53 tests pass
- [x] UserService tests: GetByID, List pagination, Update (name/email/role/validation), Delete
- [x] UserHandler tests: ListUsers (admin/non-admin/no-role), GetUser (admin/non-admin/404), UpdateUser (admin role change/name update/non-admin/invalid JSON/404), DeleteUser (admin/non-admin/404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)