### PR TITLE
feat(ui): add run launch button and confirmation dialog

### DIFF
--- a/frontend/e2e/tests/run-launch.spec.ts
+++ b/frontend/e2e/tests/run-launch.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Run Launch', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock authenticated user
+    await page.route('**/api/v1/auth/me', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: '1',
+          email: 'test@test.com',
+          name: 'Test User',
+        }),
+      })
+    })
+  })
+
+  test('shows Launch Run button on story detail page', async ({ page }) => {
+    await page.goto('/projects/proj-1/stories/story-1')
+
+    await expect(page.getByRole('button', { name: 'Launch Run' })).toBeVisible()
+  })
+
+  test('clicking Launch Run opens confirmation dialog', async ({ page }) => {
+    await page.goto('/projects/proj-1/stories/story-1')
+
+    await page.getByRole('button', { name: 'Launch Run' }).click()
+
+    await expect(page.getByText('Launch Story Run')).toBeVisible()
+    await expect(page.getByText('Claude API credits')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Confirm' })).toBeVisible()
+  })
+
+  test('confirming launch calls API and shows success toast', async ({ page }) => {
+    await page.route('**/api/v1/projects/*/stories/*/runs', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: 'run-1',
+            status: 'scheduling',
+            story_id: 'story-1',
+          }),
+        })
+      }
+    })
+
+    await page.goto('/projects/proj-1/stories/story-1')
+
+    await page.getByRole('button', { name: 'Launch Run' }).click()
+    await expect(page.getByText('Launch Story Run')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Confirm' }).click()
+
+    // Success toast should appear
+    await expect(page.getByText('Run launched')).toBeVisible()
+
+    // Button should change to "Running..." disabled state
+    await expect(page.getByRole('button', { name: 'Running...' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Running...' })).toBeDisabled()
+  })
+
+  test('409 conflict shows warning toast and keeps dialog open', async ({ page }) => {
+    await page.route('**/api/v1/projects/*/stories/*/runs', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 409,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            error: {
+              code: 'STORY_ALREADY_RUNNING',
+              message: 'Story already has an active run',
+            },
+          }),
+        })
+      }
+    })
+
+    await page.goto('/projects/proj-1/stories/story-1')
+
+    await page.getByRole('button', { name: 'Launch Run' }).click()
+    await expect(page.getByText('Launch Story Run')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Confirm' }).click()
+
+    // Warning toast should appear
+    await expect(page.getByText('Already running')).toBeVisible()
+
+    // Dialog should stay open
+    await expect(page.getByText('Launch Story Run')).toBeVisible()
+  })
+
+  test('cancel button closes dialog without making API call', async ({ page }) => {
+    let apiCalled = false
+    await page.route('**/api/v1/projects/*/stories/*/runs', async (route) => {
+      apiCalled = true
+      await route.continue()
+    })
+
+    await page.goto('/projects/proj-1/stories/story-1')
+
+    await page.getByRole('button', { name: 'Launch Run' }).click()
+    await expect(page.getByText('Launch Story Run')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Cancel' }).click()
+
+    // Dialog should close
+    await expect(page.getByText('Launch Story Run')).not.toBeVisible()
+
+    // No API call should have been made
+    expect(apiCalled).toBe(false)
+  })
+})

--- a/frontend/src/composables/__tests__/useRunLauncher.spec.ts
+++ b/frontend/src/composables/__tests__/useRunLauncher.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useRunLauncher, ALREADY_RUNNING_ERROR } from '../useRunLauncher'
+
+const mockPOST = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    POST: (...args: unknown[]) => mockPOST(...args),
+  },
+}))
+
+describe('useRunLauncher', () => {
+  beforeEach(() => {
+    mockPOST.mockReset()
+  })
+
+  it('starts with default state', () => {
+    const { data, error, isLoading } = useRunLauncher()
+    expect(data.value).toBeNull()
+    expect(error.value).toBeNull()
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('returns data on successful launch', async () => {
+    const runData = { id: 'run-1', status: 'scheduling' }
+    mockPOST.mockResolvedValue({
+      data: runData,
+      response: { status: 202 },
+    })
+
+    const { data, error, isLoading, launchRun } = useRunLauncher()
+    const result = await launchRun('proj-1', 'story-1')
+
+    expect(result).toEqual(runData)
+    expect(data.value).toEqual(runData)
+    expect(error.value).toBeNull()
+    expect(isLoading.value).toBe(false)
+    expect(mockPOST).toHaveBeenCalledWith(
+      '/projects/{id}/stories/{story_id}/runs',
+      { params: { path: { id: 'proj-1', story_id: 'story-1' } } },
+    )
+  })
+
+  it('throws ALREADY_RUNNING error on 409 response', async () => {
+    mockPOST.mockResolvedValue({
+      error: { message: 'Story already has an active run' },
+      response: { status: 409 },
+    })
+
+    const { error, launchRun } = useRunLauncher()
+    const result = await launchRun('proj-1', 'story-1')
+
+    expect(result).toBeNull()
+    expect(error.value).toBeInstanceOf(Error)
+    expect(error.value?.message).toBe(ALREADY_RUNNING_ERROR)
+  })
+
+  it('throws generic error on non-409 error response', async () => {
+    mockPOST.mockResolvedValue({
+      error: { message: 'Internal server error' },
+      response: { status: 500 },
+    })
+
+    const { error, launchRun } = useRunLauncher()
+    const result = await launchRun('proj-1', 'story-1')
+
+    expect(result).toBeNull()
+    expect(error.value).toBeInstanceOf(Error)
+    expect(error.value?.message).toBe('Internal server error')
+  })
+
+  it('uses fallback message when error has no message', async () => {
+    mockPOST.mockResolvedValue({
+      error: {},
+      response: { status: 500 },
+    })
+
+    const { error, launchRun } = useRunLauncher()
+    await launchRun('proj-1', 'story-1')
+
+    expect(error.value?.message).toBe('Failed to launch run')
+  })
+
+  it('sets isLoading while request is in flight', async () => {
+    let resolveRequest: (value: unknown) => void
+    mockPOST.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRequest = resolve
+      }),
+    )
+
+    const { isLoading, launchRun } = useRunLauncher()
+    expect(isLoading.value).toBe(false)
+
+    const promise = launchRun('proj-1', 'story-1')
+    expect(isLoading.value).toBe(true)
+
+    resolveRequest!({ data: { id: 'run-1' }, response: { status: 202 } })
+    await promise
+
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('resets error on subsequent successful call', async () => {
+    mockPOST.mockResolvedValueOnce({
+      error: { message: 'Server error' },
+      response: { status: 500 },
+    })
+
+    const { data, error, launchRun } = useRunLauncher()
+    await launchRun('proj-1', 'story-1')
+    expect(error.value).not.toBeNull()
+
+    mockPOST.mockResolvedValueOnce({
+      data: { id: 'run-2' },
+      response: { status: 202 },
+    })
+
+    await launchRun('proj-1', 'story-1')
+    expect(error.value).toBeNull()
+    expect(data.value).toEqual({ id: 'run-2' })
+  })
+})

--- a/frontend/src/composables/useRunLauncher.ts
+++ b/frontend/src/composables/useRunLauncher.ts
@@ -1,0 +1,36 @@
+import { useAsyncAction } from '@/composables/useAsyncAction'
+import { apiClient } from '@/api/client'
+
+/** Error code thrown when a story already has a run in progress (409 Conflict). */
+export const ALREADY_RUNNING_ERROR = 'ALREADY_RUNNING'
+
+/**
+ * Composable for launching a story run via the pipeline API.
+ * Wraps the POST /projects/{id}/stories/{storyId}/runs endpoint
+ * using useAsyncAction for consistent loading/error state management.
+ */
+export function useRunLauncher() {
+  const { data, error, isLoading, execute } = useAsyncAction(
+    async (projectId: string, storyId: string) => {
+      const response = await apiClient.POST(
+        '/projects/{id}/stories/{story_id}/runs' as never,
+        {
+          params: { path: { id: projectId, story_id: storyId } },
+        } as never,
+      )
+
+      const res = response as { error?: { message?: string }; response?: { status: number }; data?: unknown }
+
+      if (res.error) {
+        if (res.response?.status === 409) {
+          throw new Error(ALREADY_RUNNING_ERROR)
+        }
+        throw new Error(res.error.message ?? 'Failed to launch run')
+      }
+
+      return res.data
+    },
+  )
+
+  return { data, error, isLoading, launchRun: execute }
+}

--- a/frontend/src/features/runs/RunLaunchButton.vue
+++ b/frontend/src/features/runs/RunLaunchButton.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import Button from 'primevue/button'
+
+defineProps<{
+  storyId: string
+  storyKey: string
+  storyTitle: string
+  status: 'backlog' | 'running' | 'done' | 'failed'
+}>()
+
+const emit = defineEmits<{
+  launchClick: []
+}>()
+</script>
+
+<template>
+  <Button
+    v-if="status === 'backlog'"
+    label="Launch Run"
+    icon="pi pi-play"
+    severity="success"
+    @click="emit('launchClick')"
+  />
+  <span v-else-if="status === 'running'" v-tooltip="'A run is already in progress'">
+    <Button label="Running..." icon="pi pi-spin pi-spinner" disabled />
+  </span>
+</template>

--- a/frontend/src/features/runs/RunLaunchConfirmDialog.vue
+++ b/frontend/src/features/runs/RunLaunchConfirmDialog.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import Dialog from 'primevue/dialog'
+import Button from 'primevue/button'
+
+defineProps<{
+  visible: boolean
+  storyKey: string
+  storyTitle: string
+  loading: boolean
+}>()
+
+const emit = defineEmits<{
+  confirm: []
+  cancel: []
+  'update:visible': [value: boolean]
+}>()
+
+function handleCancel() {
+  emit('cancel')
+  emit('update:visible', false)
+}
+</script>
+
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    header="Launch Story Run"
+    class="w-full max-w-lg"
+    @update:visible="handleCancel"
+  >
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col gap-1">
+        <span class="font-semibold">{{ storyKey }}</span>
+        <span>{{ storyTitle }}</span>
+      </div>
+
+      <p>
+        Launching this run will start an AI agent container. The run will consume
+        Claude API credits and Docker resources. Do you want to proceed?
+      </p>
+    </div>
+
+    <template #footer>
+      <div class="flex justify-end gap-2">
+        <Button label="Cancel" severity="secondary" text @click="handleCancel" />
+        <Button
+          label="Confirm"
+          severity="success"
+          icon="pi pi-play"
+          :loading="loading"
+          :disabled="loading"
+          @click="emit('confirm')"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>

--- a/frontend/src/features/runs/__tests__/RunLaunchButton.spec.ts
+++ b/frontend/src/features/runs/__tests__/RunLaunchButton.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import Tooltip from 'primevue/tooltip'
+import RunLaunchButton from '../RunLaunchButton.vue'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function mountComponent(props: {
+  storyId: string
+  storyKey: string
+  storyTitle: string
+  status: 'backlog' | 'running' | 'done' | 'failed'
+}) {
+  wrapper = mount(RunLaunchButton, {
+    props,
+    global: {
+      plugins: [PrimeVue],
+      directives: { tooltip: Tooltip },
+    },
+  })
+  return wrapper
+}
+
+describe('RunLaunchButton', () => {
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('renders "Launch Run" button when status is backlog', () => {
+    mountComponent({
+      storyId: 's-1',
+      storyKey: 'S-01',
+      storyTitle: 'Test Story',
+      status: 'backlog',
+    })
+    const button = wrapper.find('button')
+    expect(button.exists()).toBe(true)
+    expect(button.text()).toContain('Launch Run')
+    expect(button.attributes('disabled')).toBeUndefined()
+  })
+
+  it('emits launchClick when button is clicked in backlog state', async () => {
+    mountComponent({
+      storyId: 's-1',
+      storyKey: 'S-01',
+      storyTitle: 'Test Story',
+      status: 'backlog',
+    })
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.emitted('launchClick')).toHaveLength(1)
+  })
+
+  it('renders disabled "Running..." button when status is running', () => {
+    mountComponent({
+      storyId: 's-1',
+      storyKey: 'S-01',
+      storyTitle: 'Test Story',
+      status: 'running',
+    })
+    const button = wrapper.find('button')
+    expect(button.exists()).toBe(true)
+    expect(button.text()).toContain('Running...')
+    expect(button.attributes('disabled')).toBeDefined()
+  })
+
+  it('does not render any button when status is done', () => {
+    mountComponent({
+      storyId: 's-1',
+      storyKey: 'S-01',
+      storyTitle: 'Test Story',
+      status: 'done',
+    })
+    expect(wrapper.find('button').exists()).toBe(false)
+  })
+
+  it('does not render any button when status is failed', () => {
+    mountComponent({
+      storyId: 's-1',
+      storyKey: 'S-01',
+      storyTitle: 'Test Story',
+      status: 'failed',
+    })
+    expect(wrapper.find('button').exists()).toBe(false)
+  })
+
+  it('does not emit launchClick when running button is clicked', async () => {
+    mountComponent({
+      storyId: 's-1',
+      storyKey: 'S-01',
+      storyTitle: 'Test Story',
+      status: 'running',
+    })
+    const button = wrapper.find('button')
+    await button.trigger('click')
+    expect(wrapper.emitted('launchClick')).toBeUndefined()
+  })
+})

--- a/frontend/src/features/runs/__tests__/RunLaunchConfirmDialog.spec.ts
+++ b/frontend/src/features/runs/__tests__/RunLaunchConfirmDialog.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { h, defineComponent } from 'vue'
+import PrimeVue from 'primevue/config'
+import RunLaunchConfirmDialog from '../RunLaunchConfirmDialog.vue'
+
+/** Stub Dialog to render inline instead of teleporting. */
+const DialogStub = defineComponent({
+  name: 'DialogStub',
+  props: ['visible', 'modal', 'header'],
+  emits: ['update:visible'],
+  setup(props, { slots, emit }) {
+    return () => {
+      if (!props.visible) return null
+      return h('div', { class: 'p-dialog' }, [
+        h('div', { class: 'p-dialog-header' }, props.header),
+        h('div', { class: 'p-dialog-content' }, slots.default?.()),
+        h('div', { class: 'p-dialog-footer' }, slots.footer?.()),
+      ])
+    }
+  },
+})
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function mountComponent(props: {
+  visible?: boolean
+  storyKey?: string
+  storyTitle?: string
+  loading?: boolean
+}) {
+  wrapper = mount(RunLaunchConfirmDialog, {
+    props: {
+      visible: true,
+      storyKey: 'S-01',
+      storyTitle: 'Test Story',
+      loading: false,
+      ...props,
+    },
+    global: {
+      plugins: [PrimeVue],
+      stubs: {
+        Dialog: DialogStub,
+      },
+    },
+  })
+  return wrapper
+}
+
+describe('RunLaunchConfirmDialog', () => {
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('renders dialog with story key, title, and warning when visible', () => {
+    mountComponent({})
+    expect(wrapper.text()).toContain('Launch Story Run')
+    expect(wrapper.text()).toContain('S-01')
+    expect(wrapper.text()).toContain('Test Story')
+    expect(wrapper.text()).toContain('Claude API credits')
+  })
+
+  it('does not render content when not visible', () => {
+    mountComponent({ visible: false })
+    expect(wrapper.find('.p-dialog').exists()).toBe(false)
+  })
+
+  it('renders Cancel and Confirm buttons in footer', () => {
+    mountComponent({})
+    const buttons = wrapper.findAll('button')
+    const cancelBtn = buttons.find((b) => b.text().includes('Cancel'))
+    const confirmBtn = buttons.find((b) => b.text().includes('Confirm'))
+    expect(cancelBtn).toBeDefined()
+    expect(confirmBtn).toBeDefined()
+  })
+
+  it('emits confirm when Confirm button is clicked', async () => {
+    mountComponent({})
+    const confirmBtn = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Confirm'))
+    await confirmBtn!.trigger('click')
+    expect(wrapper.emitted('confirm')).toHaveLength(1)
+  })
+
+  it('emits cancel and update:visible(false) when Cancel is clicked', async () => {
+    mountComponent({})
+    const cancelBtn = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Cancel'))
+    await cancelBtn!.trigger('click')
+    expect(wrapper.emitted('cancel')).toHaveLength(1)
+    expect(wrapper.emitted('update:visible')).toBeDefined()
+    expect(wrapper.emitted('update:visible')![0]![0]).toBe(false)
+  })
+
+  it('disables Confirm button when loading is true', () => {
+    mountComponent({ loading: true })
+    const confirmBtn = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Confirm'))
+    expect(confirmBtn!.attributes('disabled')).toBeDefined()
+  })
+
+  it('enables Confirm button when loading is false', () => {
+    mountComponent({ loading: false })
+    const confirmBtn = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Confirm'))
+    expect(confirmBtn!.attributes('disabled')).toBeUndefined()
+  })
+
+  it('displays resource usage warning text', () => {
+    mountComponent({})
+    expect(wrapper.text()).toContain(
+      'Launching this run will start an AI agent container',
+    )
+    expect(wrapper.text()).toContain('Do you want to proceed?')
+  })
+})

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,6 +5,7 @@ import { createPinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import ConfirmationService from 'primevue/confirmationservice'
 import ToastService from 'primevue/toastservice'
+import Tooltip from 'primevue/tooltip'
 import App from './App.vue'
 import router from './router'
 import { HopeTheme } from '@/theme'
@@ -15,6 +16,7 @@ app.use(createPinia())
 app.use(router)
 app.use(ConfirmationService)
 app.use(ToastService)
+app.directive('tooltip', Tooltip)
 app.use(PrimeVue, {
   theme: {
     preset: HopeTheme,

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -4,6 +4,7 @@ import DashboardView from '@/views/DashboardView.vue'
 import ProjectsView from '@/views/ProjectsView.vue'
 import ProjectDetailView from '@/views/ProjectDetailView.vue'
 import RunDetailView from '@/views/RunDetailView.vue'
+import StoryDetailView from '@/views/StoryDetailView.vue'
 import ApprovalsView from '@/views/ApprovalsView.vue'
 import { setupAuthGuard, setupAdminGuard } from './guards'
 
@@ -32,6 +33,12 @@ const router = createRouter({
       path: '/projects/:id',
       name: 'project-detail',
       component: ProjectDetailView,
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/projects/:projectId/stories/:storyId',
+      name: 'story-detail',
+      component: StoryDetailView,
       meta: { requiresAuth: true },
     },
     {

--- a/frontend/src/views/StoryDetailView.vue
+++ b/frontend/src/views/StoryDetailView.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { useToast } from 'primevue/usetoast'
+import Toast from 'primevue/toast'
+import RunLaunchButton from '@/features/runs/RunLaunchButton.vue'
+import RunLaunchConfirmDialog from '@/features/runs/RunLaunchConfirmDialog.vue'
+import { useRunLauncher, ALREADY_RUNNING_ERROR } from '@/composables/useRunLauncher'
+
+const route = useRoute()
+const toast = useToast()
+
+const projectId = computed(() => route.params.projectId as string)
+const storyId = computed(() => route.params.storyId as string)
+
+/** Placeholder story data — will be replaced when story detail API is available. */
+const storyKey = ref('S-01')
+const storyTitle = ref('Placeholder Story')
+const storyStatus = ref<'backlog' | 'running' | 'done' | 'failed'>('backlog')
+
+const dialogVisible = ref(false)
+const { isLoading, error, launchRun } = useRunLauncher()
+
+function handleLaunchClick() {
+  dialogVisible.value = true
+}
+
+async function handleConfirm() {
+  const result = await launchRun(projectId.value, storyId.value)
+
+  if (result !== null) {
+    toast.add({
+      severity: 'success',
+      summary: 'Run launched',
+      detail: `Run started for ${storyKey.value}`,
+      life: 3000,
+    })
+    dialogVisible.value = false
+    storyStatus.value = 'running'
+    return
+  }
+
+  if (error.value?.message === ALREADY_RUNNING_ERROR) {
+    toast.add({
+      severity: 'warn',
+      summary: 'Already running',
+      detail: 'This story already has a run in progress',
+      life: 5000,
+    })
+    // Dialog stays open on 409
+    return
+  }
+
+  toast.add({
+    severity: 'error',
+    summary: 'Launch failed',
+    detail: error.value?.message ?? 'An unexpected error occurred',
+    life: 5000,
+  })
+  dialogVisible.value = false
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-6 p-6">
+    <div class="flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-bold">{{ storyKey }}: {{ storyTitle }}</h1>
+      </div>
+      <RunLaunchButton
+        :story-id="storyId"
+        :story-key="storyKey"
+        :story-title="storyTitle"
+        :status="storyStatus"
+        @launch-click="handleLaunchClick"
+      />
+    </div>
+
+    <p>Story detail content will be implemented in a future story.</p>
+
+    <RunLaunchConfirmDialog
+      v-model:visible="dialogVisible"
+      :story-key="storyKey"
+      :story-title="storyTitle"
+      :loading="isLoading"
+      @confirm="handleConfirm"
+      @cancel="dialogVisible = false"
+    />
+
+    <Toast />
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- Add `useRunLauncher` composable for launching story runs via POST API with 409 conflict handling
- Add `RunLaunchButton.vue` component with conditional rendering based on story status (backlog → launch button, running → disabled spinner, done/failed → hidden)
- Add `RunLaunchConfirmDialog.vue` with PrimeVue Dialog showing story key, title, and resource usage warning
- Add `StoryDetailView.vue` placeholder integrating button, dialog, and toast notifications (success, 409 warning, error)
- Add story detail route at `/projects/:projectId/stories/:storyId`
- Register PrimeVue Tooltip directive globally in `main.ts`
- 21 new unit tests (7 composable + 6 button + 8 dialog) — all passing
- 5 new E2E tests covering launch flow, 409 conflict, and cancel behavior

Refs: S-3-11

## Test plan
- [x] Unit tests for `useRunLauncher`: success, 409 error, generic error, loading state, reset
- [x] Unit tests for `RunLaunchButton`: conditional rendering for all 4 statuses, emit behavior
- [x] Unit tests for `RunLaunchConfirmDialog`: open/close, confirm/cancel emit, loading disables confirm
- [x] E2E tests: navigate to story detail → see launch button → click → confirm → verify toast/button state
- [x] E2E test: 409 conflict shows warning toast, dialog stays open
- [x] ESLint passes with no errors
- [x] TypeScript type-check passes
- [x] All 113 existing + new unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)