### PR TITLE
feat(git): add PR operations to GitProvider (create, merge, CI status)

### DIFF
--- a/backend/internal/adapter/git/gh_cli_adapter.go
+++ b/backend/internal/adapter/git/gh_cli_adapter.go
@@ -2,9 +2,11 @@ package git
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"regexp"
+	"strings"
 
 	"github.com/zakari/hopeitworks/backend/internal/domain/port"
 	"github.com/zakari/hopeitworks/backend/pkg/errors"
@@ -110,4 +112,141 @@ func (a *GhCliAdapter) Push(ctx context.Context, workDir string, commitMsg strin
 	}
 
 	return nil
+}
+
+// CreatePR creates a pull request using gh CLI and returns the PR URL.
+func (a *GhCliAdapter) CreatePR(ctx context.Context, workDir string, title string, body string, baseBranch string) (string, error) {
+	a.logger.DebugContext(ctx, "creating pull request",
+		"work_dir", workDir,
+		"title", title,
+		"base_branch", baseBranch,
+	)
+
+	stdout, err := a.runner.Run(ctx, workDir, "gh", "pr", "create", "--title", title, "--body", body, "--base", baseBranch)
+	if err != nil {
+		if strings.Contains(stdout, "authentication") || strings.Contains(stdout, "login required") {
+			return "", errors.NewDomainError(
+				errors.ErrCodeGitAuthFailed,
+				fmt.Sprintf("GitHub authentication failed: %v", err),
+				map[string]any{"work_dir": workDir, "output": stdout},
+			)
+		}
+
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to create PR: %v", err),
+			map[string]any{"work_dir": workDir, "title": title, "base_branch": baseBranch, "output": stdout},
+		)
+	}
+
+	// Parse PR URL from stdout (gh pr create returns URL on last line)
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	prURL := strings.TrimSpace(lines[len(lines)-1])
+
+	if !strings.HasPrefix(prURL, "http") {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			"failed to parse PR URL from gh CLI output",
+			map[string]any{"output": stdout},
+		)
+	}
+
+	return prURL, nil
+}
+
+// MergePR squash-merges a pull request and deletes the source branch using gh CLI.
+func (a *GhCliAdapter) MergePR(ctx context.Context, workDir string, prIdentifier string) error {
+	a.logger.DebugContext(ctx, "merging pull request",
+		"work_dir", workDir,
+		"pr_identifier", prIdentifier,
+	)
+
+	stdout, err := a.runner.Run(ctx, workDir, "gh", "pr", "merge", prIdentifier, "--squash", "--delete-branch")
+	if err != nil {
+		if strings.Contains(stdout, "merge conflict") || strings.Contains(stdout, "conflicts") {
+			return errors.NewDomainError(
+				errors.ErrCodeMergeConflict,
+				fmt.Sprintf("merge conflict detected for PR %s: %v", prIdentifier, err),
+				map[string]any{"pr_identifier": prIdentifier, "work_dir": workDir, "output": stdout},
+			)
+		}
+
+		if strings.Contains(stdout, "no pull requests found") || strings.Contains(stdout, "not found") {
+			return errors.NewDomainError(
+				errors.ErrCodePRNotFound,
+				fmt.Sprintf("pull request not found: %s", prIdentifier),
+				map[string]any{"pr_identifier": prIdentifier, "work_dir": workDir, "output": stdout},
+			)
+		}
+
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to merge PR %s: %v", prIdentifier, err),
+			map[string]any{"pr_identifier": prIdentifier, "work_dir": workDir, "output": stdout},
+		)
+	}
+
+	return nil
+}
+
+// prCheck represents a single CI check result from gh pr checks --json output.
+type prCheck struct {
+	Name       string `json:"name"`
+	State      string `json:"state"`
+	Conclusion string `json:"conclusion"`
+}
+
+// GetCIStatus returns the CI check status for the current branch's PR using gh CLI.
+func (a *GhCliAdapter) GetCIStatus(ctx context.Context, workDir string) (string, error) {
+	a.logger.DebugContext(ctx, "getting CI status",
+		"work_dir", workDir,
+	)
+
+	stdout, err := a.runner.Run(ctx, workDir, "gh", "pr", "checks", "--json", "name,state,conclusion")
+	if err != nil {
+		if strings.Contains(stdout, "no pull request") {
+			return "", errors.NewDomainError(
+				errors.ErrCodePRNotFound,
+				"no pull request found for current branch",
+				map[string]any{"work_dir": workDir, "output": stdout},
+			)
+		}
+
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to get CI status: %v", err),
+			map[string]any{"work_dir": workDir, "output": stdout},
+		)
+	}
+
+	var checks []prCheck
+	if err := json.Unmarshal([]byte(stdout), &checks); err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to parse CI check JSON: %v", err),
+			map[string]any{"output": stdout},
+		)
+	}
+
+	if len(checks) == 0 {
+		return "no_checks", nil
+	}
+
+	hasPending := false
+	for _, check := range checks {
+		if check.State == "pending" || check.State == "queued" || check.State == "in_progress" {
+			hasPending = true
+			continue
+		}
+
+		if check.Conclusion == "failure" || check.Conclusion == "timed_out" || check.Conclusion == "action_required" {
+			return "fail", nil
+		}
+	}
+
+	if hasPending {
+		return "pending", nil
+	}
+
+	return "pass", nil
 }

--- a/backend/internal/adapter/git/gh_cli_adapter.go
+++ b/backend/internal/adapter/git/gh_cli_adapter.go
@@ -12,6 +12,12 @@ import (
 	"github.com/zakari/hopeitworks/backend/pkg/errors"
 )
 
+// CI check state and conclusion constants used when interpreting gh pr checks output.
+const (
+	ciStatusPending = "pending"
+	ciStatusFail    = "fail"
+)
+
 // branchNamePattern validates conventional branch naming: feat/{key}-{slug} or fix/{key}-{slug}.
 var branchNamePattern = regexp.MustCompile(`^(feat|fix)/[a-zA-Z0-9]+-[a-zA-Z0-9-]+$`)
 
@@ -234,18 +240,18 @@ func (a *GhCliAdapter) GetCIStatus(ctx context.Context, workDir string) (string,
 
 	hasPending := false
 	for _, check := range checks {
-		if check.State == "pending" || check.State == "queued" || check.State == "in_progress" {
+		if check.State == ciStatusPending || check.State == "queued" || check.State == "in_progress" {
 			hasPending = true
 			continue
 		}
 
 		if check.Conclusion == "failure" || check.Conclusion == "timed_out" || check.Conclusion == "action_required" {
-			return "fail", nil
+			return ciStatusFail, nil
 		}
 	}
 
 	if hasPending {
-		return "pending", nil
+		return ciStatusPending, nil
 	}
 
 	return "pass", nil

--- a/backend/internal/adapter/git/gh_cli_adapter_test.go
+++ b/backend/internal/adapter/git/gh_cli_adapter_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/zakari/hopeitworks/backend/pkg/errors"
 )
 
-const gitCommand = "git"
+const (
+	gitCommand  = "git"
+	testWorkDir = "/work"
+)
 
 // commandInvocation records a single command call.
 type commandInvocation struct {
@@ -112,7 +115,7 @@ func TestCreateBranch_ValidNames(t *testing.T) {
 			runner := newMockCommandRunner(mockResult{stdout: ""})
 			adapter := NewGhCliAdapter(runner, testLogger())
 
-			err := adapter.CreateBranch(context.Background(), "/work", tt.branchName)
+			err := adapter.CreateBranch(context.Background(), testWorkDir, tt.branchName)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -122,8 +125,8 @@ func TestCreateBranch_ValidNames(t *testing.T) {
 			}
 
 			inv := runner.invocations[0]
-			if inv.WorkDir != "/work" {
-				t.Errorf("expected workDir '/work', got %q", inv.WorkDir)
+			if inv.WorkDir != testWorkDir {
+				t.Errorf("expected workDir %q, got %q", testWorkDir, inv.WorkDir)
 			}
 			if inv.Name != gitCommand {
 				t.Errorf("expected command %q, got %q", gitCommand, inv.Name)
@@ -152,7 +155,7 @@ func TestCreateBranch_InvalidNames(t *testing.T) {
 			runner := newMockCommandRunner()
 			adapter := NewGhCliAdapter(runner, testLogger())
 
-			err := adapter.CreateBranch(context.Background(), "/work", tt.branchName)
+			err := adapter.CreateBranch(context.Background(), testWorkDir, tt.branchName)
 			if err == nil {
 				t.Fatal("expected error for invalid branch name, got nil")
 			}
@@ -176,7 +179,7 @@ func TestCreateBranch_GitError(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{err: fmt.Errorf("branch already exists")})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	err := adapter.CreateBranch(context.Background(), "/work", "feat/1-2-slug")
+	err := adapter.CreateBranch(context.Background(), testWorkDir, "feat/1-2-slug")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -198,7 +201,7 @@ func TestPush_Success(t *testing.T) {
 	)
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	err := adapter.Push(context.Background(), "/work", "feat(git): add clone support")
+	err := adapter.Push(context.Background(), testWorkDir, "feat(git): add clone support")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -213,8 +216,8 @@ func TestPush_Success(t *testing.T) {
 		t.Errorf("invocation 0: expected %q, got %q", gitCommand, inv0.Name)
 	}
 	assertArgs(t, inv0.Args, []string{"add", "."})
-	if inv0.WorkDir != "/work" {
-		t.Errorf("invocation 0: expected workDir '/work', got %q", inv0.WorkDir)
+	if inv0.WorkDir != testWorkDir {
+		t.Errorf("invocation 0: expected workDir %q, got %q", testWorkDir, inv0.WorkDir)
 	}
 
 	// Verify git commit -m
@@ -236,7 +239,7 @@ func TestPush_AddError(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{err: fmt.Errorf("add failed")})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	err := adapter.Push(context.Background(), "/work", "feat(git): test")
+	err := adapter.Push(context.Background(), testWorkDir, "feat(git): test")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -262,7 +265,7 @@ func TestPush_CommitError(t *testing.T) {
 	)
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	err := adapter.Push(context.Background(), "/work", "feat(git): test")
+	err := adapter.Push(context.Background(), testWorkDir, "feat(git): test")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -289,7 +292,7 @@ func TestPush_PushError(t *testing.T) {
 	)
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	err := adapter.Push(context.Background(), "/work", "feat(git): test")
+	err := adapter.Push(context.Background(), testWorkDir, "feat(git): test")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -328,7 +331,7 @@ func TestCreatePR_Success(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{stdout: prURL + "\n"})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	url, err := adapter.CreatePR(context.Background(), "/work", "feat(api): add endpoint", "PR body here", "develop")
+	url, err := adapter.CreatePR(context.Background(), testWorkDir, "feat(api): add endpoint", "PR body here", "develop")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -341,8 +344,8 @@ func TestCreatePR_Success(t *testing.T) {
 	}
 
 	inv := runner.invocations[0]
-	if inv.WorkDir != "/work" {
-		t.Errorf("expected workDir '/work', got %q", inv.WorkDir)
+	if inv.WorkDir != testWorkDir {
+		t.Errorf("expected workDir %q, got %q", testWorkDir, inv.WorkDir)
 	}
 	if inv.Name != "gh" {
 		t.Errorf("expected command 'gh', got %q", inv.Name)
@@ -356,7 +359,7 @@ func TestCreatePR_MultiLineOutput(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{stdout: output})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	url, err := adapter.CreatePR(context.Background(), "/work", "title", "body", "main")
+	url, err := adapter.CreatePR(context.Background(), testWorkDir, "title", "body", "main")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -372,7 +375,7 @@ func TestCreatePR_AuthFailure(t *testing.T) {
 	})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	_, err := adapter.CreatePR(context.Background(), "/work", "title", "body", "main")
+	_, err := adapter.CreatePR(context.Background(), testWorkDir, "title", "body", "main")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -393,7 +396,7 @@ func TestCreatePR_LoginRequired(t *testing.T) {
 	})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	_, err := adapter.CreatePR(context.Background(), "/work", "title", "body", "main")
+	_, err := adapter.CreatePR(context.Background(), testWorkDir, "title", "body", "main")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -414,7 +417,7 @@ func TestCreatePR_GenericError(t *testing.T) {
 	})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	_, err := adapter.CreatePR(context.Background(), "/work", "title", "body", "main")
+	_, err := adapter.CreatePR(context.Background(), testWorkDir, "title", "body", "main")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -432,7 +435,7 @@ func TestCreatePR_InvalidURLOutput(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{stdout: "not a URL at all\n"})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	_, err := adapter.CreatePR(context.Background(), "/work", "title", "body", "main")
+	_, err := adapter.CreatePR(context.Background(), testWorkDir, "title", "body", "main")
 	if err == nil {
 		t.Fatal("expected error for invalid URL output, got nil")
 	}
@@ -452,7 +455,7 @@ func TestMergePR_Success(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{stdout: "Merged pull request #42\n"})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	err := adapter.MergePR(context.Background(), "/work", "42")
+	err := adapter.MergePR(context.Background(), testWorkDir, "42")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -462,8 +465,8 @@ func TestMergePR_Success(t *testing.T) {
 	}
 
 	inv := runner.invocations[0]
-	if inv.WorkDir != "/work" {
-		t.Errorf("expected workDir '/work', got %q", inv.WorkDir)
+	if inv.WorkDir != testWorkDir {
+		t.Errorf("expected workDir %q, got %q", testWorkDir, inv.WorkDir)
 	}
 	if inv.Name != "gh" {
 		t.Errorf("expected command 'gh', got %q", inv.Name)
@@ -476,7 +479,7 @@ func TestMergePR_WithURL(t *testing.T) {
 	adapter := NewGhCliAdapter(runner, testLogger())
 
 	prURL := "https://github.com/owner/repo/pull/42"
-	err := adapter.MergePR(context.Background(), "/work", prURL)
+	err := adapter.MergePR(context.Background(), testWorkDir, prURL)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -492,7 +495,7 @@ func TestMergePR_MergeConflict(t *testing.T) {
 	})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	err := adapter.MergePR(context.Background(), "/work", "42")
+	err := adapter.MergePR(context.Background(), testWorkDir, "42")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -513,7 +516,7 @@ func TestMergePR_Conflicts(t *testing.T) {
 	})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	err := adapter.MergePR(context.Background(), "/work", "42")
+	err := adapter.MergePR(context.Background(), testWorkDir, "42")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -534,7 +537,7 @@ func TestMergePR_PRNotFound(t *testing.T) {
 	})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	err := adapter.MergePR(context.Background(), "/work", "999")
+	err := adapter.MergePR(context.Background(), testWorkDir, "999")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -555,7 +558,7 @@ func TestMergePR_NotFoundMessage(t *testing.T) {
 	})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	err := adapter.MergePR(context.Background(), "/work", "999")
+	err := adapter.MergePR(context.Background(), testWorkDir, "999")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -576,7 +579,7 @@ func TestMergePR_GenericError(t *testing.T) {
 	})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	err := adapter.MergePR(context.Background(), "/work", "42")
+	err := adapter.MergePR(context.Background(), testWorkDir, "42")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -597,7 +600,7 @@ func TestGetCIStatus_AllPass(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	status, err := adapter.GetCIStatus(context.Background(), testWorkDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -617,12 +620,12 @@ func TestGetCIStatus_Fail(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	status, err := adapter.GetCIStatus(context.Background(), testWorkDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if status != "fail" {
-		t.Errorf("expected status 'fail', got %q", status)
+	if status != ciStatusFail {
+		t.Errorf("expected status %q, got %q", ciStatusFail, status)
 	}
 }
 
@@ -631,12 +634,12 @@ func TestGetCIStatus_TimedOut(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	status, err := adapter.GetCIStatus(context.Background(), testWorkDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if status != "fail" {
-		t.Errorf("expected status 'fail', got %q", status)
+	if status != ciStatusFail {
+		t.Errorf("expected status %q, got %q", ciStatusFail, status)
 	}
 }
 
@@ -645,12 +648,12 @@ func TestGetCIStatus_ActionRequired(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	status, err := adapter.GetCIStatus(context.Background(), testWorkDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if status != "fail" {
-		t.Errorf("expected status 'fail', got %q", status)
+	if status != ciStatusFail {
+		t.Errorf("expected status %q, got %q", ciStatusFail, status)
 	}
 }
 
@@ -659,12 +662,12 @@ func TestGetCIStatus_Pending(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	status, err := adapter.GetCIStatus(context.Background(), testWorkDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if status != "pending" {
-		t.Errorf("expected status 'pending', got %q", status)
+	if status != ciStatusPending {
+		t.Errorf("expected status %q, got %q", ciStatusPending, status)
 	}
 }
 
@@ -673,12 +676,12 @@ func TestGetCIStatus_Queued(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	status, err := adapter.GetCIStatus(context.Background(), testWorkDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if status != "pending" {
-		t.Errorf("expected status 'pending', got %q", status)
+	if status != ciStatusPending {
+		t.Errorf("expected status %q, got %q", ciStatusPending, status)
 	}
 }
 
@@ -687,12 +690,12 @@ func TestGetCIStatus_InProgress(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	status, err := adapter.GetCIStatus(context.Background(), testWorkDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if status != "pending" {
-		t.Errorf("expected status 'pending', got %q", status)
+	if status != ciStatusPending {
+		t.Errorf("expected status %q, got %q", ciStatusPending, status)
 	}
 }
 
@@ -700,7 +703,7 @@ func TestGetCIStatus_NoChecks(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{stdout: "[]"})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	status, err := adapter.GetCIStatus(context.Background(), testWorkDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -716,7 +719,7 @@ func TestGetCIStatus_PRNotFound(t *testing.T) {
 	})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	_, err := adapter.GetCIStatus(context.Background(), "/work")
+	_, err := adapter.GetCIStatus(context.Background(), testWorkDir)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -737,7 +740,7 @@ func TestGetCIStatus_GenericError(t *testing.T) {
 	})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	_, err := adapter.GetCIStatus(context.Background(), "/work")
+	_, err := adapter.GetCIStatus(context.Background(), testWorkDir)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -755,7 +758,7 @@ func TestGetCIStatus_InvalidJSON(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{stdout: "not json at all"})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	_, err := adapter.GetCIStatus(context.Background(), "/work")
+	_, err := adapter.GetCIStatus(context.Background(), testWorkDir)
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
 	}
@@ -775,12 +778,12 @@ func TestGetCIStatus_FailBeforePending(t *testing.T) {
 	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
 	adapter := NewGhCliAdapter(runner, testLogger())
 
-	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	status, err := adapter.GetCIStatus(context.Background(), testWorkDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if status != "fail" {
-		t.Errorf("expected status 'fail', got %q", status)
+	if status != ciStatusFail {
+		t.Errorf("expected status %q, got %q", ciStatusFail, status)
 	}
 }
 

--- a/backend/internal/adapter/git/gh_cli_adapter_test.go
+++ b/backend/internal/adapter/git/gh_cli_adapter_test.go
@@ -321,6 +321,469 @@ func TestCloneRepo_FullURL(t *testing.T) {
 	assertArgs(t, inv.Args, []string{"repo", "clone", "https://github.com/owner/repo.git", "/tmp/target"})
 }
 
+// --- CreatePR Tests ---
+
+func TestCreatePR_Success(t *testing.T) {
+	prURL := "https://github.com/owner/repo/pull/42"
+	runner := newMockCommandRunner(mockResult{stdout: prURL + "\n"})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	url, err := adapter.CreatePR(context.Background(), "/work", "feat(api): add endpoint", "PR body here", "develop")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if url != prURL {
+		t.Errorf("expected PR URL %q, got %q", prURL, url)
+	}
+
+	if len(runner.invocations) != 1 {
+		t.Fatalf("expected 1 invocation, got %d", len(runner.invocations))
+	}
+
+	inv := runner.invocations[0]
+	if inv.WorkDir != "/work" {
+		t.Errorf("expected workDir '/work', got %q", inv.WorkDir)
+	}
+	if inv.Name != "gh" {
+		t.Errorf("expected command 'gh', got %q", inv.Name)
+	}
+	assertArgs(t, inv.Args, []string{"pr", "create", "--title", "feat(api): add endpoint", "--body", "PR body here", "--base", "develop"})
+}
+
+func TestCreatePR_MultiLineOutput(t *testing.T) {
+	// gh pr create sometimes outputs progress info before the URL
+	output := "Creating pull request for feat/1-2-feature into develop in owner/repo\n\nhttps://github.com/owner/repo/pull/99\n"
+	runner := newMockCommandRunner(mockResult{stdout: output})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	url, err := adapter.CreatePR(context.Background(), "/work", "title", "body", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if url != "https://github.com/owner/repo/pull/99" {
+		t.Errorf("expected parsed PR URL, got %q", url)
+	}
+}
+
+func TestCreatePR_AuthFailure(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{
+		stdout: "authentication required\nPlease run gh auth login",
+		err:    fmt.Errorf("exit status 1"),
+	})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	_, err := adapter.CreatePR(context.Background(), "/work", "title", "body", "main")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodeGitAuthFailed {
+		t.Errorf("expected code %q, got %q", errors.ErrCodeGitAuthFailed, domainErr.Code)
+	}
+}
+
+func TestCreatePR_LoginRequired(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{
+		stdout: "login required to access this resource",
+		err:    fmt.Errorf("exit status 1"),
+	})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	_, err := adapter.CreatePR(context.Background(), "/work", "title", "body", "main")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodeGitAuthFailed {
+		t.Errorf("expected code %q, got %q", errors.ErrCodeGitAuthFailed, domainErr.Code)
+	}
+}
+
+func TestCreatePR_GenericError(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{
+		stdout: "some unexpected error",
+		err:    fmt.Errorf("exit status 1"),
+	})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	_, err := adapter.CreatePR(context.Background(), "/work", "title", "body", "main")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodeGitOperationFailed {
+		t.Errorf("expected code %q, got %q", errors.ErrCodeGitOperationFailed, domainErr.Code)
+	}
+}
+
+func TestCreatePR_InvalidURLOutput(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{stdout: "not a URL at all\n"})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	_, err := adapter.CreatePR(context.Background(), "/work", "title", "body", "main")
+	if err == nil {
+		t.Fatal("expected error for invalid URL output, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodeGitOperationFailed {
+		t.Errorf("expected code %q, got %q", errors.ErrCodeGitOperationFailed, domainErr.Code)
+	}
+}
+
+// --- MergePR Tests ---
+
+func TestMergePR_Success(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{stdout: "Merged pull request #42\n"})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	err := adapter.MergePR(context.Background(), "/work", "42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(runner.invocations) != 1 {
+		t.Fatalf("expected 1 invocation, got %d", len(runner.invocations))
+	}
+
+	inv := runner.invocations[0]
+	if inv.WorkDir != "/work" {
+		t.Errorf("expected workDir '/work', got %q", inv.WorkDir)
+	}
+	if inv.Name != "gh" {
+		t.Errorf("expected command 'gh', got %q", inv.Name)
+	}
+	assertArgs(t, inv.Args, []string{"pr", "merge", "42", "--squash", "--delete-branch"})
+}
+
+func TestMergePR_WithURL(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{stdout: "Merged\n"})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	prURL := "https://github.com/owner/repo/pull/42"
+	err := adapter.MergePR(context.Background(), "/work", prURL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	inv := runner.invocations[0]
+	assertArgs(t, inv.Args, []string{"pr", "merge", prURL, "--squash", "--delete-branch"})
+}
+
+func TestMergePR_MergeConflict(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{
+		stdout: "merge conflict detected in main.go",
+		err:    fmt.Errorf("exit status 1"),
+	})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	err := adapter.MergePR(context.Background(), "/work", "42")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodeMergeConflict {
+		t.Errorf("expected code %q, got %q", errors.ErrCodeMergeConflict, domainErr.Code)
+	}
+}
+
+func TestMergePR_Conflicts(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{
+		stdout: "there are conflicts that need to be resolved",
+		err:    fmt.Errorf("exit status 1"),
+	})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	err := adapter.MergePR(context.Background(), "/work", "42")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodeMergeConflict {
+		t.Errorf("expected code %q, got %q", errors.ErrCodeMergeConflict, domainErr.Code)
+	}
+}
+
+func TestMergePR_PRNotFound(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{
+		stdout: "no pull requests found for branch feat/test",
+		err:    fmt.Errorf("exit status 1"),
+	})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	err := adapter.MergePR(context.Background(), "/work", "999")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodePRNotFound {
+		t.Errorf("expected code %q, got %q", errors.ErrCodePRNotFound, domainErr.Code)
+	}
+}
+
+func TestMergePR_NotFoundMessage(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{
+		stdout: "pull request not found",
+		err:    fmt.Errorf("exit status 1"),
+	})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	err := adapter.MergePR(context.Background(), "/work", "999")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodePRNotFound {
+		t.Errorf("expected code %q, got %q", errors.ErrCodePRNotFound, domainErr.Code)
+	}
+}
+
+func TestMergePR_GenericError(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{
+		stdout: "unexpected error occurred",
+		err:    fmt.Errorf("exit status 1"),
+	})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	err := adapter.MergePR(context.Background(), "/work", "42")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodeGitOperationFailed {
+		t.Errorf("expected code %q, got %q", errors.ErrCodeGitOperationFailed, domainErr.Code)
+	}
+}
+
+// --- GetCIStatus Tests ---
+
+func TestGetCIStatus_AllPass(t *testing.T) {
+	checksJSON := `[{"name":"CI","state":"completed","conclusion":"success"},{"name":"Lint","state":"completed","conclusion":"success"}]`
+	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "pass" {
+		t.Errorf("expected status 'pass', got %q", status)
+	}
+
+	inv := runner.invocations[0]
+	if inv.Name != "gh" {
+		t.Errorf("expected command 'gh', got %q", inv.Name)
+	}
+	assertArgs(t, inv.Args, []string{"pr", "checks", "--json", "name,state,conclusion"})
+}
+
+func TestGetCIStatus_Fail(t *testing.T) {
+	checksJSON := `[{"name":"CI","state":"completed","conclusion":"success"},{"name":"Lint","state":"completed","conclusion":"failure"}]`
+	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "fail" {
+		t.Errorf("expected status 'fail', got %q", status)
+	}
+}
+
+func TestGetCIStatus_TimedOut(t *testing.T) {
+	checksJSON := `[{"name":"CI","state":"completed","conclusion":"timed_out"}]`
+	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "fail" {
+		t.Errorf("expected status 'fail', got %q", status)
+	}
+}
+
+func TestGetCIStatus_ActionRequired(t *testing.T) {
+	checksJSON := `[{"name":"CI","state":"completed","conclusion":"action_required"}]`
+	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "fail" {
+		t.Errorf("expected status 'fail', got %q", status)
+	}
+}
+
+func TestGetCIStatus_Pending(t *testing.T) {
+	checksJSON := `[{"name":"CI","state":"pending","conclusion":""},{"name":"Lint","state":"completed","conclusion":"success"}]`
+	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "pending" {
+		t.Errorf("expected status 'pending', got %q", status)
+	}
+}
+
+func TestGetCIStatus_Queued(t *testing.T) {
+	checksJSON := `[{"name":"CI","state":"queued","conclusion":""}]`
+	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "pending" {
+		t.Errorf("expected status 'pending', got %q", status)
+	}
+}
+
+func TestGetCIStatus_InProgress(t *testing.T) {
+	checksJSON := `[{"name":"CI","state":"in_progress","conclusion":""}]`
+	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "pending" {
+		t.Errorf("expected status 'pending', got %q", status)
+	}
+}
+
+func TestGetCIStatus_NoChecks(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{stdout: "[]"})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "no_checks" {
+		t.Errorf("expected status 'no_checks', got %q", status)
+	}
+}
+
+func TestGetCIStatus_PRNotFound(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{
+		stdout: "no pull request found for branch",
+		err:    fmt.Errorf("exit status 1"),
+	})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	_, err := adapter.GetCIStatus(context.Background(), "/work")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodePRNotFound {
+		t.Errorf("expected code %q, got %q", errors.ErrCodePRNotFound, domainErr.Code)
+	}
+}
+
+func TestGetCIStatus_GenericError(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{
+		stdout: "something went wrong",
+		err:    fmt.Errorf("exit status 1"),
+	})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	_, err := adapter.GetCIStatus(context.Background(), "/work")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodeGitOperationFailed {
+		t.Errorf("expected code %q, got %q", errors.ErrCodeGitOperationFailed, domainErr.Code)
+	}
+}
+
+func TestGetCIStatus_InvalidJSON(t *testing.T) {
+	runner := newMockCommandRunner(mockResult{stdout: "not json at all"})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	_, err := adapter.GetCIStatus(context.Background(), "/work")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != errors.ErrCodeGitOperationFailed {
+		t.Errorf("expected code %q, got %q", errors.ErrCodeGitOperationFailed, domainErr.Code)
+	}
+}
+
+func TestGetCIStatus_FailBeforePending(t *testing.T) {
+	// If one check fails and another is pending, should return "fail"
+	checksJSON := `[{"name":"CI","state":"completed","conclusion":"failure"},{"name":"Deploy","state":"pending","conclusion":""}]`
+	runner := newMockCommandRunner(mockResult{stdout: checksJSON})
+	adapter := NewGhCliAdapter(runner, testLogger())
+
+	status, err := adapter.GetCIStatus(context.Background(), "/work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "fail" {
+		t.Errorf("expected status 'fail', got %q", status)
+	}
+}
+
 func assertArgs(t *testing.T, got, want []string) {
 	t.Helper()
 	if len(got) != len(want) {

--- a/backend/internal/adapter/git/gh_cli_integration_test.go
+++ b/backend/internal/adapter/git/gh_cli_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/zakari/hopeitworks/backend/pkg/exec"
 )
@@ -63,4 +64,108 @@ func TestIntegrationGhCliAdapter_CloneBranchPush(t *testing.T) {
 
 	// Clean up remote branch
 	_, _ = runner.Run(ctx, targetDir, "git", "push", "origin", "--delete", branchName)
+}
+
+// TestIntegrationGhCliAdapter_PRWorkflow tests the full PR lifecycle:
+// CreatePR -> GetCIStatus -> MergePR.
+func TestIntegrationGhCliAdapter_PRWorkflow(t *testing.T) {
+	// This integration test requires:
+	// - gh CLI installed and authenticated
+	// - git installed and configured
+	// - network access to GitHub
+	// - GITHUB_TOKEN environment variable set
+
+	if os.Getenv("GITHUB_TOKEN") == "" {
+		t.Skip("skipping: GITHUB_TOKEN not set")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "ghcli-pr-integration-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	runner := exec.NewRealCommandRunner()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	adapter := NewGhCliAdapter(runner, logger)
+
+	ctx := context.Background()
+	targetDir := filepath.Join(tmpDir, "repo")
+
+	// Clone the repository
+	err = adapter.CloneRepo(ctx, "zakari/hopeitworks", targetDir)
+	if err != nil {
+		t.Fatalf("CloneRepo failed: %v", err)
+	}
+
+	// Create a feature branch
+	branchName := "feat/integration-test-pr-workflow"
+	err = adapter.CreateBranch(ctx, targetDir, branchName)
+	if err != nil {
+		t.Fatalf("CreateBranch failed: %v", err)
+	}
+
+	// Create a test file so we have something to commit
+	testFile := filepath.Join(targetDir, "integration-pr-test.txt")
+	if writeErr := os.WriteFile(testFile, []byte("integration PR workflow test\n"), 0644); writeErr != nil {
+		t.Fatalf("failed to create test file: %v", writeErr)
+	}
+
+	// Push the commit
+	err = adapter.Push(ctx, targetDir, "test(git): integration test PR workflow")
+	if err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	// Ensure remote branch cleanup on test failure
+	defer func() {
+		_, _ = runner.Run(ctx, targetDir, "git", "push", "origin", "--delete", branchName)
+	}()
+
+	// Create a PR
+	prURL, err := adapter.CreatePR(ctx, targetDir, "test(git): integration test PR workflow", "Automated integration test PR - safe to delete", "develop")
+	if err != nil {
+		t.Fatalf("CreatePR failed: %v", err)
+	}
+
+	if prURL == "" {
+		t.Fatal("expected non-empty PR URL")
+	}
+	t.Logf("created PR: %s", prURL)
+
+	// Poll CI status with timeout
+	deadline := time.Now().Add(5 * time.Minute)
+	var ciStatus string
+	for time.Now().Before(deadline) {
+		ciStatus, err = adapter.GetCIStatus(ctx, targetDir)
+		if err != nil {
+			t.Fatalf("GetCIStatus failed: %v", err)
+		}
+
+		t.Logf("CI status: %s", ciStatus)
+
+		if ciStatus == "pass" || ciStatus == "fail" || ciStatus == "no_checks" {
+			break
+		}
+
+		time.Sleep(15 * time.Second)
+	}
+
+	if ciStatus == "pending" {
+		t.Log("CI checks did not complete within timeout, proceeding with merge attempt")
+	}
+
+	// Merge the PR (squash merge)
+	err = adapter.MergePR(ctx, targetDir, prURL)
+	if err != nil {
+		t.Fatalf("MergePR failed: %v", err)
+	}
+
+	t.Log("PR merged successfully")
+
+	// Verify branch was deleted by trying to check it on remote
+	stdout, checkErr := runner.Run(ctx, targetDir, "git", "ls-remote", "--heads", "origin", branchName)
+	if checkErr == nil && stdout != "" {
+		t.Error("expected branch to be deleted after merge, but it still exists on remote")
+	}
 }

--- a/backend/internal/domain/port/git_provider.go
+++ b/backend/internal/domain/port/git_provider.go
@@ -16,4 +16,21 @@ type GitProvider interface {
 	// Push stages all changes, commits with the given message, and pushes to origin.
 	// commitMsg must follow conventional commit format: type(scope): message.
 	Push(ctx context.Context, workDir string, commitMsg string) error
+
+	// CreatePR creates a pull request and returns the PR URL.
+	// title: PR title (should follow conventional commit format for squash merge).
+	// body: PR description/body.
+	// baseBranch: target branch (typically "main" or "develop").
+	// Returns: PR URL (e.g., "https://github.com/owner/repo/pull/123").
+	CreatePR(ctx context.Context, workDir string, title string, body string, baseBranch string) (prURL string, err error)
+
+	// MergePR squash-merges a pull request and deletes the source branch.
+	// prIdentifier: PR number (e.g., "123") or PR URL.
+	// Performs squash merge to maintain clean commit history.
+	MergePR(ctx context.Context, workDir string, prIdentifier string) error
+
+	// GetCIStatus returns the CI check status for the current branch's PR.
+	// Returns: "pass" (all checks successful), "fail" (any check failed),
+	//          "pending" (checks running), "no_checks" (no CI configured).
+	GetCIStatus(ctx context.Context, workDir string) (status string, err error)
 }

--- a/backend/pkg/errors/errors.go
+++ b/backend/pkg/errors/errors.go
@@ -19,6 +19,9 @@ const (
 const (
 	ErrCodeGitOperationFailed = "GIT_OPERATION_FAILED"
 	ErrCodeInvalidInput       = "INVALID_INPUT"
+	ErrCodeMergeConflict      = "MERGE_CONFLICT"
+	ErrCodeGitAuthFailed      = "GIT_AUTH_FAILED"
+	ErrCodePRNotFound         = "PR_NOT_FOUND"
 )
 
 // DomainError represents a structured error from the domain layer.


### PR DESCRIPTION
## Summary

- Extend `GitProvider` port interface with `CreatePR`, `MergePR`, and `GetCIStatus` methods
- Implement all three operations in `GhCliAdapter` using gh CLI with structured error handling
- Add `MERGE_CONFLICT`, `GIT_AUTH_FAILED`, `PR_NOT_FOUND` error codes to `pkg/errors`
- 24 unit tests covering all success/error paths + integration test for full PR lifecycle

## Changes

### Port Interface (`backend/internal/domain/port/git_provider.go`)
- `CreatePR(ctx, workDir, title, body, baseBranch) (prURL, error)` — creates PR via `gh pr create`
- `MergePR(ctx, workDir, prIdentifier) error` — squash-merges via `gh pr merge --squash --delete-branch`
- `GetCIStatus(ctx, workDir) (status, error)` — returns "pass", "fail", "pending", or "no_checks"

### Adapter (`backend/internal/adapter/git/gh_cli_adapter.go`)
- CreatePR: parses PR URL from stdout, detects auth failures
- MergePR: detects merge conflicts and PR not found errors
- GetCIStatus: parses `gh pr checks --json` output, maps check states to status strings

### Error Codes (`backend/pkg/errors/errors.go`)
- `MERGE_CONFLICT` — merge conflict scenarios
- `GIT_AUTH_FAILED` — authentication failures
- `PR_NOT_FOUND` — missing pull request errors

### Tests
- 24 new unit tests in `gh_cli_adapter_test.go` with mock CommandRunner
- Integration test for full CreatePR → GetCIStatus → MergePR workflow

## Test plan
- [x] All 33 unit tests pass (`go test ./internal/adapter/git/ -short`)
- [x] Full backend test suite passes (`go test ./... -short`)
- [x] `go vet ./...` passes
- [x] `gofmt` reports no formatting issues
- [ ] Integration test requires gh CLI auth and network (run manually)

Refs: S-3-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)