### PR TITLE
feat(git): add GitProvider port and gh CLI adapter

### DIFF
--- a/backend/internal/adapter/git/gh_cli_adapter.go
+++ b/backend/internal/adapter/git/gh_cli_adapter.go
@@ -1,0 +1,113 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// branchNamePattern validates conventional branch naming: feat/{key}-{slug} or fix/{key}-{slug}.
+var branchNamePattern = regexp.MustCompile(`^(feat|fix)/[a-zA-Z0-9]+-[a-zA-Z0-9-]+$`)
+
+// Compile-time check that GhCliAdapter implements GitProvider.
+var _ port.GitProvider = (*GhCliAdapter)(nil)
+
+// GhCliAdapter implements GitProvider using the gh CLI and git commands
+// via a CommandRunner for testability.
+type GhCliAdapter struct {
+	runner port.CommandRunner
+	logger *slog.Logger
+}
+
+// NewGhCliAdapter creates a new GhCliAdapter with the given CommandRunner and logger.
+func NewGhCliAdapter(runner port.CommandRunner, logger *slog.Logger) *GhCliAdapter {
+	return &GhCliAdapter{
+		runner: runner,
+		logger: logger,
+	}
+}
+
+// CloneRepo clones a repository to the target directory using gh repo clone.
+func (a *GhCliAdapter) CloneRepo(ctx context.Context, repoURL string, targetDir string) error {
+	a.logger.DebugContext(ctx, "cloning repository",
+		"repo_url", repoURL,
+		"target_dir", targetDir,
+	)
+
+	_, err := a.runner.Run(ctx, "", "gh", "repo", "clone", repoURL, targetDir)
+	if err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to clone repository %s: %v", repoURL, err),
+			map[string]any{"repo_url": repoURL, "target_dir": targetDir},
+		)
+	}
+	return nil
+}
+
+// CreateBranch creates and checks out a new branch in the given working directory.
+// The branch name must follow convention: feat/{story-key}-{slug} or fix/{story-key}-{slug}.
+func (a *GhCliAdapter) CreateBranch(ctx context.Context, workDir string, branchName string) error {
+	if !branchNamePattern.MatchString(branchName) {
+		return errors.NewDomainError(
+			errors.ErrCodeInvalidInput,
+			fmt.Sprintf("invalid branch name format: %s (expected feat/{story-key}-{slug} or fix/{story-key}-{slug})", branchName),
+			map[string]any{"branch_name": branchName},
+		)
+	}
+
+	a.logger.DebugContext(ctx, "creating branch",
+		"work_dir", workDir,
+		"branch_name", branchName,
+	)
+
+	_, err := a.runner.Run(ctx, workDir, "git", "checkout", "-b", branchName)
+	if err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to create branch %s: %v", branchName, err),
+			map[string]any{"branch_name": branchName, "work_dir": workDir},
+		)
+	}
+	return nil
+}
+
+// Push stages all changes, commits with the given message, and pushes to origin.
+func (a *GhCliAdapter) Push(ctx context.Context, workDir string, commitMsg string) error {
+	a.logger.DebugContext(ctx, "pushing changes",
+		"work_dir", workDir,
+	)
+
+	// Stage all changes
+	if _, err := a.runner.Run(ctx, workDir, "git", "add", "."); err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to stage changes: %v", err),
+			map[string]any{"work_dir": workDir},
+		)
+	}
+
+	// Commit with conventional message
+	if _, err := a.runner.Run(ctx, workDir, "git", "commit", "-m", commitMsg); err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to commit changes: %v", err),
+			map[string]any{"work_dir": workDir, "commit_msg": commitMsg},
+		)
+	}
+
+	// Push to origin
+	if _, err := a.runner.Run(ctx, workDir, "git", "push", "-u", "origin", "HEAD"); err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to push changes: %v", err),
+			map[string]any{"work_dir": workDir},
+		)
+	}
+
+	return nil
+}

--- a/backend/internal/adapter/git/gh_cli_adapter_test.go
+++ b/backend/internal/adapter/git/gh_cli_adapter_test.go
@@ -1,0 +1,333 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// commandInvocation records a single command call.
+type commandInvocation struct {
+	WorkDir string
+	Name    string
+	Args    []string
+}
+
+// mockCommandRunner tracks command invocations and returns configurable results.
+type mockCommandRunner struct {
+	invocations []commandInvocation
+	results     []mockResult
+	callIndex   int
+}
+
+type mockResult struct {
+	stdout string
+	err    error
+}
+
+func newMockCommandRunner(results ...mockResult) *mockCommandRunner {
+	return &mockCommandRunner{results: results}
+}
+
+func (m *mockCommandRunner) Run(_ context.Context, workDir string, name string, args ...string) (string, error) {
+	m.invocations = append(m.invocations, commandInvocation{
+		WorkDir: workDir,
+		Name:    name,
+		Args:    args,
+	})
+
+	if m.callIndex < len(m.results) {
+		r := m.results[m.callIndex]
+		m.callIndex++
+		return r.stdout, r.err
+	}
+	m.callIndex++
+	return "", nil
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(nil, nil))
+}
+
+func TestCloneRepo_Success(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{stdout: ""})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	err := adapter.CloneRepo(context.Background(), "owner/repo", "/tmp/target")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(runner.invocations) != 1 {
+		t.Fatalf("expected 1 invocation, got %d", len(runner.invocations))
+	}
+
+	inv := runner.invocations[0]
+	if inv.WorkDir != "" {
+		t.Errorf("expected empty workDir, got %q", inv.WorkDir)
+	}
+	if inv.Name != "gh" {
+		t.Errorf("expected command 'gh', got %q", inv.Name)
+	}
+	expectedArgs := []string{"repo", "clone", "owner/repo", "/tmp/target"}
+	assertArgs(t, inv.Args, expectedArgs)
+}
+
+func TestCloneRepo_Error(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{err: fmt.Errorf("clone failed: permission denied")})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	err := adapter.CloneRepo(context.Background(), "owner/repo", "/tmp/target")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodeGitOperationFailed {
+		t.Errorf("expected code %q, got %q", errors.ErrCodeGitOperationFailed, domainErr.Code)
+	}
+}
+
+func TestCreateBranch_ValidNames(t *testing.T) {
+	tests := []struct {
+		name       string
+		branchName string
+	}{
+		{"feature branch with story key", "feat/1-2-my-feature"},
+		{"fix branch with story key", "fix/3-4-bug-fix"},
+		{"feature with numbers", "feat/10-20-slug"},
+		{"fix with long slug", "fix/1-2-long-slug-name-here"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := newMockCommandRunner(mockResult{stdout: ""})
+			adapter := NewGhCliAdapter(runner, testLogger())
+
+			err := adapter.CreateBranch(context.Background(), "/work", tt.branchName)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(runner.invocations) != 1 {
+				t.Fatalf("expected 1 invocation, got %d", len(runner.invocations))
+			}
+
+			inv := runner.invocations[0]
+			if inv.WorkDir != "/work" {
+				t.Errorf("expected workDir '/work', got %q", inv.WorkDir)
+			}
+			if inv.Name != "git" {
+				t.Errorf("expected command 'git', got %q", inv.Name)
+			}
+			expectedArgs := []string{"checkout", "-b", tt.branchName}
+			assertArgs(t, inv.Args, expectedArgs)
+		})
+	}
+}
+
+func TestCreateBranch_InvalidNames(t *testing.T) {
+	tests := []struct {
+		name       string
+		branchName string
+	}{
+		{"missing prefix", "1-2-my-feature"},
+		{"wrong prefix", "feature/1-2-my-feature"},
+		{"no slug after key", "feat/123"},
+		{"empty string", ""},
+		{"just prefix", "feat/"},
+		{"no hyphen in key-slug", "feat/nokey"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := newMockCommandRunner()
+			adapter := NewGhCliAdapter(runner, testLogger())
+
+			err := adapter.CreateBranch(context.Background(), "/work", tt.branchName)
+			if err == nil {
+				t.Fatal("expected error for invalid branch name, got nil")
+			}
+
+			domainErr, ok := err.(*errors.DomainError)
+			if !ok {
+				t.Fatalf("expected *errors.DomainError, got %T", err)
+			}
+			if domainErr.Code != errors.ErrCodeInvalidInput {
+				t.Errorf("expected code %q, got %q", errors.ErrCodeInvalidInput, domainErr.Code)
+			}
+
+			if len(runner.invocations) != 0 {
+				t.Errorf("expected no command invocations for invalid branch name, got %d", len(runner.invocations))
+			}
+		})
+	}
+}
+
+func TestCreateBranch_GitError(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{err: fmt.Errorf("branch already exists")})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	err := adapter.CreateBranch(context.Background(), "/work", "feat/1-2-slug")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodeGitOperationFailed {
+		t.Errorf("expected code %q, got %q", errors.ErrCodeGitOperationFailed, domainErr.Code)
+	}
+}
+
+func TestPush_Success(t *testing.T) {
+	runner := newMockCommandRunner(
+		mockResult{stdout: ""},            // git add .
+		mockResult{stdout: ""},            // git commit
+		mockResult{stdout: "pushed ok\n"}, // git push
+	)
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	err := adapter.Push(context.Background(), "/work", "feat(git): add clone support")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(runner.invocations) != 3 {
+		t.Fatalf("expected 3 invocations, got %d", len(runner.invocations))
+	}
+
+	// Verify git add .
+	inv0 := runner.invocations[0]
+	if inv0.Name != "git" {
+		t.Errorf("invocation 0: expected 'git', got %q", inv0.Name)
+	}
+	assertArgs(t, inv0.Args, []string{"add", "."})
+	if inv0.WorkDir != "/work" {
+		t.Errorf("invocation 0: expected workDir '/work', got %q", inv0.WorkDir)
+	}
+
+	// Verify git commit -m
+	inv1 := runner.invocations[1]
+	if inv1.Name != "git" {
+		t.Errorf("invocation 1: expected 'git', got %q", inv1.Name)
+	}
+	assertArgs(t, inv1.Args, []string{"commit", "-m", "feat(git): add clone support"})
+
+	// Verify git push -u origin HEAD
+	inv2 := runner.invocations[2]
+	if inv2.Name != "git" {
+		t.Errorf("invocation 2: expected 'git', got %q", inv2.Name)
+	}
+	assertArgs(t, inv2.Args, []string{"push", "-u", "origin", "HEAD"})
+}
+
+func TestPush_AddError(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{err: fmt.Errorf("add failed")})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	err := adapter.Push(context.Background(), "/work", "feat(git): test")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodeGitOperationFailed {
+		t.Errorf("expected code %q, got %q", errors.ErrCodeGitOperationFailed, domainErr.Code)
+	}
+
+	// Only git add should have been called
+	if len(runner.invocations) != 1 {
+		t.Errorf("expected 1 invocation (add only), got %d", len(runner.invocations))
+	}
+}
+
+func TestPush_CommitError(t *testing.T) {
+	runner := newMockCommandRunner(
+		mockResult{stdout: ""},                       // git add succeeds
+		mockResult{err: fmt.Errorf("commit failed")}, // git commit fails
+	)
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	err := adapter.Push(context.Background(), "/work", "feat(git): test")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodeGitOperationFailed {
+		t.Errorf("expected code %q, got %q", errors.ErrCodeGitOperationFailed, domainErr.Code)
+	}
+
+	// git add and git commit should have been called
+	if len(runner.invocations) != 2 {
+		t.Errorf("expected 2 invocations (add, commit), got %d", len(runner.invocations))
+	}
+}
+
+func TestPush_PushError(t *testing.T) {
+	runner := newMockCommandRunner(
+		mockResult{stdout: ""},                     // git add succeeds
+		mockResult{stdout: ""},                     // git commit succeeds
+		mockResult{err: fmt.Errorf("push failed")}, // git push fails
+	)
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	err := adapter.Push(context.Background(), "/work", "feat(git): test")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodeGitOperationFailed {
+		t.Errorf("expected code %q, got %q", errors.ErrCodeGitOperationFailed, domainErr.Code)
+	}
+
+	// All three commands should have been called
+	if len(runner.invocations) != 3 {
+		t.Errorf("expected 3 invocations, got %d", len(runner.invocations))
+	}
+}
+
+func TestCloneRepo_FullURL(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{stdout: ""})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	err := adapter.CloneRepo(context.Background(), "https://github.com/owner/repo.git", "/tmp/target")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	inv := runner.invocations[0]
+	assertArgs(t, inv.Args, []string{"repo", "clone", "https://github.com/owner/repo.git", "/tmp/target"})
+}
+
+func assertArgs(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("expected %d args %v, got %d args %v", len(want), want, len(got), got)
+		return
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want[i], got[i])
+		}
+	}
+}

--- a/backend/internal/adapter/git/gh_cli_adapter_test.go
+++ b/backend/internal/adapter/git/gh_cli_adapter_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/zakari/hopeitworks/backend/pkg/errors"
 )
 
+const gitCommand = "git"
+
 // commandInvocation records a single command call.
 type commandInvocation struct {
 	WorkDir string
@@ -123,8 +125,8 @@ func TestCreateBranch_ValidNames(t *testing.T) {
 			if inv.WorkDir != "/work" {
 				t.Errorf("expected workDir '/work', got %q", inv.WorkDir)
 			}
-			if inv.Name != "git" {
-				t.Errorf("expected command 'git', got %q", inv.Name)
+			if inv.Name != gitCommand {
+				t.Errorf("expected command %q, got %q", gitCommand, inv.Name)
 			}
 			expectedArgs := []string{"checkout", "-b", tt.branchName}
 			assertArgs(t, inv.Args, expectedArgs)
@@ -207,8 +209,8 @@ func TestPush_Success(t *testing.T) {
 
 	// Verify git add .
 	inv0 := runner.invocations[0]
-	if inv0.Name != "git" {
-		t.Errorf("invocation 0: expected 'git', got %q", inv0.Name)
+	if inv0.Name != gitCommand {
+		t.Errorf("invocation 0: expected %q, got %q", gitCommand, inv0.Name)
 	}
 	assertArgs(t, inv0.Args, []string{"add", "."})
 	if inv0.WorkDir != "/work" {
@@ -217,15 +219,15 @@ func TestPush_Success(t *testing.T) {
 
 	// Verify git commit -m
 	inv1 := runner.invocations[1]
-	if inv1.Name != "git" {
-		t.Errorf("invocation 1: expected 'git', got %q", inv1.Name)
+	if inv1.Name != gitCommand {
+		t.Errorf("invocation 1: expected %q, got %q", gitCommand, inv1.Name)
 	}
 	assertArgs(t, inv1.Args, []string{"commit", "-m", "feat(git): add clone support"})
 
 	// Verify git push -u origin HEAD
 	inv2 := runner.invocations[2]
-	if inv2.Name != "git" {
-		t.Errorf("invocation 2: expected 'git', got %q", inv2.Name)
+	if inv2.Name != gitCommand {
+		t.Errorf("invocation 2: expected %q, got %q", gitCommand, inv2.Name)
 	}
 	assertArgs(t, inv2.Args, []string{"push", "-u", "origin", "HEAD"})
 }

--- a/backend/internal/adapter/git/gh_cli_integration_test.go
+++ b/backend/internal/adapter/git/gh_cli_integration_test.go
@@ -1,0 +1,66 @@
+//go:build integration
+
+package git
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zakari/hopeitworks/backend/pkg/exec"
+)
+
+func TestIntegrationGhCliAdapter_CloneBranchPush(t *testing.T) {
+	// This integration test requires:
+	// - gh CLI installed and authenticated
+	// - git installed and configured
+	// - network access to GitHub
+
+	tmpDir, err := os.MkdirTemp("", "ghcli-integration-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	runner := exec.NewRealCommandRunner()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	adapter := NewGhCliAdapter(runner, logger)
+
+	ctx := context.Background()
+	targetDir := filepath.Join(tmpDir, "repo")
+
+	// Clone a known public repository
+	err = adapter.CloneRepo(ctx, "zakari/hopeitworks", targetDir)
+	if err != nil {
+		t.Fatalf("CloneRepo failed: %v", err)
+	}
+
+	// Verify the clone succeeded by checking for a known file
+	if _, err := os.Stat(filepath.Join(targetDir, "CLAUDE.md")); os.IsNotExist(err) {
+		t.Fatal("expected CLAUDE.md to exist in cloned repo")
+	}
+
+	// Create a feature branch
+	branchName := "feat/integration-test-branch"
+	err = adapter.CreateBranch(ctx, targetDir, branchName)
+	if err != nil {
+		t.Fatalf("CreateBranch failed: %v", err)
+	}
+
+	// Create a test file so we have something to commit
+	testFile := filepath.Join(targetDir, "integration-test.txt")
+	if err := os.WriteFile(testFile, []byte("integration test\n"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	// Push the commit
+	err = adapter.Push(ctx, targetDir, "test(git): integration test commit")
+	if err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	// Clean up remote branch
+	_, _ = runner.Run(ctx, targetDir, "git", "push", "origin", "--delete", branchName)
+}

--- a/backend/internal/domain/port/command_runner.go
+++ b/backend/internal/domain/port/command_runner.go
@@ -1,0 +1,10 @@
+package port
+
+import "context"
+
+// CommandRunner abstracts shell command execution for testability.
+type CommandRunner interface {
+	// Run executes a command in the specified working directory.
+	// Returns stdout on success, or an error with combined output on failure.
+	Run(ctx context.Context, workDir string, name string, args ...string) (stdout string, err error)
+}

--- a/backend/internal/domain/port/git_provider.go
+++ b/backend/internal/domain/port/git_provider.go
@@ -1,0 +1,19 @@
+package port
+
+import "context"
+
+// GitProvider abstracts Git repository operations.
+// Implementations must use conventional branch naming and commit messages.
+type GitProvider interface {
+	// CloneRepo clones a repository to the target directory.
+	// repoURL format: "owner/repo" or full HTTPS URL.
+	CloneRepo(ctx context.Context, repoURL string, targetDir string) error
+
+	// CreateBranch creates and checks out a new branch in the given working directory.
+	// branchName must follow convention: feat/{story-key}-{slug} or fix/{story-key}-{slug}.
+	CreateBranch(ctx context.Context, workDir string, branchName string) error
+
+	// Push stages all changes, commits with the given message, and pushes to origin.
+	// commitMsg must follow conventional commit format: type(scope): message.
+	Push(ctx context.Context, workDir string, commitMsg string) error
+}

--- a/backend/pkg/errors/errors.go
+++ b/backend/pkg/errors/errors.go
@@ -14,12 +14,19 @@ const (
 	CategoryInternal     ErrorCategory = "internal"
 )
 
+// Error codes for git operations.
+const (
+	ErrCodeGitOperationFailed = "GIT_OPERATION_FAILED"
+	ErrCodeInvalidInput       = "INVALID_INPUT"
+)
+
 // DomainError represents a structured error from the domain layer.
 type DomainError struct {
 	Category ErrorCategory
 	Code     string
 	Message  string
 	Cause    error
+	Details  map[string]any
 }
 
 func (e *DomainError) Error() string {
@@ -85,6 +92,16 @@ func NewInternal(message string, cause error) *DomainError {
 		Code:     "INTERNAL_ERROR",
 		Message:  message,
 		Cause:    cause,
+	}
+}
+
+// NewDomainError creates a domain error with an explicit code, message, and optional details.
+func NewDomainError(code string, message string, details map[string]any) *DomainError {
+	return &DomainError{
+		Category: CategoryInternal,
+		Code:     code,
+		Message:  message,
+		Details:  details,
 	}
 }
 

--- a/backend/pkg/exec/command_runner.go
+++ b/backend/pkg/exec/command_runner.go
@@ -1,0 +1,37 @@
+package exec
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// RealCommandRunner executes shell commands using os/exec.
+type RealCommandRunner struct{}
+
+// NewRealCommandRunner creates a new RealCommandRunner.
+func NewRealCommandRunner() *RealCommandRunner {
+	return &RealCommandRunner{}
+}
+
+// Run executes a command in the specified working directory.
+// Returns stdout on success, or an error with combined output on failure.
+func (r *RealCommandRunner) Run(ctx context.Context, workDir string, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	if workDir != "" {
+		cmd.Dir = workDir
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		combined := stdout.String() + stderr.String()
+		return "", fmt.Errorf("%w: %s", err, combined)
+	}
+
+	return stdout.String(), nil
+}

--- a/backend/pkg/exec/command_runner_test.go
+++ b/backend/pkg/exec/command_runner_test.go
@@ -1,0 +1,97 @@
+package exec
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRealCommandRunner_Run_Success(t *testing.T) {
+	runner := NewRealCommandRunner()
+
+	stdout, err := runner.Run(context.Background(), "", "echo", "hello world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := strings.TrimSpace(stdout)
+	if got != "hello world" {
+		t.Errorf("expected 'hello world', got %q", got)
+	}
+}
+
+func TestRealCommandRunner_Run_FailedCommand(t *testing.T) {
+	runner := NewRealCommandRunner()
+
+	_, err := runner.Run(context.Background(), "", "ls", "/nonexistent-path-that-should-not-exist")
+	if err == nil {
+		t.Fatal("expected error for failed command, got nil")
+	}
+}
+
+func TestRealCommandRunner_Run_ContextCancellation(t *testing.T) {
+	runner := NewRealCommandRunner()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := runner.Run(ctx, "", "sleep", "10")
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+}
+
+func TestRealCommandRunner_Run_WorkingDirectory(t *testing.T) {
+	runner := NewRealCommandRunner()
+
+	tmpDir, err := os.MkdirTemp("", "cmdrunner-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	stdout, err := runner.Run(context.Background(), tmpDir, "pwd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := strings.TrimSpace(stdout)
+	// Resolve symlinks for macOS /var -> /private/var
+	resolvedTmp, _ := os.Readlink(tmpDir)
+	if resolvedTmp == "" {
+		resolvedTmp = tmpDir
+	}
+	if got != tmpDir && got != resolvedTmp {
+		t.Errorf("expected working directory %q, got %q", tmpDir, got)
+	}
+}
+
+func TestRealCommandRunner_Run_CombinedOutputOnError(t *testing.T) {
+	runner := NewRealCommandRunner()
+
+	_, err := runner.Run(context.Background(), "", "sh", "-c", "echo 'stderr msg' >&2; exit 1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "stderr msg") {
+		t.Errorf("expected error to contain stderr output, got: %v", err)
+	}
+}
+
+func TestRealCommandRunner_Run_EmptyWorkDir(t *testing.T) {
+	runner := NewRealCommandRunner()
+
+	// Empty workDir should use the current directory (no error)
+	stdout, err := runner.Run(context.Background(), "", "echo", "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := strings.TrimSpace(stdout)
+	if got != "test" {
+		t.Errorf("expected 'test', got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `GitProvider` port interface (`CloneRepo`, `CreateBranch`, `Push`) and `CommandRunner` port interface for testable shell execution
- Implement `GhCliAdapter` in `adapter/git` using `gh repo clone` and git commands via `CommandRunner`, with branch name validation and structured `DomainError` wrapping
- Implement `RealCommandRunner` in `pkg/exec` with context cancellation support
- Add `NewDomainError` constructor and git-specific error codes (`GIT_OPERATION_FAILED`, `INVALID_INPUT`) to `pkg/errors`
- Comprehensive unit tests with mock `CommandRunner` and integration test (build-tagged)

## Test plan
- [x] Unit tests for `RealCommandRunner` (success, failure, context cancellation, working directory)
- [x] Unit tests for `GhCliAdapter.CloneRepo` (success, error wrapping, full URL)
- [x] Unit tests for `GhCliAdapter.CreateBranch` (valid names, invalid names, git errors)
- [x] Unit tests for `GhCliAdapter.Push` (full sequence, add/commit/push error cases)
- [x] Integration test with `//go:build integration` tag for real git operations
- [x] `go vet ./...` passes
- [x] `gofmt` clean
- [x] All existing tests pass (`go test ./... -short`)

Refs: S-3-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)