### PR TITLE
feat(ui): add epic detail split view with story list and filters

### DIFF
--- a/frontend/e2e/tests/epic-detail.spec.ts
+++ b/frontend/e2e/tests/epic-detail.spec.ts
@@ -1,0 +1,221 @@
+import { test, expect } from '@playwright/test'
+
+const mockStories = [
+  {
+    id: 's1',
+    epic_id: 'e1',
+    project_id: 'p1',
+    key: 'S-01',
+    title: 'Setup authentication',
+    status: 'done',
+    objective: 'Implement authentication flow',
+    acceptance_criteria: 'Users can log in and out',
+    target_files: ['src/auth.ts', 'src/middleware.ts'],
+    depends_on: ['S-00'],
+    created_at: '2026-01-15T10:00:00Z',
+    updated_at: '2026-01-15T10:00:00Z',
+  },
+  {
+    id: 's2',
+    epic_id: 'e1',
+    project_id: 'p1',
+    key: 'S-02',
+    title: 'Add user profile page',
+    status: 'backlog',
+    objective: 'Create the profile UI',
+    created_at: '2026-01-16T10:00:00Z',
+    updated_at: '2026-01-16T10:00:00Z',
+  },
+  {
+    id: 's3',
+    epic_id: 'e1',
+    project_id: 'p1',
+    key: 'S-03',
+    title: 'Fix login bug',
+    status: 'failed',
+    objective: 'Resolve intermittent login failure',
+    created_at: '2026-01-17T10:00:00Z',
+    updated_at: '2026-01-17T10:00:00Z',
+  },
+  {
+    id: 's4',
+    epic_id: 'e1',
+    project_id: 'p1',
+    key: 'S-04',
+    title: 'Running pipeline test',
+    status: 'running',
+    created_at: '2026-01-18T10:00:00Z',
+    updated_at: '2026-01-18T10:00:00Z',
+  },
+]
+
+test.describe('Epic Detail Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/v1/auth/me', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: '1',
+          email: 'test@test.com',
+          name: 'Test User',
+          role: 'admin',
+        }),
+      })
+    })
+
+    await page.route('**/api/v1/projects*', async (route) => {
+      if (route.request().url().includes('/stories') || route.request().url().includes('/epics')) {
+        return route.fallback()
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [{ id: 'p1', name: 'Test Project', description: 'A test project' }],
+          pagination: { total: 1, page: 1, per_page: 20 },
+        }),
+      })
+    })
+  })
+
+  test('displays story list on left and detail panel on right', async ({ page }) => {
+    await page.route('**/api/v1/projects/p1/stories*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: mockStories }),
+      })
+    })
+
+    await page.goto('/projects/p1/epics/e1')
+
+    await expect(page.locator('h1')).toHaveText('Epic Stories')
+    await expect(page.getByText('S-01')).toBeVisible()
+    await expect(page.getByText('Setup authentication')).toBeVisible()
+    await expect(page.getByText('S-02')).toBeVisible()
+    await expect(page.getByText('Select a story to view details')).toBeVisible()
+  })
+
+  test('clicking a story shows its detail in the right panel', async ({ page }) => {
+    await page.route('**/api/v1/projects/p1/stories*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: mockStories }),
+      })
+    })
+
+    await page.goto('/projects/p1/epics/e1')
+
+    await page.getByText('Setup authentication').click()
+
+    await expect(page.getByText('Implement authentication flow')).toBeVisible()
+    await expect(page.getByText('Users can log in and out')).toBeVisible()
+    await expect(page.getByText('src/auth.ts')).toBeVisible()
+    await expect(page.getByText('S-00')).toBeVisible()
+  })
+
+  test('filters stories by status', async ({ page }) => {
+    await page.route('**/api/v1/projects/p1/stories*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: mockStories }),
+      })
+    })
+
+    await page.goto('/projects/p1/epics/e1')
+
+    await expect(page.getByText('S-01')).toBeVisible()
+    await expect(page.getByText('S-02')).toBeVisible()
+    await expect(page.getByText('S-03')).toBeVisible()
+    await expect(page.getByText('S-04')).toBeVisible()
+  })
+
+  test('filters stories by text search with debounce', async ({ page }) => {
+    await page.route('**/api/v1/projects/p1/stories*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: mockStories }),
+      })
+    })
+
+    await page.goto('/projects/p1/epics/e1')
+
+    await page.getByPlaceholder('Search stories...').fill('login')
+
+    await expect(page.getByText('S-03')).toBeVisible()
+    await expect(page.getByText('S-01')).not.toBeVisible()
+    await expect(page.getByText('S-02')).not.toBeVisible()
+  })
+
+  test('keyboard navigation with J/K/Enter', async ({ page }) => {
+    await page.route('**/api/v1/projects/p1/stories*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: mockStories }),
+      })
+    })
+
+    await page.goto('/projects/p1/epics/e1')
+
+    await expect(page.getByText('S-01')).toBeVisible()
+
+    await page.keyboard.press('j')
+    await page.keyboard.press('Enter')
+
+    await expect(page.getByText('Add user profile page').nth(1)).toBeVisible()
+  })
+
+  test('displays error message with retry button on API failure', async ({ page }) => {
+    let callCount = 0
+    await page.route('**/api/v1/projects/p1/stories*', async (route) => {
+      callCount++
+      if (callCount === 1) {
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            error: { code: 'INTERNAL', message: 'Server error' },
+          }),
+        })
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: mockStories }),
+        })
+      }
+    })
+
+    await page.goto('/projects/p1/epics/e1')
+
+    await expect(page.getByText('Failed to load stories')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible()
+
+    await page.getByRole('button', { name: 'Retry' }).click()
+
+    await expect(page.getByText('S-01')).toBeVisible()
+  })
+
+  test('shows loading skeleton on initial load', async ({ page }) => {
+    await page.route('**/api/v1/projects/p1/stories*', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: mockStories }),
+      })
+    })
+
+    await page.goto('/projects/p1/epics/e1')
+
+    const skeletons = page.locator('.p-skeleton')
+    await expect(skeletons.first()).toBeVisible()
+
+    await expect(page.getByText('S-01')).toBeVisible()
+  })
+})

--- a/frontend/e2e/tests/epic-detail.spec.ts
+++ b/frontend/e2e/tests/epic-detail.spec.ts
@@ -127,10 +127,21 @@ test.describe('Epic Detail Page', () => {
 
     await page.goto('/projects/p1/epics/e1')
 
+    // All stories visible initially
     await expect(page.getByText('S-01')).toBeVisible()
     await expect(page.getByText('S-02')).toBeVisible()
     await expect(page.getByText('S-03')).toBeVisible()
     await expect(page.getByText('S-04')).toBeVisible()
+
+    // Open the status dropdown and select "Done"
+    await page.locator('.p-select').click()
+    await page.getByRole('option', { name: 'Done' }).click()
+
+    // Only the done story should remain visible
+    await expect(page.getByText('S-01')).toBeVisible()
+    await expect(page.getByText('S-02')).not.toBeVisible()
+    await expect(page.getByText('S-03')).not.toBeVisible()
+    await expect(page.getByText('S-04')).not.toBeVisible()
   })
 
   test('filters stories by text search with debounce', async ({ page }) => {

--- a/frontend/src/composables/__tests__/useStories.spec.ts
+++ b/frontend/src/composables/__tests__/useStories.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useStories } from '../useStories'
+
+const mockGet = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+  },
+}))
+
+const mockStories = [
+  {
+    id: 's1',
+    epic_id: 'e1',
+    project_id: 'p1',
+    key: 'S-01',
+    title: 'Setup authentication',
+    status: 'done',
+    created_at: '2026-01-15T10:00:00Z',
+    updated_at: '2026-01-15T10:00:00Z',
+  },
+  {
+    id: 's2',
+    epic_id: 'e1',
+    project_id: 'p1',
+    key: 'S-02',
+    title: 'Add user profile page',
+    status: 'backlog',
+    created_at: '2026-01-16T10:00:00Z',
+    updated_at: '2026-01-16T10:00:00Z',
+  },
+]
+
+describe('useStories', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockGet.mockReset()
+    mockGet.mockResolvedValue({
+      data: { data: [] },
+      error: undefined,
+    })
+  })
+
+  it('exposes reactive computed properties from the store', () => {
+    const { stories, isLoading, error, selectedStory } = useStories('p1', 'e1')
+    expect(stories.value).toEqual([])
+    expect(isLoading.value).toBe(false)
+    expect(error.value).toBeNull()
+    expect(selectedStory.value).toBeNull()
+  })
+
+  it('fetches stories and updates reactive state', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockStories },
+      error: undefined,
+    })
+
+    const { stories, isLoading, fetchStories } = useStories('p1', 'e1')
+    await fetchStories()
+
+    expect(stories.value).toEqual(mockStories)
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('exposes error state on fetch failure', async () => {
+    mockGet.mockResolvedValue({
+      data: undefined,
+      error: { error: { code: 'INTERNAL', message: 'Server error' } },
+    })
+
+    const { error, fetchStories } = useStories('p1', 'e1')
+    await fetchStories()
+
+    expect(error.value).toBe('Failed to load stories')
+  })
+
+  it('retry re-fetches with the same project and epic IDs', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: [] },
+      error: undefined,
+    })
+
+    const { fetchStories, retry } = useStories('p1', 'e1')
+    await fetchStories()
+
+    expect(mockGet).toHaveBeenCalledTimes(1)
+
+    mockGet.mockClear()
+    await retry()
+
+    expect(mockGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('selectStory updates the selected story', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockStories },
+      error: undefined,
+    })
+
+    const { selectedStory, selectedStoryId, fetchStories, selectStory } = useStories('p1', 'e1')
+    await fetchStories()
+
+    selectStory('s2')
+    expect(selectedStoryId.value).toBe('s2')
+    expect(selectedStory.value).toEqual(mockStories[1])
+  })
+
+  it('setFilters updates the filter state', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockStories },
+      error: undefined,
+    })
+
+    const { stories, filters, fetchStories, setFilters } = useStories('p1', 'e1')
+    await fetchStories()
+
+    setFilters({ search: 'profile' })
+    expect(filters.value.search).toBe('profile')
+    expect(stories.value).toHaveLength(1)
+    expect(stories.value[0]!.id).toBe('s2')
+  })
+})

--- a/frontend/src/composables/useStories.ts
+++ b/frontend/src/composables/useStories.ts
@@ -1,0 +1,58 @@
+import { computed, onMounted, ref, watch } from 'vue'
+import { useStoriesStore, type StoryFilters } from '@/stores/stories'
+
+/**
+ * Composable for story list operations within an epic.
+ * Wraps the stories store with reactive computed properties, auto-fetch, and retry logic.
+ */
+export function useStories(projectId: string, epicId: string) {
+  const store = useStoriesStore()
+  const lastProjectId = ref(projectId)
+  const lastEpicId = ref(epicId)
+
+  /** Fetch stories for the given epic */
+  async function fetchStories() {
+    await store.fetchStoriesByEpic(lastProjectId.value, lastEpicId.value)
+  }
+
+  /** Re-execute the last fetch call */
+  async function retry() {
+    await store.fetchStoriesByEpic(lastProjectId.value, lastEpicId.value)
+  }
+
+  /** Update filters and trigger re-render via computed */
+  function setFilters(newFilters: Partial<StoryFilters>) {
+    store.setFilters(newFilters)
+  }
+
+  /** Select a story by ID */
+  function selectStory(storyId: string | null) {
+    store.setSelectedStory(storyId)
+  }
+
+  /** Watch for filter changes that require re-fetch (status) */
+  watch(
+    () => store.filters.status,
+    () => {
+      fetchStories()
+    },
+  )
+
+  onMounted(() => {
+    fetchStories()
+  })
+
+  return {
+    stories: computed(() => store.filteredStories),
+    allStories: computed(() => store.items),
+    selectedStory: computed(() => store.selectedStory),
+    selectedStoryId: computed(() => store.selectedStoryId),
+    filters: computed(() => store.filters),
+    isLoading: computed(() => store.isLoading),
+    error: computed(() => store.error),
+    fetchStories,
+    retry,
+    setFilters,
+    selectStory,
+  }
+}

--- a/frontend/src/features/board/EpicDetailLayout.vue
+++ b/frontend/src/features/board/EpicDetailLayout.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import type { Story, StoryFilters } from '@/stores/stories'
+import StoryListPanel from './StoryListPanel.vue'
+import StoryDetailPanel from './StoryDetailPanel.vue'
+
+defineProps<{
+  stories: Story[]
+  selectedStory: Story | null
+  selectedStoryId: string | null
+  filters: StoryFilters
+}>()
+
+const emit = defineEmits<{
+  select: [storyId: string]
+  'update:filters': [filters: StoryFilters]
+}>()
+</script>
+
+<template>
+  <div class="flex h-full gap-4">
+    <div class="w-[300px] shrink-0 overflow-y-auto">
+      <StoryListPanel
+        :stories="stories"
+        :selected-id="selectedStoryId"
+        :filters="filters"
+        @select="emit('select', $event)"
+        @update:filters="emit('update:filters', $event)"
+      />
+    </div>
+    <div
+      class="flex-1 overflow-y-auto"
+      style="border-left: 1px solid var(--p-surface-200)"
+    >
+      <StoryDetailPanel :story="selectedStory" />
+    </div>
+  </div>
+</template>

--- a/frontend/src/features/board/EpicDetailLayout.vue
+++ b/frontend/src/features/board/EpicDetailLayout.vue
@@ -27,10 +27,7 @@ const emit = defineEmits<{
         @update:filters="emit('update:filters', $event)"
       />
     </div>
-    <div
-      class="flex-1 overflow-y-auto"
-      style="border-left: 1px solid var(--p-surface-200)"
-    >
+    <div class="flex-1 overflow-y-auto border-l border-surface-200">
       <StoryDetailPanel :story="selectedStory" />
     </div>
   </div>

--- a/frontend/src/features/board/StoryDetailPanel.vue
+++ b/frontend/src/features/board/StoryDetailPanel.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import Badge from 'primevue/badge'
+import type { Story } from '@/stores/stories'
+
+defineProps<{
+  story: Story | null
+}>()
+
+const severityMap: Record<string, 'secondary' | 'info' | 'success' | 'danger'> = {
+  backlog: 'secondary',
+  running: 'info',
+  done: 'success',
+  failed: 'danger',
+}
+</script>
+
+<template>
+  <div class="h-full overflow-y-auto">
+    <div
+      v-if="!story"
+      class="flex items-center justify-center h-full"
+      style="color: var(--p-text-muted-color)"
+    >
+      <div class="flex flex-col items-center gap-3">
+        <i class="pi pi-book" style="font-size: 2.5rem" />
+        <p style="font-size: 1rem">Select a story to view details</p>
+      </div>
+    </div>
+
+    <div v-else class="flex flex-col gap-4 p-4">
+      <div class="flex items-center gap-3">
+        <span style="font-family: monospace; font-size: 1rem; color: var(--p-text-muted-color)">
+          {{ story.key }}
+        </span>
+        <Badge :value="story.status" :severity="severityMap[story.status] ?? 'secondary'" />
+      </div>
+
+      <h2 class="m-0" style="font-size: 1.25rem; font-weight: 600">{{ story.title }}</h2>
+
+      <div v-if="story.objective" class="flex flex-col gap-1">
+        <h3 class="m-0" style="font-size: 0.85rem; font-weight: 600; text-transform: uppercase; color: var(--p-text-muted-color)">
+          Objective
+        </h3>
+        <p class="m-0" style="white-space: pre-wrap">{{ story.objective }}</p>
+      </div>
+
+      <div v-if="story.acceptance_criteria" class="flex flex-col gap-1">
+        <h3 class="m-0" style="font-size: 0.85rem; font-weight: 600; text-transform: uppercase; color: var(--p-text-muted-color)">
+          Acceptance Criteria
+        </h3>
+        <p class="m-0" style="white-space: pre-wrap">{{ story.acceptance_criteria }}</p>
+      </div>
+
+      <div v-if="story.target_files && story.target_files.length > 0" class="flex flex-col gap-1">
+        <h3 class="m-0" style="font-size: 0.85rem; font-weight: 600; text-transform: uppercase; color: var(--p-text-muted-color)">
+          Target Files
+        </h3>
+        <ul class="m-0 pl-5">
+          <li v-for="file in story.target_files" :key="file" style="font-family: monospace; font-size: 0.85rem">
+            {{ file }}
+          </li>
+        </ul>
+      </div>
+
+      <div v-if="story.depends_on && story.depends_on.length > 0" class="flex flex-col gap-1">
+        <h3 class="m-0" style="font-size: 0.85rem; font-weight: 600; text-transform: uppercase; color: var(--p-text-muted-color)">
+          Dependencies
+        </h3>
+        <ul class="m-0 pl-5">
+          <li v-for="dep in story.depends_on" :key="dep" style="font-family: monospace; font-size: 0.85rem">
+            {{ dep }}
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/features/board/StoryFilterBar.vue
+++ b/frontend/src/features/board/StoryFilterBar.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import Select from 'primevue/select'
+import InputText from 'primevue/inputtext'
+import type { StoryFilters } from '@/stores/stories'
+
+const props = defineProps<{
+  modelValue: StoryFilters
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [filters: StoryFilters]
+}>()
+
+const statusOptions = [
+  { label: 'All statuses', value: 'all' },
+  { label: 'Backlog', value: 'backlog' },
+  { label: 'Running', value: 'running' },
+  { label: 'Done', value: 'done' },
+  { label: 'Failed', value: 'failed' },
+]
+
+const localSearch = ref(props.modelValue.search)
+let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+watch(localSearch, (newValue) => {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer)
+  }
+  debounceTimer = setTimeout(() => {
+    emit('update:modelValue', { ...props.modelValue, search: newValue })
+  }, 200)
+})
+
+watch(
+  () => props.modelValue.search,
+  (newValue) => {
+    if (newValue !== localSearch.value) {
+      localSearch.value = newValue
+    }
+  },
+)
+
+function handleStatusChange(value: string) {
+  emit('update:modelValue', { ...props.modelValue, status: value })
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-2">
+    <Select
+      :model-value="modelValue.status ?? 'all'"
+      :options="statusOptions"
+      option-label="label"
+      option-value="value"
+      placeholder="Filter by status"
+      class="w-full"
+      @update:model-value="handleStatusChange"
+    />
+    <div class="relative">
+      <i
+        class="pi pi-search absolute"
+        style="left: 0.75rem; top: 50%; transform: translateY(-50%); color: var(--p-text-muted-color)"
+      />
+      <InputText
+        v-model="localSearch"
+        placeholder="Search stories..."
+        class="w-full"
+        style="padding-left: 2.25rem"
+      />
+    </div>
+  </div>
+</template>

--- a/frontend/src/features/board/StoryListPanel.vue
+++ b/frontend/src/features/board/StoryListPanel.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import type { Story, StoryFilters } from '@/stores/stories'
+import StoryStatusCard from './StoryStatusCard.vue'
+import StoryFilterBar from './StoryFilterBar.vue'
+import { useKeyboard } from '@/composables/useKeyboard'
+
+const props = defineProps<{
+  stories: Story[]
+  selectedId: string | null
+  filters: StoryFilters
+}>()
+
+const emit = defineEmits<{
+  select: [storyId: string]
+  'update:filters': [filters: StoryFilters]
+}>()
+
+const selectedIndex = ref(0)
+
+/** Sync selection index when selectedId changes externally */
+watch(
+  () => props.selectedId,
+  (newId) => {
+    if (newId) {
+      const idx = props.stories.findIndex((s) => s.id === newId)
+      if (idx >= 0) {
+        selectedIndex.value = idx
+      }
+    }
+  },
+)
+
+/** Reset index when stories list changes */
+watch(
+  () => props.stories.length,
+  () => {
+    if (selectedIndex.value >= props.stories.length) {
+      selectedIndex.value = Math.max(0, props.stories.length - 1)
+    }
+  },
+)
+
+useKeyboard({
+  j: () => {
+    if (props.stories.length === 0) return
+    selectedIndex.value = Math.min(selectedIndex.value + 1, props.stories.length - 1)
+  },
+  k: () => {
+    if (props.stories.length === 0) return
+    selectedIndex.value = Math.max(selectedIndex.value - 1, 0)
+  },
+  Enter: () => {
+    if (props.stories.length === 0) return
+    const story = props.stories[selectedIndex.value]
+    if (story) {
+      emit('select', story.id)
+    }
+  },
+})
+
+function handleCardClick(storyId: string) {
+  const idx = props.stories.findIndex((s) => s.id === storyId)
+  if (idx >= 0) {
+    selectedIndex.value = idx
+  }
+  emit('select', storyId)
+}
+
+function handleFilterUpdate(newFilters: StoryFilters) {
+  emit('update:filters', newFilters)
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-3 h-full">
+    <StoryFilterBar :model-value="filters" @update:model-value="handleFilterUpdate" />
+    <div
+      class="flex flex-col gap-1 overflow-y-auto"
+      style="flex: 1; min-height: 0"
+      role="listbox"
+      aria-label="Story list"
+    >
+      <p
+        v-if="stories.length === 0"
+        class="p-4 text-center"
+        style="color: var(--p-text-muted-color)"
+      >
+        No stories match the current filters
+      </p>
+      <StoryStatusCard
+        v-for="(story, index) in stories"
+        :key="story.id"
+        :story="story"
+        :is-selected="story.id === selectedId || (selectedId === null && index === selectedIndex)"
+        @click="handleCardClick"
+      />
+    </div>
+  </div>
+</template>

--- a/frontend/src/features/board/StoryStatusCard.vue
+++ b/frontend/src/features/board/StoryStatusCard.vue
@@ -21,21 +21,14 @@ const severityMap: Record<string, 'secondary' | 'info' | 'success' | 'danger'> =
 
 <template>
   <div
-    class="flex flex-col gap-2 p-3 cursor-pointer"
+    class="story-card flex flex-col gap-2 p-3 cursor-pointer"
+    :class="isSelected ? 'story-card--selected' : 'story-card--default'"
     role="button"
     tabindex="0"
     :aria-label="`Story: ${story.key} - ${story.title}`"
     :aria-selected="isSelected"
-    :style="{
-      border: isSelected ? '2px solid var(--p-primary-color)' : '1px solid var(--p-surface-200)',
-      borderRadius: 'var(--p-border-radius)',
-      background: isSelected ? 'var(--p-primary-50)' : 'var(--p-surface-0)',
-      transition: 'border-color 0.2s, background-color 0.2s',
-    }"
     @click="emit('click', story.id)"
     @keydown.enter="emit('click', story.id)"
-    @mouseenter="!isSelected && (($event.currentTarget as HTMLElement).style.background = 'var(--p-surface-50)')"
-    @mouseleave="!isSelected && (($event.currentTarget as HTMLElement).style.background = 'var(--p-surface-0)')"
   >
     <div class="flex items-center justify-between gap-2">
       <span style="font-family: monospace; font-size: 0.8rem; color: var(--p-text-muted-color)">
@@ -57,3 +50,21 @@ const severityMap: Record<string, 'secondary' | 'info' | 'success' | 'danger'> =
     </span>
   </div>
 </template>
+
+<style scoped>
+.story-card {
+  border-radius: var(--p-border-radius);
+  transition: border-color 0.2s, background-color 0.2s;
+}
+.story-card--selected {
+  border: 2px solid var(--p-primary-color);
+  background: var(--p-primary-50);
+}
+.story-card--default {
+  border: 1px solid var(--p-surface-200);
+  background: var(--p-surface-0);
+}
+.story-card--default:hover {
+  background: var(--p-surface-50);
+}
+</style>

--- a/frontend/src/features/board/StoryStatusCard.vue
+++ b/frontend/src/features/board/StoryStatusCard.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import Badge from 'primevue/badge'
+import type { Story } from '@/stores/stories'
+
+defineProps<{
+  story: Story
+  isSelected: boolean
+}>()
+
+const emit = defineEmits<{
+  click: [storyId: string]
+}>()
+
+const severityMap: Record<string, 'secondary' | 'info' | 'success' | 'danger'> = {
+  backlog: 'secondary',
+  running: 'info',
+  done: 'success',
+  failed: 'danger',
+}
+</script>
+
+<template>
+  <div
+    class="flex flex-col gap-2 p-3 cursor-pointer"
+    role="button"
+    tabindex="0"
+    :aria-label="`Story: ${story.key} - ${story.title}`"
+    :aria-selected="isSelected"
+    :style="{
+      border: isSelected ? '2px solid var(--p-primary-color)' : '1px solid var(--p-surface-200)',
+      borderRadius: 'var(--p-border-radius)',
+      background: isSelected ? 'var(--p-primary-50)' : 'var(--p-surface-0)',
+      transition: 'border-color 0.2s, background-color 0.2s',
+    }"
+    @click="emit('click', story.id)"
+    @keydown.enter="emit('click', story.id)"
+    @mouseenter="!isSelected && (($event.currentTarget as HTMLElement).style.background = 'var(--p-surface-50)')"
+    @mouseleave="!isSelected && (($event.currentTarget as HTMLElement).style.background = 'var(--p-surface-0)')"
+  >
+    <div class="flex items-center justify-between gap-2">
+      <span style="font-family: monospace; font-size: 0.8rem; color: var(--p-text-muted-color)">
+        {{ story.key }}
+      </span>
+      <Badge :value="story.status" :severity="severityMap[story.status] ?? 'secondary'" />
+    </div>
+    <span
+      style="
+        font-size: 0.9rem;
+        font-weight: 500;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      "
+    >
+      {{ story.title }}
+    </span>
+  </div>
+</template>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -9,6 +9,7 @@ import ApprovalsView from '@/views/ApprovalsView.vue'
 import PipelineConfigView from '@/views/PipelineConfigView.vue'
 import PromptTemplatesView from '@/views/PromptTemplatesView.vue'
 import BoardView from '@/views/BoardView.vue'
+import EpicDetailView from '@/views/EpicDetailView.vue'
 import { setupAuthGuard, setupAdminGuard } from './guards'
 
 const router = createRouter({
@@ -47,7 +48,7 @@ const router = createRouter({
     {
       path: '/projects/:id/epics/:epicId',
       name: 'epic-detail',
-      component: () => import('@/views/ProjectDetailView.vue'),
+      component: EpicDetailView,
       meta: { requiresAuth: true },
     },
     {

--- a/frontend/src/stores/__tests__/stories.spec.ts
+++ b/frontend/src/stores/__tests__/stories.spec.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useStoriesStore } from '../stories'
+
+const mockGet = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+  },
+}))
+
+const mockStories = [
+  {
+    id: 's1',
+    epic_id: 'e1',
+    project_id: 'p1',
+    key: 'S-01',
+    title: 'Setup authentication',
+    status: 'done',
+    objective: 'Implement auth flow',
+    acceptance_criteria: 'Users can log in',
+    target_files: ['src/auth.ts'],
+    depends_on: [],
+    created_at: '2026-01-15T10:00:00Z',
+    updated_at: '2026-01-15T10:00:00Z',
+  },
+  {
+    id: 's2',
+    epic_id: 'e1',
+    project_id: 'p1',
+    key: 'S-02',
+    title: 'Add user profile page',
+    status: 'backlog',
+    created_at: '2026-01-16T10:00:00Z',
+    updated_at: '2026-01-16T10:00:00Z',
+  },
+  {
+    id: 's3',
+    epic_id: 'e1',
+    project_id: 'p1',
+    key: 'S-03',
+    title: 'Fix login bug',
+    status: 'failed',
+    created_at: '2026-01-17T10:00:00Z',
+    updated_at: '2026-01-17T10:00:00Z',
+  },
+]
+
+describe('useStoriesStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockGet.mockReset()
+  })
+
+  it('starts with default state', () => {
+    const store = useStoriesStore()
+    expect(store.items).toEqual([])
+    expect(store.selectedStoryId).toBeNull()
+    expect(store.filters).toEqual({ status: null, search: '' })
+    expect(store.isLoading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('fetches stories successfully and populates items', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockStories },
+      error: undefined,
+    })
+
+    const store = useStoriesStore()
+    await store.fetchStoriesByEpic('p1', 'e1')
+
+    expect(store.items).toEqual(mockStories)
+    expect(store.isLoading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('sets error state when API returns an error', async () => {
+    mockGet.mockResolvedValue({
+      data: undefined,
+      error: { error: { code: 'INTERNAL', message: 'Server error' } },
+    })
+
+    const store = useStoriesStore()
+    await store.fetchStoriesByEpic('p1', 'e1')
+
+    expect(store.items).toEqual([])
+    expect(store.error).toBe('Failed to load stories')
+    expect(store.isLoading).toBe(false)
+  })
+
+  it('sets error state when API call throws', async () => {
+    mockGet.mockRejectedValue(new Error('Network error'))
+
+    const store = useStoriesStore()
+    await store.fetchStoriesByEpic('p1', 'e1')
+
+    expect(store.items).toEqual([])
+    expect(store.error).toBe('Network error')
+    expect(store.isLoading).toBe(false)
+  })
+
+  it('sets fallback error message for non-Error thrown values', async () => {
+    mockGet.mockRejectedValue('unknown error')
+
+    const store = useStoriesStore()
+    await store.fetchStoriesByEpic('p1', 'e1')
+
+    expect(store.error).toBe('Failed to load stories')
+  })
+
+  it('clears previous error on new fetch', async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        data: undefined,
+        error: { error: { code: 'INTERNAL', message: 'fail' } },
+      })
+      .mockResolvedValueOnce({
+        data: { data: [] },
+        error: undefined,
+      })
+
+    const store = useStoriesStore()
+
+    await store.fetchStoriesByEpic('p1', 'e1')
+    expect(store.error).toBe('Failed to load stories')
+
+    await store.fetchStoriesByEpic('p1', 'e1')
+    expect(store.error).toBeNull()
+  })
+
+  it('clearError resets error state', async () => {
+    mockGet.mockResolvedValue({
+      data: undefined,
+      error: { error: { code: 'INTERNAL', message: 'fail' } },
+    })
+
+    const store = useStoriesStore()
+    await store.fetchStoriesByEpic('p1', 'e1')
+    expect(store.error).toBe('Failed to load stories')
+
+    store.clearError()
+    expect(store.error).toBeNull()
+  })
+
+  it('sets selected story', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockStories },
+      error: undefined,
+    })
+
+    const store = useStoriesStore()
+    await store.fetchStoriesByEpic('p1', 'e1')
+
+    store.setSelectedStory('s2')
+    expect(store.selectedStoryId).toBe('s2')
+    expect(store.selectedStory).toEqual(mockStories[1])
+  })
+
+  it('returns null for selectedStory when no story is selected', () => {
+    const store = useStoriesStore()
+    expect(store.selectedStory).toBeNull()
+  })
+
+  it('returns null for selectedStory when selected ID does not match', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockStories },
+      error: undefined,
+    })
+
+    const store = useStoriesStore()
+    await store.fetchStoriesByEpic('p1', 'e1')
+
+    store.setSelectedStory('nonexistent')
+    expect(store.selectedStory).toBeNull()
+  })
+
+  it('filters stories by status', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockStories },
+      error: undefined,
+    })
+
+    const store = useStoriesStore()
+    await store.fetchStoriesByEpic('p1', 'e1')
+
+    store.setFilters({ status: 'done' })
+    expect(store.filteredStories).toHaveLength(1)
+    expect(store.filteredStories[0]!.id).toBe('s1')
+  })
+
+  it('filters stories by text search on key and title', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockStories },
+      error: undefined,
+    })
+
+    const store = useStoriesStore()
+    await store.fetchStoriesByEpic('p1', 'e1')
+
+    store.setFilters({ search: 'login' })
+    expect(store.filteredStories).toHaveLength(1)
+    expect(store.filteredStories[0]!.id).toBe('s3')
+  })
+
+  it('filters stories by search on key', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockStories },
+      error: undefined,
+    })
+
+    const store = useStoriesStore()
+    await store.fetchStoriesByEpic('p1', 'e1')
+
+    store.setFilters({ search: 'S-01' })
+    expect(store.filteredStories).toHaveLength(1)
+    expect(store.filteredStories[0]!.id).toBe('s1')
+  })
+
+  it('returns all stories when status filter is "all"', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockStories },
+      error: undefined,
+    })
+
+    const store = useStoriesStore()
+    await store.fetchStoriesByEpic('p1', 'e1')
+
+    store.setFilters({ status: 'all' })
+    expect(store.filteredStories).toHaveLength(3)
+  })
+
+  it('combines status and text filters', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockStories },
+      error: undefined,
+    })
+
+    const store = useStoriesStore()
+    await store.fetchStoriesByEpic('p1', 'e1')
+
+    store.setFilters({ status: 'backlog', search: 'profile' })
+    expect(store.filteredStories).toHaveLength(1)
+    expect(store.filteredStories[0]!.id).toBe('s2')
+  })
+
+  it('resets all state', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockStories },
+      error: undefined,
+    })
+
+    const store = useStoriesStore()
+    await store.fetchStoriesByEpic('p1', 'e1')
+    store.setSelectedStory('s1')
+    store.setFilters({ status: 'done', search: 'test' })
+
+    expect(store.items).toHaveLength(3)
+
+    store.reset()
+
+    expect(store.items).toEqual([])
+    expect(store.selectedStoryId).toBeNull()
+    expect(store.filters).toEqual({ status: null, search: '' })
+    expect(store.error).toBeNull()
+    expect(store.isLoading).toBe(false)
+  })
+})

--- a/frontend/src/stores/stories.ts
+++ b/frontend/src/stores/stories.ts
@@ -4,7 +4,7 @@ import { apiClient } from '@/api/client'
 
 /**
  * Story entity type.
- * TODO(S-2-2): Replace with generated type from OpenAPI schema once Stories CRUD API lands.
+ * TODO(2-2): Replace with generated type from OpenAPI schema once Stories CRUD API lands.
  */
 export interface Story {
   id: string

--- a/frontend/src/stores/stories.ts
+++ b/frontend/src/stores/stories.ts
@@ -1,8 +1,130 @@
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
+import { apiClient } from '@/api/client'
 
+/**
+ * Story entity type.
+ * TODO(S-2-2): Replace with generated type from OpenAPI schema once Stories CRUD API lands.
+ */
+export interface Story {
+  id: string
+  epic_id: string
+  project_id: string
+  key: string
+  title: string
+  status: 'backlog' | 'running' | 'done' | 'failed'
+  objective?: string
+  acceptance_criteria?: string
+  target_files?: string[]
+  depends_on?: string[]
+  created_at: string
+  updated_at: string
+}
+
+/** Filter state for the story list */
+export interface StoryFilters {
+  status: string | null
+  search: string
+}
+
+/**
+ * Pinia store for story state management.
+ * Handles fetching, filtering, and selecting stories within an epic.
+ */
 export const useStoriesStore = defineStore('stories', () => {
-  const items = ref<Array<{ id: string; summary: string; status: string }>>([])
+  const items = ref<Story[]>([])
+  const selectedStoryId = ref<string | null>(null)
+  const filters = ref<StoryFilters>({ status: null, search: '' })
   const isLoading = ref(false)
-  return { items, isLoading }
+  const error = ref<string | null>(null)
+
+  /** Stories filtered by current filter state */
+  const filteredStories = computed(() => {
+    let result = items.value
+
+    if (filters.value.status && filters.value.status !== 'all') {
+      result = result.filter((s) => s.status === filters.value.status)
+    }
+
+    if (filters.value.search) {
+      const term = filters.value.search.toLowerCase()
+      result = result.filter(
+        (s) => s.key.toLowerCase().includes(term) || s.title.toLowerCase().includes(term),
+      )
+    }
+
+    return result
+  })
+
+  /** Currently selected story */
+  const selectedStory = computed(() =>
+    items.value.find((s) => s.id === selectedStoryId.value) ?? null,
+  )
+
+  /** Fetch stories for an epic from the API */
+  async function fetchStoriesByEpic(projectId: string, epicId: string) {
+    isLoading.value = true
+    error.value = null
+    try {
+      const { data, error: apiError } = await apiClient.GET(
+        '/projects/{projectId}/stories' as '/projects/{projectId}/epics',
+        {
+          params: {
+            path: { projectId },
+            query: { epic_id: epicId } as Record<string, string>,
+          },
+        } as Parameters<typeof apiClient.GET>[1],
+      )
+      if (apiError) {
+        error.value = 'Failed to load stories'
+        return
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const responseData = data as any
+      items.value = responseData?.data ?? []
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load stories'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  /** Set the currently selected story */
+  function setSelectedStory(storyId: string | null) {
+    selectedStoryId.value = storyId
+  }
+
+  /** Update filter state */
+  function setFilters(newFilters: Partial<StoryFilters>) {
+    filters.value = { ...filters.value, ...newFilters }
+  }
+
+  /** Clear current error state */
+  function clearError() {
+    error.value = null
+  }
+
+  /** Reset store state to initial values */
+  function reset() {
+    items.value = []
+    selectedStoryId.value = null
+    filters.value = { status: null, search: '' }
+    error.value = null
+    isLoading.value = false
+  }
+
+  return {
+    items,
+    selectedStoryId,
+    filters,
+    isLoading,
+    error,
+    filteredStories,
+    selectedStory,
+    fetchStoriesByEpic,
+    setSelectedStory,
+    setFilters,
+    clearError,
+    reset,
+  }
 })

--- a/frontend/src/views/EpicDetailView.vue
+++ b/frontend/src/views/EpicDetailView.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-import { watch } from 'vue'
+import { ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import Button from 'primevue/button'
 import Message from 'primevue/message'
 import Skeleton from 'primevue/skeleton'
 import EpicDetailLayout from '@/features/board/EpicDetailLayout.vue'
 import { useStories } from '@/composables/useStories'
-import type { StoryFilters } from '@/stores/stories'
 
 const route = useRoute()
 const router = useRouter()
@@ -33,10 +32,15 @@ if (initialStatus || initialSearch) {
   setFilters({ status: initialStatus, search: initialSearch })
 }
 
-/** Sync filters to URL query params */
+/** Sync filters to URL query params — skip the initial render to avoid redundant replace */
+const filtersInitialized = ref(false)
 watch(
   filters,
   (newFilters) => {
+    if (!filtersInitialized.value) {
+      filtersInitialized.value = true
+      return
+    }
     router.replace({
       query: {
         ...route.query,
@@ -48,13 +52,6 @@ watch(
   { deep: true },
 )
 
-function handleSelect(storyId: string) {
-  selectStory(storyId)
-}
-
-function handleFilterUpdate(newFilters: StoryFilters) {
-  setFilters(newFilters)
-}
 </script>
 
 <template>
@@ -105,8 +102,8 @@ function handleFilterUpdate(newFilters: StoryFilters) {
       :selected-story="selectedStory"
       :selected-story-id="selectedStoryId"
       :filters="filters"
-      @select="handleSelect"
-      @update:filters="handleFilterUpdate"
+      @select="selectStory"
+      @update:filters="setFilters"
     />
   </div>
 </template>

--- a/frontend/src/views/EpicDetailView.vue
+++ b/frontend/src/views/EpicDetailView.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import { watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import Skeleton from 'primevue/skeleton'
+import EpicDetailLayout from '@/features/board/EpicDetailLayout.vue'
+import { useStories } from '@/composables/useStories'
+import type { StoryFilters } from '@/stores/stories'
+
+const route = useRoute()
+const router = useRouter()
+
+const projectId = route.params.id as string
+const epicId = route.params.epicId as string
+
+const {
+  stories,
+  selectedStory,
+  selectedStoryId,
+  filters,
+  isLoading,
+  error,
+  retry,
+  setFilters,
+  selectStory,
+} = useStories(projectId, epicId)
+
+/** Initialize filters from URL query params */
+const initialStatus = (route.query.status as string) || null
+const initialSearch = (route.query.search as string) || ''
+if (initialStatus || initialSearch) {
+  setFilters({ status: initialStatus, search: initialSearch })
+}
+
+/** Sync filters to URL query params */
+watch(
+  filters,
+  (newFilters) => {
+    router.replace({
+      query: {
+        ...route.query,
+        status: newFilters.status && newFilters.status !== 'all' ? newFilters.status : undefined,
+        search: newFilters.search || undefined,
+      },
+    })
+  },
+  { deep: true },
+)
+
+function handleSelect(storyId: string) {
+  selectStory(storyId)
+}
+
+function handleFilterUpdate(newFilters: StoryFilters) {
+  setFilters(newFilters)
+}
+</script>
+
+<template>
+  <div class="flex flex-col h-full p-6">
+    <div class="flex items-center gap-3 mb-4">
+      <Button
+        icon="pi pi-arrow-left"
+        severity="secondary"
+        text
+        rounded
+        aria-label="Back to board"
+        @click="router.push({ name: 'project-board', params: { id: projectId } })"
+      />
+      <h1 class="m-0 text-2xl font-bold">Epic Stories</h1>
+    </div>
+
+    <div v-if="isLoading && stories.length === 0" class="flex gap-4 flex-1">
+      <div class="w-[300px] shrink-0 flex flex-col gap-3">
+        <Skeleton width="100%" height="2.5rem" />
+        <Skeleton width="100%" height="2.5rem" />
+        <div v-for="n in 5" :key="n" class="flex flex-col gap-2 p-3">
+          <div class="flex justify-between">
+            <Skeleton width="4rem" height="1rem" />
+            <Skeleton width="3rem" height="1.25rem" />
+          </div>
+          <Skeleton width="80%" height="1rem" />
+        </div>
+      </div>
+      <div class="flex-1 flex flex-col gap-3 p-4">
+        <Skeleton width="6rem" height="1rem" />
+        <Skeleton width="60%" height="1.5rem" />
+        <Skeleton width="100%" height="3rem" />
+        <Skeleton width="100%" height="3rem" />
+      </div>
+    </div>
+
+    <Message v-else-if="error" severity="error" :closable="false">
+      <div class="flex items-center gap-3">
+        <span>{{ error }}</span>
+        <Button label="Retry" severity="secondary" text size="small" @click="retry()" />
+      </div>
+    </Message>
+
+    <EpicDetailLayout
+      v-else
+      class="flex-1 min-h-0"
+      :stories="stories"
+      :selected-story="selectedStory"
+      :selected-story-id="selectedStoryId"
+      :filters="filters"
+      @select="handleSelect"
+      @update:filters="handleFilterUpdate"
+    />
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- Add epic detail page (`/projects/:id/epics/:epicId`) with split layout: 300px story list panel (left) + flexible detail panel (right)
- Implement StoryStatusCard, StoryFilterBar, StoryListPanel, StoryDetailPanel, EpicDetailLayout, and EpicDetailView components
- Add stories Pinia store with filtering (status + text search), selection, and API fetch logic
- Add useStories composable with auto-fetch, retry, and filter URL sync
- Support keyboard navigation (J/K to move, Enter to select) and click selection
- Include loading skeleton, error state with retry button, and empty state

## Test plan
- [x] 22 unit tests pass (16 store tests + 6 composable tests)
- [x] ESLint passes with no errors
- [x] No new type-check errors introduced (pre-existing schema errors remain)
- [ ] E2E tests cover: story list display, status filter, text search, keyboard nav, click selection, error/retry, loading skeleton
- [ ] Manual verification of split layout rendering and responsive behavior

Refs: S-2-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)