### PR TITLE
feat(ui): add pipeline configuration page

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -29,6 +29,8 @@ tags:
     description: Epic management endpoints
   - name: prompt-templates
     description: Prompt template management endpoints
+  - name: pipeline-configs
+    description: Pipeline configuration endpoints
 
 paths:
   # ── Auth ────────────────────────────────────────────────────────────────
@@ -534,6 +536,54 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  # ── Pipeline Configs ─────────────────────────────────────────────────
+  /projects/{projectId}/pipeline:
+    get:
+      operationId: getPipelineConfig
+      summary: Get the pipeline configuration for a project
+      tags: [pipeline-configs]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+      responses:
+        "200":
+          description: Pipeline configuration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PipelineConfig"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    put:
+      operationId: updatePipelineConfig
+      summary: Update the pipeline configuration for a project
+      tags: [pipeline-configs]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdatePipelineConfigRequest"
+      responses:
+        "200":
+          description: Pipeline configuration updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PipelineConfig"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
 # ── Components ──────────────────────────────────────────────────────────
 components:
   securitySchemes:
@@ -961,6 +1011,84 @@ components:
             $ref: "#/components/schemas/PromptTemplate"
         pagination:
           $ref: "#/components/schemas/Pagination"
+
+    # ── Pipeline Config ──────────────────────────────────────────────
+    PipelineStep:
+      type: object
+      required:
+        - id
+        - name
+        - action_type
+        - model
+        - auto_approve
+        - retry_policy
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 880e8400-e29b-41d4-a716-446655440000
+        name:
+          type: string
+          example: implement
+        action_type:
+          type: string
+          enum: [implement, review, merge, test, custom]
+          example: implement
+        model:
+          type: string
+          enum: [claude-opus-4-6, claude-sonnet-4-5, claude-haiku-4-3]
+          example: claude-opus-4-6
+        auto_approve:
+          type: boolean
+          example: false
+        retry_policy:
+          $ref: "#/components/schemas/RetryPolicy"
+
+    RetryPolicy:
+      type: object
+      required:
+        - max_retries
+        - retry_type
+      properties:
+        max_retries:
+          type: integer
+          minimum: 0
+          maximum: 10
+          example: 2
+        retry_type:
+          type: string
+          enum: [none, on-failure, always]
+          example: on-failure
+
+    PipelineConfig:
+      type: object
+      required:
+        - project_id
+        - steps
+        - updated_at
+      properties:
+        project_id:
+          type: string
+          format: uuid
+          example: 660e8400-e29b-41d4-a716-446655440000
+        steps:
+          type: array
+          items:
+            $ref: "#/components/schemas/PipelineStep"
+        updated_at:
+          type: string
+          format: date-time
+          example: "2026-02-15T10:30:00Z"
+
+    UpdatePipelineConfigRequest:
+      type: object
+      required:
+        - steps
+      properties:
+        steps:
+          type: array
+          items:
+            $ref: "#/components/schemas/PipelineStep"
 
     # ── Shared ─────────────────────────────────────────────────────────
     Pagination:

--- a/frontend/e2e/tests/pipeline-config.spec.ts
+++ b/frontend/e2e/tests/pipeline-config.spec.ts
@@ -1,0 +1,263 @@
+import { test, expect } from '@playwright/test'
+
+const mockSteps = [
+  {
+    id: 's1',
+    name: 'implement',
+    action_type: 'implement',
+    model: 'claude-opus-4-6',
+    auto_approve: false,
+    retry_policy: { max_retries: 2, retry_type: 'on-failure' },
+  },
+  {
+    id: 's2',
+    name: 'review',
+    action_type: 'review',
+    model: 'claude-sonnet-4-5',
+    auto_approve: true,
+    retry_policy: { max_retries: 1, retry_type: 'on-failure' },
+  },
+  {
+    id: 's3',
+    name: 'merge',
+    action_type: 'merge',
+    model: 'claude-sonnet-4-5',
+    auto_approve: false,
+    retry_policy: { max_retries: 0, retry_type: 'none' },
+  },
+]
+
+const mockPipelineConfig = {
+  project_id: 'proj-1',
+  steps: mockSteps,
+  updated_at: '2026-02-15T10:30:00Z',
+}
+
+test.describe('Pipeline Configuration Page', () => {
+  test.describe('Admin user', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.route('**/api/v1/auth/me', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: '1',
+            email: 'admin@test.com',
+            name: 'Admin User',
+            role: 'admin',
+          }),
+        })
+      })
+
+      await page.route('**/api/v1/projects/proj-1/pipeline', async (route) => {
+        if (route.request().method() === 'GET') {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(mockPipelineConfig),
+          })
+        } else if (route.request().method() === 'PUT') {
+          const body = route.request().postDataJSON()
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              ...mockPipelineConfig,
+              steps: body.steps,
+              updated_at: new Date().toISOString(),
+            }),
+          })
+        }
+      })
+    })
+
+    test('displays pipeline steps as an ordered list', async ({ page }) => {
+      await page.goto('/projects/proj-1/pipeline')
+
+      await expect(page.locator('h1')).toHaveText('Pipeline Configuration')
+      await expect(page.getByText('implement')).toBeVisible()
+      await expect(page.getByText('review')).toBeVisible()
+      await expect(page.getByText('merge')).toBeVisible()
+    })
+
+    test('shows admin controls: Add Step and Save buttons', async ({ page }) => {
+      await page.goto('/projects/proj-1/pipeline')
+
+      await expect(page.getByTestId('add-step-btn')).toBeVisible()
+      await expect(page.getByTestId('save-config-btn')).toBeVisible()
+      await expect(page.getByTestId('save-config-btn')).toBeDisabled()
+    })
+
+    test('shows move up/down and remove buttons for each step', async ({ page }) => {
+      await page.goto('/projects/proj-1/pipeline')
+
+      const moveUpButtons = page.getByTestId('move-up')
+      const moveDownButtons = page.getByTestId('move-down')
+      const removeButtons = page.getByTestId('remove-step')
+
+      await expect(moveUpButtons).toHaveCount(3)
+      await expect(moveDownButtons).toHaveCount(3)
+      await expect(removeButtons).toHaveCount(3)
+    })
+
+    test('removes a step when remove button is clicked', async ({ page }) => {
+      await page.goto('/projects/proj-1/pipeline')
+
+      await expect(page.getByTestId('remove-step')).toHaveCount(3)
+
+      await page.getByTestId('remove-step').first().click()
+
+      await expect(page.getByTestId('remove-step')).toHaveCount(2)
+      await expect(page.getByTestId('save-config-btn')).toBeEnabled()
+    })
+
+    test('reorders steps when move down is clicked', async ({ page }) => {
+      await page.goto('/projects/proj-1/pipeline')
+
+      // Click move down on first step
+      await page.getByTestId('move-down').first().click()
+
+      // Save button should be enabled since config is dirty
+      await expect(page.getByTestId('save-config-btn')).toBeEnabled()
+    })
+
+    test('adds a new step via the dialog', async ({ page }) => {
+      await page.goto('/projects/proj-1/pipeline')
+
+      await page.getByTestId('add-step-btn').click()
+
+      // Dialog should appear
+      await expect(page.getByText('Add Pipeline Step')).toBeVisible()
+
+      // Fill form
+      await page.getByTestId('step-name-input').fill('test-step')
+      await page.getByTestId('add-step-submit').click()
+
+      // Dialog should close and save button should be enabled
+      await expect(page.getByTestId('save-config-btn')).toBeEnabled()
+    })
+
+    test('validates required step name in add dialog', async ({ page }) => {
+      await page.goto('/projects/proj-1/pipeline')
+
+      await page.getByTestId('add-step-btn').click()
+      await page.getByTestId('add-step-submit').click()
+
+      await expect(page.getByText('Step name is required')).toBeVisible()
+    })
+
+    test('saves configuration and shows success toast', async ({ page }) => {
+      await page.goto('/projects/proj-1/pipeline')
+
+      // Make a change to enable save
+      await page.getByTestId('remove-step').first().click()
+
+      // Click save
+      await page.getByTestId('save-config-btn').click()
+
+      // Success toast should appear
+      await expect(page.getByText('Configuration saved')).toBeVisible()
+
+      // Save button should be disabled again
+      await expect(page.getByTestId('save-config-btn')).toBeDisabled()
+    })
+  })
+
+  test.describe('Non-admin user', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.route('**/api/v1/auth/me', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: '2',
+            email: 'user@test.com',
+            name: 'Regular User',
+            role: 'user',
+          }),
+        })
+      })
+
+      await page.route('**/api/v1/projects/proj-1/pipeline', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockPipelineConfig),
+        })
+      })
+    })
+
+    test('displays pipeline steps in read-only mode', async ({ page }) => {
+      await page.goto('/projects/proj-1/pipeline')
+
+      await expect(page.locator('h1')).toHaveText('Pipeline Configuration')
+      await expect(page.getByText('implement')).toBeVisible()
+      await expect(page.getByText('review')).toBeVisible()
+      await expect(page.getByText('merge')).toBeVisible()
+    })
+
+    test('does not show admin controls', async ({ page }) => {
+      await page.goto('/projects/proj-1/pipeline')
+
+      await expect(page.getByTestId('add-step-btn')).not.toBeVisible()
+      await expect(page.getByTestId('save-config-btn')).not.toBeVisible()
+      await expect(page.getByTestId('move-up')).not.toBeVisible()
+      await expect(page.getByTestId('move-down')).not.toBeVisible()
+      await expect(page.getByTestId('remove-step')).not.toBeVisible()
+    })
+  })
+
+  test.describe('Error state', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.route('**/api/v1/auth/me', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: '1',
+            email: 'admin@test.com',
+            name: 'Admin User',
+            role: 'admin',
+          }),
+        })
+      })
+    })
+
+    test('displays error message with retry button when API fails', async ({ page }) => {
+      await page.route('**/api/v1/projects/proj-1/pipeline', async (route) => {
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            error: { code: 'INTERNAL', message: 'Server error' },
+          }),
+        })
+      })
+
+      await page.goto('/projects/proj-1/pipeline')
+
+      await expect(page.getByTestId('error-message')).toBeVisible()
+      await expect(page.getByText('Retry')).toBeVisible()
+    })
+
+    test('displays loading skeleton while fetching', async ({ page }) => {
+      await page.route('**/api/v1/projects/proj-1/pipeline', async (route) => {
+        // Delay response to see loading state
+        await new Promise((r) => setTimeout(r, 500))
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockPipelineConfig),
+        })
+      })
+
+      await page.goto('/projects/proj-1/pipeline')
+
+      // Loading skeleton should be visible briefly
+      await expect(page.getByTestId('loading-skeleton')).toBeVisible()
+
+      // Then steps should appear
+      await expect(page.getByText('implement')).toBeVisible()
+    })
+  })
+})

--- a/frontend/e2e/tests/pipeline-config.spec.ts
+++ b/frontend/e2e/tests/pipeline-config.spec.ts
@@ -75,9 +75,9 @@ test.describe('Pipeline Configuration Page', () => {
       await page.goto('/projects/proj-1/pipeline')
 
       await expect(page.locator('h1')).toHaveText('Pipeline Configuration')
-      await expect(page.getByText('implement')).toBeVisible()
-      await expect(page.getByText('review')).toBeVisible()
-      await expect(page.getByText('merge')).toBeVisible()
+      await expect(page.locator('.font-semibold').filter({ hasText: 'implement' })).toBeVisible()
+      await expect(page.locator('.font-semibold').filter({ hasText: 'review' })).toBeVisible()
+      await expect(page.locator('.font-semibold').filter({ hasText: 'merge' })).toBeVisible()
     })
 
     test('shows admin controls: Add Step and Save buttons', async ({ page }) => {
@@ -191,9 +191,9 @@ test.describe('Pipeline Configuration Page', () => {
       await page.goto('/projects/proj-1/pipeline')
 
       await expect(page.locator('h1')).toHaveText('Pipeline Configuration')
-      await expect(page.getByText('implement')).toBeVisible()
-      await expect(page.getByText('review')).toBeVisible()
-      await expect(page.getByText('merge')).toBeVisible()
+      await expect(page.locator('.font-semibold').filter({ hasText: 'implement' })).toBeVisible()
+      await expect(page.locator('.font-semibold').filter({ hasText: 'review' })).toBeVisible()
+      await expect(page.locator('.font-semibold').filter({ hasText: 'merge' })).toBeVisible()
     })
 
     test('does not show admin controls', async ({ page }) => {
@@ -257,7 +257,7 @@ test.describe('Pipeline Configuration Page', () => {
       await expect(page.getByTestId('loading-skeleton')).toBeVisible()
 
       // Then steps should appear
-      await expect(page.getByText('implement')).toBeVisible()
+      await expect(page.locator('.font-semibold').filter({ hasText: 'implement' })).toBeVisible()
     })
   })
 })

--- a/frontend/src/composables/__tests__/usePipelineConfig.spec.ts
+++ b/frontend/src/composables/__tests__/usePipelineConfig.spec.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
-import { ref } from 'vue'
+import { ref, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
 import { usePipelineConfig } from '../usePipelineConfig'
 import type { PipelineStep } from '@/stores/pipelineConfig'
-
- 
 
 const mockGet = vi.fn()
 const mockPut = vi.fn()
@@ -44,28 +43,49 @@ describe('usePipelineConfig', () => {
     mockPut.mockReset()
   })
 
-  it('exposes reactive computed properties from the store', () => {
+  it('exposes reactive computed properties from the store', async () => {
     mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
 
-    const projectId = ref('proj-1')
-    const { config, steps, isLoading, isSaving, error, isDirty } =
-      usePipelineConfig(projectId)
+    let composableResult: ReturnType<typeof usePipelineConfig> | undefined
 
-    expect(config.value).toBeNull()
-    expect(steps.value).toEqual([])
-    expect(isLoading.value).toBe(false)
-    expect(isSaving.value).toBe(false)
-    expect(error.value).toBeNull()
-    expect(isDirty.value).toBe(false)
+    mount({
+      setup() {
+        const projectId = ref('proj-1')
+        composableResult = usePipelineConfig(projectId)
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    expect(composableResult).toBeDefined()
+
+    // onMounted triggers fetch automatically, wait for it to complete
+    await nextTick()
+
+    expect(composableResult!.config.value).toEqual(mockConfig)
+    expect(composableResult!.steps.value).toHaveLength(2)
+    expect(composableResult!.isLoading.value).toBe(false)
+    expect(composableResult!.isSaving.value).toBe(false)
+    expect(composableResult!.error.value).toBeNull()
+    expect(composableResult!.isDirty.value).toBe(false)
   })
 
   it('provides retry that re-fetches with the same project ID', async () => {
     mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
 
-    const projectId = ref('proj-1')
-    const { retry } = usePipelineConfig(projectId)
+    let composableResult: ReturnType<typeof usePipelineConfig> | undefined
 
-    await retry()
+    mount({
+      setup() {
+        const projectId = ref('proj-1')
+        composableResult = usePipelineConfig(projectId)
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    await nextTick()
+    await composableResult!.retry()
 
     expect(mockGet).toHaveBeenCalledWith('/projects/{projectId}/pipeline', {
       params: { path: { projectId: 'proj-1' } },
@@ -76,14 +96,22 @@ describe('usePipelineConfig', () => {
     mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
     mockPut.mockResolvedValue({ data: mockConfig, error: undefined })
 
-    const projectId = ref('proj-1')
-    const { saveConfig, addStep, retry } = usePipelineConfig(projectId)
+    let composableResult: ReturnType<typeof usePipelineConfig> | undefined
 
-    // Explicitly fetch config so it is populated
-    await retry()
+    mount({
+      setup() {
+        const projectId = ref('proj-1')
+        composableResult = usePipelineConfig(projectId)
+        return {}
+      },
+      template: '<div></div>',
+    })
 
-    addStep(makeStep({ id: 's3', name: 'test' }))
-    const result = await saveConfig()
+    await nextTick()
+    await composableResult!.retry()
+
+    composableResult!.addStep(makeStep({ id: 's3', name: 'test' }))
+    const result = await composableResult!.saveConfig()
 
     expect(result).toBe(true)
     expect(mockPut).toHaveBeenCalledWith('/projects/{projectId}/pipeline', {
@@ -95,58 +123,94 @@ describe('usePipelineConfig', () => {
   it('addStep adds step to the store', async () => {
     mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
 
-    const projectId = ref('proj-1')
-    const { steps, addStep, retry } = usePipelineConfig(projectId)
+    let composableResult: ReturnType<typeof usePipelineConfig> | undefined
 
-    await retry()
+    mount({
+      setup() {
+        const projectId = ref('proj-1')
+        composableResult = usePipelineConfig(projectId)
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    await nextTick()
+    await composableResult!.retry()
 
     const newStep = makeStep({ id: 's3', name: 'test' })
-    addStep(newStep)
+    composableResult!.addStep(newStep)
 
-    expect(steps.value).toHaveLength(3)
-    expect(steps.value[2]!.id).toBe('s3')
+    expect(composableResult!.steps.value).toHaveLength(3)
+    expect(composableResult!.steps.value[2]!.id).toBe('s3')
   })
 
   it('removeStep removes step from the store', async () => {
     mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
 
-    const projectId = ref('proj-1')
-    const { steps, removeStep, retry } = usePipelineConfig(projectId)
+    let composableResult: ReturnType<typeof usePipelineConfig> | undefined
 
-    await retry()
+    mount({
+      setup() {
+        const projectId = ref('proj-1')
+        composableResult = usePipelineConfig(projectId)
+        return {}
+      },
+      template: '<div></div>',
+    })
 
-    removeStep(0)
+    await nextTick()
+    await composableResult!.retry()
 
-    expect(steps.value).toHaveLength(1)
-    expect(steps.value[0]!.id).toBe('s2')
+    composableResult!.removeStep(0)
+
+    expect(composableResult!.steps.value).toHaveLength(1)
+    expect(composableResult!.steps.value[0]!.id).toBe('s2')
   })
 
   it('reorderSteps swaps steps in the store', async () => {
     mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
 
-    const projectId = ref('proj-1')
-    const { steps, reorderSteps, retry } = usePipelineConfig(projectId)
+    let composableResult: ReturnType<typeof usePipelineConfig> | undefined
 
-    await retry()
+    mount({
+      setup() {
+        const projectId = ref('proj-1')
+        composableResult = usePipelineConfig(projectId)
+        return {}
+      },
+      template: '<div></div>',
+    })
 
-    reorderSteps(0, 1)
+    await nextTick()
+    await composableResult!.retry()
 
-    expect(steps.value[0]!.id).toBe('s2')
-    expect(steps.value[1]!.id).toBe('s1')
+    composableResult!.reorderSteps(0, 1)
+
+    expect(composableResult!.steps.value[0]!.id).toBe('s2')
+    expect(composableResult!.steps.value[1]!.id).toBe('s1')
   })
 
   it('updateStep updates a step in the store', async () => {
     mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
 
-    const projectId = ref('proj-1')
-    const { steps, updateStep, retry } = usePipelineConfig(projectId)
+    let composableResult: ReturnType<typeof usePipelineConfig> | undefined
 
-    await retry()
+    mount({
+      setup() {
+        const projectId = ref('proj-1')
+        composableResult = usePipelineConfig(projectId)
+        return {}
+      },
+      template: '<div></div>',
+    })
 
-    const step = steps.value[0]!
+    await nextTick()
+    await composableResult!.retry()
+
+    const step = composableResult!.steps.value[0]!
     const updated: PipelineStep = { ...step, model: 'claude-haiku-4-3' }
-    updateStep(0, updated)
+    composableResult!.updateStep(0, updated)
 
-    expect(steps.value[0]!.model).toBe('claude-haiku-4-3')
+    expect(composableResult!.steps.value[0]!.model).toBe('claude-haiku-4-3')
   })
 })

--- a/frontend/src/composables/__tests__/usePipelineConfig.spec.ts
+++ b/frontend/src/composables/__tests__/usePipelineConfig.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { ref } from 'vue'
+import { usePipelineConfig } from '../usePipelineConfig'
+import type { PipelineStep } from '@/stores/pipelineConfig'
+
+ 
+
+const mockGet = vi.fn()
+const mockPut = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+    PUT: (...args: unknown[]) => mockPut(...args),
+  },
+}))
+
+function makeStep(overrides: Partial<PipelineStep> = {}): PipelineStep {
+  return {
+    id: crypto.randomUUID(),
+    name: 'implement',
+    action_type: 'implement',
+    model: 'claude-opus-4-6',
+    auto_approve: false,
+    retry_policy: { max_retries: 2, retry_type: 'on-failure' },
+    ...overrides,
+  }
+}
+
+const mockConfig = {
+  project_id: 'proj-1',
+  steps: [
+    makeStep({ id: 's1', name: 'implement' }),
+    makeStep({ id: 's2', name: 'review', action_type: 'review' }),
+  ],
+  updated_at: '2026-02-15T10:30:00Z',
+}
+
+describe('usePipelineConfig', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockGet.mockReset()
+    mockPut.mockReset()
+  })
+
+  it('exposes reactive computed properties from the store', () => {
+    mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+
+    const projectId = ref('proj-1')
+    const { config, steps, isLoading, isSaving, error, isDirty } =
+      usePipelineConfig(projectId)
+
+    expect(config.value).toBeNull()
+    expect(steps.value).toEqual([])
+    expect(isLoading.value).toBe(false)
+    expect(isSaving.value).toBe(false)
+    expect(error.value).toBeNull()
+    expect(isDirty.value).toBe(false)
+  })
+
+  it('provides retry that re-fetches with the same project ID', async () => {
+    mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+
+    const projectId = ref('proj-1')
+    const { retry } = usePipelineConfig(projectId)
+
+    await retry()
+
+    expect(mockGet).toHaveBeenCalledWith('/projects/{projectId}/pipeline', {
+      params: { path: { projectId: 'proj-1' } },
+    })
+  })
+
+  it('saveConfig calls store save with correct project ID', async () => {
+    mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+    mockPut.mockResolvedValue({ data: mockConfig, error: undefined })
+
+    const projectId = ref('proj-1')
+    const { saveConfig, addStep, retry } = usePipelineConfig(projectId)
+
+    // Explicitly fetch config so it is populated
+    await retry()
+
+    addStep(makeStep({ id: 's3', name: 'test' }))
+    const result = await saveConfig()
+
+    expect(result).toBe(true)
+    expect(mockPut).toHaveBeenCalledWith('/projects/{projectId}/pipeline', {
+      params: { path: { projectId: 'proj-1' } },
+      body: { steps: expect.any(Array) },
+    })
+  })
+
+  it('addStep adds step to the store', async () => {
+    mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+
+    const projectId = ref('proj-1')
+    const { steps, addStep, retry } = usePipelineConfig(projectId)
+
+    await retry()
+
+    const newStep = makeStep({ id: 's3', name: 'test' })
+    addStep(newStep)
+
+    expect(steps.value).toHaveLength(3)
+    expect(steps.value[2]!.id).toBe('s3')
+  })
+
+  it('removeStep removes step from the store', async () => {
+    mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+
+    const projectId = ref('proj-1')
+    const { steps, removeStep, retry } = usePipelineConfig(projectId)
+
+    await retry()
+
+    removeStep(0)
+
+    expect(steps.value).toHaveLength(1)
+    expect(steps.value[0]!.id).toBe('s2')
+  })
+
+  it('reorderSteps swaps steps in the store', async () => {
+    mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+
+    const projectId = ref('proj-1')
+    const { steps, reorderSteps, retry } = usePipelineConfig(projectId)
+
+    await retry()
+
+    reorderSteps(0, 1)
+
+    expect(steps.value[0]!.id).toBe('s2')
+    expect(steps.value[1]!.id).toBe('s1')
+  })
+
+  it('updateStep updates a step in the store', async () => {
+    mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+
+    const projectId = ref('proj-1')
+    const { steps, updateStep, retry } = usePipelineConfig(projectId)
+
+    await retry()
+
+    const step = steps.value[0]!
+    const updated: PipelineStep = { ...step, model: 'claude-haiku-4-3' }
+    updateStep(0, updated)
+
+    expect(steps.value[0]!.model).toBe('claude-haiku-4-3')
+  })
+})

--- a/frontend/src/composables/usePipelineConfig.ts
+++ b/frontend/src/composables/usePipelineConfig.ts
@@ -1,0 +1,69 @@
+import { computed, onMounted, watch } from 'vue'
+import { usePipelineConfigStore, type PipelineStep } from '@/stores/pipelineConfig'
+import type { Ref } from 'vue'
+
+/**
+ * Composable for pipeline configuration operations.
+ * Wraps the pipeline config store with reactive computed properties.
+ * Auto-fetches config on mount when projectId is provided.
+ */
+export function usePipelineConfig(projectId: Ref<string>) {
+  const store = usePipelineConfigStore()
+
+  onMounted(() => {
+    if (projectId.value) {
+      store.fetchConfig(projectId.value)
+    }
+  })
+
+  watch(projectId, (newId) => {
+    if (newId) {
+      store.fetchConfig(newId)
+    }
+  })
+
+  async function retry() {
+    if (projectId.value) {
+      await store.fetchConfig(projectId.value)
+    }
+  }
+
+  async function saveConfig(): Promise<boolean> {
+    if (projectId.value) {
+      return await store.saveConfig(projectId.value)
+    }
+    return false
+  }
+
+  function addStep(step: PipelineStep) {
+    store.addStep(step)
+  }
+
+  function removeStep(index: number) {
+    store.removeStep(index)
+  }
+
+  function reorderSteps(fromIndex: number, toIndex: number) {
+    store.reorderSteps(fromIndex, toIndex)
+  }
+
+  function updateStep(index: number, step: PipelineStep) {
+    store.updateStep(index, step)
+  }
+
+  return {
+    config: computed(() => store.config),
+    steps: computed(() => store.steps),
+    isLoading: computed(() => store.isLoading),
+    isSaving: computed(() => store.isSaving),
+    error: computed(() => store.error),
+    isDirty: computed(() => store.isDirty),
+    fetchConfig: retry,
+    saveConfig,
+    retry,
+    addStep,
+    removeStep,
+    reorderSteps,
+    updateStep,
+  }
+}

--- a/frontend/src/features/pipeline/AddStepDialog.vue
+++ b/frontend/src/features/pipeline/AddStepDialog.vue
@@ -1,0 +1,200 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import Dialog from 'primevue/dialog'
+import InputText from 'primevue/inputtext'
+import Select from 'primevue/select'
+import Checkbox from 'primevue/checkbox'
+import InputNumber from 'primevue/inputnumber'
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import type { PipelineStep } from '@/stores/pipelineConfig'
+
+const modelOptions = [
+  { label: 'Claude Opus 4.6', value: 'claude-opus-4-6' },
+  { label: 'Claude Sonnet 4.5', value: 'claude-sonnet-4-5' },
+  { label: 'Claude Haiku 4.3', value: 'claude-haiku-4-3' },
+]
+
+const actionTypeOptions = [
+  { label: 'Implement', value: 'implement' },
+  { label: 'Review', value: 'review' },
+  { label: 'Merge', value: 'merge' },
+  { label: 'Test', value: 'test' },
+  { label: 'Custom', value: 'custom' },
+]
+
+const retryTypeOptions = [
+  { label: 'None', value: 'none' },
+  { label: 'On Failure', value: 'on-failure' },
+  { label: 'Always', value: 'always' },
+]
+
+const props = defineProps<{
+  visible: boolean
+}>()
+
+const emit = defineEmits<{
+  add: [step: PipelineStep]
+  cancel: []
+  'update:visible': [value: boolean]
+}>()
+
+const name = ref('')
+const actionType = ref<PipelineStep['action_type']>('implement')
+const model = ref<PipelineStep['model']>('claude-sonnet-4-5')
+const autoApprove = ref(false)
+const maxRetries = ref(2)
+const retryType = ref<PipelineStep['retry_policy']['retry_type']>('on-failure')
+const validationError = ref<string | null>(null)
+
+function resetForm() {
+  name.value = ''
+  actionType.value = 'implement'
+  model.value = 'claude-sonnet-4-5'
+  autoApprove.value = false
+  maxRetries.value = 2
+  retryType.value = 'on-failure'
+  validationError.value = null
+}
+
+watch(
+  () => props.visible,
+  (isVisible) => {
+    if (isVisible) {
+      resetForm()
+    }
+  },
+)
+
+function handleAdd() {
+  if (!name.value.trim()) {
+    validationError.value = 'Step name is required'
+    return
+  }
+
+  const step: PipelineStep = {
+    id: crypto.randomUUID(),
+    name: name.value.trim(),
+    action_type: actionType.value,
+    model: model.value,
+    auto_approve: autoApprove.value,
+    retry_policy: {
+      max_retries: maxRetries.value,
+      retry_type: retryType.value,
+    },
+  }
+
+  emit('add', step)
+  close()
+}
+
+function close() {
+  emit('update:visible', false)
+  emit('cancel')
+}
+</script>
+
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    header="Add Pipeline Step"
+    class="w-full max-w-lg"
+    @update:visible="close"
+  >
+    <form class="flex flex-col gap-4" @submit.prevent="handleAdd">
+      <div class="flex flex-col gap-2">
+        <label for="step-name" class="text-sm font-medium">Name *</label>
+        <InputText
+          id="step-name"
+          v-model="name"
+          class="w-full"
+          placeholder="e.g., implement, review"
+          :invalid="!!validationError"
+          data-testid="step-name-input"
+        />
+        <small v-if="validationError" class="text-red-500">{{ validationError }}</small>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <label for="action-type" class="text-sm font-medium">Action Type</label>
+        <Select
+          id="action-type"
+          v-model="actionType"
+          :options="actionTypeOptions"
+          option-label="label"
+          option-value="value"
+          class="w-full"
+          data-testid="action-type-select"
+        />
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <label for="model-select" class="text-sm font-medium">Model</label>
+        <Select
+          id="model-select"
+          v-model="model"
+          :options="modelOptions"
+          option-label="label"
+          option-value="value"
+          class="w-full"
+          data-testid="model-select"
+        />
+      </div>
+
+      <div class="flex items-center gap-2">
+        <Checkbox
+          v-model="autoApprove"
+          :binary="true"
+          input-id="add-auto-approve"
+          data-testid="auto-approve-checkbox"
+        />
+        <label for="add-auto-approve" class="text-sm font-medium">Auto Approve</label>
+      </div>
+
+      <div class="grid grid-cols-2 gap-4">
+        <div class="flex flex-col gap-2">
+          <label for="max-retries" class="text-sm font-medium">Max Retries</label>
+          <InputNumber
+            id="max-retries"
+            v-model="maxRetries"
+            :min="0"
+            :max="10"
+            class="w-full"
+            data-testid="max-retries-input"
+          />
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <label for="retry-type" class="text-sm font-medium">Retry Type</label>
+          <Select
+            id="retry-type"
+            v-model="retryType"
+            :options="retryTypeOptions"
+            option-label="label"
+            option-value="value"
+            class="w-full"
+            data-testid="retry-type-select"
+          />
+        </div>
+      </div>
+
+      <Message v-if="validationError" severity="error" :closable="false">
+        {{ validationError }}
+      </Message>
+    </form>
+
+    <template #footer>
+      <div class="flex justify-end gap-2">
+        <Button label="Cancel" severity="secondary" text @click="close" />
+        <Button
+          label="Add"
+          severity="success"
+          icon="pi pi-plus"
+          data-testid="add-step-submit"
+          @click="handleAdd"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>

--- a/frontend/src/features/pipeline/PipelineStepCard.vue
+++ b/frontend/src/features/pipeline/PipelineStepCard.vue
@@ -1,0 +1,186 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import Card from 'primevue/card'
+import Button from 'primevue/button'
+import Tag from 'primevue/tag'
+import Select from 'primevue/select'
+import Checkbox from 'primevue/checkbox'
+import InputNumber from 'primevue/inputnumber'
+import type { PipelineStep } from '@/stores/pipelineConfig'
+
+const modelOptions = [
+  { label: 'Claude Opus 4.6', value: 'claude-opus-4-6' },
+  { label: 'Claude Sonnet 4.5', value: 'claude-sonnet-4-5' },
+  { label: 'Claude Haiku 4.3', value: 'claude-haiku-4-3' },
+]
+
+const retryTypeOptions = [
+  { label: 'None', value: 'none' },
+  { label: 'On Failure', value: 'on-failure' },
+  { label: 'Always', value: 'always' },
+]
+
+const props = defineProps<{
+  step: PipelineStep
+  index: number
+  isAdmin: boolean
+  expanded: boolean
+  isFirst: boolean
+  isLast: boolean
+}>()
+
+const emit = defineEmits<{
+  toggle: []
+  update: [step: PipelineStep]
+  remove: []
+  moveUp: []
+  moveDown: []
+}>()
+
+const modelLabel = computed(() => {
+  return modelOptions.find((o) => o.value === props.step.model)?.label ?? props.step.model
+})
+
+const autoApproveSeverity = computed(() => {
+  return props.step.auto_approve ? 'success' : 'secondary'
+})
+
+function onModelChange(value: PipelineStep['model']) {
+  emit('update', { ...props.step, model: value })
+}
+
+function onAutoApproveChange(value: boolean) {
+  emit('update', { ...props.step, auto_approve: value })
+}
+
+function onMaxRetriesChange(value: number) {
+  emit('update', {
+    ...props.step,
+    retry_policy: { ...props.step.retry_policy, max_retries: value },
+  })
+}
+
+function onRetryTypeChange(value: PipelineStep['retry_policy']['retry_type']) {
+  emit('update', {
+    ...props.step,
+    retry_policy: { ...props.step.retry_policy, retry_type: value },
+  })
+}
+</script>
+
+<template>
+  <Card class="cursor-pointer" @click="emit('toggle')">
+    <template #content>
+      <div class="flex flex-col gap-3">
+        <!-- Collapsed header row -->
+        <div class="flex items-center gap-3">
+          <span class="font-mono text-sm opacity-60">{{ index + 1 }}.</span>
+          <span class="font-semibold">{{ step.name }}</span>
+          <Tag :value="step.action_type" severity="info" />
+          <span class="text-sm opacity-70">{{ modelLabel }}</span>
+          <Tag
+            :value="step.auto_approve ? 'Auto' : 'Manual'"
+            :severity="autoApproveSeverity"
+            class="ml-auto"
+          />
+
+          <template v-if="isAdmin">
+            <Button
+              icon="pi pi-arrow-up"
+              text
+              rounded
+              size="small"
+              :disabled="isFirst"
+              aria-label="Move up"
+              data-testid="move-up"
+              @click.stop="emit('moveUp')"
+            />
+            <Button
+              icon="pi pi-arrow-down"
+              text
+              rounded
+              size="small"
+              :disabled="isLast"
+              aria-label="Move down"
+              data-testid="move-down"
+              @click.stop="emit('moveDown')"
+            />
+            <Button
+              icon="pi pi-trash"
+              text
+              rounded
+              size="small"
+              severity="danger"
+              aria-label="Remove step"
+              data-testid="remove-step"
+              @click.stop="emit('remove')"
+            />
+          </template>
+        </div>
+
+        <!-- Expanded details -->
+        <div v-if="expanded" class="flex flex-col gap-4 pt-3" @click.stop>
+          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div class="flex flex-col gap-2">
+              <label class="text-sm font-medium">Model</label>
+              <Select
+                :model-value="step.model"
+                :options="modelOptions"
+                option-label="label"
+                option-value="value"
+                :disabled="!isAdmin"
+                class="w-full"
+                data-testid="model-select"
+                @update:model-value="onModelChange"
+              />
+            </div>
+
+            <div class="flex flex-col gap-2">
+              <label class="text-sm font-medium">Auto Approve</label>
+              <div class="flex items-center gap-2">
+                <Checkbox
+                  :model-value="step.auto_approve"
+                  :binary="true"
+                  :disabled="!isAdmin"
+                  input-id="auto-approve"
+                  data-testid="auto-approve-checkbox"
+                  @update:model-value="onAutoApproveChange"
+                />
+                <label for="auto-approve" class="text-sm">
+                  {{ step.auto_approve ? 'Enabled' : 'Disabled' }}
+                </label>
+              </div>
+            </div>
+
+            <div class="flex flex-col gap-2">
+              <label class="text-sm font-medium">Max Retries</label>
+              <InputNumber
+                :model-value="step.retry_policy.max_retries"
+                :min="0"
+                :max="10"
+                :disabled="!isAdmin"
+                class="w-full"
+                data-testid="max-retries-input"
+                @update:model-value="onMaxRetriesChange"
+              />
+            </div>
+
+            <div class="flex flex-col gap-2">
+              <label class="text-sm font-medium">Retry Type</label>
+              <Select
+                :model-value="step.retry_policy.retry_type"
+                :options="retryTypeOptions"
+                option-label="label"
+                option-value="value"
+                :disabled="!isAdmin"
+                class="w-full"
+                data-testid="retry-type-select"
+                @update:model-value="onRetryTypeChange"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+  </Card>
+</template>

--- a/frontend/src/features/pipeline/PipelineStepList.vue
+++ b/frontend/src/features/pipeline/PipelineStepList.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import PipelineStepCard from './PipelineStepCard.vue'
+import type { PipelineStep } from '@/stores/pipelineConfig'
+
+defineProps<{
+  steps: PipelineStep[]
+  isAdmin: boolean
+}>()
+
+const emit = defineEmits<{
+  update: [index: number, step: PipelineStep]
+  remove: [index: number]
+  reorder: [fromIndex: number, toIndex: number]
+}>()
+
+const expandedIndex = ref<number | null>(null)
+
+function toggleExpand(index: number) {
+  expandedIndex.value = expandedIndex.value === index ? null : index
+}
+
+function handleMoveUp(index: number) {
+  if (index > 0) {
+    emit('reorder', index, index - 1)
+    expandedIndex.value = index - 1
+  }
+}
+
+function handleMoveDown(index: number, stepsLength: number) {
+  if (index < stepsLength - 1) {
+    emit('reorder', index, index + 1)
+    expandedIndex.value = index + 1
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-3">
+    <PipelineStepCard
+      v-for="(step, index) in steps"
+      :key="step.id"
+      :step="step"
+      :index="index"
+      :is-admin="isAdmin"
+      :expanded="expandedIndex === index"
+      :is-first="index === 0"
+      :is-last="index === steps.length - 1"
+      @toggle="toggleExpand(index)"
+      @update="(updatedStep: PipelineStep) => emit('update', index, updatedStep)"
+      @remove="emit('remove', index)"
+      @move-up="handleMoveUp(index)"
+      @move-down="handleMoveDown(index, steps.length)"
+    />
+  </div>
+</template>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -6,6 +6,7 @@ import ProjectDetailView from '@/views/ProjectDetailView.vue'
 import RunDetailView from '@/views/RunDetailView.vue'
 import StoryDetailView from '@/views/StoryDetailView.vue'
 import ApprovalsView from '@/views/ApprovalsView.vue'
+import PipelineConfigView from '@/views/PipelineConfigView.vue'
 import { setupAuthGuard, setupAdminGuard } from './guards'
 
 const router = createRouter({
@@ -39,6 +40,12 @@ const router = createRouter({
       path: '/projects/:projectId/stories/:storyId',
       name: 'story-detail',
       component: StoryDetailView,
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/projects/:id/pipeline',
+      name: 'project-pipeline',
+      component: PipelineConfigView,
       meta: { requiresAuth: true },
     },
     {

--- a/frontend/src/stores/__tests__/pipelineConfig.spec.ts
+++ b/frontend/src/stores/__tests__/pipelineConfig.spec.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { usePipelineConfigStore, type PipelineStep } from '../pipelineConfig'
+
+const mockGet = vi.fn()
+const mockPut = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+    PUT: (...args: unknown[]) => mockPut(...args),
+  },
+}))
+
+function makeStep(overrides: Partial<PipelineStep> = {}): PipelineStep {
+  return {
+    id: crypto.randomUUID(),
+    name: 'implement',
+    action_type: 'implement',
+    model: 'claude-opus-4-6',
+    auto_approve: false,
+    retry_policy: { max_retries: 2, retry_type: 'on-failure' },
+    ...overrides,
+  }
+}
+
+const mockConfig = {
+  project_id: 'proj-1',
+  steps: [
+    makeStep({ id: 's1', name: 'implement', action_type: 'implement' }),
+    makeStep({ id: 's2', name: 'review', action_type: 'review' }),
+    makeStep({ id: 's3', name: 'merge', action_type: 'merge' }),
+  ],
+  updated_at: '2026-02-15T10:30:00Z',
+}
+
+describe('usePipelineConfigStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockGet.mockReset()
+    mockPut.mockReset()
+  })
+
+  it('starts with default state', () => {
+    const store = usePipelineConfigStore()
+    expect(store.config).toBeNull()
+    expect(store.steps).toEqual([])
+    expect(store.isLoading).toBe(false)
+    expect(store.error).toBeNull()
+    expect(store.isDirty).toBe(false)
+    expect(store.isSaving).toBe(false)
+  })
+
+  describe('fetchConfig', () => {
+    it('fetches config successfully', async () => {
+      mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+
+      expect(store.config).toEqual(mockConfig)
+      expect(store.steps).toHaveLength(3)
+      expect(store.isLoading).toBe(false)
+      expect(store.error).toBeNull()
+      expect(store.isDirty).toBe(false)
+      expect(mockGet).toHaveBeenCalledWith('/projects/{projectId}/pipeline', {
+        params: { path: { projectId: 'proj-1' } },
+      })
+    })
+
+    it('sets error when API returns an error', async () => {
+      mockGet.mockResolvedValue({
+        data: undefined,
+        error: { error: { code: 'NOT_FOUND', message: 'Not found' } },
+      })
+
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+
+      expect(store.config).toBeNull()
+      expect(store.error).toBe('Failed to load pipeline configuration')
+      expect(store.isLoading).toBe(false)
+    })
+
+    it('sets error when API call throws', async () => {
+      mockGet.mockRejectedValue(new Error('Network error'))
+
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+
+      expect(store.config).toBeNull()
+      expect(store.error).toBe('Network error')
+      expect(store.isLoading).toBe(false)
+    })
+
+    it('resets isDirty after successful fetch', async () => {
+      mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+      store.addStep(makeStep())
+      expect(store.isDirty).toBe(true)
+
+      await store.fetchConfig('proj-1')
+      expect(store.isDirty).toBe(false)
+    })
+  })
+
+  describe('local mutations', () => {
+    beforeEach(async () => {
+      mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+    })
+
+    it('addStep adds a step and marks dirty', async () => {
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+
+      const newStep = makeStep({ id: 's4', name: 'test', action_type: 'test' })
+      store.addStep(newStep)
+
+      expect(store.steps).toHaveLength(4)
+      expect(store.steps[3]).toEqual(newStep)
+      expect(store.isDirty).toBe(true)
+    })
+
+    it('removeStep removes a step by index and marks dirty', async () => {
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+
+      store.removeStep(1)
+
+      expect(store.steps).toHaveLength(2)
+      expect(store.steps[0]!.id).toBe('s1')
+      expect(store.steps[1]!.id).toBe('s3')
+      expect(store.isDirty).toBe(true)
+    })
+
+    it('reorderSteps swaps steps and marks dirty', async () => {
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+
+      store.reorderSteps(0, 2)
+
+      expect(store.steps[0]!.id).toBe('s2')
+      expect(store.steps[1]!.id).toBe('s3')
+      expect(store.steps[2]!.id).toBe('s1')
+      expect(store.isDirty).toBe(true)
+    })
+
+    it('updateStep updates a step at index and marks dirty', async () => {
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+
+      const step = store.steps[0]!
+      const updated: PipelineStep = { ...step, model: 'claude-haiku-4-3' }
+      store.updateStep(0, updated)
+
+      expect(store.steps[0]!.model).toBe('claude-haiku-4-3')
+      expect(store.isDirty).toBe(true)
+    })
+
+    it('updateSteps replaces all steps and marks dirty', async () => {
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+
+      const newSteps = [makeStep({ id: 'new1', name: 'only-step' })]
+      store.updateSteps(newSteps)
+
+      expect(store.steps).toHaveLength(1)
+      expect(store.steps[0]!.id).toBe('new1')
+      expect(store.isDirty).toBe(true)
+    })
+
+    it('mutations do nothing when config is null', () => {
+      const store = usePipelineConfigStore()
+      store.addStep(makeStep())
+      store.removeStep(0)
+      store.reorderSteps(0, 1)
+      store.updateStep(0, makeStep())
+      store.updateSteps([makeStep()])
+      expect(store.config).toBeNull()
+      expect(store.isDirty).toBe(false)
+    })
+  })
+
+  describe('saveConfig', () => {
+    it('saves config successfully and resets isDirty', async () => {
+      mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+      store.addStep(makeStep({ id: 's4', name: 'test' }))
+      expect(store.isDirty).toBe(true)
+
+      const updatedConfig = { ...mockConfig, steps: store.steps }
+      mockPut.mockResolvedValue({ data: updatedConfig, error: undefined })
+
+      const result = await store.saveConfig('proj-1')
+
+      expect(result).toBe(true)
+      expect(store.isDirty).toBe(false)
+      expect(store.isSaving).toBe(false)
+      expect(store.error).toBeNull()
+      expect(mockPut).toHaveBeenCalledWith('/projects/{projectId}/pipeline', {
+        params: { path: { projectId: 'proj-1' } },
+        body: { steps: expect.any(Array) },
+      })
+    })
+
+    it('returns false and sets error when API returns error', async () => {
+      mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+      store.addStep(makeStep())
+
+      mockPut.mockResolvedValue({
+        data: undefined,
+        error: { error: { code: 'BAD_REQUEST', message: 'Invalid config' } },
+      })
+
+      const result = await store.saveConfig('proj-1')
+
+      expect(result).toBe(false)
+      expect(store.error).toBe('Invalid config')
+      expect(store.isSaving).toBe(false)
+    })
+
+    it('returns false and sets error when API call throws', async () => {
+      mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+
+      mockPut.mockRejectedValue(new Error('Network error'))
+
+      const result = await store.saveConfig('proj-1')
+
+      expect(result).toBe(false)
+      expect(store.error).toBe('Network error')
+      expect(store.isSaving).toBe(false)
+    })
+
+    it('returns false when config is null', async () => {
+      const store = usePipelineConfigStore()
+      const result = await store.saveConfig('proj-1')
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('reset', () => {
+    it('resets all state to initial values', async () => {
+      mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+      store.addStep(makeStep())
+
+      store.reset()
+
+      expect(store.config).toBeNull()
+      expect(store.steps).toEqual([])
+      expect(store.isLoading).toBe(false)
+      expect(store.error).toBeNull()
+      expect(store.isDirty).toBe(false)
+      expect(store.isSaving).toBe(false)
+    })
+  })
+})

--- a/frontend/src/stores/pipelineConfig.ts
+++ b/frontend/src/stores/pipelineConfig.ts
@@ -1,0 +1,150 @@
+import { ref, computed } from 'vue'
+import { defineStore } from 'pinia'
+import { apiClient } from '@/api/client'
+import type { components } from '@/api/schema'
+
+export type PipelineConfig = components['schemas']['PipelineConfig']
+export type PipelineStep = components['schemas']['PipelineStep']
+export type RetryPolicy = components['schemas']['RetryPolicy']
+
+/**
+ * Pinia store for pipeline configuration state management.
+ * Handles fetching, local editing, and saving pipeline config for a project.
+ */
+export const usePipelineConfigStore = defineStore('pipelineConfig', () => {
+  const config = ref<PipelineConfig | null>(null)
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+  const isDirty = ref(false)
+  const isSaving = ref(false)
+
+  const steps = computed(() => config.value?.steps ?? [])
+
+  /** Fetch pipeline configuration from the API */
+  async function fetchConfig(projectId: string) {
+    isLoading.value = true
+    error.value = null
+    try {
+      const { data, error: apiError } = await apiClient.GET(
+        '/projects/{projectId}/pipeline',
+        {
+          params: { path: { projectId } },
+        },
+      )
+      if (apiError) {
+        error.value = 'Failed to load pipeline configuration'
+        return
+      }
+      config.value = data as PipelineConfig
+      isDirty.value = false
+    } catch (e) {
+      error.value =
+        e instanceof Error ? e.message : 'Failed to load pipeline configuration'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  /** Update the local config steps (marks as dirty) */
+  function updateSteps(newSteps: PipelineStep[]) {
+    if (config.value) {
+      config.value = { ...config.value, steps: newSteps }
+      isDirty.value = true
+    }
+  }
+
+  /** Add a step to the local config */
+  function addStep(step: PipelineStep) {
+    if (config.value) {
+      config.value = { ...config.value, steps: [...config.value.steps, step] }
+      isDirty.value = true
+    }
+  }
+
+  /** Remove a step by index */
+  function removeStep(index: number) {
+    if (config.value) {
+      const newSteps = config.value.steps.filter((_, i) => i !== index)
+      config.value = { ...config.value, steps: newSteps }
+      isDirty.value = true
+    }
+  }
+
+  /** Reorder steps by swapping fromIndex and toIndex */
+  function reorderSteps(fromIndex: number, toIndex: number) {
+    if (!config.value) return
+    const newSteps = [...config.value.steps]
+    const removed = newSteps.splice(fromIndex, 1)
+    const movedStep = removed[0]
+    if (!movedStep) return
+    newSteps.splice(toIndex, 0, movedStep)
+    config.value = { ...config.value, steps: newSteps }
+    isDirty.value = true
+  }
+
+  /** Update a single step at the given index */
+  function updateStep(index: number, step: PipelineStep) {
+    if (!config.value) return
+    const newSteps = [...config.value.steps]
+    newSteps[index] = step
+    config.value = { ...config.value, steps: newSteps }
+    isDirty.value = true
+  }
+
+  /** Save pipeline configuration to the API */
+  async function saveConfig(projectId: string): Promise<boolean> {
+    if (!config.value) return false
+    isSaving.value = true
+    error.value = null
+    try {
+      const { data, error: apiError } = await apiClient.PUT(
+        '/projects/{projectId}/pipeline',
+        {
+          params: { path: { projectId } },
+          body: { steps: config.value.steps },
+        },
+      )
+      if (apiError) {
+        const message =
+          (apiError as { error?: { message?: string } })?.error?.message ??
+          'Failed to save pipeline configuration'
+        throw new Error(message)
+      }
+      config.value = data as PipelineConfig
+      isDirty.value = false
+      return true
+    } catch (e) {
+      error.value =
+        e instanceof Error ? e.message : 'Failed to save pipeline configuration'
+      return false
+    } finally {
+      isSaving.value = false
+    }
+  }
+
+  /** Reset store state */
+  function reset() {
+    config.value = null
+    isLoading.value = false
+    error.value = null
+    isDirty.value = false
+    isSaving.value = false
+  }
+
+  return {
+    config,
+    steps,
+    isLoading,
+    error,
+    isDirty,
+    isSaving,
+    fetchConfig,
+    updateSteps,
+    addStep,
+    removeStep,
+    reorderSteps,
+    updateStep,
+    saveConfig,
+    reset,
+  }
+})

--- a/frontend/src/views/PipelineConfigView.vue
+++ b/frontend/src/views/PipelineConfigView.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { useToast } from 'primevue/usetoast'
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import Skeleton from 'primevue/skeleton'
+import Toast from 'primevue/toast'
+import PipelineStepList from '@/features/pipeline/PipelineStepList.vue'
+import AddStepDialog from '@/features/pipeline/AddStepDialog.vue'
+import { usePipelineConfig } from '@/composables/usePipelineConfig'
+import { useAuth } from '@/composables/useAuth'
+import type { PipelineStep } from '@/stores/pipelineConfig'
+
+const route = useRoute()
+const toast = useToast()
+const { user } = useAuth()
+
+const projectId = computed(() => route.params.id as string)
+const {
+  steps,
+  isLoading,
+  isSaving,
+  error,
+  isDirty,
+  retry,
+  saveConfig,
+  addStep,
+  removeStep,
+  reorderSteps,
+  updateStep,
+} = usePipelineConfig(projectId)
+
+const isAdmin = computed(() => user.value?.role === 'admin')
+const showAddDialog = ref(false)
+
+function handleAddStep(step: PipelineStep) {
+  addStep(step)
+}
+
+function handleUpdateStep(index: number, step: PipelineStep) {
+  updateStep(index, step)
+}
+
+function handleRemoveStep(index: number) {
+  removeStep(index)
+}
+
+function handleReorder(fromIndex: number, toIndex: number) {
+  reorderSteps(fromIndex, toIndex)
+}
+
+async function handleSave() {
+  const success = await saveConfig()
+  if (success) {
+    toast.add({
+      severity: 'success',
+      summary: 'Configuration saved',
+      detail: 'Pipeline configuration has been updated successfully',
+      life: 3000,
+    })
+  } else {
+    toast.add({
+      severity: 'error',
+      summary: 'Save failed',
+      detail: 'Failed to save pipeline configuration. Please try again.',
+      life: 5000,
+    })
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-6 p-6">
+    <div class="flex items-center justify-between">
+      <h1 class="text-2xl font-bold">Pipeline Configuration</h1>
+      <div v-if="isAdmin && !isLoading && !error" class="flex gap-2">
+        <Button
+          label="Add Step"
+          icon="pi pi-plus"
+          severity="secondary"
+          data-testid="add-step-btn"
+          @click="showAddDialog = true"
+        />
+        <Button
+          label="Save"
+          icon="pi pi-save"
+          severity="success"
+          :disabled="!isDirty"
+          :loading="isSaving"
+          data-testid="save-config-btn"
+          @click="handleSave"
+        />
+      </div>
+    </div>
+
+    <!-- Loading state -->
+    <div v-if="isLoading" class="flex flex-col gap-3" data-testid="loading-skeleton">
+      <Skeleton height="4rem" />
+      <Skeleton height="4rem" />
+      <Skeleton height="4rem" />
+    </div>
+
+    <!-- Error state -->
+    <Message v-else-if="error" severity="error" :closable="false" data-testid="error-message">
+      <div class="flex items-center gap-3">
+        <span>{{ error }}</span>
+        <Button label="Retry" severity="secondary" text size="small" @click="retry()" />
+      </div>
+    </Message>
+
+    <!-- Empty state -->
+    <Message
+      v-else-if="steps.length === 0"
+      severity="info"
+      :closable="false"
+      data-testid="empty-message"
+    >
+      <span>No pipeline steps configured.</span>
+      <Button
+        v-if="isAdmin"
+        label="Add your first step"
+        text
+        size="small"
+        class="ml-2"
+        @click="showAddDialog = true"
+      />
+    </Message>
+
+    <!-- Step list -->
+    <PipelineStepList
+      v-else
+      :steps="steps"
+      :is-admin="isAdmin"
+      @update="handleUpdateStep"
+      @remove="handleRemoveStep"
+      @reorder="handleReorder"
+    />
+
+    <!-- Add step dialog (admin only) -->
+    <AddStepDialog
+      v-if="isAdmin"
+      v-model:visible="showAddDialog"
+      @add="handleAddStep"
+    />
+
+    <Toast />
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- Add visual pipeline configuration page at `/projects/:id/pipeline` with admin/non-admin views
- Add pipeline config endpoints (GET/PUT) and schemas (PipelineConfig, PipelineStep, RetryPolicy) to OpenAPI spec
- Implement full CRUD for pipeline steps: add, remove, reorder, edit model/retry policy, save with dirty tracking

## Changes

### API Contract (`api/openapi.yaml`)
- Add `pipeline-configs` tag
- Add `GET /projects/{projectId}/pipeline` and `PUT /projects/{projectId}/pipeline` endpoints
- Add `PipelineConfig`, `PipelineStep`, `RetryPolicy`, `UpdatePipelineConfigRequest` schemas

### Frontend Store & Composable
- `stores/pipelineConfig.ts` — Pinia store with `fetchConfig`, `saveConfig`, `addStep`, `removeStep`, `reorderSteps`, `updateStep`, `isDirty` tracking
- `composables/usePipelineConfig.ts` — Composable wrapping store with auto-fetch on mount and reactive computed properties

### Frontend Components
- `features/pipeline/PipelineStepCard.vue` — Expandable card showing step name, action type, model, auto-approve badge; expanded view with model selector, auto-approve checkbox, retry policy fields; admin controls (move up/down, remove)
- `features/pipeline/PipelineStepList.vue` — Ordered list of step cards with expand/collapse state management
- `features/pipeline/AddStepDialog.vue` — Dialog with form for adding new steps (name, action type, model, auto-approve, retry policy) with validation

### Frontend View & Routing
- `views/PipelineConfigView.vue` — Route view with loading skeleton, error message with retry, empty state, step list, admin controls (Add Step, Save)
- Route registered at `/projects/:id/pipeline` (name: `project-pipeline`, requires auth)

### Tests
- 16 unit tests for pipelineConfig store (fetch, save, mutations, dirty tracking, reset)
- 7 unit tests for usePipelineConfig composable (retry, save, add/remove/reorder/update)
- E2E tests for admin view (display steps, add/remove/reorder, save with toast), non-admin view (read-only), and error/loading states

## Test plan
- [x] All 136 unit tests pass (18 test files, including 23 new tests)
- [x] TypeScript type-check passes clean (`vue-tsc --build`)
- [x] ESLint passes clean
- [ ] E2E tests (require running app server)

Refs: 6-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)