### PR TITLE
feat(api): add story markdown import endpoint with frontmatter parsing

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -487,6 +487,33 @@ paths:
         "409":
           $ref: "#/components/responses/Conflict"
 
+  /projects/{projectId}/stories/import:
+    post:
+      operationId: importStories
+      summary: Bulk import stories from markdown with YAML frontmatter
+      tags: [stories]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportStoriesRequest"
+      responses:
+        "200":
+          description: Import result with per-story success and error counts
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportStoriesResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
   /projects/{projectId}/stories/{storyId}:
     get:
       operationId: getStory
@@ -1322,6 +1349,47 @@ components:
           $ref: "#/components/schemas/StoryStatus"
         acceptance_criteria:
           type: string
+
+    # ── Story Import ──────────────────────────────────────────────────
+    ImportStoriesRequest:
+      type: object
+      required: [content]
+      properties:
+        content:
+          type: string
+          description: Raw markdown content with YAML frontmatter story blocks
+
+    ImportStoriesResult:
+      type: object
+      required: [imported, updated, failed, errors]
+      properties:
+        imported:
+          type: integer
+          description: Number of newly created stories
+        updated:
+          type: integer
+          description: Number of updated stories (key already existed)
+        failed:
+          type: integer
+          description: Number of stories that failed to import
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ImportStoryError"
+
+    ImportStoryError:
+      type: object
+      required: [key, message, code]
+      properties:
+        key:
+          type: string
+          description: Story key (may be empty if key could not be extracted)
+        message:
+          type: string
+          description: Human-readable error description
+        code:
+          type: string
+          description: Machine-readable error code
 
     # ── Prompt Template ────────────────────────────────────────────────
     PromptTemplate:

--- a/backend/internal/adapter/markdown/parser.go
+++ b/backend/internal/adapter/markdown/parser.go
@@ -138,15 +138,15 @@ func parseBlock(block storyBlock) ParsedStory {
 // extractTitleAndBody extracts the first H1 heading as the title and the
 // remaining content as acceptance criteria.
 func extractTitleAndBody(body string) (title, acceptanceCriteria string) {
-	loc := titleRegex.FindStringIndex(body)
+	loc := titleRegex.FindStringSubmatchIndex(body)
 	if loc == nil {
 		return "", strings.TrimSpace(body)
 	}
 
-	match := titleRegex.FindStringSubmatch(body)
-	title = strings.TrimSpace(match[1])
+	// loc[0]:loc[1] is the full match extent; loc[2]:loc[3] is the capture group (title text).
+	title = strings.TrimSpace(body[loc[2]:loc[3]])
 
-	// Everything after the title line becomes the acceptance criteria
+	// Everything after the title line becomes the acceptance criteria.
 	remaining := body[loc[1]:]
 	acceptanceCriteria = strings.TrimSpace(remaining)
 

--- a/backend/internal/adapter/markdown/parser.go
+++ b/backend/internal/adapter/markdown/parser.go
@@ -1,0 +1,154 @@
+package markdown
+
+import (
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FrontmatterFields represents the parsed YAML frontmatter of a story block.
+type FrontmatterFields struct {
+	Key       string   `yaml:"key"`
+	Epic      string   `yaml:"epic"`
+	DependsOn []string `yaml:"depends_on"`
+	Scope     string   `yaml:"scope"`
+	Status    string   `yaml:"status"`
+}
+
+// ParsedStory holds the result of parsing one story block from markdown.
+// ParseError is non-nil if YAML frontmatter failed to parse.
+type ParsedStory struct {
+	Key                string
+	Title              string
+	Epic               string
+	DependsOn          []string
+	Scope              string
+	Status             string
+	AcceptanceCriteria string
+	ParseError         error
+}
+
+const frontmatterDelimiter = "---"
+
+var titleRegex = regexp.MustCompile(`(?m)^# (.+)$`)
+
+// ParseStoryMarkdown splits a markdown document into individual story blocks
+// and parses the YAML frontmatter and title from each.
+// Blocks are delimited by lines consisting solely of "---".
+// Returns one ParsedStory per detected block (with ParseError set for invalid YAML).
+func ParseStoryMarkdown(content string) []ParsedStory {
+	blocks := splitIntoBlocks(content)
+	stories := make([]ParsedStory, 0, len(blocks))
+
+	for _, block := range blocks {
+		story := parseBlock(block)
+		stories = append(stories, story)
+	}
+
+	return stories
+}
+
+// splitIntoBlocks splits raw markdown content into individual story blocks.
+// Each block is expected to start with "---" (frontmatter open), followed by
+// YAML content, then "---" (frontmatter close), then the markdown body.
+func splitIntoBlocks(content string) []storyBlock {
+	lines := strings.Split(content, "\n")
+	var blocks []storyBlock
+
+	i := 0
+	for i < len(lines) {
+		// Skip empty lines between blocks
+		if strings.TrimSpace(lines[i]) != frontmatterDelimiter {
+			i++
+			continue
+		}
+
+		// Found opening "---", start collecting frontmatter
+		fmStart := i + 1
+		i++
+
+		// Find closing "---"
+		fmEnd := -1
+		for i < len(lines) {
+			if strings.TrimSpace(lines[i]) == frontmatterDelimiter {
+				fmEnd = i
+				i++
+				break
+			}
+			i++
+		}
+
+		if fmEnd == -1 {
+			// No closing "---" found, skip this incomplete block
+			break
+		}
+
+		frontmatter := strings.Join(lines[fmStart:fmEnd], "\n")
+
+		// Collect body until next "---" or end of content
+		bodyStart := i
+		bodyEnd := len(lines)
+		for j := i; j < len(lines); j++ {
+			if strings.TrimSpace(lines[j]) == frontmatterDelimiter {
+				bodyEnd = j
+				break
+			}
+		}
+
+		body := strings.Join(lines[bodyStart:bodyEnd], "\n")
+		i = bodyEnd
+
+		blocks = append(blocks, storyBlock{
+			frontmatter: frontmatter,
+			body:        body,
+		})
+	}
+
+	return blocks
+}
+
+type storyBlock struct {
+	frontmatter string
+	body        string
+}
+
+// parseBlock parses a single story block into a ParsedStory.
+func parseBlock(block storyBlock) ParsedStory {
+	var fields FrontmatterFields
+	if err := yaml.Unmarshal([]byte(block.frontmatter), &fields); err != nil {
+		return ParsedStory{
+			ParseError: err,
+		}
+	}
+
+	title, acceptanceCriteria := extractTitleAndBody(block.body)
+
+	return ParsedStory{
+		Key:                fields.Key,
+		Title:              title,
+		Epic:               fields.Epic,
+		DependsOn:          fields.DependsOn,
+		Scope:              fields.Scope,
+		Status:             fields.Status,
+		AcceptanceCriteria: acceptanceCriteria,
+	}
+}
+
+// extractTitleAndBody extracts the first H1 heading as the title and the
+// remaining content as acceptance criteria.
+func extractTitleAndBody(body string) (title, acceptanceCriteria string) {
+	loc := titleRegex.FindStringIndex(body)
+	if loc == nil {
+		return "", strings.TrimSpace(body)
+	}
+
+	match := titleRegex.FindStringSubmatch(body)
+	title = strings.TrimSpace(match[1])
+
+	// Everything after the title line becomes the acceptance criteria
+	remaining := body[loc[1]:]
+	acceptanceCriteria = strings.TrimSpace(remaining)
+
+	return title, acceptanceCriteria
+}

--- a/backend/internal/adapter/markdown/parser_test.go
+++ b/backend/internal/adapter/markdown/parser_test.go
@@ -1,0 +1,279 @@
+package markdown
+
+import (
+	"testing"
+)
+
+const testKeyS03 = "S-03"
+
+func TestParseStoryMarkdown_SingleStory(t *testing.T) {
+	content := `---
+key: S-03
+epic: E-01
+depends_on:
+  - S-01
+  - S-02
+scope: backend
+status: backlog
+---
+# Story Title Here
+
+Acceptance criteria and other body text here.
+`
+	stories := ParseStoryMarkdown(content)
+
+	if len(stories) != 1 {
+		t.Fatalf("expected 1 story, got %d", len(stories))
+	}
+
+	s := stories[0]
+	if s.ParseError != nil {
+		t.Fatalf("unexpected parse error: %v", s.ParseError)
+	}
+	if s.Key != testKeyS03 {
+		t.Errorf("expected key %q, got %q", testKeyS03, s.Key)
+	}
+	if s.Title != "Story Title Here" {
+		t.Errorf("expected title 'Story Title Here', got %q", s.Title)
+	}
+	if s.Epic != "E-01" {
+		t.Errorf("expected epic 'E-01', got %q", s.Epic)
+	}
+	if len(s.DependsOn) != 2 || s.DependsOn[0] != "S-01" || s.DependsOn[1] != "S-02" {
+		t.Errorf("expected depends_on [S-01, S-02], got %v", s.DependsOn)
+	}
+	if s.Scope != "backend" {
+		t.Errorf("expected scope 'backend', got %q", s.Scope)
+	}
+	if s.Status != "backlog" {
+		t.Errorf("expected status 'backlog', got %q", s.Status)
+	}
+	if s.AcceptanceCriteria != "Acceptance criteria and other body text here." {
+		t.Errorf("expected acceptance criteria 'Acceptance criteria and other body text here.', got %q", s.AcceptanceCriteria)
+	}
+}
+
+func TestParseStoryMarkdown_MultiStory(t *testing.T) {
+	content := `---
+key: S-03
+scope: backend
+---
+# First Story
+
+Body of first story.
+
+---
+key: S-04
+scope: frontend
+depends_on:
+  - S-03
+---
+# Second Story
+
+Body of second story.
+`
+	stories := ParseStoryMarkdown(content)
+
+	if len(stories) != 2 {
+		t.Fatalf("expected 2 stories, got %d", len(stories))
+	}
+
+	if stories[0].Key != testKeyS03 {
+		t.Errorf("first story: expected key %q, got %q", testKeyS03, stories[0].Key)
+	}
+	if stories[0].Title != "First Story" {
+		t.Errorf("first story: expected title 'First Story', got %q", stories[0].Title)
+	}
+	if stories[0].AcceptanceCriteria != "Body of first story." {
+		t.Errorf("first story: expected acceptance criteria 'Body of first story.', got %q", stories[0].AcceptanceCriteria)
+	}
+
+	if stories[1].Key != "S-04" {
+		t.Errorf("second story: expected key 'S-04', got %q", stories[1].Key)
+	}
+	if stories[1].Title != "Second Story" {
+		t.Errorf("second story: expected title 'Second Story', got %q", stories[1].Title)
+	}
+	if len(stories[1].DependsOn) != 1 || stories[1].DependsOn[0] != testKeyS03 {
+		t.Errorf("second story: expected depends_on [%s], got %v", testKeyS03, stories[1].DependsOn)
+	}
+}
+
+func TestParseStoryMarkdown_InvalidYAML(t *testing.T) {
+	content := `---
+key: S-05
+scope: [invalid yaml
+---
+# Invalid Story
+
+Body text.
+`
+	stories := ParseStoryMarkdown(content)
+
+	if len(stories) != 1 {
+		t.Fatalf("expected 1 story, got %d", len(stories))
+	}
+
+	if stories[0].ParseError == nil {
+		t.Fatal("expected parse error for invalid YAML, got nil")
+	}
+}
+
+func TestParseStoryMarkdown_MissingTitle(t *testing.T) {
+	content := `---
+key: S-06
+scope: backend
+---
+
+No heading here, just body text.
+`
+	stories := ParseStoryMarkdown(content)
+
+	if len(stories) != 1 {
+		t.Fatalf("expected 1 story, got %d", len(stories))
+	}
+
+	if stories[0].Title != "" {
+		t.Errorf("expected empty title, got %q", stories[0].Title)
+	}
+	if stories[0].Key != "S-06" {
+		t.Errorf("expected key 'S-06', got %q", stories[0].Key)
+	}
+}
+
+func TestParseStoryMarkdown_OnlyKeyInFrontmatter(t *testing.T) {
+	content := `---
+key: S-07
+---
+# Minimal Story
+`
+	stories := ParseStoryMarkdown(content)
+
+	if len(stories) != 1 {
+		t.Fatalf("expected 1 story, got %d", len(stories))
+	}
+
+	s := stories[0]
+	if s.ParseError != nil {
+		t.Fatalf("unexpected parse error: %v", s.ParseError)
+	}
+	if s.Key != "S-07" {
+		t.Errorf("expected key 'S-07', got %q", s.Key)
+	}
+	if s.Title != "Minimal Story" {
+		t.Errorf("expected title 'Minimal Story', got %q", s.Title)
+	}
+	if s.Epic != "" {
+		t.Errorf("expected empty epic, got %q", s.Epic)
+	}
+	if len(s.DependsOn) != 0 {
+		t.Errorf("expected empty depends_on, got %v", s.DependsOn)
+	}
+	if s.Scope != "" {
+		t.Errorf("expected empty scope, got %q", s.Scope)
+	}
+	if s.Status != "" {
+		t.Errorf("expected empty status, got %q", s.Status)
+	}
+}
+
+func TestParseStoryMarkdown_NoFrontmatterDelimiters(t *testing.T) {
+	content := `Just some plain text without any frontmatter.
+
+# Not a story
+
+This is not a story block.
+`
+	stories := ParseStoryMarkdown(content)
+
+	if len(stories) != 0 {
+		t.Fatalf("expected 0 stories for content without frontmatter, got %d", len(stories))
+	}
+}
+
+func TestParseStoryMarkdown_DependsOnAsList(t *testing.T) {
+	content := `---
+key: S-08
+depends_on:
+  - S-01
+  - S-02
+  - S-03
+---
+# Dependencies Story
+
+Has multiple dependencies.
+`
+	stories := ParseStoryMarkdown(content)
+
+	if len(stories) != 1 {
+		t.Fatalf("expected 1 story, got %d", len(stories))
+	}
+
+	if len(stories[0].DependsOn) != 3 {
+		t.Fatalf("expected 3 dependencies, got %d", len(stories[0].DependsOn))
+	}
+	expected := []string{"S-01", "S-02", "S-03"}
+	for i, dep := range stories[0].DependsOn {
+		if dep != expected[i] {
+			t.Errorf("expected dependency[%d] = %q, got %q", i, expected[i], dep)
+		}
+	}
+}
+
+func TestParseStoryMarkdown_EmptyContent(t *testing.T) {
+	stories := ParseStoryMarkdown("")
+
+	if len(stories) != 0 {
+		t.Fatalf("expected 0 stories for empty content, got %d", len(stories))
+	}
+}
+
+func TestParseStoryMarkdown_MixedValidAndInvalid(t *testing.T) {
+	content := `---
+key: S-10
+scope: backend
+---
+# Valid Story
+
+This is valid.
+
+---
+key: S-11
+scope: [broken
+---
+# Invalid Story
+
+This has bad YAML.
+
+---
+key: S-12
+scope: frontend
+---
+# Another Valid Story
+
+This is also valid.
+`
+	stories := ParseStoryMarkdown(content)
+
+	if len(stories) != 3 {
+		t.Fatalf("expected 3 stories, got %d", len(stories))
+	}
+
+	if stories[0].ParseError != nil {
+		t.Errorf("first story should be valid, got error: %v", stories[0].ParseError)
+	}
+	if stories[0].Key != "S-10" {
+		t.Errorf("first story key should be 'S-10', got %q", stories[0].Key)
+	}
+
+	if stories[1].ParseError == nil {
+		t.Error("second story should have parse error")
+	}
+
+	if stories[2].ParseError != nil {
+		t.Errorf("third story should be valid, got error: %v", stories[2].ParseError)
+	}
+	if stories[2].Key != "S-12" {
+		t.Errorf("third story key should be 'S-12', got %q", stories[2].Key)
+	}
+}

--- a/backend/internal/api/handler/gen_server.go
+++ b/backend/internal/api/handler/gen_server.go
@@ -248,6 +248,38 @@ type Error struct {
 	} `json:"error"`
 }
 
+// ImportStoriesRequest defines model for ImportStoriesRequest.
+type ImportStoriesRequest struct {
+	// Content Raw markdown content with YAML frontmatter story blocks
+	Content string `json:"content"`
+}
+
+// ImportStoriesResult defines model for ImportStoriesResult.
+type ImportStoriesResult struct {
+	Errors []ImportStoryError `json:"errors"`
+
+	// Failed Number of stories that failed to import
+	Failed int `json:"failed"`
+
+	// Imported Number of newly created stories
+	Imported int `json:"imported"`
+
+	// Updated Number of updated stories (key already existed)
+	Updated int `json:"updated"`
+}
+
+// ImportStoryError defines model for ImportStoryError.
+type ImportStoryError struct {
+	// Code Machine-readable error code
+	Code string `json:"code"`
+
+	// Key Story key (may be empty if key could not be extracted)
+	Key string `json:"key"`
+
+	// Message Human-readable error description
+	Message string `json:"message"`
+}
+
 // LoginRequest defines model for LoginRequest.
 type LoginRequest struct {
 	Email    openapi_types.Email `json:"email"`
@@ -662,6 +694,9 @@ type CreateRunJSONRequestBody = CreateRunRequest
 // CreateStoryJSONRequestBody defines body for CreateStory for application/json ContentType.
 type CreateStoryJSONRequestBody = CreateStoryRequest
 
+// ImportStoriesJSONRequestBody defines body for ImportStories for application/json ContentType.
+type ImportStoriesJSONRequestBody = ImportStoriesRequest
+
 // UpdateStoryJSONRequestBody defines body for UpdateStory for application/json ContentType.
 type UpdateStoryJSONRequestBody = UpdateStoryRequest
 
@@ -798,6 +833,9 @@ type ServerInterface interface {
 	// Create a new story in a project
 	// (POST /projects/{projectId}/stories)
 	CreateStory(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath)
+	// Bulk import stories from markdown with YAML frontmatter
+	// (POST /projects/{projectId}/stories/import)
+	ImportStories(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath)
 	// Delete a story
 	// (DELETE /projects/{projectId}/stories/{storyId})
 	DeleteStory(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, storyId StoryIdPath)
@@ -963,6 +1001,12 @@ func (_ Unimplemented) ListStories(w http.ResponseWriter, r *http.Request, proje
 // Create a new story in a project
 // (POST /projects/{projectId}/stories)
 func (_ Unimplemented) CreateStory(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Bulk import stories from markdown with YAML frontmatter
+// (POST /projects/{projectId}/stories/import)
+func (_ Unimplemented) ImportStories(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1738,6 +1782,37 @@ func (siw *ServerInterfaceWrapper) CreateStory(w http.ResponseWriter, r *http.Re
 	handler.ServeHTTP(w, r)
 }
 
+// ImportStories operation middleware
+func (siw *ServerInterfaceWrapper) ImportStories(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ImportStories(w, r, projectId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // DeleteStory operation middleware
 func (siw *ServerInterfaceWrapper) DeleteStory(w http.ResponseWriter, r *http.Request) {
 
@@ -2456,6 +2531,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Post(options.BaseURL+"/projects/{projectId}/stories", wrapper.CreateStory)
 	})
 	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/projects/{projectId}/stories/import", wrapper.ImportStories)
+	})
+	r.Group(func(r chi.Router) {
 		r.Delete(options.BaseURL+"/projects/{projectId}/stories/{storyId}", wrapper.DeleteStory)
 	})
 	r.Group(func(r chi.Router) {
@@ -2504,75 +2582,80 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xdWXMjN5L+K4jafRhHkCKpltoePU0f9qxmPW6F1ArHbo+CAVUlSYyKQDWA6jZXwf++",
-	"gaMOVKEO3rLbTxJZOPP4kJnILD4HIVsmjAKVIrh6DhLM8RIkcP3px4SE19ENlgv1KQIRcpJIwmhwpZ+h",
-	"+/vr98EgIOqLRDUbBBQvIbgKQHcNBgGHzynhEAVXkqcwCES4gCVW480YX2IZXAVpSlRLuUpUTyE5ofNg",
-	"vR4ETXPfgmApD6FlfrLr3Dd4DjeKGvXp1SNE0+Uj8GzyzynwVTF7gucQlOeLYIbTWAZXk0GwJJQs06X+",
-	"385LqIQ5cDMx8Ja5ryUsBUqAIzuHd3rg0+YlnI8HwRL/ZtcwHneviLN/QyibuGEftzAjyQbYkSe3KW0U",
-	"iZS2LICrjjtOfse4fLtqYMtPBOIISYYE4xI9rhoYo55O9VMPX4KQA5YQTbH0L0Ayvmrav37YQgFhOu9I",
-	"g4+wTGIsoUUUlolE0jZrWY/MR9ppSWvVWSSMCtCI9RZHt/A5BSHVp5BRCVT/i5MkJiFW6xz9W6jFPpem",
-	"+U8Os+Aq+I9RgYYj81SMfuSccTOVu9m3OELcTrYeBO8YncUkPMLEOfyFdkr0Fzibn6EoNVMBgiUm8Xdq",
-	"VT8x/kiiCOjhl5VPhYYIR0tCEQ5DEALl7F0Pgl+Y/ImlNDoilSiTaKbnXA+Ce4pTuWCc/B8cYQ3ObOqx",
-	"7aEGfKe1XR2jJYlNOEuAS2Kk2RnsOYDf8DKJITt8Z4wjNTxQaZeNZoBlykEEGuF/BjpXWno+ViBfUZ1M",
-	"E8vD3gvg6I0zZGWky0t9WmSfJ55hhcQyFS6yPeLwKWbzYBAAVefMp9I3hE4TzuYchFp2xCgEDz7sKUDi",
-	"k1l60Yo9quNFK6Emqj2RNqfrGyT0v8ieWO7uJ33p+M8VuvEN0E2+jfe5TGQGyo3brS/wveEMulafl0Al",
-	"MkNtzu0Mx6clRSrm+R+WIswBkWweQudIH0Xo+Vn/nT7Bar0+OzsLuqfSXzznIpQPqk8Qqc9ZDl8IfFVj",
-	"Adf2T5gKyZaKhsWqyh170N+zSduvmTO3KW1kR0ISiAnVo83IvN5ASEj0P0QZe/XnOMwkt1EWe23LjuPb",
-	"hf0Cc45Xte5mfb5uhqUk6mdNuGPanoMafZqprI2eRjqr0yeRmIYwDTmRwAn20iyCBGgkpoakOc0b5C+j",
-	"yUC7OP32OgieYOVqxt1wPHG17dKHLWbH5At4VyRC5qqEQlWgagUzrkVV/SsWWBH5oRWr2443TeY701TR",
-	"AfM5yOmMxCA2o5gkMq4gUYFAMZsTmnk1VRRqFx5F3Wx0n7So47IuHyVz21nS+fj89XA8GU4uP07GV6/G",
-	"V+Px/yqKZjyOsIShJAYZ6sK0/ZFdG8wIVzHG99+P4YeL8XgI5399HF5Moosh/n7yenhx8fr15eXFxXg8",
-	"HpdX2iSNfU/+Wkd7LE6rC3v9ej8LK+Sxr51QrKFo6RlWgUvIUhvl6BT2d6bpehCkSbRvIakIr8G8grCD",
-	"DJ4tMSrLH7huYml9TZL/M/HaQFhiR3tbDVylQB6FTvCcUJwJe9sIN0XLKgH0SpyxvDvRNnZtG+D/OmRR",
-	"VcLvfryd/vLh4/SnD/e/vPerrsQkNkdHFBG1EhzflIY1zmltZUsQQqFWXaG+ErlA1+8Rfgwn569KjkiX",
-	"TOjlFyPX6VFpb6jgI9vPClUbj0jtJ7oLTwXwv9mPZyFbloXaNPfhAhbiK+MVVBAQphxu/ibEpDxK3riL",
-	"Ctl0eQffBm8cEaxYWlW2eOJbgyJaVm55PvY1lUxil14X596QWXkbptMgCwrm03l3Y22fdw2m4eEBuGp6",
-	"tiq1Xe2dhMQHD+3geb4H8HRw0yy+ExOdVTcY19N2Z6PiZEilXBv7GoMAp5JNcZJw9sWVvhmORQE1j4zF",
-	"gKnPIvjhh/3wfckiiMv7DWOcRjBkSSqGF8PXanfmG8EoBTm8GF4W3y0weUqHF8NX7t7rY/SwRFoJpt28",
-	"acJiEq66hPNWtb0xTb1nruMFGYZnhKiwpjKxV6isv39iK9MTwOi0KveFHR1xkLpv85UCryHZ5eV+VnMk",
-	"w80KUb6XzcwzS509WGgZnU9rpLkBqSMpw6EwcaOw2dFdpX0G3k4Sajupb9UU0dtYfUvivh8tLuvPaZX5",
-	"FuZESOAH9x7qivYPTAG9Z7B5PHpbT6Q07A8b+yWD5kB92QqpEXCJf5sqdcromTsfzgV96X7e65QY26Sq",
-	"spRRfTDR4QyTOOXa1Im/4pVwNdRp0L7v8nKdab0bT6nPLVezFjrfD+DdU6NfH+0RT0uuecOx0YmzlWj0",
-	"VFCciAWTG4cJ3AOhTyiMb7rpevgsARqph4OAp5Sa/3ImKFXAJNb/hJiGEMcmTlxIR9G/IajWczcu1O8F",
-	"yUs3BnmkbBPwvk3pHhBbifmJYTqlbZ6sV/a31ENGJSaF0f6yFDVm86m0B1LdcUzpH0jxIJk2XPTZp4xH",
-	"wEuPm0JTJkvO0KY8sDNMflHoV7QGmfyVyMVdFk3CcfxhFlx96qNL3behHWP4o1E97zAfskSr7e8Tt9GC",
-	"Y9xBbnZVWU1kIZ9TsB4EiZRDMSM2wk1oFm0weUgDdDccT74LBvXrzg3vNzc9Mr/V69CDnK/lS9Utj9jy",
-	"XVpNnbL7uvL+X/nsW33VV2516WtlAbXczm8tWzjuuBaokKe4XCzgPDIWtp24cf97MDIMIJ3WzMj38oHf",
-	"ETo3glvNuJMppwLlTfV9d6z++ZyCchsGiHEkdHfTSrd4ghWKGXtKE+2wQI+joqCsOjB60C7H9bsN09O6",
-	"+V1o4b1Wh+1S+kzfCJUbbJnFZ0fSGQe/mON86xy+7fP1ahJk1uXecDXSaZ8XUb3Tl+wKt80e7GThZFMW",
-	"Zqn123Bx3bbB7dIGS8taJnJL2WoPXGZT5CnkttUxMgR7E/D3k3f2B80f604Pa+Dcvdgsnknh61B/va+g",
-	"5t2S6DKIDZWGs9hhlM6vVwaYAN5XdAXwI93I7CswfKi7wdaA88a0dzd5wouOjI7Whdfr3sxgVzKyB3tV",
-	"i9opzVUFTRCmnMjVnRoxiz6zJwJvUl/l0j9+/YgkewKKhPK+sECYooWUyQcar5C5P0BmgKygKf+UlTSp",
-	"7gWncEL+G1amKoTQGcuqTbDJErCd/oslcC1/ZfxJoI+Al4GnzEhjMnpzc62tZbkAVO6V+d5LTPHc+I7q",
-	"5FRCdPYv+nFBBCJC97KGty2LYTMkeSoX+aBqArVAjkN59i+1k5iEQAWUlvvP649KingcXAWKOuJqNGIJ",
-	"UDPmGePzke0kRqptAdrOTt/cXAeD4AtwYfY4PpucjfV5lQDFCQmugldn47NXms9yobk3wqlcjLRbrMWT",
-	"GTFVQqrF4DoKrky6271RQ1ub9ZZFq71V+jjpdGtXNCVPoVqPdj4e721uo1X1IiO9JiRSXWw1SxUCLABH",
-	"tob3DuTwnZHUmtDn8q2kPxfnYjW1arv1ILgYT5oWmu98VK97stoYXH16GAQiXS4xX5m1I0KVrsFvROhb",
-	"6gxE8VxotFXq+qDGyAWApbJVAlgqcxFweHFRJ8HPbD6HCLFUligYa7TacqfO3tS4SrfClHOlmR2bM8fS",
-	"HDz7+jvId2YQ/94OL2fvSntAWbLsHuj0d3BoFK/KKfIQddGM22vqZpHILrIPiAvVu/Je0DA5OMt0FnJG",
-	"IIhcET8wTIy7haJUrau7/LW7S15l24YqGTcQRhS+tgiQPTtFo9YpY+gmazRwXo/QEKEqmoyKMv6mIFW5",
-	"cbnsv0f7cjn6+uGAcFDOUfOImLXUIDKBPjZDOVH3gaFqTBzHxaAFH/OvHpRp6dV8pxz0QKrvLTk9sv7n",
-	"2X8e/ljz0LoBwba6uRsfDZGsPpZyU+usLKvl6JlEa4NHMZh8Qpe/7/X3BX8300/7FgOP9lw0v+XCLCXa",
-	"kiiq00V3p7xK3qWi2S7C7RQcNBoQ+yfU+JgivJvNsRvplZGS0x09rpB+sYUfilIP9Z3Q8m4M2D+EeePe",
-	"R/ZuevDfBi+OB2G7iYyhape2uniXvylnPYKEhO2GyY+6xcZWifM2nz6WyR/CjMkrIXvZMJr4pn7P5DyE",
-	"eUXoXkwaM74uB85BpT5bITBGGLoMHV2muaM8PBzSSipfjR7ZRDIlrHXe61vSoxtHqtOr7k7F23u284/8",
-	"9pcSJh118SBTJmjtsDR6Nu9362Gc7UMmu2Gk9Ka6fuacZvvuttzmPNzd+qOagV5waDL8XgITxsdR5ZMb",
-	"iYY9NROxhODN9uGJ+HQoi3JjuD+SjJzEkDwwVOx2PmS2aiO2NJ4HWX1EW+C6UtW+DwvlUF6Iu1KfrWhb",
-	"IFMPknJ7S3kiuJELQIl3Sa51WXY+bPOhad7ttO6fewdzYb3JZcf2ZLeUoT8kLPlQZj8y24hIPKXtfvNt",
-	"SsXb1baxmGP6z4eEuqz+qZc/rGm6L+dXDdbIaT1Tl6N7m9IX7eeWXv93ZDdX19B4Xoaa0tM4uduDhXtl",
-	"kMEFT2mX6DQCg5AsK7VtxIY72+aFR9UqN/NsucRDAapHWWtNeiYIJBmakVgCV26JLdKxGd0Dm+D+XdMr",
-	"q/O3kDXe9w78L6N+gpWaOGbsCaUJ+gu35QFZGpJq1DSrKT5pnvKQwFivdOgFkVa6ShUOJpb3qClxEhXS",
-	"aJutyxNsZImpXraCYmXElh1apcqUpguSTZ3FSwZlJ2v7yLBsq1DqcmRU5duKP9oqQn8AspC3LhwfPduX",
-	"2veIQu5FOnvcZpRe0d8vDmn4//sMRBpGNmBFUyzgZXBifCzNPv2ddX4KOeFIB9abff+TcetQEYLND4Gj",
-	"icqfUcmmqGQL0DQeElkBWWduX6kUTnyzwQDPm6z65vqVf/BlfzGC6sDNkSHdcFisoEc2YPkdWy/ZYvUX",
-	"ah4/t9B5J5k3P8f51Z9vy5qtSGqTXeuR027sGj0Xv5PULxFyj6LdjU+Vn4PqnUjp0Ot3avtW2N6FSC0p",
-	"mS+MZeMTIseLyPB0VuTJ9PQcN60Zn6fn7wEzRrc9n04pZX8a2rIlVbU/qqnzi6dUjJ717yuu21IAtrmx",
-	"KX7u8dAXYcXLyhruTiwwZTmauuXJMIqn1OCSWQ6RAmWvvvdchdSiZX0vSLfz/R1X/s/L0V0uR6teb4mp",
-	"qbB1e408vNctvs2Stfw1Br3YZ2h5LGT3l7elllsZq83nEq97lkLZEtcD1kHdm+rf36XNXikEzYjcbJ3v",
-	"mZzj4xT87m5FH5M75kzTReVVY7tgUIuFvTuPDmUel1829ELeFaHl41vJM2tU+ErtuPtmmE8PSioE8C+Z",
-	"LLkkfHNzjb5M0CMWgOxvWpv3oYxwQkZfJlqo7Iy1vu5v/wGNEkZMpY9NfNDF6fWMCs230htePD2zY6yp",
-	"cLW9d6lo21sq0d7bZAl75i6n7bQPYY2ormhR5y5cJ6UpN6V9mOx6oWVDbtqibynVjMX1w/r/AwAA//+0",
-	"zzbWboEAAA==",
+	"H4sIAAAAAAAC/+w9aXMbN7J/BTXvfUiqSJGUJSerT+sru9rn2CrJqtQ+r4oFzTQpRDPAGMBY5lPxv7/C",
+	"MQc4mIMUDyXOJ1sk0Gj0he5GN/gYhCxJGQUqRXD2GKSY4wQkcP3Xu5SE59EFlnfqrwhEyEkqCaPBmf4O",
+	"XV+fvw0GAVEfpGrYIKA4geAsAD01GAQcvmSEQxScSZ7BIBDhHSRYwZsxnmAZnAVZRtRIuUjVTCE5ofNg",
+	"uRwETWtfgmAZD6FlffLUtS/wHC4UNerLq68QzZJb4PniXzLgi3L1FM8hqK4XwQxnsQzOJoMgIZQkWaL/",
+	"b9clVMIcuFkYeMva5xISgVLgyK7hXR74tBmF4/EgSPA3i8N43I0RZ79DKJu4Yb9uYUaaA3giTy4z2igS",
+	"GW1BgKuJT1z8inH5etHAll8IxBGSDAnGJbpdNDBGfTvV33r4EoQcsIRoiqUfAcn4omn/+ssWCggz+Yk0",
+	"+ARJGmMJLaKQpBJJO6wFH1lAehJKSzVZpIwK0BbrNY4u4UsGQqq/QkYlUP1fnKYxCbHCc/S7UMg+Vpb5",
+	"bw6z4Cz4r1FpDUfmWzF6xznjZil3s69xhLhdbDkI3jA6i0m4h4UL8xfaJdEPcDQ/QlFmlgIECSbxjwqr",
+	"Xxi/JVEEdPdoFUuhIcJRQijCYQhCoIK9y0HwgclfWEajPVKJMolmes3lILimOJN3jJP/gz3g4KymvrYz",
+	"FMA3WtvVMVqR2JSzFLgkRpodYI8BfMNJGkN++M4YRwo8UGnRRjPAMuMgAm3h3wOdKy09Hisjv6I6uSZW",
+	"wV4L4OiVA3IF0umpPi3yvycesEJimQnXst3i8D5m82AQAFXnzOfKJ4ROU87mHIRCO2IUghuf7SmNxGeD",
+	"ejmK3arjRSuhJqo9kdan6ysk9H+RPbHc3U/60vHXBbrwAegm39r7TFKZG+XG7dYRfGs4g87V3wlQiQyo",
+	"9bmd2/FpRZHKdf7NMoQ5IJKvQ+gc6aMIPT7qf6f3sFguj46Ogu6l9AePhQgVQPUJIvU5y+ErgQcFC7j2",
+	"f8JMSJYoGpZYVSf2oL9nk3ZeM2cuM9rIjpSkEBOqoc3IvD5ASEj1f4hy9urf4zCX3EZZ7LUtC8e3C/sB",
+	"5hwvatMNfr5phqUk6udNuDDtzEGNPs1U1k5PI53V6ZNKTEOYhpxI4AR7aRZBCjQSU0PSguYN8pfTZKBD",
+	"nH57HQT3sHA142o4nrjaduqzLWbH5Ct4MRIhc1VCWVWgCoMZ16Kq/ivusCLyTautbjveNJmvzFBFB8zn",
+	"IKczEoNYj2KSyHjFEpUWKGZzQvOoZtUKtQuPom4O3Sct6risy0fF3XZQOh4fvxyOJ8PJ6afJ+OzF+Gw8",
+	"/l9F0ZzHEZYwlMRYhrowbX5k14AZ4Sph/PTTGH4+GY+HcPy32+HJJDoZ4p8mL4cnJy9fnp6enIzH43EV",
+	"0yZp7Hvy1ybaY3G6itjLl9tBrJTHvn5CiUM50gNWGZeQZTbL0Snsb8zQ5SDI0mjbQrIivMbmlYQd5ObZ",
+	"EmMF/YEbJlbwa5L898TrA2GJHe1tdXCVAnkUOsVzQnEu7G0QLsqRqwTQmDiwvDvRPnZtG+D/OGTRqoRf",
+	"vbucfvj4afrLx+sPb/2qKzGJzdERRURhguOLClgTnNYwS0AIZbXqCvVA5B06f4vwbTg5flEJRLpkQqNf",
+	"Qq7TY2W8oYKPbOdJyrhUQk1ANB6VFedtJYjCDyjB/D5iDxTZUWZb/37163ukT5kESwncunW3MQvvRY8N",
+	"mgV7oCx0COHlu+gtwCXMhQ3W6sI8wyQ2QaFLgw8604fYTG+RgEDyDktkhiPJlHfLeMWZLHJng8B81Q6V",
+	"wkO8QFar8zW80KyytwGzQwpUf7iHBcIxBxwtEHwjQkL0Y+BN8zlGKce7XLQg0CAnfjvzFu/aVdPdwa84",
+	"vCMUhgpRfBsD0msgqwhN/pQvB6Y2/EOCF+gWECSpXCAy0x+GLIsjrYTqm2+S49AlRgm+otLuEv/MEkxX",
+	"kawO6eeq5PAHhho+Qr5X7lCjwuoEj2txMgH87/bPo5Al1dPIDPcd6FiIB8ZXjnMBYcbh4u9CTKpQisFd",
+	"m8yXKyb4NnjhnB0rIdKqPZ341KFIc1dHHo99QyWT2KXXyXGnEphJgzybXyzn3Y0NWt40xHS795xWY8bW",
+	"09hieyUh9ZnCdq/neAtej+PwGOQ7nRkH64aoeNqeJVjJDkilXGsnCQYBziSb4jTl7KsrfTMci9JHuGUs",
+	"Bkx9rvzPP2+H7wmLIK7uN4xxFsGQpZkYngxfqt2ZTwSjFOTwZHhafnaHyX02PBm+cPdeh9EjhGglmM7P",
+	"TFMWk3DRJZyXauyFGep1lp30hWF4TogV1qws7BUqm6g7cHjoyTx2hoPbsh0dCcx6UuKBAq9ZstPT7WCz",
+	"p4jLClGxl/XiKkudLYRWOZ0PG125meQ9KcOubOJa+e695zi2mTE/SI78oEmRplT82upbEfftaHFVfw6r",
+	"zJcwV3Ee33n0UFe0f2EK6C2D9S+SNo1EKmB/XjsuGTTfsFW9kBoBE/xtqtQpp2cRfDiVNZXCGm9QYnyT",
+	"VZWljOqDiQ5VvJ1x7erED3ghXA11BrTvu4qus6x34xn1Be1q1VLn+xl499ToN0eH1NNKAN5wbHTa2ZVr",
+	"pKmgOBV3TK6d33MPhD45bL7uput57xRopL4cBDyj1PyvYEI1FxNiGkIcmwueUjrK+Q3Z8J67cU39Vix5",
+	"5aqvSHGvY7wvM7oFi63E/MBmOqNtkaxX9jfUQ0YlJqXT/rwUNWbzqbQHUj1wzOifSPEgnTbc0NtvGY+A",
+	"V75uzM9GQUGbKmAHTHHD71e0Bpn8jci7qzybhOP44yw4+9xHl7rLGDpg+LNRPYsPbvIKyc0LATbRgn0U",
+	"D6xXY7BagUa+ZGAjCBKpgGJG7NUUoXm2wRQQDtDVcDz5MRjU6xTWLExY98j8XusYdnK+VqshNjxiq5fg",
+	"NXXKL9qr+3/h82/1HX111KlvVHntVozze8vWHHdcC6yQp6wKKM15ZDxsu3Dj/rfgZBiDdFg3o9jLR35F",
+	"6DwGXz+FzDgVqBiqC1Vi9Z8vGaiwYYAYR0JPN6P0iHtYoJix+yzVAQv0OCpKyqoDowftCrt+tWZdaTe/",
+	"Sy281uqwWS3utb1xdW8BNyq/tZB0qdAHc5xvXHy7eaFtTYIMXu4NVyOdtnkR1bvu0GK4adlvJwsn67Iw",
+	"74nZhIvLtg1uVu9bQStJ5Yay1Z64zJcoej/sqH2U9vYm4B+nYPRPWvjZXdfZwLlrsV4+k8LDUH+8raTm",
+	"VUJ0/9KaSsNZ7DBKN8YoB0wA7yu6AviebmS2lRje1d1ga8J5bdq7mzzgRUdORxvCa7zXc9iVjGzBX9Wi",
+	"dkh3VZkmCDNO5OJKQcyzz+yewKvM13L4r98+IcnugSKhoi8sEKboTsr0I40XyNwfIAMg70Qs/sp7EdX0",
+	"klM4Jf8DC9POReiM5QWS2FQJ2En/ZCmcy98YvxfoE+Ak8PQHapuMXl2ca29Z3gGqzspj7wRTPDexozo5",
+	"lRAd/Yd+uiMCEaFnWcfb9rOxGZI8k3cFULWAQpDjUB79R+0kJiFQARV0fz3/pKSIx8FZoKgjzkYjlgI1",
+	"MI8Yn4/sJDFSY0uj7ez01cV5MAi+Ahdmj+OjydFYn1cpUJyS4Cx4cTQ+eqH5LO8090Y4k3cjHRZr8WRG",
+	"TJWQajE4j4IzU+52bdTQNlW+ZtFiay16Tjnd0hVNyTNYbSQ9Ho+3trbRqnp3oMYJiUx3Sc4yZQHuAEe2",
+	"+f4K5PCNkdSa0BfyraS/EOcSm1qb7HIQnIwnTYgWOx/VGxatNgZnn28GgciSBPOFwR0RqnRNF5USOke5",
+	"EcVzoa2tUtcbBaMQAJbJVglgmSxEwOHFSZ0E79l8DhFimaxQMNbWasOdOntTcJVuhRnnSjM7NmeOpTl4",
+	"9vUPkG8MEP/edi9nbyp7QHmV+xbo9A9waBQvqr0tEHXRjNtr6maRyC+yd2gXVu/Ke5mGyc5ZptsHcgJB",
+	"5Ir4js3EuFsoKm32esrfuqcU7fFtViXnBsKIwkOLANmzUzRqnXKGLvJBA+ddk4YMVTlkVL6/0ZSkqg6u",
+	"vtfRY3z1HYnlzQ7NQbVGzSNi1lODyCT62AwVRN2GDVUwcRyXQEs+Fh/dKNfSq/lOH/eOVN/bK75n/S+q",
+	"/zz8se6hDQOCTXXzaXw0RLL6WKlNrbOyqpajRxItjT2KwdQTuvx9qz8v+bueftrnRzzac9L8PI1BJdqQ",
+	"KGrSSfek4nkLl4pmuwi3U3DQ6EBsn1DjfYrw03yOp5FeOSkF3dHtAukXafymKPNQ30ktP40B2zdh3rz3",
+	"nqObHvzPW8j2ZsKeJjKGql3a6tq74omr5QhSErY7Ju/0iLW9EucZrj6eyZ/CjSlamHv5MJr4pkPV1DyE",
+	"RSv3VlwaA1/38RdGpb5aKTBGGLocHd1f/UR5uNmll1S9Gt2zi2R6z+u817eke3eO1KQX3ZPKZ7c2i4/8",
+	"/pcSJp118VimXNDazdLo0TzM2MM524ZMdpuRyhOT/dw5zfan+3Lr8/Dp3h/VDPQahybH7zkwYbwfVT64",
+	"k2jYU3MRKxa82T88EJ925VGube73JCMHcSR3bCqedj7kvmqjbWk8D/L+iLbE9UpX+zY8lF1FIS6mPl/R",
+	"jkCmHyTj9pbyQOZG3gFKvSi53mU1+LDDh2Z4d9C6fe7tLIT1FpftO5LdUIb+lGbJZ2W2I7ONFolntD1u",
+	"vsyoeL3YNBezz/h5l6Yu73/qFQ9rmm4r+FXAGjmtV+oKdC8z+qzj3Mq7nXsOc3UPjecV44weJsjd3Fi4",
+	"Vwa5ueAZ7RKdRsOQv4nVZhuuineznnVWbeVmniUJHgpQM6paa8ozQSDJ0IzEErgKS2yTjq3oHtgC9x+b",
+	"3povng9svO8dNL+gJZmu7EdZin7gtj0gL0NSg5pWNc0nzUvu0jDWOx16mcj8qbSyw8E+ZacpcRAV0tY2",
+	"x8uTbGSp6V62gmJlxLYdWqXKlabLJJs+i+dslJ2q7T2bZduFUpcjoyrfV/7RdhH6E5ClvHXZ8ZF9MLGx",
+	"7sd5AfKZiqb3Yc09Byy+lzI9omqGIa4HGAOSAh8abtrKIoRpVLy5WN6YPE+RdiT0dRbf2yc4S5PJWVK+",
+	"W+p9r3QzyX20v6PSI3++Fbva4x6u8qsw/TLoxnL9MVPoxgQ1nHJNWaznwYnxvs6kw1dbFP6Tk0h3HJLm",
+	"rNXBuLWr3Nb67sveROWvfHpTPr3F0DQeEnnrY2dVaqWJU3y3aSzPG2x9q1SrvzG2vezWKuDmnKYeOCwx",
+	"6FHHWn0d7jnHWv4W4/1XxTqv6Xkry5wfmvu+4rAVSW2KyDxy2m27Ro/lT/P1K+Hdomh326eVXyDsXQLs",
+	"0OsP6vuusL3LIrUUEz8zlo0PaDmeRW2yg5GnRtlz3LTWKh+evzusdd70fDqklP3laMuWIuv+Vk2dXzyj",
+	"YvSof9J32Va8ssldY/kLw7u+wi2f2Wu49bOGKa8u1iMPZqN4Ro1dMugQKVD+ow2eS7xatqzv1f5msb8T",
+	"yv91rf+Ua/3VqLfC1EzYjtNGHl7rEd9ns2XxAEcv9hlaHiRdXjRmZpZbOavN3xVe92zis83ZO+zguzZ9",
+	"639In32lhTkncrN3vmVyjvfTqv50L3qf3DFnmn4OYdXZLhnU4mE/nUe7co+rz2Q9k1dOtHx8LxWSjQq/",
+	"8uqB+6bR5xslFQL411yWXBK+ujhHXyfoFgtAKdbPkJmXfEY4JaOvEy1UdsXaXPfnZoFGKSOmR82W7Ohn",
+	"Feq1QJpvlbeJPDPzY6yp5bp9duW5AW+TT/tsU9/uWbtacNYOwjpRXdmizl24QUpTVVU7mPx6oWVDbsGt",
+	"D5XVWtvlzfL/AwAA//86jC8P4YcAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/backend/internal/api/handler/server.go
+++ b/backend/internal/api/handler/server.go
@@ -136,6 +136,11 @@ func (s *Server) DeleteStory(w http.ResponseWriter, r *http.Request, projectID P
 	s.stories.DeleteStory(w, r, projectID, storyID)
 }
 
+// ImportStories delegates to StoryHandler.
+func (s *Server) ImportStories(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath) {
+	s.stories.ImportStories(w, r, projectID)
+}
+
 // ListPromptTemplates delegates to PromptTemplateHandler.
 func (s *Server) ListPromptTemplates(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, params ListPromptTemplatesParams) {
 	s.promptTemplates.ListPromptTemplates(w, r, projectID, params)

--- a/backend/internal/api/handler/story_handler.go
+++ b/backend/internal/api/handler/story_handler.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/adapter/markdown"
 	"github.com/zakari/hopeitworks/backend/internal/api/middleware"
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
 	"github.com/zakari/hopeitworks/backend/internal/domain/service"
@@ -187,6 +188,65 @@ func (h *StoryHandler) DeleteStory(w http.ResponseWriter, r *http.Request, _ Pro
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// ImportStories handles POST /projects/{projectId}/stories/import.
+// Only admin users can import stories.
+func (h *StoryHandler) ImportStories(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath) {
+	if !middleware.IsAdmin(r.Context()) {
+		writeErrorResponse(w, errors.NewForbidden("Admin access required"))
+		return
+	}
+
+	var req ImportStoriesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErrorResponse(w, errors.NewValidation("body", "invalid JSON"))
+		return
+	}
+
+	if strings.TrimSpace(req.Content) == "" {
+		writeErrorResponse(w, errors.NewValidation("content", "must not be empty"))
+		return
+	}
+
+	parsed := markdown.ParseStoryMarkdown(req.Content)
+	inputs := make([]service.ImportStoryInput, len(parsed))
+	for i, p := range parsed {
+		inputs[i] = service.ImportStoryInput{
+			Key:                p.Key,
+			Title:              p.Title,
+			Epic:               p.Epic,
+			DependsOn:          p.DependsOn,
+			Scope:              p.Scope,
+			Status:             p.Status,
+			AcceptanceCriteria: p.AcceptanceCriteria,
+			ParseError:         p.ParseError,
+		}
+	}
+
+	result, err := h.service.Import(r.Context(), projectID, inputs)
+	if err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+
+	apiErrors := make([]ImportStoryError, len(result.Errors))
+	for i, e := range result.Errors {
+		apiErrors[i] = ImportStoryError{
+			Key:     e.Key,
+			Message: e.Message,
+			Code:    e.Code,
+		}
+	}
+
+	resp := ImportStoriesResult{
+		Imported: result.Imported,
+		Updated:  result.Updated,
+		Failed:   result.Failed,
+		Errors:   apiErrors,
+	}
+
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // toAPIStory converts a domain Story to the API Story type.

--- a/backend/internal/domain/service/story_import.go
+++ b/backend/internal/domain/service/story_import.go
@@ -1,0 +1,160 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// ImportStoryInput represents a single parsed story to be imported.
+// This is the input DTO that the handler maps from the markdown adapter's ParsedStory.
+type ImportStoryInput struct {
+	Key                string
+	Title              string
+	Epic               string
+	DependsOn          []string
+	Scope              string
+	Status             string
+	AcceptanceCriteria string
+	ParseError         error
+}
+
+// ImportResult holds the aggregated result of a markdown import operation.
+type ImportResult struct {
+	Imported int
+	Updated  int
+	Failed   int
+	Errors   []ImportStoryError
+}
+
+// ImportStoryError describes a per-story import failure.
+type ImportStoryError struct {
+	Key     string
+	Message string
+	Code    string
+}
+
+// Import processes a slice of parsed stories, creating or updating each one.
+// Stories with parse errors or missing required fields are recorded in the errors list.
+// Each story is processed independently (no transaction) to allow partial success.
+func (s *StoryService) Import(ctx context.Context, projectID uuid.UUID, stories []ImportStoryInput) (*ImportResult, error) {
+	result := &ImportResult{
+		Errors: make([]ImportStoryError, 0),
+	}
+
+	for _, input := range stories {
+		if input.ParseError != nil {
+			result.Failed++
+			result.Errors = append(result.Errors, ImportStoryError{
+				Key:     input.Key,
+				Message: fmt.Sprintf("invalid YAML frontmatter: %v", input.ParseError),
+				Code:    "YAML_PARSE_ERROR",
+			})
+			continue
+		}
+
+		if input.Key == "" {
+			result.Failed++
+			result.Errors = append(result.Errors, ImportStoryError{
+				Key:     "",
+				Message: "key is required",
+				Code:    "VALIDATION_ERROR",
+			})
+			continue
+		}
+
+		if input.Title == "" {
+			result.Failed++
+			result.Errors = append(result.Errors, ImportStoryError{
+				Key:     input.Key,
+				Message: "title is required",
+				Code:    "VALIDATION_ERROR",
+			})
+			continue
+		}
+
+		existing, err := s.repo.GetByKey(ctx, projectID, input.Key)
+		if err != nil {
+			domainErr, ok := err.(*errors.DomainError)
+			if !ok || domainErr.Category != errors.CategoryNotFound {
+				result.Failed++
+				result.Errors = append(result.Errors, ImportStoryError{
+					Key:     input.Key,
+					Message: fmt.Sprintf("failed to check existing story: %v", err),
+					Code:    "IMPORT_ERROR",
+				})
+				continue
+			}
+			// Not found — create new story
+			story := buildStoryFromInput(projectID, input)
+			_, createErr := s.repo.Create(ctx, story)
+			if createErr != nil {
+				result.Failed++
+				result.Errors = append(result.Errors, ImportStoryError{
+					Key:     input.Key,
+					Message: fmt.Sprintf("failed to create story: %v", createErr),
+					Code:    "IMPORT_ERROR",
+				})
+				continue
+			}
+			result.Imported++
+			continue
+		}
+
+		// Found — update existing story
+		updateStoryFromInput(existing, input)
+		_, updateErr := s.repo.Update(ctx, existing)
+		if updateErr != nil {
+			result.Failed++
+			result.Errors = append(result.Errors, ImportStoryError{
+				Key:     input.Key,
+				Message: fmt.Sprintf("failed to update story: %v", updateErr),
+				Code:    "IMPORT_ERROR",
+			})
+			continue
+		}
+		result.Updated++
+	}
+
+	return result, nil
+}
+
+func buildStoryFromInput(projectID uuid.UUID, input ImportStoryInput) *model.Story {
+	story := &model.Story{
+		ProjectID: projectID,
+		Key:       input.Key,
+		Title:     input.Title,
+		DependsOn: input.DependsOn,
+		Status:    model.StoryStatusBacklog,
+	}
+
+	if input.Scope != "" {
+		story.Scope = &input.Scope
+	}
+	if input.Status != "" {
+		story.Status = input.Status
+	}
+	if input.AcceptanceCriteria != "" {
+		story.AcceptanceCriteria = &input.AcceptanceCriteria
+	}
+
+	return story
+}
+
+func updateStoryFromInput(existing *model.Story, input ImportStoryInput) {
+	existing.Title = input.Title
+	existing.DependsOn = input.DependsOn
+
+	if input.Scope != "" {
+		existing.Scope = &input.Scope
+	}
+	if input.Status != "" {
+		existing.Status = input.Status
+	}
+	if input.AcceptanceCriteria != "" {
+		existing.AcceptanceCriteria = &input.AcceptanceCriteria
+	}
+}

--- a/backend/internal/domain/service/story_service_test.go
+++ b/backend/internal/domain/service/story_service_test.go
@@ -2,12 +2,15 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
 	"github.com/zakari/hopeitworks/backend/pkg/errors"
 )
+
+const testStoryKeyS01 = "S-01"
 
 // mockStoryRepo is a mock implementation of port.StoryRepository for testing.
 type mockStoryRepo struct {
@@ -143,7 +146,7 @@ func TestStoryService_Create(t *testing.T) {
 	}{
 		{
 			name:    "valid story with default status",
-			params:  CreateStoryParams{ProjectID: projectID, Key: "S-01", Title: "Story 1"},
+			params:  CreateStoryParams{ProjectID: projectID, Key: testStoryKeyS01, Title: "Story 1"},
 			wantErr: false,
 		},
 		{
@@ -153,7 +156,7 @@ func TestStoryService_Create(t *testing.T) {
 		},
 		{
 			name:    "valid story with all fields",
-			params:  CreateStoryParams{ProjectID: projectID, Key: "S-03", Title: "Story 3", Objective: storyStrPtr("An objective"), TargetFiles: []string{"main.go"}, DependsOn: []string{"S-01"}, Scope: storyStrPtr("backend"), AcceptanceCriteria: storyStrPtr("It works")},
+			params:  CreateStoryParams{ProjectID: projectID, Key: "S-03", Title: "Story 3", Objective: storyStrPtr("An objective"), TargetFiles: []string{"main.go"}, DependsOn: []string{testStoryKeyS01}, Scope: storyStrPtr("backend"), AcceptanceCriteria: storyStrPtr("It works")},
 			wantErr: false,
 		},
 		{
@@ -204,31 +207,31 @@ func TestStoryService_Create(t *testing.T) {
 		},
 		{
 			name:    "empty title",
-			params:  CreateStoryParams{ProjectID: projectID, Key: "S-01", Title: ""},
+			params:  CreateStoryParams{ProjectID: projectID, Key: testStoryKeyS01, Title: ""},
 			wantErr: true,
 			errCode: "VALIDATION_ERROR",
 		},
 		{
 			name:    "title too long",
-			params:  CreateStoryParams{ProjectID: projectID, Key: "S-01", Title: string(make([]byte, 256))},
+			params:  CreateStoryParams{ProjectID: projectID, Key: testStoryKeyS01, Title: string(make([]byte, 256))},
 			wantErr: true,
 			errCode: "VALIDATION_ERROR",
 		},
 		{
 			name:    "missing project_id",
-			params:  CreateStoryParams{Key: "S-01", Title: "Story"},
+			params:  CreateStoryParams{Key: testStoryKeyS01, Title: "Story"},
 			wantErr: true,
 			errCode: "VALIDATION_ERROR",
 		},
 		{
 			name:    "invalid status",
-			params:  CreateStoryParams{ProjectID: projectID, Key: "S-01", Title: "Story", Status: "invalid"},
+			params:  CreateStoryParams{ProjectID: projectID, Key: testStoryKeyS01, Title: "Story", Status: "invalid"},
 			wantErr: true,
 			errCode: "VALIDATION_ERROR",
 		},
 		{
 			name:    "invalid scope",
-			params:  CreateStoryParams{ProjectID: projectID, Key: "S-01", Title: "Story", Scope: storyStrPtr("invalid")},
+			params:  CreateStoryParams{ProjectID: projectID, Key: testStoryKeyS01, Title: "Story", Scope: storyStrPtr("invalid")},
 			wantErr: true,
 			errCode: "VALIDATION_ERROR",
 		},
@@ -298,13 +301,13 @@ func TestStoryService_GetByID(t *testing.T) {
 	svc := NewStoryService(repo)
 
 	id := uuid.New()
-	repo.stories[id] = &model.Story{ID: id, Key: "S-01", Title: "test-story", ProjectID: uuid.New(), Status: "backlog"}
+	repo.stories[id] = &model.Story{ID: id, Key: testStoryKeyS01, Title: "test-story", ProjectID: uuid.New(), Status: "backlog"}
 
 	result, err := svc.GetByID(context.Background(), id)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.Key != "S-01" {
+	if result.Key != testStoryKeyS01 {
 		t.Errorf("expected key 'S-01', got %q", result.Key)
 	}
 
@@ -542,7 +545,7 @@ func TestStoryService_Delete(t *testing.T) {
 	svc := NewStoryService(repo)
 
 	id := uuid.New()
-	repo.stories[id] = &model.Story{ID: id, Key: "S-01", Title: "to-delete", ProjectID: uuid.New(), Status: "backlog"}
+	repo.stories[id] = &model.Story{ID: id, Key: testStoryKeyS01, Title: "to-delete", ProjectID: uuid.New(), Status: "backlog"}
 
 	err := svc.Delete(context.Background(), id)
 	if err != nil {
@@ -564,6 +567,212 @@ func TestStoryService_Delete(t *testing.T) {
 	}
 	if domainErr.Category != errors.CategoryNotFound {
 		t.Errorf("expected not_found category, got %q", domainErr.Category)
+	}
+}
+
+func TestStoryService_Import_AllNew(t *testing.T) {
+	repo := newMockStoryRepo()
+	svc := NewStoryService(repo)
+	projectID := uuid.New()
+
+	stories := []ImportStoryInput{
+		{Key: testStoryKeyS01, Title: "First Story", Scope: "backend"},
+		{Key: "S-02", Title: "Second Story", Scope: "frontend"},
+	}
+
+	result, err := svc.Import(context.Background(), projectID, stories)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Imported != 2 {
+		t.Errorf("expected imported=2, got %d", result.Imported)
+	}
+	if result.Updated != 0 {
+		t.Errorf("expected updated=0, got %d", result.Updated)
+	}
+	if result.Failed != 0 {
+		t.Errorf("expected failed=0, got %d", result.Failed)
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("expected no errors, got %v", result.Errors)
+	}
+}
+
+func TestStoryService_Import_AllExisting(t *testing.T) {
+	repo := newMockStoryRepo()
+	svc := NewStoryService(repo)
+	projectID := uuid.New()
+
+	// Pre-create stories
+	id1 := uuid.New()
+	id2 := uuid.New()
+	repo.stories[id1] = &model.Story{ID: id1, ProjectID: projectID, Key: testStoryKeyS01, Title: "Old Title 1", Status: "backlog"}
+	repo.stories[id2] = &model.Story{ID: id2, ProjectID: projectID, Key: "S-02", Title: "Old Title 2", Status: "backlog"}
+
+	stories := []ImportStoryInput{
+		{Key: testStoryKeyS01, Title: "New Title 1", Scope: "backend"},
+		{Key: "S-02", Title: "New Title 2", Scope: "frontend"},
+	}
+
+	result, err := svc.Import(context.Background(), projectID, stories)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Imported != 0 {
+		t.Errorf("expected imported=0, got %d", result.Imported)
+	}
+	if result.Updated != 2 {
+		t.Errorf("expected updated=2, got %d", result.Updated)
+	}
+	if result.Failed != 0 {
+		t.Errorf("expected failed=0, got %d", result.Failed)
+	}
+
+	// Verify titles were updated
+	for _, s := range repo.stories {
+		if s.Key == testStoryKeyS01 && s.Title != "New Title 1" {
+			t.Errorf("expected S-01 title to be 'New Title 1', got %q", s.Title)
+		}
+		if s.Key == "S-02" && s.Title != "New Title 2" {
+			t.Errorf("expected S-02 title to be 'New Title 2', got %q", s.Title)
+		}
+	}
+}
+
+func TestStoryService_Import_MixNewAndExisting(t *testing.T) {
+	repo := newMockStoryRepo()
+	svc := NewStoryService(repo)
+	projectID := uuid.New()
+
+	id1 := uuid.New()
+	repo.stories[id1] = &model.Story{ID: id1, ProjectID: projectID, Key: testStoryKeyS01, Title: "Existing", Status: "backlog"}
+
+	stories := []ImportStoryInput{
+		{Key: testStoryKeyS01, Title: "Updated Title"},
+		{Key: "S-02", Title: "Brand New Story"},
+	}
+
+	result, err := svc.Import(context.Background(), projectID, stories)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Imported != 1 {
+		t.Errorf("expected imported=1, got %d", result.Imported)
+	}
+	if result.Updated != 1 {
+		t.Errorf("expected updated=1, got %d", result.Updated)
+	}
+	if result.Failed != 0 {
+		t.Errorf("expected failed=0, got %d", result.Failed)
+	}
+}
+
+func TestStoryService_Import_ParseError(t *testing.T) {
+	repo := newMockStoryRepo()
+	svc := NewStoryService(repo)
+	projectID := uuid.New()
+
+	stories := []ImportStoryInput{
+		{Key: testStoryKeyS01, Title: "Valid Story"},
+		{ParseError: fmt.Errorf("yaml: unmarshal error")},
+	}
+
+	result, err := svc.Import(context.Background(), projectID, stories)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Imported != 1 {
+		t.Errorf("expected imported=1, got %d", result.Imported)
+	}
+	if result.Failed != 1 {
+		t.Errorf("expected failed=1, got %d", result.Failed)
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(result.Errors))
+	}
+	if result.Errors[0].Code != "YAML_PARSE_ERROR" {
+		t.Errorf("expected error code 'YAML_PARSE_ERROR', got %q", result.Errors[0].Code)
+	}
+}
+
+func TestStoryService_Import_EmptyKey(t *testing.T) {
+	repo := newMockStoryRepo()
+	svc := NewStoryService(repo)
+	projectID := uuid.New()
+
+	stories := []ImportStoryInput{
+		{Key: "", Title: "No Key Story"},
+	}
+
+	result, err := svc.Import(context.Background(), projectID, stories)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Failed != 1 {
+		t.Errorf("expected failed=1, got %d", result.Failed)
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(result.Errors))
+	}
+	if result.Errors[0].Code != "VALIDATION_ERROR" {
+		t.Errorf("expected error code 'VALIDATION_ERROR', got %q", result.Errors[0].Code)
+	}
+	if result.Errors[0].Message != "key is required" {
+		t.Errorf("expected message 'key is required', got %q", result.Errors[0].Message)
+	}
+}
+
+func TestStoryService_Import_EmptyTitle(t *testing.T) {
+	repo := newMockStoryRepo()
+	svc := NewStoryService(repo)
+	projectID := uuid.New()
+
+	stories := []ImportStoryInput{
+		{Key: testStoryKeyS01, Title: ""},
+	}
+
+	result, err := svc.Import(context.Background(), projectID, stories)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Failed != 1 {
+		t.Errorf("expected failed=1, got %d", result.Failed)
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(result.Errors))
+	}
+	if result.Errors[0].Code != "VALIDATION_ERROR" {
+		t.Errorf("expected error code 'VALIDATION_ERROR', got %q", result.Errors[0].Code)
+	}
+	if result.Errors[0].Key != testStoryKeyS01 {
+		t.Errorf("expected error key 'S-01', got %q", result.Errors[0].Key)
+	}
+}
+
+func TestStoryService_Import_CreateFailure(t *testing.T) {
+	repo := newMockStoryRepo()
+	repo.createFn = func(_ context.Context, _ *model.Story) (*model.Story, error) {
+		return nil, fmt.Errorf("database connection lost")
+	}
+	svc := NewStoryService(repo)
+	projectID := uuid.New()
+
+	stories := []ImportStoryInput{
+		{Key: testStoryKeyS01, Title: "Story That Fails"},
+	}
+
+	result, err := svc.Import(context.Background(), projectID, stories)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Failed != 1 {
+		t.Errorf("expected failed=1, got %d", result.Failed)
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(result.Errors))
+	}
+	if result.Errors[0].Code != "IMPORT_ERROR" {
+		t.Errorf("expected error code 'IMPORT_ERROR', got %q", result.Errors[0].Code)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `POST /projects/{projectId}/stories/import` endpoint for bulk importing stories from markdown with YAML frontmatter
- Implement markdown parser in `adapter/markdown/` that extracts frontmatter fields (key, epic, depends_on, scope, status) and H1 title from story blocks
- Add `StoryService.Import()` with upsert logic: creates new stories or updates existing ones by key, with partial success support
- Admin-only access control, per-story error reporting with typed error codes (YAML_PARSE_ERROR, VALIDATION_ERROR, IMPORT_ERROR)

## Changes
- `api/openapi.yaml` — new import endpoint + ImportStoriesRequest/Result/Error schemas
- `backend/internal/adapter/markdown/parser.go` — markdown frontmatter parser
- `backend/internal/adapter/markdown/parser_test.go` — 9 unit tests for parser
- `backend/internal/domain/service/story_import.go` — Import method + input/result types
- `backend/internal/domain/service/story_service_test.go` — 7 unit tests for Import
- `backend/internal/api/handler/story_handler.go` — ImportStories handler
- `backend/internal/api/handler/server.go` — delegation wiring
- `backend/internal/api/handler/gen_server.go` — regenerated from OpenAPI spec

## Test plan
- [x] All parser unit tests pass (9 tests: single/multi story, invalid YAML, missing title, empty content, mixed valid/invalid)
- [x] All service Import unit tests pass (7 tests: all-new, all-existing, mix, parse error, empty key, empty title, create failure)
- [x] `go build ./...` compiles successfully
- [x] `golangci-lint run ./...` passes with no errors
- [x] `go test ./... -short` all tests pass

Refs: S-2-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)