### PR TITLE
feat(stories): add story board page with epic list and story counts

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -25,6 +25,8 @@ tags:
     description: User management endpoints
   - name: projects
     description: Project management endpoints
+  - name: epics
+    description: Epic management endpoints
 
 paths:
   # ── Auth ────────────────────────────────────────────────────────────────
@@ -298,6 +300,49 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  # ── Epics ─────────────────────────────────────────────────────────────
+  /projects/{id}/epics:
+    get:
+      operationId: listEpicsByProject
+      summary: List all epics for a project with story counts
+      tags: [epics]
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+        - $ref: "#/components/parameters/PageParam"
+        - $ref: "#/components/parameters/PerPageParam"
+        - $ref: "#/components/parameters/SortByParam"
+      responses:
+        "200":
+          description: Paginated list of epics with story counts
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpicList"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /projects/{id}/epics/{epicId}:
+    get:
+      operationId: getEpic
+      summary: Get a single epic by ID
+      tags: [epics]
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+        - $ref: "#/components/parameters/EpicIdPath"
+      responses:
+        "200":
+          description: Epic details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Epic"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
 # ── Components ──────────────────────────────────────────────────────────
 components:
   securitySchemes:
@@ -337,6 +382,15 @@ components:
         maximum: 100
         default: 20
       description: Items per page
+
+    EpicIdPath:
+      name: epicId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: Epic UUID
 
     SortByParam:
       name: sort_by
@@ -521,6 +575,85 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Project"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+
+    # ── Epic ──────────────────────────────────────────────────────────
+    Epic:
+      type: object
+      required:
+        - id
+        - project_id
+        - name
+        - status
+        - story_counts
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 770e8400-e29b-41d4-a716-446655440000
+        project_id:
+          type: string
+          format: uuid
+          example: 660e8400-e29b-41d4-a716-446655440000
+        name:
+          type: string
+          example: "Project Foundation & Authentication"
+        description:
+          type: string
+          example: "Admin can create an account, authenticate, and configure a first project"
+        status:
+          type: string
+          enum: [open, in_progress, completed]
+          example: in_progress
+        story_counts:
+          $ref: "#/components/schemas/StoryCounts"
+        created_at:
+          type: string
+          format: date-time
+          example: "2026-01-15T10:30:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          example: "2026-01-15T10:30:00Z"
+
+    StoryCounts:
+      type: object
+      required:
+        - total
+        - backlog
+        - running
+        - done
+        - failed
+      properties:
+        total:
+          type: integer
+          example: 12
+        backlog:
+          type: integer
+          example: 5
+        running:
+          type: integer
+          example: 3
+        done:
+          type: integer
+          example: 3
+        failed:
+          type: integer
+          example: 1
+
+    EpicList:
+      type: object
+      required:
+        - data
+        - pagination
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Epic"
         pagination:
           $ref: "#/components/schemas/Pagination"
 

--- a/frontend/src/composables/__tests__/useEpics.spec.ts
+++ b/frontend/src/composables/__tests__/useEpics.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useEpics } from '../useEpics'
+
+const mockGet = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+  },
+}))
+
+describe('useEpics', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockGet.mockReset()
+  })
+
+  it('exposes reactive computed properties from the store', () => {
+    const { epics, pagination, isLoading, error } = useEpics()
+    expect(epics.value).toEqual([])
+    expect(pagination.value).toBeNull()
+    expect(isLoading.value).toBe(false)
+    expect(error.value).toBeNull()
+  })
+
+  it('fetches epics and updates reactive state', async () => {
+    const epicData = [
+      {
+        id: 'e1',
+        project_id: 'p1',
+        name: 'Epic 1',
+        status: 'open',
+        story_counts: { total: 5, backlog: 5, running: 0, done: 0, failed: 0 },
+        created_at: '2026-01-15T10:00:00Z',
+        updated_at: '2026-01-15T10:00:00Z',
+      },
+    ]
+    mockGet.mockResolvedValue({
+      data: { data: epicData, pagination: { total: 1, page: 1, per_page: 20 } },
+      error: undefined,
+    })
+
+    const { epics, pagination, isLoading, fetchEpics } = useEpics()
+    await fetchEpics('p1', { page: 1, per_page: 20 })
+
+    expect(epics.value).toEqual(epicData)
+    expect(pagination.value).toEqual({ total: 1, page: 1, per_page: 20 })
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('exposes error state on fetch failure', async () => {
+    mockGet.mockResolvedValue({
+      data: undefined,
+      error: { error: { code: 'INTERNAL', message: 'Server error' } },
+    })
+
+    const { error, fetchEpics } = useEpics()
+    await fetchEpics('p1')
+
+    expect(error.value).toBe('Failed to load epics')
+  })
+
+  it('retry re-fetches with the same project ID and params', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: [], pagination: { total: 0, page: 2, per_page: 10 } },
+      error: undefined,
+    })
+
+    const { fetchEpics, retry } = useEpics()
+    await fetchEpics('p1', { page: 2, per_page: 10 })
+
+    expect(mockGet).toHaveBeenCalledTimes(1)
+    expect(mockGet).toHaveBeenCalledWith('/projects/{id}/epics', {
+      params: {
+        path: { id: 'p1' },
+        query: { page: 2, per_page: 10, sort_by: undefined },
+      },
+    })
+
+    mockGet.mockClear()
+    await retry()
+
+    expect(mockGet).toHaveBeenCalledTimes(1)
+    expect(mockGet).toHaveBeenCalledWith('/projects/{id}/epics', {
+      params: {
+        path: { id: 'p1' },
+        query: { page: 2, per_page: 10, sort_by: undefined },
+      },
+    })
+  })
+
+  it('retry does nothing when no previous fetch was made', async () => {
+    const { retry } = useEpics()
+    await retry()
+
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/composables/useEpics.ts
+++ b/frontend/src/composables/useEpics.ts
@@ -1,0 +1,35 @@
+import { computed, ref } from 'vue'
+import { useEpicsStore, type FetchEpicsParams } from '@/stores/epics'
+
+/**
+ * Composable for epic list operations within a project.
+ * Wraps the epics store with reactive computed properties and retry logic.
+ */
+export function useEpics() {
+  const store = useEpicsStore()
+  const lastProjectId = ref<string>('')
+  const lastParams = ref<FetchEpicsParams>({})
+
+  /** Fetch epics for a project, storing params for retry */
+  async function fetchEpics(projectId: string, params: FetchEpicsParams = {}) {
+    lastProjectId.value = projectId
+    lastParams.value = params
+    await store.fetchEpics(projectId, params)
+  }
+
+  /** Re-execute the last fetchEpics call with same params */
+  async function retry() {
+    if (lastProjectId.value) {
+      await store.fetchEpics(lastProjectId.value, lastParams.value)
+    }
+  }
+
+  return {
+    epics: computed(() => store.items),
+    pagination: computed(() => store.pagination),
+    isLoading: computed(() => store.isLoading),
+    error: computed(() => store.error),
+    fetchEpics,
+    retry,
+  }
+}

--- a/frontend/src/features/stories/EpicCard.vue
+++ b/frontend/src/features/stories/EpicCard.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import Card from 'primevue/card'
+import Tag from 'primevue/tag'
+import Badge from 'primevue/badge'
+import type { Epic } from '@/stores/epics'
+
+const props = defineProps<{
+  epic: Epic
+}>()
+
+const emit = defineEmits<{
+  click: [epic: Epic]
+}>()
+
+/** Map story status to PrimeVue severity for Tag color */
+type TagSeverity = 'success' | 'info' | 'danger' | 'secondary' | 'warn' | 'contrast' | undefined
+
+interface StatusEntry {
+  label: string
+  count: number
+  severity: TagSeverity
+}
+
+const statusEntries = computed<StatusEntry[]>(() => {
+  const c = props.epic.story_counts
+  return [
+    { label: 'Done', count: c.done, severity: 'success' as TagSeverity },
+    { label: 'Running', count: c.running, severity: 'info' as TagSeverity },
+    { label: 'Backlog', count: c.backlog, severity: 'secondary' as TagSeverity },
+    { label: 'Failed', count: c.failed, severity: 'danger' as TagSeverity },
+  ].filter((e) => e.count > 0)
+})
+
+/** Map epic status to a display label */
+const epicStatusLabel = computed(() => {
+  const map: Record<string, string> = {
+    open: 'Open',
+    in_progress: 'In Progress',
+    completed: 'Completed',
+  }
+  return map[props.epic.status] ?? props.epic.status
+})
+
+/** Map epic status to PrimeVue Tag severity */
+const epicStatusSeverity = computed<TagSeverity>(() => {
+  const map: Record<string, TagSeverity> = {
+    open: 'secondary',
+    in_progress: 'info',
+    completed: 'success',
+  }
+  return map[props.epic.status] ?? 'secondary'
+})
+
+/** Progress percentage based on done stories */
+const progressPercent = computed(() => {
+  const total = props.epic.story_counts.total
+  if (total === 0) return 0
+  return Math.round((props.epic.story_counts.done / total) * 100)
+})
+</script>
+
+<template>
+  <Card
+    class="cursor-pointer transition-shadow hover:shadow-md"
+    @click="emit('click', epic)"
+  >
+    <template #header>
+      <div class="flex items-center justify-between px-4 pt-4">
+        <Tag :value="epicStatusLabel" :severity="epicStatusSeverity" />
+        <Badge :value="String(epic.story_counts.total)" severity="secondary" />
+      </div>
+    </template>
+    <template #title>
+      {{ epic.name }}
+    </template>
+    <template #subtitle>
+      <span v-if="epic.description" class="line-clamp-2">{{ epic.description }}</span>
+    </template>
+    <template #content>
+      <div class="flex flex-col gap-3">
+        <!-- Progress bar -->
+        <div class="flex items-center gap-2">
+          <div class="h-2 flex-1 overflow-hidden rounded-full bg-surface-200">
+            <div
+              class="h-full rounded-full bg-green-500 transition-all"
+              :style="{ width: `${progressPercent}%` }"
+            />
+          </div>
+          <span class="text-sm text-surface-500">{{ progressPercent }}%</span>
+        </div>
+
+        <!-- Story count tags -->
+        <div class="flex flex-wrap gap-2">
+          <Tag
+            v-for="entry in statusEntries"
+            :key="entry.label"
+            :value="`${entry.count} ${entry.label}`"
+            :severity="entry.severity"
+          />
+        </div>
+      </div>
+    </template>
+  </Card>
+</template>

--- a/frontend/src/features/stories/EpicEmptyState.vue
+++ b/frontend/src/features/stories/EpicEmptyState.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import Button from 'primevue/button'
+
+const emit = defineEmits<{
+  import: []
+}>()
+</script>
+
+<template>
+  <div class="flex flex-col items-center justify-center gap-4 py-16">
+    <i class="pi pi-th-large text-4xl text-surface-400" />
+    <h2 class="text-xl font-semibold">No epics yet</h2>
+    <p class="text-surface-500">Import stories from your repository to get started</p>
+    <Button
+      label="Import Stories"
+      icon="pi pi-upload"
+      severity="success"
+      @click="emit('import')"
+    />
+  </div>
+</template>

--- a/frontend/src/features/stories/EpicList.vue
+++ b/frontend/src/features/stories/EpicList.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import type { Epic } from '@/stores/epics'
+import EpicCard from './EpicCard.vue'
+
+defineProps<{
+  epics: Epic[]
+}>()
+
+const emit = defineEmits<{
+  'epic-click': [epic: Epic]
+}>()
+</script>
+
+<template>
+  <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+    <EpicCard
+      v-for="epic in epics"
+      :key="epic.id"
+      :epic="epic"
+      @click="emit('epic-click', $event)"
+    />
+  </div>
+</template>

--- a/frontend/src/features/stories/__tests__/EpicCard.spec.ts
+++ b/frontend/src/features/stories/__tests__/EpicCard.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import EpicCard from '../EpicCard.vue'
+import type { Epic } from '@/stores/epics'
+
+const baseEpic: Epic = {
+  id: 'e1',
+  project_id: 'p1',
+  name: 'Project Foundation',
+  description: 'Admin can create an account and configure a project',
+  status: 'in_progress',
+  story_counts: { total: 12, backlog: 5, running: 3, done: 3, failed: 1 },
+  created_at: '2026-01-15T10:00:00Z',
+  updated_at: '2026-01-15T10:00:00Z',
+}
+
+function mountComponent(epic: Epic = baseEpic) {
+  return mount(EpicCard, {
+    props: { epic },
+    global: {
+      plugins: [PrimeVue],
+    },
+  })
+}
+
+describe('EpicCard', () => {
+  it('renders the epic name', () => {
+    const wrapper = mountComponent()
+    expect(wrapper.text()).toContain('Project Foundation')
+  })
+
+  it('renders the epic description', () => {
+    const wrapper = mountComponent()
+    expect(wrapper.text()).toContain('Admin can create an account')
+  })
+
+  it('renders story count tags for non-zero statuses', () => {
+    const wrapper = mountComponent()
+    expect(wrapper.text()).toContain('3 Done')
+    expect(wrapper.text()).toContain('3 Running')
+    expect(wrapper.text()).toContain('5 Backlog')
+    expect(wrapper.text()).toContain('1 Failed')
+  })
+
+  it('does not render tags for zero-count statuses', () => {
+    const epic: Epic = {
+      ...baseEpic,
+      story_counts: { total: 5, backlog: 5, running: 0, done: 0, failed: 0 },
+    }
+    const wrapper = mountComponent(epic)
+    expect(wrapper.text()).toContain('5 Backlog')
+    expect(wrapper.text()).not.toContain('Done')
+    expect(wrapper.text()).not.toContain('Running')
+    expect(wrapper.text()).not.toContain('Failed')
+  })
+
+  it('renders the total story count badge', () => {
+    const wrapper = mountComponent()
+    expect(wrapper.text()).toContain('12')
+  })
+
+  it('renders the epic status tag', () => {
+    const wrapper = mountComponent()
+    expect(wrapper.text()).toContain('In Progress')
+  })
+
+  it('renders Completed status for completed epics', () => {
+    const epic: Epic = {
+      ...baseEpic,
+      status: 'completed',
+      story_counts: { total: 12, backlog: 0, running: 0, done: 12, failed: 0 },
+    }
+    const wrapper = mountComponent(epic)
+    expect(wrapper.text()).toContain('Completed')
+  })
+
+  it('renders progress percentage', () => {
+    const wrapper = mountComponent()
+    expect(wrapper.text()).toContain('25%')
+  })
+
+  it('renders 0% progress when no stories are done', () => {
+    const epic: Epic = {
+      ...baseEpic,
+      story_counts: { total: 5, backlog: 5, running: 0, done: 0, failed: 0 },
+    }
+    const wrapper = mountComponent(epic)
+    expect(wrapper.text()).toContain('0%')
+  })
+
+  it('renders 100% progress when all stories are done', () => {
+    const epic: Epic = {
+      ...baseEpic,
+      story_counts: { total: 10, backlog: 0, running: 0, done: 10, failed: 0 },
+    }
+    const wrapper = mountComponent(epic)
+    expect(wrapper.text()).toContain('100%')
+  })
+
+  it('emits click event with the epic when card is clicked', async () => {
+    const wrapper = mountComponent()
+    await wrapper.find('.p-card').trigger('click')
+    expect(wrapper.emitted('click')).toBeDefined()
+    expect(wrapper.emitted('click')![0]).toEqual([baseEpic])
+  })
+})

--- a/frontend/src/features/stories/__tests__/EpicEmptyState.spec.ts
+++ b/frontend/src/features/stories/__tests__/EpicEmptyState.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import EpicEmptyState from '../EpicEmptyState.vue'
+
+function mountComponent() {
+  return mount(EpicEmptyState, {
+    global: {
+      plugins: [PrimeVue],
+    },
+  })
+}
+
+describe('EpicEmptyState', () => {
+  it('renders the heading text', () => {
+    const wrapper = mountComponent()
+    expect(wrapper.text()).toContain('No epics yet')
+  })
+
+  it('renders the description text', () => {
+    const wrapper = mountComponent()
+    expect(wrapper.text()).toContain('Import stories from your repository to get started')
+  })
+
+  it('renders the CTA button with correct label', () => {
+    const wrapper = mountComponent()
+    const button = wrapper.find('button')
+    expect(button.exists()).toBe(true)
+    expect(button.text()).toContain('Import Stories')
+  })
+
+  it('emits "import" event when CTA button is clicked', async () => {
+    const wrapper = mountComponent()
+    const button = wrapper.find('button')
+    await button.trigger('click')
+    expect(wrapper.emitted('import')).toHaveLength(1)
+  })
+
+  it('renders an icon', () => {
+    const wrapper = mountComponent()
+    const icon = wrapper.find('.pi-th-large')
+    expect(icon.exists()).toBe(true)
+  })
+})

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -5,6 +5,7 @@ import ProjectsView from '@/views/ProjectsView.vue'
 import ProjectDetailView from '@/views/ProjectDetailView.vue'
 import RunDetailView from '@/views/RunDetailView.vue'
 import ApprovalsView from '@/views/ApprovalsView.vue'
+import StoryBoardView from '@/views/StoryBoardView.vue'
 import { setupAuthGuard, setupAdminGuard } from './guards'
 
 const router = createRouter({
@@ -32,6 +33,18 @@ const router = createRouter({
       path: '/projects/:id',
       name: 'project-detail',
       component: ProjectDetailView,
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/projects/:id/board',
+      name: 'story-board',
+      component: StoryBoardView,
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/projects/:id/epics/:epicId',
+      name: 'epic-detail',
+      component: () => import('@/views/ProjectDetailView.vue'),
       meta: { requiresAuth: true },
     },
     {

--- a/frontend/src/stores/__tests__/epics.spec.ts
+++ b/frontend/src/stores/__tests__/epics.spec.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useEpicsStore } from '../epics'
+
+const mockGet = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+  },
+}))
+
+const mockEpic = {
+  id: 'e1',
+  project_id: 'p1',
+  name: 'Epic 1',
+  description: 'First epic',
+  status: 'in_progress',
+  story_counts: { total: 12, backlog: 5, running: 3, done: 3, failed: 1 },
+  created_at: '2026-01-15T10:00:00Z',
+  updated_at: '2026-01-15T10:00:00Z',
+}
+
+describe('useEpicsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockGet.mockReset()
+  })
+
+  it('starts with default state', () => {
+    const store = useEpicsStore()
+    expect(store.items).toEqual([])
+    expect(store.pagination).toBeNull()
+    expect(store.isLoading).toBe(false)
+    expect(store.error).toBeNull()
+    expect(store.projectId).toBeNull()
+  })
+
+  it('fetches epics successfully and populates items and pagination', async () => {
+    const epics = [mockEpic]
+    const pagination = { total: 1, page: 1, per_page: 20 }
+
+    mockGet.mockResolvedValue({
+      data: { data: epics, pagination },
+      error: undefined,
+    })
+
+    const store = useEpicsStore()
+    await store.fetchEpics('p1', { page: 1, per_page: 20 })
+
+    expect(store.items).toEqual(epics)
+    expect(store.pagination).toEqual(pagination)
+    expect(store.isLoading).toBe(false)
+    expect(store.error).toBeNull()
+    expect(store.projectId).toBe('p1')
+    expect(mockGet).toHaveBeenCalledWith('/projects/{id}/epics', {
+      params: {
+        path: { id: 'p1' },
+        query: { page: 1, per_page: 20, sort_by: undefined },
+      },
+    })
+  })
+
+  it('sets error state when API returns an error', async () => {
+    mockGet.mockResolvedValue({
+      data: undefined,
+      error: { error: { code: 'INTERNAL', message: 'Server error' } },
+    })
+
+    const store = useEpicsStore()
+    await store.fetchEpics('p1')
+
+    expect(store.items).toEqual([])
+    expect(store.pagination).toBeNull()
+    expect(store.error).toBe('Failed to load epics')
+    expect(store.isLoading).toBe(false)
+  })
+
+  it('sets error state when API call throws', async () => {
+    mockGet.mockRejectedValue(new Error('Network error'))
+
+    const store = useEpicsStore()
+    await store.fetchEpics('p1')
+
+    expect(store.items).toEqual([])
+    expect(store.error).toBe('Network error')
+    expect(store.isLoading).toBe(false)
+  })
+
+  it('sets fallback error message for non-Error thrown values', async () => {
+    mockGet.mockRejectedValue('unknown error')
+
+    const store = useEpicsStore()
+    await store.fetchEpics('p1')
+
+    expect(store.error).toBe('Failed to load epics')
+  })
+
+  it('resets all state', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: [mockEpic], pagination: { total: 1, page: 1, per_page: 20 } },
+      error: undefined,
+    })
+
+    const store = useEpicsStore()
+    await store.fetchEpics('p1')
+
+    expect(store.items).toHaveLength(1)
+
+    store.reset()
+
+    expect(store.items).toEqual([])
+    expect(store.pagination).toBeNull()
+    expect(store.error).toBeNull()
+    expect(store.projectId).toBeNull()
+  })
+
+  it('clears previous error on new fetch', async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        data: undefined,
+        error: { error: { code: 'INTERNAL', message: 'fail' } },
+      })
+      .mockResolvedValueOnce({
+        data: { data: [], pagination: { total: 0, page: 1, per_page: 20 } },
+        error: undefined,
+      })
+
+    const store = useEpicsStore()
+
+    await store.fetchEpics('p1')
+    expect(store.error).toBe('Failed to load epics')
+
+    await store.fetchEpics('p1')
+    expect(store.error).toBeNull()
+  })
+})

--- a/frontend/src/stores/epics.ts
+++ b/frontend/src/stores/epics.ts
@@ -1,0 +1,71 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+import { apiClient } from '@/api/client'
+import type { components } from '@/api/schema'
+
+/** Epic entity matching the OpenAPI Epic schema */
+export type Epic = components['schemas']['Epic']
+
+/** Story count breakdown by status */
+export type StoryCounts = components['schemas']['StoryCounts']
+
+/** Pagination metadata from API list responses */
+export type Pagination = components['schemas']['Pagination']
+
+/** Parameters for fetching paginated epic lists */
+export interface FetchEpicsParams {
+  page?: number
+  per_page?: number
+  sort_by?: string
+}
+
+/**
+ * Pinia store for epic state management within a project.
+ * Handles fetching, storing, and resetting the epic list with pagination.
+ */
+export const useEpicsStore = defineStore('epics', () => {
+  const items = ref<Epic[]>([])
+  const pagination = ref<Pagination | null>(null)
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+  const projectId = ref<string | null>(null)
+
+  /** Fetch epics from the API for a given project */
+  async function fetchEpics(pid: string, params: FetchEpicsParams = {}) {
+    isLoading.value = true
+    error.value = null
+    projectId.value = pid
+    try {
+      const { data, error: apiError } = await apiClient.GET('/projects/{id}/epics', {
+        params: {
+          path: { id: pid },
+          query: {
+            page: params.page,
+            per_page: params.per_page,
+            sort_by: params.sort_by,
+          },
+        },
+      })
+      if (apiError) {
+        error.value = 'Failed to load epics'
+        return
+      }
+      items.value = (data?.data as Epic[]) ?? []
+      pagination.value = (data?.pagination as Pagination) ?? null
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load epics'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  /** Reset store state to initial values */
+  function reset() {
+    items.value = []
+    pagination.value = null
+    error.value = null
+    projectId.value = null
+  }
+
+  return { items, pagination, isLoading, error, projectId, fetchEpics, reset }
+})

--- a/frontend/src/views/StoryBoardView.vue
+++ b/frontend/src/views/StoryBoardView.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import ProgressSpinner from 'primevue/progressspinner'
+import EpicList from '@/features/stories/EpicList.vue'
+import EpicEmptyState from '@/features/stories/EpicEmptyState.vue'
+import { useEpics } from '@/composables/useEpics'
+import type { Epic } from '@/stores/epics'
+
+const route = useRoute()
+const router = useRouter()
+const { epics, isLoading, error, fetchEpics, retry } = useEpics()
+
+const projectId = route.params.id as string
+
+onMounted(() => {
+  fetchEpics(projectId)
+})
+
+function handleEpicClick(epic: Epic) {
+  router.push({
+    name: 'epic-detail',
+    params: { id: projectId, epicId: epic.id },
+  })
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-6 p-6">
+    <div class="flex items-center justify-between">
+      <h1 class="text-2xl font-bold">Story Board</h1>
+      <Button
+        label="Import Stories"
+        icon="pi pi-upload"
+        severity="secondary"
+        disabled
+      />
+    </div>
+
+    <ProgressSpinner
+      v-if="isLoading && epics.length === 0"
+      class="flex justify-center"
+    />
+
+    <Message v-else-if="error" severity="error" :closable="false">
+      <div class="flex items-center gap-3">
+        <span>{{ error }}</span>
+        <Button label="Retry" severity="secondary" text size="small" @click="retry()" />
+      </div>
+    </Message>
+
+    <EpicEmptyState
+      v-else-if="!isLoading && !error && epics.length === 0"
+      @import="() => {}"
+    />
+
+    <EpicList
+      v-else
+      :epics="epics"
+      @epic-click="handleEpicClick"
+    />
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- Adds story board page at `/projects/:id/board` displaying epics as cards with story count breakdowns by status (backlog, running, done, failed)
- Extends OpenAPI spec with Epic/StoryCounts schemas and epic list/detail endpoints
- Creates full feature stack: Pinia store, composable, Vue components (EpicCard, EpicList, EpicEmptyState), StoryBoardView, and routes

## Changes
- **api/openapi.yaml** — Added `epics` tag, `GET /projects/{id}/epics` and `GET /projects/{id}/epics/{epicId}` endpoints, `Epic`, `StoryCounts`, `EpicList` schemas, `EpicIdPath` parameter
- **frontend/src/stores/epics.ts** — Pinia store for epic state management with fetch, error handling, and reset
- **frontend/src/composables/useEpics.ts** — Composable wrapping store with retry logic
- **frontend/src/features/stories/EpicCard.vue** — Epic card with status tag, progress bar, story count breakdown by status with severity colors
- **frontend/src/features/stories/EpicList.vue** — Responsive grid of epic cards (1/2/3 columns)
- **frontend/src/features/stories/EpicEmptyState.vue** — Empty state with import CTA
- **frontend/src/views/StoryBoardView.vue** — Page composing all components with loading/error/empty states
- **frontend/src/router/index.ts** — Added `/projects/:id/board` (story-board) and `/projects/:id/epics/:epicId` (epic-detail placeholder) routes
- **Tests** — 23 new unit tests covering store, composable, EpicCard, and EpicEmptyState (99 total, all passing)

## Acceptance Criteria
- [x] Navigate to `/projects/:id/board` → epic cards show title, description, story counts by status with correct colors
- [x] No epics exist → empty state with CTA shown
- [x] Click an epic card → navigates to `/projects/:id/epics/:epicId`

## Test plan
- [x] All 99 unit tests pass (`npm run test:unit`)
- [x] ESLint passes (`npm run lint`)
- [x] TypeScript type-check passes (`npm run type-check`)
- [ ] Verify epic cards render correctly with real API data (requires backend stories 2-1/2-2)
- [ ] Verify navigation from project detail to story board

Refs: S-2-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)