### PR TITLE
feat(ui): add prompt template editor with Monaco and preview

### DIFF
--- a/frontend/e2e/tests/epic-detail.spec.ts
+++ b/frontend/e2e/tests/epic-detail.spec.ts
@@ -90,7 +90,7 @@ test.describe('Epic Detail Page', () => {
 
     await page.goto('/projects/p1/epics/e1')
 
-    await expect(page.locator('h1')).toHaveText('Epic Stories')
+    await expect(page.getByRole('heading', { name: 'Epic Stories' })).toBeVisible()
     await expect(page.getByText('S-01')).toBeVisible()
     await expect(page.getByText('Setup authentication')).toBeVisible()
     await expect(page.getByText('S-02')).toBeVisible()

--- a/frontend/e2e/tests/template-editor.spec.ts
+++ b/frontend/e2e/tests/template-editor.spec.ts
@@ -151,7 +151,7 @@ test.describe('Template Editor', () => {
         page.getByText('You are working on S-14: Add user authentication'),
       ).toBeVisible()
 
-      await page.getByRole('button', { name: 'Close' }).click()
+      await page.locator('.p-dialog-footer').getByRole('button', { name: 'Close' }).click()
 
       await expect(page.getByText('Template Preview')).not.toBeVisible()
     })

--- a/frontend/e2e/tests/template-editor.spec.ts
+++ b/frontend/e2e/tests/template-editor.spec.ts
@@ -1,0 +1,227 @@
+import { test, expect } from '@playwright/test'
+
+const PROJECT_ID = 'p1'
+
+const mockTemplate = {
+  id: 't1',
+  project_id: PROJECT_ID,
+  name: 'Implement Feature',
+  template_content: 'You are working on {{story_key}}: {{story_title}}',
+  type: 'implement',
+  created_at: '2026-02-10T10:00:00Z',
+  updated_at: '2026-02-10T10:00:00Z',
+}
+
+function setupProjectRoute(page: import('@playwright/test').Page) {
+  return page.route(`**/api/v1/projects/${PROJECT_ID}`, async (route) => {
+    if (route.request().url().includes('/templates')) return route.fallback()
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: PROJECT_ID,
+        name: 'Test Project',
+        owner_id: 'u1',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      }),
+    })
+  })
+}
+
+test.describe('Template Editor', () => {
+  test.describe('as admin', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.route('**/api/v1/auth/me', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: 'u1',
+            email: 'admin@test.com',
+            name: 'Admin User',
+            role: 'admin',
+          }),
+        })
+      })
+
+      await setupProjectRoute(page)
+    })
+
+    test('displays editor with template content for existing template', async ({ page }) => {
+      await page.route(`**/api/v1/projects/${PROJECT_ID}/templates/t1`, async (route) => {
+        if (route.request().method() === 'GET') {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(mockTemplate),
+          })
+        } else {
+          await route.fallback()
+        }
+      })
+
+      await page.goto(`/projects/${PROJECT_ID}/templates/t1`)
+
+      // Toolbar buttons visible for admin
+      await expect(page.getByRole('button', { name: 'Preview' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Save' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible()
+
+      // Variable sidebar visible
+      await expect(page.getByText('Context Variables')).toBeVisible()
+      await expect(page.getByText('{{story_key}}')).toBeVisible()
+    })
+
+    test('shows empty editor for create mode', async ({ page }) => {
+      await page.goto(`/projects/${PROJECT_ID}/templates/new`)
+
+      await expect(page.getByRole('button', { name: 'Preview' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Save' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible()
+    })
+
+    test('cancel navigates back to template list', async ({ page }) => {
+      await page.route(`**/api/v1/projects/${PROJECT_ID}/templates*`, async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: [],
+            pagination: { total: 0, page: 1, per_page: 20 },
+          }),
+        })
+      })
+
+      await page.goto(`/projects/${PROJECT_ID}/templates/new`)
+
+      await page.getByRole('button', { name: 'Cancel' }).click()
+
+      await expect(page).toHaveURL(new RegExp(`/projects/${PROJECT_ID}/templates$`))
+    })
+
+    test('displays error state with retry when template fetch fails', async ({ page }) => {
+      let callCount = 0
+      await page.route(`**/api/v1/projects/${PROJECT_ID}/templates/t1`, async (route) => {
+        callCount++
+        if (callCount === 1) {
+          await route.fulfill({
+            status: 500,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              error: { code: 'INTERNAL', message: 'Server error' },
+            }),
+          })
+        } else {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(mockTemplate),
+          })
+        }
+      })
+
+      await page.goto(`/projects/${PROJECT_ID}/templates/t1`)
+
+      await expect(page.getByText('Failed to load template')).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible()
+
+      await page.getByRole('button', { name: 'Retry' }).click()
+
+      await expect(page.getByText('Context Variables')).toBeVisible()
+    })
+
+    test('preview dialog shows rendered template output', async ({ page }) => {
+      await page.route(`**/api/v1/projects/${PROJECT_ID}/templates/t1`, async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockTemplate),
+        })
+      })
+
+      await page.goto(`/projects/${PROJECT_ID}/templates/t1`)
+
+      await expect(page.getByText('Context Variables')).toBeVisible()
+
+      await page.getByRole('button', { name: 'Preview' }).click()
+
+      await expect(page.getByText('Template Preview')).toBeVisible()
+      await expect(
+        page.getByText('You are working on S-14: Add user authentication'),
+      ).toBeVisible()
+
+      await page.getByRole('button', { name: 'Close' }).click()
+
+      await expect(page.getByText('Template Preview')).not.toBeVisible()
+    })
+
+    test('variable sidebar shows all context variables', async ({ page }) => {
+      await page.route(`**/api/v1/projects/${PROJECT_ID}/templates/t1`, async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockTemplate),
+        })
+      })
+
+      await page.goto(`/projects/${PROJECT_ID}/templates/t1`)
+
+      await expect(page.getByText('Context Variables')).toBeVisible()
+      await expect(page.getByText('{{story_key}}')).toBeVisible()
+      await expect(page.getByText('{{story_title}}')).toBeVisible()
+      await expect(page.getByText('{{story_objective}}')).toBeVisible()
+      await expect(page.getByText('{{target_files}}')).toBeVisible()
+      await expect(page.getByText('{{acceptance_criteria}}')).toBeVisible()
+      await expect(page.getByText('{{error_context}}')).toBeVisible()
+      await expect(page.getByText('{{diff_content}}')).toBeVisible()
+      await expect(page.getByText('{{branch_name}}')).toBeVisible()
+      await expect(page.getByText('{{repo_url}}')).toBeVisible()
+    })
+  })
+
+  test.describe('as non-admin', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.route('**/api/v1/auth/me', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: 'u2',
+            email: 'user@test.com',
+            name: 'Regular User',
+            role: 'member',
+          }),
+        })
+      })
+
+      await setupProjectRoute(page)
+    })
+
+    test('editor is read-only and Save button is hidden for non-admin', async ({ page }) => {
+      await page.route(`**/api/v1/projects/${PROJECT_ID}/templates/t1`, async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockTemplate),
+        })
+      })
+
+      await page.goto(`/projects/${PROJECT_ID}/templates/t1`)
+
+      // Preview and Cancel visible
+      await expect(page.getByRole('button', { name: 'Preview' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible()
+
+      // Save not visible for non-admin
+      await expect(page.getByRole('button', { name: 'Save' })).not.toBeVisible()
+    })
+
+    test('redirects non-admin from create route', async ({ page }) => {
+      await page.goto(`/projects/${PROJECT_ID}/templates/new`)
+
+      // Admin guard should redirect non-admin to dashboard
+      await expect(page).toHaveURL('/')
+    })
+  })
+})

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,10 +8,13 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@guolao/vue-monaco-editor": "^1.6.0",
         "@primevue/themes": "^4.5.4",
         "@vee-validate/zod": "^4.15.1",
         "@vueuse/core": "^14.2.1",
         "date-fns": "^4.1.0",
+        "handlebars": "^4.7.8",
+        "monaco-editor": "^0.55.1",
         "openapi-fetch": "^0.17.0",
         "pinia": "^3.0.4",
         "primeicons": "^7.0.0",
@@ -1373,6 +1376,52 @@
         }
       }
     },
+    "node_modules/@guolao/vue-monaco-editor": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@guolao/vue-monaco-editor/-/vue-monaco-editor-1.6.0.tgz",
+      "integrity": "sha512-w2IiJ6eJGGeuIgCK6EKZOAfhHTTUB5aZwslzwGbZ5e89Hb4avx6++GkLTW8p84Sng/arFMjLPPxSBI56cFudyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.6.1",
+        "vue-demi": "latest"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.7.2",
+        "monaco-editor": ">=0.43.0",
+        "vue": "^2.6.14 || >=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@guolao/vue-monaco-editor/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1486,6 +1535,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2741,6 +2799,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.21",
@@ -4232,6 +4297,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -4919,6 +4993,27 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -5734,6 +5829,18 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
@@ -5790,6 +5897,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -5833,6 +5949,16 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/mrmime": {
@@ -5881,6 +6007,12 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
     "node_modules/node-releases": {
@@ -6802,6 +6934,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6825,6 +6966,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
     },
     "node_modules/std-env": {
@@ -7226,6 +7373,19 @@
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "license": "MIT"
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/undici": {
       "version": "7.22.0",
@@ -8006,6 +8166,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,10 +19,13 @@
     "generate:api": "openapi-typescript ../api/openapi.yaml -o src/api/schema.d.ts"
   },
   "dependencies": {
+    "@guolao/vue-monaco-editor": "^1.6.0",
     "@primevue/themes": "^4.5.4",
     "@vee-validate/zod": "^4.15.1",
     "@vueuse/core": "^14.2.1",
     "date-fns": "^4.1.0",
+    "handlebars": "^4.7.8",
+    "monaco-editor": "^0.55.1",
     "openapi-fetch": "^0.17.0",
     "pinia": "^3.0.4",
     "primeicons": "^7.0.0",

--- a/frontend/src/composables/__tests__/useTemplateEditor.spec.ts
+++ b/frontend/src/composables/__tests__/useTemplateEditor.spec.ts
@@ -160,6 +160,29 @@ describe('useTemplateEditor', () => {
     expect(result!.canSave.value).toBe(false)
   })
 
+  it('canSave requires non-empty name for new templates', async () => {
+    let result: ReturnType<typeof useTemplateEditor> | undefined
+
+    mount({
+      setup() {
+        result = useTemplateEditor('p1', 'new')
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    await nextTick()
+
+    result!.content.value = 'some content'
+    expect(result!.canSave.value).toBe(false)
+
+    result!.name.value = 'My Template'
+    expect(result!.canSave.value).toBe(true)
+
+    result!.name.value = '   '
+    expect(result!.canSave.value).toBe(false)
+  })
+
   it('saves existing template with PUT', async () => {
     mockGet.mockResolvedValue({ data: mockTemplate, error: undefined })
     mockPut.mockResolvedValue({ data: { ...mockTemplate, template_content: 'updated' }, error: undefined })

--- a/frontend/src/composables/__tests__/useTemplateEditor.spec.ts
+++ b/frontend/src/composables/__tests__/useTemplateEditor.spec.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useTemplateEditor } from '../useTemplateEditor'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockPut = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+    POST: (...args: unknown[]) => mockPost(...args),
+    PUT: (...args: unknown[]) => mockPut(...args),
+  },
+}))
+
+const mockTemplate = {
+  id: 't1',
+  project_id: 'p1',
+  name: 'Implement Template',
+  template_content: 'You are working on {{story_key}}: {{story_title}}',
+  type: 'implement' as const,
+  created_at: '2026-01-15T10:00:00Z',
+  updated_at: '2026-01-15T10:00:00Z',
+}
+
+describe('useTemplateEditor', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockPut.mockReset()
+  })
+
+  it('fetches template on mount for existing template', async () => {
+    mockGet.mockResolvedValue({ data: mockTemplate, error: undefined })
+
+    let result: ReturnType<typeof useTemplateEditor> | undefined
+
+    mount({
+      setup() {
+        result = useTemplateEditor('p1', 't1')
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    await nextTick()
+
+    expect(mockGet).toHaveBeenCalledWith('/projects/{projectId}/templates/{templateId}', {
+      params: { path: { projectId: 'p1', templateId: 't1' } },
+    })
+    expect(result!.content.value).toBe(mockTemplate.template_content)
+    expect(result!.loading.value).toBe(false)
+    expect(result!.isNewTemplate.value).toBe(false)
+  })
+
+  it('does not fetch on mount for new template', async () => {
+    let result: ReturnType<typeof useTemplateEditor> | undefined
+
+    mount({
+      setup() {
+        result = useTemplateEditor('p1', 'new')
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    await nextTick()
+
+    expect(mockGet).not.toHaveBeenCalled()
+    expect(result!.isNewTemplate.value).toBe(true)
+    expect(result!.content.value).toBe('')
+  })
+
+  it('handles fetch error', async () => {
+    mockGet.mockResolvedValue({ data: undefined, error: { message: 'not found' } })
+
+    let result: ReturnType<typeof useTemplateEditor> | undefined
+
+    mount({
+      setup() {
+        result = useTemplateEditor('p1', 't1')
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    await nextTick()
+
+    expect(result!.error.value).toBe('Failed to load template')
+    expect(result!.loading.value).toBe(false)
+  })
+
+  it('handles fetch exception', async () => {
+    mockGet.mockRejectedValue(new Error('Network error'))
+
+    let result: ReturnType<typeof useTemplateEditor> | undefined
+
+    mount({
+      setup() {
+        result = useTemplateEditor('p1', 't1')
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    await nextTick()
+
+    expect(result!.error.value).toBe('Network error')
+  })
+
+  it('tracks isDirty when content changes', async () => {
+    mockGet.mockResolvedValue({ data: mockTemplate, error: undefined })
+
+    let result: ReturnType<typeof useTemplateEditor> | undefined
+
+    mount({
+      setup() {
+        result = useTemplateEditor('p1', 't1')
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    await nextTick()
+
+    expect(result!.isDirty.value).toBe(false)
+
+    result!.content.value = 'modified content'
+    expect(result!.isDirty.value).toBe(true)
+
+    result!.content.value = mockTemplate.template_content
+    expect(result!.isDirty.value).toBe(false)
+  })
+
+  it('canSave requires isDirty and non-empty content', async () => {
+    mockGet.mockResolvedValue({ data: mockTemplate, error: undefined })
+
+    let result: ReturnType<typeof useTemplateEditor> | undefined
+
+    mount({
+      setup() {
+        result = useTemplateEditor('p1', 't1')
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    await nextTick()
+
+    expect(result!.canSave.value).toBe(false)
+
+    result!.content.value = 'new content'
+    expect(result!.canSave.value).toBe(true)
+
+    result!.content.value = '   '
+    expect(result!.canSave.value).toBe(false)
+  })
+
+  it('saves existing template with PUT', async () => {
+    mockGet.mockResolvedValue({ data: mockTemplate, error: undefined })
+    mockPut.mockResolvedValue({ data: { ...mockTemplate, template_content: 'updated' }, error: undefined })
+
+    let result: ReturnType<typeof useTemplateEditor> | undefined
+
+    mount({
+      setup() {
+        result = useTemplateEditor('p1', 't1')
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    await nextTick()
+
+    result!.content.value = 'updated content'
+    const success = await result!.saveTemplate()
+
+    expect(success).toBe(true)
+    expect(mockPut).toHaveBeenCalledWith('/projects/{projectId}/templates/{templateId}', {
+      params: { path: { projectId: 'p1', templateId: 't1' } },
+      body: { template_content: 'updated content' },
+    })
+    expect(result!.isDirty.value).toBe(false)
+  })
+
+  it('creates new template with POST', async () => {
+    mockPost.mockResolvedValue({ data: { ...mockTemplate, id: 'new-id' }, error: undefined })
+
+    let result: ReturnType<typeof useTemplateEditor> | undefined
+
+    mount({
+      setup() {
+        result = useTemplateEditor('p1', 'new')
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    await nextTick()
+
+    result!.content.value = 'new template content'
+    const success = await result!.saveTemplate('New Template', 'implement')
+
+    expect(success).toBe(true)
+    expect(mockPost).toHaveBeenCalledWith('/projects/{projectId}/templates', {
+      params: { path: { projectId: 'p1' } },
+      body: {
+        name: 'New Template',
+        type: 'implement',
+        template_content: 'new template content',
+      },
+    })
+  })
+
+  it('handles save error for existing template', async () => {
+    mockGet.mockResolvedValue({ data: mockTemplate, error: undefined })
+    mockPut.mockResolvedValue({ data: undefined, error: { message: 'forbidden' } })
+
+    let result: ReturnType<typeof useTemplateEditor> | undefined
+
+    mount({
+      setup() {
+        result = useTemplateEditor('p1', 't1')
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    await nextTick()
+
+    result!.content.value = 'updated content'
+    const success = await result!.saveTemplate()
+
+    expect(success).toBe(false)
+    expect(result!.error.value).toBe('Failed to save template')
+    expect(result!.saving.value).toBe(false)
+  })
+
+  it('handles save exception', async () => {
+    mockGet.mockResolvedValue({ data: mockTemplate, error: undefined })
+    mockPut.mockRejectedValue(new Error('Network error'))
+
+    let result: ReturnType<typeof useTemplateEditor> | undefined
+
+    mount({
+      setup() {
+        result = useTemplateEditor('p1', 't1')
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    await nextTick()
+
+    result!.content.value = 'updated content'
+    const success = await result!.saveTemplate()
+
+    expect(success).toBe(false)
+    expect(result!.error.value).toBe('Network error')
+  })
+
+  it('previews template with client-side Handlebars', async () => {
+    let result: ReturnType<typeof useTemplateEditor> | undefined
+
+    mount({
+      setup() {
+        result = useTemplateEditor('p1', 'new')
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    await nextTick()
+
+    result!.content.value = 'Working on {{story_key}}: {{story_title}}'
+    await result!.previewTemplate()
+
+    expect(result!.previewContent.value).toBe('Working on S-14: Add user authentication')
+    expect(result!.previewError.value).toBeNull()
+    expect(result!.previewLoading.value).toBe(false)
+  })
+
+  it('handles preview error for invalid template syntax', async () => {
+    let result: ReturnType<typeof useTemplateEditor> | undefined
+
+    mount({
+      setup() {
+        result = useTemplateEditor('p1', 'new')
+        return {}
+      },
+      template: '<div></div>',
+    })
+
+    await nextTick()
+
+    result!.content.value = '{{#if}}'
+    await result!.previewTemplate()
+
+    expect(result!.previewError.value).toBeTruthy()
+    expect(result!.previewLoading.value).toBe(false)
+  })
+})

--- a/frontend/src/composables/useTemplateEditor.ts
+++ b/frontend/src/composables/useTemplateEditor.ts
@@ -40,7 +40,12 @@ export function useTemplateEditor(projectId: string, templateId: string) {
 
   const isNewTemplate = computed(() => templateId === 'new')
   const isDirty = computed(() => content.value !== originalContent.value)
-  const canSave = computed(() => isDirty.value && content.value.trim() !== '')
+  const canSave = computed(
+    () =>
+      isDirty.value &&
+      content.value.trim() !== '' &&
+      (!isNewTemplate.value || name.value.trim() !== ''),
+  )
 
   /** Fetch an existing template from the API */
   async function fetchTemplate() {

--- a/frontend/src/composables/useTemplateEditor.ts
+++ b/frontend/src/composables/useTemplateEditor.ts
@@ -1,0 +1,156 @@
+import { ref, computed, onMounted } from 'vue'
+import Handlebars from 'handlebars'
+import { apiClient } from '@/api/client'
+import type { PromptTemplate, PromptTemplateType } from '@/stores/promptTemplates'
+
+/** Sample context data used for template preview rendering */
+const sampleContext = {
+  story_key: 'S-14',
+  story_title: 'Add user authentication',
+  story_objective: 'Implement JWT-based authentication with refresh tokens',
+  target_files: [
+    'backend/internal/api/middleware/auth.go',
+    'backend/internal/domain/service/auth_service.go',
+  ],
+  acceptance_criteria:
+    '- Given a valid JWT token, the user can access protected endpoints\n- When the token expires, the user receives a 401 error\n- When the user logs out, the token is invalidated',
+  error_context: 'Error: test failed in auth_test.go line 42: expected status 200, got 401',
+  diff_content:
+    'diff --git a/auth.go b/auth.go\nindex 1234567..abcdefg 100644\n--- a/auth.go\n+++ b/auth.go\n@@ -10,6 +10,7 @@ func Login() {\n+    validateToken()\n',
+  branch_name: 'feat/1-3-auth',
+  repo_url: 'https://github.com/user/repo',
+}
+
+/**
+ * Composable for template editor state and actions.
+ * Handles fetching, saving, and previewing prompt templates.
+ */
+export function useTemplateEditor(projectId: string, templateId: string) {
+  const template = ref<PromptTemplate | null>(null)
+  const content = ref('')
+  const name = ref('')
+  const type = ref<PromptTemplateType>('custom')
+  const loading = ref(false)
+  const saving = ref(false)
+  const error = ref<string | null>(null)
+  const previewLoading = ref(false)
+  const previewError = ref<string | null>(null)
+  const previewContent = ref('')
+  const originalContent = ref('')
+
+  const isNewTemplate = computed(() => templateId === 'new')
+  const isDirty = computed(() => content.value !== originalContent.value)
+  const canSave = computed(() => isDirty.value && content.value.trim() !== '')
+
+  /** Fetch an existing template from the API */
+  async function fetchTemplate() {
+    if (isNewTemplate.value) return
+    loading.value = true
+    error.value = null
+    try {
+      const { data, error: apiError } = await apiClient.GET(
+        '/projects/{projectId}/templates/{templateId}',
+        {
+          params: { path: { projectId, templateId } },
+        },
+      )
+      if (apiError) {
+        error.value = 'Failed to load template'
+        return
+      }
+      const t = data as PromptTemplate
+      template.value = t
+      content.value = t.template_content
+      originalContent.value = t.template_content
+      name.value = t.name
+      type.value = t.type
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load template'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /** Save or create a template via the API */
+  async function saveTemplate(templateName?: string, templateType?: PromptTemplateType) {
+    saving.value = true
+    error.value = null
+    try {
+      if (isNewTemplate.value) {
+        const { error: apiError } = await apiClient.POST(
+          '/projects/{projectId}/templates',
+          {
+            params: { path: { projectId } },
+            body: {
+              name: templateName ?? name.value,
+              type: templateType ?? type.value,
+              template_content: content.value,
+            },
+          },
+        )
+        if (apiError) {
+          error.value = 'Failed to create template'
+          return false
+        }
+      } else {
+        const { error: apiError } = await apiClient.PUT(
+          '/projects/{projectId}/templates/{templateId}',
+          {
+            params: { path: { projectId, templateId } },
+            body: { template_content: content.value },
+          },
+        )
+        if (apiError) {
+          error.value = 'Failed to save template'
+          return false
+        }
+      }
+      originalContent.value = content.value
+      return true
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to save template'
+      return false
+    } finally {
+      saving.value = false
+    }
+  }
+
+  /** Render the template with sample context data using client-side Handlebars */
+  async function previewTemplate() {
+    previewLoading.value = true
+    previewError.value = null
+    try {
+      const compiled = Handlebars.compile(content.value)
+      previewContent.value = compiled(sampleContext)
+    } catch (e) {
+      previewError.value = e instanceof Error ? e.message : 'Failed to render preview'
+    } finally {
+      previewLoading.value = false
+    }
+  }
+
+  onMounted(() => {
+    if (!isNewTemplate.value) {
+      fetchTemplate()
+    }
+  })
+
+  return {
+    template,
+    content,
+    name,
+    type,
+    loading,
+    saving,
+    error,
+    isDirty,
+    canSave,
+    isNewTemplate,
+    previewLoading,
+    previewError,
+    previewContent,
+    fetchTemplate,
+    saveTemplate,
+    previewTemplate,
+  }
+}

--- a/frontend/src/features/templates/MonacoEditorWrapper.vue
+++ b/frontend/src/features/templates/MonacoEditorWrapper.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { Editor } from '@guolao/vue-monaco-editor'
+import type * as monacoEditor from 'monaco-editor'
+
+interface Props {
+  modelValue: string
+  readonly?: boolean
+  language?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  readonly: false,
+  language: 'handlebars',
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const editorInstance = ref<monacoEditor.editor.IStandaloneCodeEditor | null>(null)
+const monacoInstance = ref<typeof monacoEditor | null>(null)
+
+const editorOptions = {
+  readOnly: props.readonly,
+  minimap: { enabled: false },
+  wordWrap: 'on' as const,
+  automaticLayout: true,
+  scrollBeyondLastLine: false,
+  fontSize: 14,
+  lineNumbers: 'on' as const,
+  renderWhitespace: 'boundary' as const,
+  tabSize: 2,
+}
+
+/** Update readonly option when the prop changes */
+watch(
+  () => props.readonly,
+  (readOnly) => {
+    editorInstance.value?.updateOptions({ readOnly })
+  },
+)
+
+function handleMount(editor: monacoEditor.editor.IStandaloneCodeEditor, monaco: typeof monacoEditor) {
+  editorInstance.value = editor
+  monacoInstance.value = monaco
+}
+
+function handleChange(value: string | undefined) {
+  emit('update:modelValue', value ?? '')
+}
+
+/** Insert text at the current cursor position */
+function insertAtCursor(text: string) {
+  const editor = editorInstance.value
+  const monaco = monacoInstance.value
+  if (!editor || !monaco) return
+
+  const selection = editor.getSelection()
+  if (!selection) return
+
+  const range = new monaco.Range(
+    selection.startLineNumber,
+    selection.startColumn,
+    selection.endLineNumber,
+    selection.endColumn,
+  )
+
+  editor.executeEdits('', [{ range, text, forceMoveMarkers: true }])
+  editor.focus()
+}
+
+defineExpose({ insertAtCursor })
+</script>
+
+<template>
+  <Editor
+    :value="modelValue"
+    :language="language"
+    theme="vs-dark"
+    :options="editorOptions"
+    height="100%"
+    @mount="handleMount"
+    @change="handleChange"
+  />
+</template>

--- a/frontend/src/features/templates/TemplateEditorLayout.vue
+++ b/frontend/src/features/templates/TemplateEditorLayout.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import InputText from 'primevue/inputtext'
+import Select from 'primevue/select'
 import MonacoEditorWrapper from './MonacoEditorWrapper.vue'
 import TemplateVariableSidebar from './TemplateVariableSidebar.vue'
 import TemplateEditorToolbar from './TemplateEditorToolbar.vue'
 import TemplatePreviewDialog from './TemplatePreviewDialog.vue'
+import type { PromptTemplateType } from '@/stores/promptTemplates'
 
 interface Props {
   content: string
@@ -11,6 +14,9 @@ interface Props {
   isDirty: boolean
   isSaving: boolean
   canSave: boolean
+  isNewTemplate: boolean
+  templateName: string
+  templateType: PromptTemplateType
   previewVisible: boolean
   previewContent: string
   previewLoading: boolean
@@ -21,11 +27,21 @@ defineProps<Props>()
 
 const emit = defineEmits<{
   'update:content': [content: string]
+  'update:templateName': [name: string]
+  'update:templateType': [type: PromptTemplateType]
   'update:previewVisible': [visible: boolean]
   save: []
   cancel: []
   preview: []
 }>()
+
+const typeOptions: { label: string; value: PromptTemplateType }[] = [
+  { label: 'Implement', value: 'implement' },
+  { label: 'Retry', value: 'retry' },
+  { label: 'Review', value: 'review' },
+  { label: 'Merge', value: 'merge' },
+  { label: 'Custom', value: 'custom' },
+]
 
 const editorRef = ref<InstanceType<typeof MonacoEditorWrapper> | null>(null)
 </script>
@@ -43,6 +59,35 @@ const editorRef = ref<InstanceType<typeof MonacoEditorWrapper> | null>(null)
       @save="emit('save')"
       @cancel="emit('cancel')"
     />
+
+    <!-- Name / type fields shown only when creating a new template -->
+    <div
+      v-if="isNewTemplate"
+      class="flex items-center gap-4 border-b border-surface-200 px-4 py-3 dark:border-surface-700"
+    >
+      <div class="flex flex-1 flex-col gap-1">
+        <label class="text-xs font-medium text-surface-500">Template Name</label>
+        <InputText
+          :value="templateName"
+          placeholder="e.g. Default Implement Prompt"
+          size="small"
+          class="w-full"
+          @input="emit('update:templateName', ($event.target as HTMLInputElement).value)"
+        />
+      </div>
+      <div class="flex flex-col gap-1">
+        <label class="text-xs font-medium text-surface-500">Type</label>
+        <Select
+          :model-value="templateType"
+          :options="typeOptions"
+          option-label="label"
+          option-value="value"
+          size="small"
+          class="w-40"
+          @update:model-value="emit('update:templateType', $event)"
+        />
+      </div>
+    </div>
 
     <!-- Main content area -->
     <div class="flex flex-1 overflow-hidden">

--- a/frontend/src/features/templates/TemplateEditorLayout.vue
+++ b/frontend/src/features/templates/TemplateEditorLayout.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import MonacoEditorWrapper from './MonacoEditorWrapper.vue'
+import TemplateVariableSidebar from './TemplateVariableSidebar.vue'
+import TemplateEditorToolbar from './TemplateEditorToolbar.vue'
+import TemplatePreviewDialog from './TemplatePreviewDialog.vue'
+
+interface Props {
+  content: string
+  isAdmin: boolean
+  isDirty: boolean
+  isSaving: boolean
+  canSave: boolean
+  previewVisible: boolean
+  previewContent: string
+  previewLoading: boolean
+  previewError: string | null
+}
+
+defineProps<Props>()
+
+const emit = defineEmits<{
+  'update:content': [content: string]
+  'update:previewVisible': [visible: boolean]
+  save: []
+  cancel: []
+  preview: []
+}>()
+
+const editorRef = ref<InstanceType<typeof MonacoEditorWrapper> | null>(null)
+</script>
+
+<template>
+  <div class="flex h-full flex-col">
+    <!-- Toolbar -->
+    <TemplateEditorToolbar
+      class="border-b border-surface-200 dark:border-surface-700"
+      :is-admin="isAdmin"
+      :can-save="canSave"
+      :is-saving="isSaving"
+      :is-dirty="isDirty"
+      @preview="emit('preview')"
+      @save="emit('save')"
+      @cancel="emit('cancel')"
+    />
+
+    <!-- Main content area -->
+    <div class="flex flex-1 overflow-hidden">
+      <!-- Monaco editor -->
+      <div class="flex-1">
+        <MonacoEditorWrapper
+          ref="editorRef"
+          :model-value="content"
+          :readonly="!isAdmin"
+          @update:model-value="emit('update:content', $event)"
+        />
+      </div>
+
+      <!-- Variable sidebar -->
+      <TemplateVariableSidebar
+        class="w-[250px] shrink-0 overflow-y-auto border-l border-surface-200 dark:border-surface-700"
+        :editor-ref="editorRef"
+      />
+    </div>
+
+    <!-- Preview dialog -->
+    <TemplatePreviewDialog
+      :visible="previewVisible"
+      :rendered-content="previewContent"
+      :loading="previewLoading"
+      :error="previewError"
+      @update:visible="emit('update:previewVisible', $event)"
+    />
+  </div>
+</template>

--- a/frontend/src/features/templates/TemplateEditorToolbar.vue
+++ b/frontend/src/features/templates/TemplateEditorToolbar.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import Button from 'primevue/button'
+
+interface Props {
+  isAdmin: boolean
+  canSave: boolean
+  isSaving: boolean
+  isDirty: boolean
+}
+
+defineProps<Props>()
+
+const emit = defineEmits<{
+  preview: []
+  save: []
+  cancel: []
+}>()
+</script>
+
+<template>
+  <div class="flex items-center justify-between px-4 py-2">
+    <div class="flex items-center gap-2">
+      <span v-if="isDirty" class="text-xs text-orange-500">Unsaved changes</span>
+    </div>
+    <div class="flex items-center gap-2">
+      <Button
+        label="Preview"
+        icon="pi pi-eye"
+        severity="secondary"
+        outlined
+        size="small"
+        @click="emit('preview')"
+      />
+      <Button
+        v-if="isAdmin"
+        label="Save"
+        icon="pi pi-save"
+        severity="success"
+        size="small"
+        :disabled="!canSave"
+        :loading="isSaving"
+        @click="emit('save')"
+      />
+      <Button
+        label="Cancel"
+        severity="secondary"
+        text
+        size="small"
+        @click="emit('cancel')"
+      />
+    </div>
+  </div>
+</template>

--- a/frontend/src/features/templates/TemplatePreviewDialog.vue
+++ b/frontend/src/features/templates/TemplatePreviewDialog.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import Dialog from 'primevue/dialog'
+import Button from 'primevue/button'
+import Skeleton from 'primevue/skeleton'
+import Message from 'primevue/message'
+
+interface Props {
+  visible: boolean
+  renderedContent: string
+  loading: boolean
+  error: string | null
+}
+
+defineProps<Props>()
+
+const emit = defineEmits<{
+  'update:visible': [visible: boolean]
+}>()
+</script>
+
+<template>
+  <Dialog
+    :visible="visible"
+    header="Template Preview"
+    modal
+    :style="{ width: '50rem' }"
+    :closable="true"
+    @update:visible="emit('update:visible', $event)"
+  >
+    <!-- Loading state -->
+    <div v-if="loading" class="flex flex-col gap-3">
+      <Skeleton height="1rem" />
+      <Skeleton height="1rem" />
+      <Skeleton height="1rem" width="75%" />
+    </div>
+
+    <!-- Error state -->
+    <Message v-else-if="error" severity="error" :closable="false">
+      {{ error }}
+    </Message>
+
+    <!-- Rendered content -->
+    <pre
+      v-else
+      class="max-h-[60vh] overflow-auto rounded-md bg-surface-900 p-4 text-sm text-surface-100 whitespace-pre-wrap"
+    >{{ renderedContent }}</pre>
+
+    <template #footer>
+      <Button
+        label="Close"
+        severity="secondary"
+        @click="emit('update:visible', false)"
+      />
+    </template>
+  </Dialog>
+</template>

--- a/frontend/src/features/templates/TemplateVariableSidebar.vue
+++ b/frontend/src/features/templates/TemplateVariableSidebar.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+interface EditorRef {
+  insertAtCursor: (text: string) => void
+}
+
+interface Props {
+  editorRef: EditorRef | null
+}
+
+const props = defineProps<Props>()
+
+const variables = [
+  { name: 'story_key', description: 'Unique story identifier (e.g., S-14)' },
+  { name: 'story_title', description: 'Story title/summary' },
+  { name: 'story_objective', description: 'Story objective text' },
+  { name: 'target_files', description: 'Array of target file paths' },
+  { name: 'acceptance_criteria', description: 'Story acceptance criteria text' },
+  { name: 'error_context', description: 'Error output from previous failed run (retry only)' },
+  { name: 'diff_content', description: 'Git diff from previous attempt (retry/review only)' },
+  { name: 'branch_name', description: 'Git branch name for this run' },
+  { name: 'repo_url', description: 'Git repository URL' },
+]
+
+function formatPlaceholder(name: string): string {
+  return `{{${name}}}`
+}
+
+function handleVariableClick(variableName: string) {
+  if (!props.editorRef) return
+  props.editorRef.insertAtCursor(`{{${variableName}}}`)
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-1 p-3">
+    <h3 class="mb-2 text-sm font-semibold text-surface-500">Context Variables</h3>
+    <button
+      v-for="variable in variables"
+      :key="variable.name"
+      class="cursor-pointer rounded-md p-2 text-left transition-colors hover:bg-surface-100 dark:hover:bg-surface-700"
+      :title="variable.description"
+      @click="handleVariableClick(variable.name)"
+    >
+      <div class="text-sm font-mono font-medium text-primary-600 dark:text-primary-400">
+        {{ formatPlaceholder(variable.name) }}
+      </div>
+      <div class="text-xs text-surface-500">{{ variable.description }}</div>
+    </button>
+  </div>
+</template>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -63,6 +63,17 @@ const router = createRouter({
           name: 'project-templates',
           component: PromptTemplatesView,
         },
+        {
+          path: 'templates/new',
+          name: 'template-create',
+          component: () => import('@/views/TemplateEditorView.vue'),
+          meta: { requiresAdmin: true },
+        },
+        {
+          path: 'templates/:templateId',
+          name: 'template-editor',
+          component: () => import('@/views/TemplateEditorView.vue'),
+        },
       ],
     },
     {

--- a/frontend/src/views/TemplateEditorView.vue
+++ b/frontend/src/views/TemplateEditorView.vue
@@ -22,6 +22,8 @@ const isAdmin = computed(() => user.value?.role === 'admin')
 
 const {
   content,
+  name,
+  type,
   loading,
   saving,
   error,
@@ -97,11 +99,16 @@ async function handlePreview() {
     :is-dirty="isDirty"
     :is-saving="saving"
     :can-save="canSave"
+    :is-new-template="isNewTemplate"
+    :template-name="name"
+    :template-type="type"
     :preview-visible="previewVisible"
     :preview-content="previewContent"
     :preview-loading="previewLoading"
     :preview-error="previewError"
     @update:content="content = $event"
+    @update:template-name="name = $event"
+    @update:template-type="type = $event"
     @update:preview-visible="previewVisible = $event"
     @save="handleSave"
     @cancel="handleCancel"

--- a/frontend/src/views/TemplateEditorView.vue
+++ b/frontend/src/views/TemplateEditorView.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useToast } from 'primevue/usetoast'
+import Toast from 'primevue/toast'
+import Skeleton from 'primevue/skeleton'
+import Message from 'primevue/message'
+import Button from 'primevue/button'
+import { useAuth } from '@/composables/useAuth'
+import { useTemplateEditor } from '@/composables/useTemplateEditor'
+import TemplateEditorLayout from '@/features/templates/TemplateEditorLayout.vue'
+
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+
+const projectId = computed(() => (route.params.id ?? route.params.projectId) as string)
+const templateId = computed(() => (route.params.templateId as string) ?? 'new')
+
+const { user } = useAuth()
+const isAdmin = computed(() => user.value?.role === 'admin')
+
+const {
+  content,
+  loading,
+  saving,
+  error,
+  isDirty,
+  canSave,
+  isNewTemplate,
+  previewLoading,
+  previewError,
+  previewContent,
+  fetchTemplate,
+  saveTemplate,
+  previewTemplate,
+} = useTemplateEditor(projectId.value, templateId.value)
+
+const previewVisible = ref(false)
+
+async function handleSave() {
+  const success = await saveTemplate()
+  if (success) {
+    toast.add({
+      severity: 'success',
+      summary: 'Saved',
+      detail: isNewTemplate.value ? 'Template created successfully' : 'Template saved successfully',
+      life: 3000,
+    })
+    if (isNewTemplate.value) {
+      router.push({ name: 'project-templates', params: { id: projectId.value } })
+    }
+  } else {
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail: error.value ?? 'Failed to save template',
+      life: 5000,
+    })
+  }
+}
+
+function handleCancel() {
+  router.push({ name: 'project-templates', params: { id: projectId.value } })
+}
+
+async function handlePreview() {
+  await previewTemplate()
+  previewVisible.value = true
+}
+</script>
+
+<template>
+  <Toast />
+
+  <!-- Loading state -->
+  <div v-if="loading" class="flex flex-col gap-4 p-6">
+    <Skeleton height="2rem" width="30%" />
+    <Skeleton height="60vh" />
+  </div>
+
+  <!-- Error state -->
+  <div v-else-if="error && !content" class="p-6">
+    <Message severity="error" :closable="false">
+      <div class="flex items-center gap-3">
+        <span>{{ error }}</span>
+        <Button label="Retry" severity="secondary" text size="small" @click="fetchTemplate()" />
+      </div>
+    </Message>
+  </div>
+
+  <!-- Editor -->
+  <TemplateEditorLayout
+    v-else
+    :content="content"
+    :is-admin="isAdmin"
+    :is-dirty="isDirty"
+    :is-saving="saving"
+    :can-save="canSave"
+    :preview-visible="previewVisible"
+    :preview-content="previewContent"
+    :preview-loading="previewLoading"
+    :preview-error="previewError"
+    @update:content="content = $event"
+    @update:preview-visible="previewVisible = $event"
+    @save="handleSave"
+    @cancel="handleCancel"
+    @preview="handlePreview"
+  />
+</template>


### PR DESCRIPTION
## Summary
- Add prompt template editor page with Monaco editor, Handlebars syntax highlighting, and variable sidebar for inserting context placeholders
- Support create (POST) and edit (PUT) modes with admin-only save, read-only mode for non-admin users
- Client-side Handlebars template preview with sample context data
- Routes: `/projects/:id/templates/:templateId` (edit) and `/projects/:id/templates/new` (create, admin-only)
- `useTemplateEditor` composable with isDirty/canSave tracking, loading/error/retry states

## Test plan
- [x] 12 unit tests for `useTemplateEditor` composable (fetch, save, preview, dirty tracking, error handling)
- [x] E2E tests for editor display, preview dialog, variable sidebar, cancel navigation, admin vs non-admin, error+retry
- [x] ESLint passes
- [x] All 202 existing tests still pass (no regressions)

## Story
Refs: S-6-6 — Prompt Template Editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)