### PR TITLE
feat(pipeline): add agent run action with CLAUDE.md composition and container lifecycle

### DIFF
--- a/_bmad-output/implementation-artifacts/3-8-agent-run-action-compose-claude-md-launch-container-stream-logs.md
+++ b/_bmad-output/implementation-artifacts/3-8-agent-run-action-compose-claude-md-launch-container-stream-logs.md
@@ -1,6 +1,6 @@
 # Story 3.8: [BACK] Agent run action — compose CLAUDE.md + launch container + stream logs
 
-Status: ready-for-dev
+Status: done
 
 ## Story
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -84,7 +84,7 @@ development_status:
   3-5-ndjson-log-streaming-from-container: done
   3-6-events-table-pgxlisten-event-bus: done
   3-7-pipeline-executor-sequential-step-runner: done
-  3-8-agent-run-action-compose-claude-md-launch-container-stream-logs: backlog
+  3-8-agent-run-action-compose-claude-md-launch-container-stream-logs: done
   3-9-container-timeout-enforcement-orphan-cleanup: done
   3-10-run-launch-api-endpoint-single-story: backlog
   3-11-run-launch-button-confirmation-dialog: done
@@ -405,7 +405,7 @@ parallel_waves:
       # Epic 3
       - key: 3-8-agent-run-action-compose-claude-md-launch-container-stream-logs
         domain: back
-        status: backlog
+        status: done
         explicit_deps: [3-4-docker-container-lifecycle-manager-create-start-stop-cleanup, 3-5-ndjson-log-streaming-from-container, 3-6-events-table-pgxlisten-event-bus, 3-7-pipeline-executor-sequential-step-runner]
       - key: 3-10-run-launch-api-endpoint-single-story
         domain: back

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
+	actionadapter "github.com/zakari/hopeitworks/backend/internal/adapter/action"
 	dockeradapter "github.com/zakari/hopeitworks/backend/internal/adapter/docker"
 	hbadapter "github.com/zakari/hopeitworks/backend/internal/adapter/handlebars"
 	pgadapter "github.com/zakari/hopeitworks/backend/internal/adapter/postgres"
@@ -105,7 +106,7 @@ func run() error {
 
 	// Template rendering service (Handlebars engine for prompt templates)
 	handlebarsRenderer := hbadapter.NewRenderer()
-	_ = service.NewTemplateService(promptTemplateRepo, handlebarsRenderer, logger)
+	templateSvc := service.NewTemplateService(promptTemplateRepo, handlebarsRenderer, logger)
 
 	// Auth handler
 	authHandler := handler.NewAuthHandler(authService, userRepo, false)
@@ -123,6 +124,36 @@ func run() error {
 	containerMgr, err := dockeradapter.NewDockerContainerManager(cfg.Docker.Host, logger)
 	if err != nil {
 		logger.Warn("docker container manager unavailable, timeout enforcer and orphan cleaner disabled", "error", err)
+	}
+
+	// Event publisher (for persisting events to DB)
+	eventRepo := pgadapter.NewEventRepo(queries)
+
+	// Action registry
+	actionReg := service.NewActionRegistry()
+
+	// Agent run action (requires Docker)
+	if containerMgr != nil {
+		logStreamer, logErr := dockeradapter.NewDockerLogStreamerFromHost(cfg.Docker.Host, logger)
+		if logErr != nil {
+			logger.Warn("log streamer unavailable, agent_run action disabled", "error", logErr)
+		} else {
+			agentCfg := actionadapter.AgentConfig{
+				DefaultImage:  getEnvOrDefault("AGENT_IMAGE", "hopeitworks/agent:latest"),
+				DefaultMemory: 4294967296, // 4GB
+				DefaultCPUs:   2.0,
+				NetworkName:   cfg.Docker.AgentNetwork,
+				LogTailLines:  50,
+				ClaudeMDPath:  getEnvOrDefault("CLAUDE_MD_PATH", "agent/claude-md"),
+			}
+			agentRunAction := actionadapter.NewAgentRunAction(
+				containerMgr, logStreamer, eventRepo,
+				storyRepo, projectRepo, runRepo,
+				templateSvc, agentCfg, logger,
+			)
+			actionReg.Register(agentRunAction)
+			logger.Info("agent_run action registered")
+		}
 	}
 
 	// Orphan cleanup and timeout enforcement (requires Docker)

--- a/backend/internal/adapter/action/agent_run.go
+++ b/backend/internal/adapter/action/agent_run.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
@@ -236,8 +237,16 @@ func (a *AgentRunAction) streamAndWait(
 		}
 	}()
 
-	// Wait for container exit
+	// Wait for container exit.
+	// When the context is cancelled, the LogStreamer closes doneCh without sending
+	// a value, so exitCode will be 0 (zero value). Check ctx.Err() to distinguish
+	// a clean exit code 0 from a cancellation.
 	exitCode := <-doneCh
+	if err := ctx.Err(); err != nil {
+		// Context was cancelled or deadline exceeded; propagate the context error.
+		wg.Wait()
+		return -1, err
+	}
 
 	// Wait for log goroutine to finish
 	wg.Wait()
@@ -252,8 +261,10 @@ func (a *AgentRunAction) streamAndWait(
 }
 
 // cleanupContainer stops and removes the container, logging errors without failing.
+// It uses a dedicated timeout context to ensure cleanup never hangs indefinitely.
 func (a *AgentRunAction) cleanupContainer(containerID string) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	if err := a.containerMgr.Stop(ctx, containerID); err != nil {
 		a.logger.Warn("failed to stop container during cleanup",

--- a/backend/internal/adapter/action/agent_run.go
+++ b/backend/internal/adapter/action/agent_run.go
@@ -1,0 +1,315 @@
+package action
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+)
+
+// AgentConfig holds configuration for agent container execution.
+type AgentConfig struct {
+	// DefaultImage is the Docker image for agent containers (e.g., "hopeitworks/agent:latest").
+	DefaultImage string
+	// DefaultMemory is the memory limit in bytes (e.g., 4GB = 4294967296).
+	DefaultMemory int64
+	// DefaultCPUs is the CPU limit (e.g., 2.0).
+	DefaultCPUs float64
+	// NetworkName is the Docker network for agent containers.
+	NetworkName string
+	// LogTailLines is the number of log lines to keep for error context.
+	LogTailLines int
+	// ClaudeMDPath is the path to the agent/claude-md/ directory.
+	ClaudeMDPath string
+}
+
+// AgentRunAction implements model.Action for running Claude Code agents in containers.
+type AgentRunAction struct {
+	containerMgr port.ContainerManager
+	logStreamer  port.LogStreamer
+	eventPub     port.EventPublisher
+	storyRepo    port.StoryRepository
+	projectRepo  port.ProjectRepository
+	runRepo      port.RunRepository
+	templateSvc  *service.TemplateService
+	composer     *CLAUDEMDComposer
+	config       AgentConfig
+	logger       *slog.Logger
+}
+
+// NewAgentRunAction creates a new agent run action.
+func NewAgentRunAction(
+	containerMgr port.ContainerManager,
+	logStreamer port.LogStreamer,
+	eventPub port.EventPublisher,
+	storyRepo port.StoryRepository,
+	projectRepo port.ProjectRepository,
+	runRepo port.RunRepository,
+	templateSvc *service.TemplateService,
+	config AgentConfig,
+	logger *slog.Logger,
+) *AgentRunAction {
+	return &AgentRunAction{
+		containerMgr: containerMgr,
+		logStreamer:  logStreamer,
+		eventPub:     eventPub,
+		storyRepo:    storyRepo,
+		projectRepo:  projectRepo,
+		runRepo:      runRepo,
+		templateSvc:  templateSvc,
+		composer:     NewCLAUDEMDComposer(config.ClaudeMDPath),
+		config:       config,
+		logger:       logger,
+	}
+}
+
+// Name returns the action identifier.
+func (a *AgentRunAction) Name() string {
+	return "agent_run"
+}
+
+// Execute runs the agent in a container: fetches story, composes CLAUDE.md,
+// renders prompt, creates container, streams logs, and waits for exit.
+func (a *AgentRunAction) Execute(ctx context.Context, runCtx *model.RunContext) error {
+	// 1. Fetch story
+	story, err := a.storyRepo.GetByID(ctx, runCtx.StoryID)
+	if err != nil {
+		return fmt.Errorf("fetch story: %w", err)
+	}
+
+	// 2. Fetch project
+	project, err := a.projectRepo.GetByID(ctx, runCtx.ProjectID)
+	if err != nil {
+		return fmt.Errorf("fetch project: %w", err)
+	}
+
+	// 3. Compose CLAUDE.md
+	scope := ""
+	if story.Scope != nil {
+		scope = *story.Scope
+	}
+	claudeMD, err := a.composer.Compose(scope)
+	if err != nil {
+		return fmt.Errorf("compose CLAUDE.md: %w", err)
+	}
+
+	// 4. Resolve and render prompt template
+	templateName := a.resolveTemplateName(runCtx)
+	branchName, _ := runCtx.Metadata["branch_name"].(string)
+	repoURL := ""
+	if project.RepoURL != nil {
+		repoURL = *project.RepoURL
+	}
+
+	tmplCtx := &model.TemplateContext{
+		StoryKey:           story.Key,
+		StoryTitle:         story.Title,
+		StoryObjective:     derefString(story.Objective),
+		TargetFiles:        story.TargetFiles,
+		AcceptanceCriteria: derefString(story.AcceptanceCriteria),
+		BranchName:         branchName,
+		RepoURL:            repoURL,
+	}
+	prompt, err := a.templateSvc.RenderForStory(ctx, runCtx.ProjectID, templateName, tmplCtx)
+	if err != nil {
+		return fmt.Errorf("render prompt template %q: %w", templateName, err)
+	}
+
+	// 5. Create container
+	containerID, err := a.createContainer(ctx, runCtx, project, story, claudeMD, prompt, branchName)
+	if err != nil {
+		return fmt.Errorf("create container: %w", err)
+	}
+	defer a.cleanupContainer(containerID)
+
+	// 6. Start container
+	if err := a.containerMgr.Start(ctx, containerID); err != nil {
+		return fmt.Errorf("start container: %w", err)
+	}
+
+	// 7. Persist container ID to run step
+	a.persistContainerID(ctx, runCtx.RunStep.ID, containerID)
+
+	// 8. Stream logs + wait for exit
+	exitCode, err := a.streamAndWait(ctx, containerID, runCtx)
+	if err != nil {
+		return fmt.Errorf("stream/wait: %w", err)
+	}
+
+	// 9. Check exit code
+	if exitCode != 0 {
+		return fmt.Errorf("agent exited with code %d", exitCode)
+	}
+
+	return nil
+}
+
+// resolveTemplateName determines which prompt template to use.
+func (a *AgentRunAction) resolveTemplateName(runCtx *model.RunContext) string {
+	if name, ok := runCtx.Metadata["template_name"].(string); ok && name != "" {
+		return name
+	}
+	return service.TemplateNameImplement
+}
+
+// createContainer builds ContainerOpts and creates the container.
+func (a *AgentRunAction) createContainer(
+	ctx context.Context,
+	runCtx *model.RunContext,
+	project *model.Project,
+	story *model.Story,
+	claudeMD, prompt, branchName string,
+) (string, error) {
+	repoURL := ""
+	if project.RepoURL != nil {
+		repoURL = *project.RepoURL
+	}
+
+	opts := model.ContainerOpts{
+		Image:       a.config.DefaultImage,
+		NetworkName: a.config.NetworkName,
+		Memory:      a.config.DefaultMemory,
+		CPUs:        a.config.DefaultCPUs,
+		Env: []string{
+			"CLAUDE_MD_CONTENT=" + claudeMD,
+			"REPO_URL=" + repoURL,
+			"BRANCH_NAME=" + branchName,
+			"STORY_KEY=" + story.Key,
+			"PROMPT_CONTENT=" + prompt,
+			"GITHUB_TOKEN=" + os.Getenv("GITHUB_TOKEN"),
+			"CLAUDE_CODE_OAUTH_TOKEN=" + os.Getenv("CLAUDE_CODE_OAUTH_TOKEN"),
+		},
+		Labels: map[string]string{
+			"managed_by": "hopeitworks",
+			"run_id":     runCtx.Run.ID.String(),
+			"step_id":    runCtx.RunStep.ID.String(),
+			"story_key":  story.Key,
+		},
+	}
+
+	return a.containerMgr.Create(ctx, opts)
+}
+
+// streamAndWait starts log streaming, waits for container exit, and handles log tail.
+func (a *AgentRunAction) streamAndWait(
+	ctx context.Context,
+	containerID string,
+	runCtx *model.RunContext,
+) (int, error) {
+	runID := runCtx.Run.ID.String()
+	stepID := runCtx.RunStep.ID.String()
+
+	logCh, doneCh, err := a.logStreamer.StreamLogs(ctx, containerID, runID, stepID)
+	if err != nil {
+		return -1, fmt.Errorf("start log streaming: %w", err)
+	}
+
+	// Ring buffer for log tail
+	tailSize := a.config.LogTailLines
+	if tailSize <= 0 {
+		tailSize = 50
+	}
+	logTail := make([]string, 0, tailSize)
+
+	// Consume logs in goroutine
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for logEvent := range logCh {
+			// Maintain ring buffer
+			if len(logTail) >= tailSize {
+				logTail = logTail[1:]
+			}
+			logTail = append(logTail, logEvent.Message)
+
+			// Forward to event system
+			a.publishLogEvent(ctx, runCtx, logEvent)
+		}
+	}()
+
+	// Wait for container exit
+	exitCode := <-doneCh
+
+	// Wait for log goroutine to finish
+	wg.Wait()
+
+	// On failure, persist log tail
+	if exitCode != 0 {
+		tail := strings.Join(logTail, "\n")
+		a.persistLogTail(ctx, runCtx.RunStep.ID, tail)
+	}
+
+	return exitCode, nil
+}
+
+// cleanupContainer stops and removes the container, logging errors without failing.
+func (a *AgentRunAction) cleanupContainer(containerID string) {
+	ctx := context.Background()
+
+	if err := a.containerMgr.Stop(ctx, containerID); err != nil {
+		a.logger.Warn("failed to stop container during cleanup",
+			"container_id", containerID, "error", err)
+	}
+
+	if err := a.containerMgr.Remove(ctx, containerID); err != nil {
+		a.logger.Warn("failed to remove container during cleanup",
+			"container_id", containerID, "error", err)
+	}
+
+	a.logger.Debug("container cleaned up", "container_id", containerID)
+}
+
+// persistContainerID saves the container ID to the run step.
+func (a *AgentRunAction) persistContainerID(ctx context.Context, stepID uuid.UUID, containerID string) {
+	if _, err := a.runRepo.UpdateRunStepContainerInfo(ctx, stepID, &containerID, nil); err != nil {
+		a.logger.Warn("failed to persist container ID to run step",
+			"step_id", stepID, "container_id", containerID, "error", err)
+	}
+}
+
+// persistLogTail saves the log tail to the run step.
+func (a *AgentRunAction) persistLogTail(ctx context.Context, stepID uuid.UUID, logTail string) {
+	if _, err := a.runRepo.UpdateRunStepContainerInfo(ctx, stepID, nil, &logTail); err != nil {
+		a.logger.Warn("failed to persist log tail to run step",
+			"step_id", stepID, "error", err)
+	}
+}
+
+// publishLogEvent publishes a log event to the event system.
+func (a *AgentRunAction) publishLogEvent(ctx context.Context, runCtx *model.RunContext, logEvent model.LogEvent) {
+	payload, err := json.Marshal(logEvent)
+	if err != nil {
+		a.logger.Error("failed to marshal log event", "error", err)
+		return
+	}
+
+	event := model.Event{
+		ID:         uuid.New(),
+		ProjectID:  runCtx.ProjectID,
+		EntityType: "log",
+		EntityID:   runCtx.RunStep.ID,
+		Action:     "emitted",
+		Payload:    payload,
+	}
+
+	if err := a.eventPub.Publish(ctx, event); err != nil {
+		a.logger.Warn("failed to publish log event", "error", err)
+	}
+}
+
+// derefString safely dereferences a string pointer, returning empty string if nil.
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -759,14 +759,16 @@ func TestAgentRunAction_ContainerCreateFailure(t *testing.T) {
 func TestAgentRunAction_ContextCancellation(t *testing.T) {
 	f := newAgentRunFixture(t)
 
-	// Configure wait to block until context is cancelled
+	// Configure wait to block until context is cancelled.
+	// This simulates the real LogStreamer behavior: when context is cancelled,
+	// the done channel is closed without sending a value (zero value = 0).
 	f.logStreamer.streamLogsFn = func(ctx context.Context, _, _, _ string) (<-chan model.LogEvent, <-chan int, error) {
 		logCh := make(chan model.LogEvent)
 		doneCh := make(chan int, 1)
 		go func() {
 			<-ctx.Done()
 			close(logCh)
-			doneCh <- -1
+			close(doneCh) // no value — mimics real LogStreamer on cancellation
 		}()
 		return logCh, doneCh, nil
 	}
@@ -783,6 +785,9 @@ func TestAgentRunAction_ContextCancellation(t *testing.T) {
 	err := f.action.Execute(ctx, runCtx)
 	if err == nil {
 		t.Fatal("expected error for context cancellation, got nil")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("expected context canceled error, got: %v", err)
 	}
 
 	// Verify container was cleaned up

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -1,0 +1,901 @@
+package action_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/adapter/action"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+const testContainerID = "container-123"
+
+// testLogger creates a silent logger for tests.
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func strPtr(s string) *string { return &s }
+
+// --- Mock implementations ---
+
+type mockContainerManager struct {
+	createFn         func(ctx context.Context, opts model.ContainerOpts) (string, error)
+	startFn          func(ctx context.Context, containerID string) error
+	stopFn           func(ctx context.Context, containerID string) error
+	removeFn         func(ctx context.Context, containerID string) error
+	waitFn           func(ctx context.Context, containerID string) (int, error)
+	listContainersFn func(ctx context.Context, labels map[string]string) ([]port.ContainerInfo, error)
+
+	mu          sync.Mutex
+	createCalls []model.ContainerOpts
+	startCalls  []string
+	stopCalls   []string
+	removeCalls []string
+}
+
+func (m *mockContainerManager) Create(ctx context.Context, opts model.ContainerOpts) (string, error) {
+	m.mu.Lock()
+	m.createCalls = append(m.createCalls, opts)
+	m.mu.Unlock()
+	if m.createFn != nil {
+		return m.createFn(ctx, opts)
+	}
+	return testContainerID, nil
+}
+
+func (m *mockContainerManager) Start(ctx context.Context, containerID string) error {
+	m.mu.Lock()
+	m.startCalls = append(m.startCalls, containerID)
+	m.mu.Unlock()
+	if m.startFn != nil {
+		return m.startFn(ctx, containerID)
+	}
+	return nil
+}
+
+func (m *mockContainerManager) Stop(ctx context.Context, containerID string) error {
+	m.mu.Lock()
+	m.stopCalls = append(m.stopCalls, containerID)
+	m.mu.Unlock()
+	if m.stopFn != nil {
+		return m.stopFn(ctx, containerID)
+	}
+	return nil
+}
+
+func (m *mockContainerManager) Remove(ctx context.Context, containerID string) error {
+	m.mu.Lock()
+	m.removeCalls = append(m.removeCalls, containerID)
+	m.mu.Unlock()
+	if m.removeFn != nil {
+		return m.removeFn(ctx, containerID)
+	}
+	return nil
+}
+
+func (m *mockContainerManager) Wait(ctx context.Context, containerID string) (int, error) {
+	if m.waitFn != nil {
+		return m.waitFn(ctx, containerID)
+	}
+	return 0, nil
+}
+
+func (m *mockContainerManager) ListContainers(ctx context.Context, labels map[string]string) ([]port.ContainerInfo, error) {
+	if m.listContainersFn != nil {
+		return m.listContainersFn(ctx, labels)
+	}
+	return nil, nil
+}
+
+type mockLogStreamer struct {
+	streamLogsFn func(ctx context.Context, containerID, runID, stepID string) (<-chan model.LogEvent, <-chan int, error)
+}
+
+func (m *mockLogStreamer) StreamLogs(ctx context.Context, containerID, runID, stepID string) (<-chan model.LogEvent, <-chan int, error) {
+	if m.streamLogsFn != nil {
+		return m.streamLogsFn(ctx, containerID, runID, stepID)
+	}
+	logCh := make(chan model.LogEvent)
+	doneCh := make(chan int, 1)
+	close(logCh)
+	doneCh <- 0
+	return logCh, doneCh, nil
+}
+
+type mockEventPublisher struct {
+	mu     sync.Mutex
+	events []model.Event
+}
+
+func (m *mockEventPublisher) Publish(_ context.Context, event model.Event) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, event)
+	return nil
+}
+
+func (m *mockEventPublisher) getEvents() []model.Event {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]model.Event, len(m.events))
+	copy(result, m.events)
+	return result
+}
+
+type mockStoryRepo struct {
+	getByIDFn func(ctx context.Context, id uuid.UUID) (*model.Story, error)
+}
+
+func (m *mockStoryRepo) Create(_ context.Context, s *model.Story) (*model.Story, error) {
+	return s, nil
+}
+func (m *mockStoryRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Story, error) {
+	if m.getByIDFn != nil {
+		return m.getByIDFn(ctx, id)
+	}
+	return nil, errors.NewNotFound("story", id)
+}
+func (m *mockStoryRepo) GetByKey(_ context.Context, _ uuid.UUID, _ string) (*model.Story, error) {
+	return nil, nil
+}
+func (m *mockStoryRepo) ListByProject(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Story, error) {
+	return nil, nil
+}
+func (m *mockStoryRepo) ListByStatus(_ context.Context, _ uuid.UUID, _ []string, _, _ int32) ([]*model.Story, error) {
+	return nil, nil
+}
+func (m *mockStoryRepo) ListByEpic(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Story, error) {
+	return nil, nil
+}
+func (m *mockStoryRepo) CountByProject(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+func (m *mockStoryRepo) CountByStatus(_ context.Context, _ uuid.UUID, _ []string) (int64, error) {
+	return 0, nil
+}
+func (m *mockStoryRepo) Update(_ context.Context, s *model.Story) (*model.Story, error) {
+	return s, nil
+}
+func (m *mockStoryRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
+
+type mockProjectRepo struct {
+	getByIDFn func(ctx context.Context, id uuid.UUID) (*model.Project, error)
+}
+
+func (m *mockProjectRepo) Create(_ context.Context, p *model.Project) (*model.Project, error) {
+	return p, nil
+}
+func (m *mockProjectRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Project, error) {
+	if m.getByIDFn != nil {
+		return m.getByIDFn(ctx, id)
+	}
+	return nil, errors.NewNotFound("project", id)
+}
+func (m *mockProjectRepo) List(_ context.Context, _, _ int32) ([]*model.Project, error) {
+	return nil, nil
+}
+func (m *mockProjectRepo) Count(_ context.Context) (int64, error) { return 0, nil }
+func (m *mockProjectRepo) Update(_ context.Context, p *model.Project) (*model.Project, error) {
+	return p, nil
+}
+func (m *mockProjectRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
+
+type mockRunRepo struct {
+	updateRunStepContainerInfoFn func(ctx context.Context, id uuid.UUID, containerID *string, logTail *string) (*model.RunStep, error)
+
+	mu                    sync.Mutex
+	containerInfoCalls    []containerInfoCall
+	createRunFn           func(ctx context.Context, run *model.Run) (*model.Run, error)
+	getRunFn              func(ctx context.Context, id uuid.UUID) (*model.Run, error)
+	listRunsByProjectFn   func(ctx context.Context, projectID uuid.UUID, limit, offset int32) ([]*model.Run, error)
+	listRunsByStoryFn     func(ctx context.Context, storyID uuid.UUID, limit, offset int32) ([]*model.Run, error)
+	updateRunStatusFn     func(ctx context.Context, id uuid.UUID, status model.RunStatus, startedAt, completedAt *time.Time, errorMsg *string) (*model.Run, error)
+	countRunsByProjectFn  func(ctx context.Context, projectID uuid.UUID) (int64, error)
+	countRunsByStoryFn    func(ctx context.Context, storyID uuid.UUID) (int64, error)
+	createRunStepFn       func(ctx context.Context, step *model.RunStep) (*model.RunStep, error)
+	getRunStepFn          func(ctx context.Context, id uuid.UUID) (*model.RunStep, error)
+	listRunStepsByRunFn   func(ctx context.Context, runID uuid.UUID) ([]*model.RunStep, error)
+	updateRunStepStatusFn func(ctx context.Context, id uuid.UUID, status model.StepStatus, startedAt, completedAt *time.Time, errorMsg *string) (*model.RunStep, error)
+}
+
+type containerInfoCall struct {
+	ID          uuid.UUID
+	ContainerID *string
+	LogTail     *string
+}
+
+func (m *mockRunRepo) UpdateRunStepContainerInfo(ctx context.Context, id uuid.UUID, containerID *string, logTail *string) (*model.RunStep, error) {
+	m.mu.Lock()
+	m.containerInfoCalls = append(m.containerInfoCalls, containerInfoCall{ID: id, ContainerID: containerID, LogTail: logTail})
+	m.mu.Unlock()
+	if m.updateRunStepContainerInfoFn != nil {
+		return m.updateRunStepContainerInfoFn(ctx, id, containerID, logTail)
+	}
+	return &model.RunStep{ID: id}, nil
+}
+
+func (m *mockRunRepo) CreateRun(ctx context.Context, run *model.Run) (*model.Run, error) {
+	if m.createRunFn != nil {
+		return m.createRunFn(ctx, run)
+	}
+	return run, nil
+}
+func (m *mockRunRepo) GetRun(ctx context.Context, id uuid.UUID) (*model.Run, error) {
+	if m.getRunFn != nil {
+		return m.getRunFn(ctx, id)
+	}
+	return nil, errors.NewNotFound("run", id)
+}
+func (m *mockRunRepo) ListRunsByProject(ctx context.Context, projectID uuid.UUID, limit, offset int32) ([]*model.Run, error) {
+	if m.listRunsByProjectFn != nil {
+		return m.listRunsByProjectFn(ctx, projectID, limit, offset)
+	}
+	return nil, nil
+}
+func (m *mockRunRepo) ListRunsByStory(ctx context.Context, storyID uuid.UUID, limit, offset int32) ([]*model.Run, error) {
+	if m.listRunsByStoryFn != nil {
+		return m.listRunsByStoryFn(ctx, storyID, limit, offset)
+	}
+	return nil, nil
+}
+func (m *mockRunRepo) UpdateRunStatus(ctx context.Context, id uuid.UUID, status model.RunStatus, startedAt, completedAt *time.Time, errorMsg *string) (*model.Run, error) {
+	if m.updateRunStatusFn != nil {
+		return m.updateRunStatusFn(ctx, id, status, startedAt, completedAt, errorMsg)
+	}
+	return &model.Run{ID: id, Status: status}, nil
+}
+func (m *mockRunRepo) CountRunsByProject(ctx context.Context, projectID uuid.UUID) (int64, error) {
+	if m.countRunsByProjectFn != nil {
+		return m.countRunsByProjectFn(ctx, projectID)
+	}
+	return 0, nil
+}
+func (m *mockRunRepo) CountRunsByStory(ctx context.Context, storyID uuid.UUID) (int64, error) {
+	if m.countRunsByStoryFn != nil {
+		return m.countRunsByStoryFn(ctx, storyID)
+	}
+	return 0, nil
+}
+func (m *mockRunRepo) CreateRunStep(ctx context.Context, step *model.RunStep) (*model.RunStep, error) {
+	if m.createRunStepFn != nil {
+		return m.createRunStepFn(ctx, step)
+	}
+	return step, nil
+}
+func (m *mockRunRepo) GetRunStep(ctx context.Context, id uuid.UUID) (*model.RunStep, error) {
+	if m.getRunStepFn != nil {
+		return m.getRunStepFn(ctx, id)
+	}
+	return nil, errors.NewNotFound("run_step", id)
+}
+func (m *mockRunRepo) ListRunStepsByRun(ctx context.Context, runID uuid.UUID) ([]*model.RunStep, error) {
+	if m.listRunStepsByRunFn != nil {
+		return m.listRunStepsByRunFn(ctx, runID)
+	}
+	return nil, nil
+}
+func (m *mockRunRepo) UpdateRunStepStatus(ctx context.Context, id uuid.UUID, status model.StepStatus, startedAt, completedAt *time.Time, errorMsg *string) (*model.RunStep, error) {
+	if m.updateRunStepStatusFn != nil {
+		return m.updateRunStepStatusFn(ctx, id, status, startedAt, completedAt, errorMsg)
+	}
+	return &model.RunStep{ID: id, Status: status}, nil
+}
+
+func (m *mockRunRepo) getContainerInfoCalls() []containerInfoCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]containerInfoCall, len(m.containerInfoCalls))
+	copy(result, m.containerInfoCalls)
+	return result
+}
+
+type mockPromptTemplateRepo struct{}
+
+func (m *mockPromptTemplateRepo) Create(_ context.Context, _ *model.PromptTemplate) (*model.PromptTemplate, error) {
+	return nil, nil
+}
+func (m *mockPromptTemplateRepo) GetByID(_ context.Context, _ uuid.UUID) (*model.PromptTemplate, error) {
+	return nil, nil
+}
+func (m *mockPromptTemplateRepo) GetByProjectAndName(_ context.Context, _ uuid.UUID, _ string) (*model.PromptTemplate, error) {
+	// Return not found so the TemplateService falls back to defaults
+	return nil, errors.NewNotFound("prompt_template", "implement")
+}
+func (m *mockPromptTemplateRepo) ListByProject(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.PromptTemplate, error) {
+	return nil, nil
+}
+func (m *mockPromptTemplateRepo) CountByProject(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+func (m *mockPromptTemplateRepo) Update(_ context.Context, t *model.PromptTemplate) (*model.PromptTemplate, error) {
+	return t, nil
+}
+func (m *mockPromptTemplateRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
+
+type mockTemplateRenderer struct{}
+
+func (m *mockTemplateRenderer) Render(templateContent string, _ *model.TemplateContext) (string, error) {
+	return "rendered: " + templateContent[:20], nil
+}
+
+// --- Test fixture ---
+
+type agentRunFixture struct {
+	projectID uuid.UUID
+	storyID   uuid.UUID
+	runID     uuid.UUID
+	stepID    uuid.UUID
+
+	story   *model.Story
+	project *model.Project
+	run     *model.Run
+	runStep *model.RunStep
+
+	containerMgr *mockContainerManager
+	logStreamer  *mockLogStreamer
+	eventPub     *mockEventPublisher
+	storyRepo    *mockStoryRepo
+	projectRepo  *mockProjectRepo
+	runRepo      *mockRunRepo
+	templateSvc  *service.TemplateService
+
+	action *action.AgentRunAction
+}
+
+func newAgentRunFixture(t *testing.T) *agentRunFixture {
+	t.Helper()
+
+	f := &agentRunFixture{
+		projectID: uuid.New(),
+		storyID:   uuid.New(),
+		runID:     uuid.New(),
+		stepID:    uuid.New(),
+	}
+
+	backendScope := "backend"
+	repoURL := "https://github.com/test/repo"
+	f.story = &model.Story{
+		ID:                 f.storyID,
+		ProjectID:          f.projectID,
+		Key:                "S-42",
+		Title:              "Test Story",
+		Objective:          strPtr("Implement feature X"),
+		Scope:              &backendScope,
+		AcceptanceCriteria: strPtr("AC: feature works"),
+		TargetFiles:        []string{"main.go", "handler.go"},
+		Status:             "backlog",
+		CreatedAt:          time.Now(),
+		UpdatedAt:          time.Now(),
+	}
+
+	f.project = &model.Project{
+		ID:      f.projectID,
+		Name:    "Test Project",
+		RepoURL: &repoURL,
+	}
+
+	f.run = &model.Run{
+		ID:        f.runID,
+		ProjectID: f.projectID,
+		StoryID:   f.storyID,
+		Status:    model.RunStatusRunning,
+	}
+
+	f.runStep = &model.RunStep{
+		ID:        f.stepID,
+		RunID:     f.runID,
+		StepName:  "agent-run",
+		StepOrder: 1,
+		Action:    "agent_run",
+		Status:    model.StepStatusRunning,
+	}
+
+	f.containerMgr = &mockContainerManager{
+		createFn: func(_ context.Context, _ model.ContainerOpts) (string, error) {
+			return testContainerID, nil
+		},
+	}
+
+	f.logStreamer = &mockLogStreamer{
+		streamLogsFn: func(_ context.Context, _, _, _ string) (<-chan model.LogEvent, <-chan int, error) {
+			logCh := make(chan model.LogEvent, 3)
+			doneCh := make(chan int, 1)
+			go func() {
+				logCh <- model.LogEvent{Message: "line 1", Level: "info", Timestamp: time.Now()}
+				logCh <- model.LogEvent{Message: "line 2", Level: "info", Timestamp: time.Now()}
+				logCh <- model.LogEvent{Message: "line 3", Level: "info", Timestamp: time.Now()}
+				close(logCh)
+				doneCh <- 0
+			}()
+			return logCh, doneCh, nil
+		},
+	}
+
+	f.eventPub = &mockEventPublisher{}
+	f.storyRepo = &mockStoryRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			if id == f.storyID {
+				return f.story, nil
+			}
+			return nil, errors.NewNotFound("story", id)
+		},
+	}
+	f.projectRepo = &mockProjectRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Project, error) {
+			if id == f.projectID {
+				return f.project, nil
+			}
+			return nil, errors.NewNotFound("project", id)
+		},
+	}
+	f.runRepo = &mockRunRepo{}
+
+	// Set up CLAUDE.md test directory
+	claudeMDDir := setupTestClaudeMDDir(t)
+
+	// Create a real TemplateService with mock dependencies
+	promptTemplateRepo := &mockPromptTemplateRepo{}
+	renderer := &mockTemplateRenderer{}
+	f.templateSvc = service.NewTemplateService(promptTemplateRepo, renderer, testLogger())
+
+	agentCfg := action.AgentConfig{
+		DefaultImage:  "hopeitworks/agent:latest",
+		DefaultMemory: 4294967296,
+		DefaultCPUs:   2.0,
+		NetworkName:   "test-network",
+		LogTailLines:  50,
+		ClaudeMDPath:  claudeMDDir,
+	}
+
+	f.action = action.NewAgentRunAction(
+		f.containerMgr,
+		f.logStreamer,
+		f.eventPub,
+		f.storyRepo,
+		f.projectRepo,
+		f.runRepo,
+		f.templateSvc,
+		agentCfg,
+		testLogger(),
+	)
+
+	return f
+}
+
+func (f *agentRunFixture) newRunContext() *model.RunContext {
+	return &model.RunContext{
+		Run:       f.run,
+		RunStep:   f.runStep,
+		ProjectID: f.projectID,
+		StoryID:   f.storyID,
+		Metadata: map[string]any{
+			"branch_name": "feat/s-42-test",
+		},
+	}
+}
+
+// --- Tests ---
+
+func TestAgentRunAction_Name(t *testing.T) {
+	f := newAgentRunFixture(t)
+	if f.action.Name() != "agent_run" {
+		t.Errorf("expected action name %q, got %q", "agent_run", f.action.Name())
+	}
+}
+
+func TestAgentRunAction_HappyPath(t *testing.T) {
+	f := newAgentRunFixture(t)
+	runCtx := f.newRunContext()
+
+	err := f.action.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Verify container was created with correct opts
+	f.containerMgr.mu.Lock()
+	createCalls := f.containerMgr.createCalls
+	f.containerMgr.mu.Unlock()
+	if len(createCalls) != 1 {
+		t.Fatalf("expected 1 create call, got %d", len(createCalls))
+	}
+
+	opts := createCalls[0]
+	if opts.Image != "hopeitworks/agent:latest" {
+		t.Errorf("expected image %q, got %q", "hopeitworks/agent:latest", opts.Image)
+	}
+	if opts.NetworkName != "test-network" {
+		t.Errorf("expected network %q, got %q", "test-network", opts.NetworkName)
+	}
+	if opts.Memory != 4294967296 {
+		t.Errorf("expected memory 4294967296, got %d", opts.Memory)
+	}
+	if opts.CPUs != 2.0 {
+		t.Errorf("expected CPUs 2.0, got %f", opts.CPUs)
+	}
+
+	// Verify labels
+	if opts.Labels["managed_by"] != "hopeitworks" {
+		t.Error("expected managed_by label")
+	}
+	if opts.Labels["run_id"] != f.runID.String() {
+		t.Errorf("expected run_id label %s, got %s", f.runID, opts.Labels["run_id"])
+	}
+	if opts.Labels["step_id"] != f.stepID.String() {
+		t.Errorf("expected step_id label %s, got %s", f.stepID, opts.Labels["step_id"])
+	}
+	if opts.Labels["story_key"] != "S-42" {
+		t.Errorf("expected story_key label S-42, got %s", opts.Labels["story_key"])
+	}
+
+	// Verify env vars contain expected keys
+	envMap := make(map[string]string)
+	for _, env := range opts.Env {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+	if _, ok := envMap["CLAUDE_MD_CONTENT"]; !ok {
+		t.Error("expected CLAUDE_MD_CONTENT env var")
+	}
+	if envMap["REPO_URL"] != "https://github.com/test/repo" {
+		t.Errorf("expected REPO_URL, got %q", envMap["REPO_URL"])
+	}
+	if envMap["BRANCH_NAME"] != "feat/s-42-test" {
+		t.Errorf("expected BRANCH_NAME feat/s-42-test, got %q", envMap["BRANCH_NAME"])
+	}
+	if envMap["STORY_KEY"] != "S-42" {
+		t.Errorf("expected STORY_KEY S-42, got %q", envMap["STORY_KEY"])
+	}
+	if _, ok := envMap["PROMPT_CONTENT"]; !ok {
+		t.Error("expected PROMPT_CONTENT env var")
+	}
+
+	// Verify container was started
+	f.containerMgr.mu.Lock()
+	startCalls := f.containerMgr.startCalls
+	f.containerMgr.mu.Unlock()
+	if len(startCalls) != 1 || startCalls[0] != testContainerID {
+		t.Errorf("expected start called with container-123, got %v", startCalls)
+	}
+
+	// Verify container ID was persisted
+	infoCalls := f.runRepo.getContainerInfoCalls()
+	var foundContainerIDPersist bool
+	for _, call := range infoCalls {
+		if call.ContainerID != nil && *call.ContainerID == testContainerID {
+			foundContainerIDPersist = true
+		}
+	}
+	if !foundContainerIDPersist {
+		t.Error("expected container ID to be persisted")
+	}
+
+	// Verify log events were published
+	events := f.eventPub.getEvents()
+	if len(events) < 3 {
+		t.Errorf("expected at least 3 log events published, got %d", len(events))
+	}
+	for _, e := range events {
+		if e.EntityType != "log" || e.Action != "emitted" {
+			t.Errorf("expected log.emitted event, got %s.%s", e.EntityType, e.Action)
+		}
+	}
+
+	// Verify container was cleaned up (stop + remove)
+	f.containerMgr.mu.Lock()
+	stopCalls := f.containerMgr.stopCalls
+	removeCalls := f.containerMgr.removeCalls
+	f.containerMgr.mu.Unlock()
+	if len(stopCalls) < 1 {
+		t.Error("expected container stop called during cleanup")
+	}
+	if len(removeCalls) < 1 {
+		t.Error("expected container remove called during cleanup")
+	}
+}
+
+func TestAgentRunAction_FrontendScope(t *testing.T) {
+	f := newAgentRunFixture(t)
+	frontendScope := "frontend"
+	f.story.Scope = &frontendScope
+	runCtx := f.newRunContext()
+
+	err := f.action.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Verify CLAUDE.md content includes frontend.md
+	f.containerMgr.mu.Lock()
+	createCalls := f.containerMgr.createCalls
+	f.containerMgr.mu.Unlock()
+	if len(createCalls) != 1 {
+		t.Fatalf("expected 1 create call, got %d", len(createCalls))
+	}
+
+	envMap := make(map[string]string)
+	for _, env := range createCalls[0].Env {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+	claudeMD := envMap["CLAUDE_MD_CONTENT"]
+	if !strings.Contains(claudeMD, "Frontend Instructions") {
+		t.Error("expected CLAUDE_MD_CONTENT to contain frontend instructions")
+	}
+	if strings.Contains(claudeMD, "Backend Instructions") {
+		t.Error("CLAUDE_MD_CONTENT should not contain backend instructions for frontend scope")
+	}
+}
+
+func TestAgentRunAction_SharedScope(t *testing.T) {
+	f := newAgentRunFixture(t)
+	f.story.Scope = nil // nil scope
+	runCtx := f.newRunContext()
+
+	err := f.action.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	f.containerMgr.mu.Lock()
+	createCalls := f.containerMgr.createCalls
+	f.containerMgr.mu.Unlock()
+
+	envMap := make(map[string]string)
+	for _, env := range createCalls[0].Env {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+	claudeMD := envMap["CLAUDE_MD_CONTENT"]
+	if !strings.Contains(claudeMD, "Base Instructions") {
+		t.Error("expected CLAUDE_MD_CONTENT to contain base instructions")
+	}
+	if !strings.Contains(claudeMD, "Project Context") {
+		t.Error("expected CLAUDE_MD_CONTENT to contain project context")
+	}
+	if strings.Contains(claudeMD, "Backend Instructions") || strings.Contains(claudeMD, "Frontend Instructions") {
+		t.Error("CLAUDE_MD_CONTENT should not contain scope-specific instructions for nil scope")
+	}
+}
+
+func TestAgentRunAction_AgentFailure(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	// Configure log streamer to send 10 events then exit with code 1
+	f.logStreamer.streamLogsFn = func(_ context.Context, _, _, _ string) (<-chan model.LogEvent, <-chan int, error) {
+		logCh := make(chan model.LogEvent, 10)
+		doneCh := make(chan int, 1)
+		go func() {
+			for i := 0; i < 10; i++ {
+				logCh <- model.LogEvent{
+					Message:   fmt.Sprintf("log line %d", i),
+					Level:     "info",
+					Timestamp: time.Now(),
+				}
+			}
+			close(logCh)
+			doneCh <- 1 // non-zero exit code
+		}()
+		return logCh, doneCh, nil
+	}
+
+	runCtx := f.newRunContext()
+	err := f.action.Execute(context.Background(), runCtx)
+	if err == nil {
+		t.Fatal("expected error for non-zero exit code, got nil")
+	}
+	if !strings.Contains(err.Error(), "exited with code 1") {
+		t.Errorf("expected error to contain 'exited with code 1', got: %v", err)
+	}
+
+	// Verify log tail was persisted
+	infoCalls := f.runRepo.getContainerInfoCalls()
+	var foundLogTail bool
+	for _, call := range infoCalls {
+		if call.LogTail != nil {
+			foundLogTail = true
+			tail := *call.LogTail
+			// Should contain the last log lines
+			if !strings.Contains(tail, "log line") {
+				t.Errorf("expected log tail to contain log lines, got: %s", tail)
+			}
+		}
+	}
+	if !foundLogTail {
+		t.Error("expected log tail to be persisted on failure")
+	}
+
+	// Verify container was cleaned up
+	f.containerMgr.mu.Lock()
+	removeCalls := f.containerMgr.removeCalls
+	f.containerMgr.mu.Unlock()
+	if len(removeCalls) < 1 {
+		t.Error("expected container to be removed on failure")
+	}
+}
+
+func TestAgentRunAction_ContainerCreateFailure(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	f.containerMgr.createFn = func(_ context.Context, _ model.ContainerOpts) (string, error) {
+		return "", fmt.Errorf("docker error: no space left on device")
+	}
+
+	runCtx := f.newRunContext()
+	err := f.action.Execute(context.Background(), runCtx)
+	if err == nil {
+		t.Fatal("expected error for container create failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "create container") {
+		t.Errorf("expected error to wrap 'create container', got: %v", err)
+	}
+
+	// Verify Start and Wait were NOT called
+	f.containerMgr.mu.Lock()
+	startCalls := f.containerMgr.startCalls
+	f.containerMgr.mu.Unlock()
+	if len(startCalls) > 0 {
+		t.Error("expected Start to NOT be called after create failure")
+	}
+}
+
+func TestAgentRunAction_ContextCancellation(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	// Configure wait to block until context is cancelled
+	f.logStreamer.streamLogsFn = func(ctx context.Context, _, _, _ string) (<-chan model.LogEvent, <-chan int, error) {
+		logCh := make(chan model.LogEvent)
+		doneCh := make(chan int, 1)
+		go func() {
+			<-ctx.Done()
+			close(logCh)
+			doneCh <- -1
+		}()
+		return logCh, doneCh, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel after a short delay
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	runCtx := f.newRunContext()
+	err := f.action.Execute(ctx, runCtx)
+	if err == nil {
+		t.Fatal("expected error for context cancellation, got nil")
+	}
+
+	// Verify container was cleaned up
+	f.containerMgr.mu.Lock()
+	stopCalls := f.containerMgr.stopCalls
+	removeCalls := f.containerMgr.removeCalls
+	f.containerMgr.mu.Unlock()
+	if len(stopCalls) < 1 {
+		t.Error("expected container stop called on cancellation")
+	}
+	if len(removeCalls) < 1 {
+		t.Error("expected container remove called on cancellation")
+	}
+}
+
+func TestAgentRunAction_TemplateNotFound(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	// Override metadata to use a non-existent template
+	runCtx := f.newRunContext()
+	runCtx.Metadata["template_name"] = "nonexistent-template"
+
+	err := f.action.Execute(context.Background(), runCtx)
+	if err == nil {
+		t.Fatal("expected error for missing template, got nil")
+	}
+	if !strings.Contains(err.Error(), "render prompt template") {
+		t.Errorf("expected error to wrap 'render prompt template', got: %v", err)
+	}
+
+	// Verify no container was created
+	f.containerMgr.mu.Lock()
+	createCalls := f.containerMgr.createCalls
+	f.containerMgr.mu.Unlock()
+	if len(createCalls) > 0 {
+		t.Error("expected no container to be created when template is not found")
+	}
+}
+
+func TestAgentRunAction_StoryNotFound(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	f.storyRepo.getByIDFn = func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+		return nil, errors.NewNotFound("story", id)
+	}
+
+	runCtx := f.newRunContext()
+	err := f.action.Execute(context.Background(), runCtx)
+	if err == nil {
+		t.Fatal("expected error for story not found, got nil")
+	}
+	if !strings.Contains(err.Error(), "fetch story") {
+		t.Errorf("expected error to wrap 'fetch story', got: %v", err)
+	}
+
+	// Verify no container was created
+	f.containerMgr.mu.Lock()
+	createCalls := f.containerMgr.createCalls
+	f.containerMgr.mu.Unlock()
+	if len(createCalls) > 0 {
+		t.Error("expected no container to be created when story is not found")
+	}
+}
+
+func TestAgentRunAction_ProjectNotFound(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	f.projectRepo.getByIDFn = func(_ context.Context, id uuid.UUID) (*model.Project, error) {
+		return nil, errors.NewNotFound("project", id)
+	}
+
+	runCtx := f.newRunContext()
+	err := f.action.Execute(context.Background(), runCtx)
+	if err == nil {
+		t.Fatal("expected error for project not found, got nil")
+	}
+	if !strings.Contains(err.Error(), "fetch project") {
+		t.Errorf("expected error to wrap 'fetch project', got: %v", err)
+	}
+}
+
+func TestAgentRunAction_MetadataTemplateName(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	// Use the default template name (implement) — should work
+	runCtx := f.newRunContext()
+	delete(runCtx.Metadata, "template_name") // ensure no override
+
+	err := f.action.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Fatalf("expected no error with default template, got %v", err)
+	}
+}
+
+func TestAgentRunAction_CleanupOnAllPaths(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	// Make start fail
+	f.containerMgr.startFn = func(_ context.Context, _ string) error {
+		return fmt.Errorf("docker start error")
+	}
+
+	runCtx := f.newRunContext()
+	err := f.action.Execute(context.Background(), runCtx)
+	if err == nil {
+		t.Fatal("expected error for start failure, got nil")
+	}
+
+	// Even though start failed, cleanup should still run (deferred)
+	f.containerMgr.mu.Lock()
+	removeCalls := f.containerMgr.removeCalls
+	f.containerMgr.mu.Unlock()
+	if len(removeCalls) < 1 {
+		t.Error("expected container cleanup even when start fails")
+	}
+}

--- a/backend/internal/adapter/action/claude_md_composer.go
+++ b/backend/internal/adapter/action/claude_md_composer.go
@@ -1,0 +1,47 @@
+package action
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CLAUDEMDComposer reads and concatenates CLAUDE.md template files
+// based on the story scope.
+type CLAUDEMDComposer struct {
+	basePath string
+}
+
+// NewCLAUDEMDComposer creates a new composer with the given base path.
+func NewCLAUDEMDComposer(basePath string) *CLAUDEMDComposer {
+	return &CLAUDEMDComposer{basePath: basePath}
+}
+
+// Compose builds the CLAUDE.md content for the given scope.
+// Composition rule: base.md + (backend.md | frontend.md | nothing) + project.md
+func (c *CLAUDEMDComposer) Compose(scope string) (string, error) {
+	files := []string{"base.md"}
+
+	switch strings.ToLower(scope) {
+	case "backend":
+		files = append(files, "backend.md")
+	case "frontend":
+		files = append(files, "frontend.md")
+		// "shared", "", or any other value: no scope-specific file
+	}
+
+	files = append(files, "project.md")
+
+	var parts []string
+	for _, f := range files {
+		path := filepath.Join(c.basePath, f)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("read CLAUDE.md template %q: %w", path, err)
+		}
+		parts = append(parts, strings.TrimSpace(string(content)))
+	}
+
+	return strings.Join(parts, "\n\n"), nil
+}

--- a/backend/internal/adapter/action/claude_md_composer_test.go
+++ b/backend/internal/adapter/action/claude_md_composer_test.go
@@ -1,0 +1,197 @@
+package action_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zakari/hopeitworks/backend/internal/adapter/action"
+)
+
+func setupTestClaudeMDDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	writeFile(t, dir, "base.md", "# Base Instructions\nCommon guidelines.")
+	writeFile(t, dir, "backend.md", "# Backend Instructions\nGo patterns.")
+	writeFile(t, dir, "frontend.md", "# Frontend Instructions\nVue patterns.")
+	writeFile(t, dir, "project.md", "# Project Context\nCurrent status.")
+
+	return dir
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file %s: %v", name, err)
+	}
+}
+
+func TestCLAUDEMDComposer_BackendScope(t *testing.T) {
+	dir := setupTestClaudeMDDir(t)
+	composer := action.NewCLAUDEMDComposer(dir)
+
+	result, err := composer.Compose("backend")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should contain all three files: base + backend + project
+	if !strings.Contains(result, "# Base Instructions") {
+		t.Error("expected base.md content in result")
+	}
+	if !strings.Contains(result, "# Backend Instructions") {
+		t.Error("expected backend.md content in result")
+	}
+	if !strings.Contains(result, "# Project Context") {
+		t.Error("expected project.md content in result")
+	}
+	// Should NOT contain frontend content
+	if strings.Contains(result, "# Frontend Instructions") {
+		t.Error("unexpected frontend.md content in result")
+	}
+
+	// Verify parts are separated by double newline
+	parts := strings.Split(result, "\n\n")
+	if len(parts) < 3 {
+		t.Errorf("expected at least 3 parts separated by double newline, got %d", len(parts))
+	}
+}
+
+func TestCLAUDEMDComposer_FrontendScope(t *testing.T) {
+	dir := setupTestClaudeMDDir(t)
+	composer := action.NewCLAUDEMDComposer(dir)
+
+	result, err := composer.Compose("frontend")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "# Base Instructions") {
+		t.Error("expected base.md content in result")
+	}
+	if !strings.Contains(result, "# Frontend Instructions") {
+		t.Error("expected frontend.md content in result")
+	}
+	if !strings.Contains(result, "# Project Context") {
+		t.Error("expected project.md content in result")
+	}
+	if strings.Contains(result, "# Backend Instructions") {
+		t.Error("unexpected backend.md content in result")
+	}
+}
+
+func TestCLAUDEMDComposer_SharedScope(t *testing.T) {
+	dir := setupTestClaudeMDDir(t)
+	composer := action.NewCLAUDEMDComposer(dir)
+
+	result, err := composer.Compose("shared")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "# Base Instructions") {
+		t.Error("expected base.md content in result")
+	}
+	if !strings.Contains(result, "# Project Context") {
+		t.Error("expected project.md content in result")
+	}
+	// No scope-specific content
+	if strings.Contains(result, "# Backend Instructions") {
+		t.Error("unexpected backend.md content in result")
+	}
+	if strings.Contains(result, "# Frontend Instructions") {
+		t.Error("unexpected frontend.md content in result")
+	}
+}
+
+func TestCLAUDEMDComposer_EmptyScope(t *testing.T) {
+	dir := setupTestClaudeMDDir(t)
+	composer := action.NewCLAUDEMDComposer(dir)
+
+	result, err := composer.Compose("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "# Base Instructions") {
+		t.Error("expected base.md content in result")
+	}
+	if !strings.Contains(result, "# Project Context") {
+		t.Error("expected project.md content in result")
+	}
+	if strings.Contains(result, "# Backend Instructions") {
+		t.Error("unexpected backend.md content in result")
+	}
+	if strings.Contains(result, "# Frontend Instructions") {
+		t.Error("unexpected frontend.md content in result")
+	}
+}
+
+func TestCLAUDEMDComposer_CaseInsensitive(t *testing.T) {
+	dir := setupTestClaudeMDDir(t)
+	composer := action.NewCLAUDEMDComposer(dir)
+
+	result, err := composer.Compose("BACKEND")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "# Backend Instructions") {
+		t.Error("expected backend.md content for uppercase scope")
+	}
+}
+
+func TestCLAUDEMDComposer_MissingBaseFile(t *testing.T) {
+	dir := t.TempDir()
+	// Only write project.md, not base.md
+	writeFile(t, dir, "project.md", "# Project")
+
+	composer := action.NewCLAUDEMDComposer(dir)
+
+	_, err := composer.Compose("")
+	if err == nil {
+		t.Fatal("expected error for missing base.md, got nil")
+	}
+	if !strings.Contains(err.Error(), "base.md") {
+		t.Errorf("error should mention base.md, got: %v", err)
+	}
+}
+
+func TestCLAUDEMDComposer_MissingProjectFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "base.md", "# Base")
+	// No project.md
+
+	composer := action.NewCLAUDEMDComposer(dir)
+
+	_, err := composer.Compose("")
+	if err == nil {
+		t.Fatal("expected error for missing project.md, got nil")
+	}
+	if !strings.Contains(err.Error(), "project.md") {
+		t.Errorf("error should mention project.md, got: %v", err)
+	}
+}
+
+func TestCLAUDEMDComposer_TrimsWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "base.md", "\n  # Base  \n\n")
+	writeFile(t, dir, "project.md", "\n  # Project  \n\n")
+
+	composer := action.NewCLAUDEMDComposer(dir)
+
+	result, err := composer.Compose("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Each part should be trimmed
+	if strings.HasPrefix(result, "\n") {
+		t.Error("result should not start with newline")
+	}
+	if strings.HasSuffix(result, "\n\n") {
+		t.Error("result should not end with double newline")
+	}
+}

--- a/backend/internal/adapter/docker/log_streamer.go
+++ b/backend/internal/adapter/docker/log_streamer.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
@@ -38,6 +39,19 @@ type LogStreamer struct {
 // NewDockerLogStreamer creates a LogStreamer with an existing Docker client.
 func NewDockerLogStreamer(client logStreamClient, logger *slog.Logger) *LogStreamer {
 	return &LogStreamer{client: client, logger: logger, idleTimeout: DefaultIdleTimeout}
+}
+
+// NewDockerLogStreamerFromHost creates a LogStreamer by connecting to Docker
+// via the specified host URL (e.g., "tcp://socket-proxy:2375").
+func NewDockerLogStreamerFromHost(dockerHost string, logger *slog.Logger) (*LogStreamer, error) {
+	cli, err := client.NewClientWithOpts(
+		client.WithHost(dockerHost),
+		client.WithAPIVersionNegotiation(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating docker client for log streamer: %w", err)
+	}
+	return &LogStreamer{client: cli, logger: logger, idleTimeout: DefaultIdleTimeout}, nil
 }
 
 // StreamLogs streams log events from a container.

--- a/backend/internal/adapter/postgres/run_repo.go
+++ b/backend/internal/adapter/postgres/run_repo.go
@@ -194,19 +194,7 @@ func (r *RunRepo) UpdateRunStepStatus(ctx context.Context, id uuid.UUID, status 
 }
 
 func (r *RunRepo) UpdateRunStepContainerInfo(ctx context.Context, id uuid.UUID, containerID *string, logTail *string) (*model.RunStep, error) {
-	// Fetch current step to preserve its status.
-	step, err := r.queries.GetRunStep(ctx, id)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, apperrors.NewNotFound("run step", id)
-		}
-		return nil, apperrors.NewInternal("failed to get run step for container info update", err)
-	}
-
-	params := UpdateRunStepStatusParams{
-		ID:     id,
-		Status: step.Status,
-	}
+	params := UpdateRunStepContainerInfoParams{ID: id}
 	if containerID != nil {
 		params.ContainerID = pgtype.Text{String: *containerID, Valid: true}
 	}
@@ -214,7 +202,7 @@ func (r *RunRepo) UpdateRunStepContainerInfo(ctx context.Context, id uuid.UUID, 
 		params.LogTail = pgtype.Text{String: *logTail, Valid: true}
 	}
 
-	row, err := r.queries.UpdateRunStepStatus(ctx, params)
+	row, err := r.queries.UpdateRunStepContainerInfo(ctx, params)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, apperrors.NewNotFound("run step", id)

--- a/backend/internal/adapter/postgres/run_repo.go
+++ b/backend/internal/adapter/postgres/run_repo.go
@@ -193,6 +193,37 @@ func (r *RunRepo) UpdateRunStepStatus(ctx context.Context, id uuid.UUID, status 
 	return toDomainRunStep(row), nil
 }
 
+func (r *RunRepo) UpdateRunStepContainerInfo(ctx context.Context, id uuid.UUID, containerID *string, logTail *string) (*model.RunStep, error) {
+	// Fetch current step to preserve its status.
+	step, err := r.queries.GetRunStep(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperrors.NewNotFound("run step", id)
+		}
+		return nil, apperrors.NewInternal("failed to get run step for container info update", err)
+	}
+
+	params := UpdateRunStepStatusParams{
+		ID:     id,
+		Status: step.Status,
+	}
+	if containerID != nil {
+		params.ContainerID = pgtype.Text{String: *containerID, Valid: true}
+	}
+	if logTail != nil {
+		params.LogTail = pgtype.Text{String: *logTail, Valid: true}
+	}
+
+	row, err := r.queries.UpdateRunStepStatus(ctx, params)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperrors.NewNotFound("run step", id)
+		}
+		return nil, apperrors.NewInternal("failed to update run step container info", err)
+	}
+	return toDomainRunStep(row), nil
+}
+
 // toDomainRun maps a sqlc-generated Run to a domain Run.
 func toDomainRun(r Run) *model.Run {
 	run := &model.Run{

--- a/backend/internal/adapter/postgres/run_steps.sql.go
+++ b/backend/internal/adapter/postgres/run_steps.sql.go
@@ -115,6 +115,40 @@ func (q *Queries) ListRunStepsByRun(ctx context.Context, runID uuid.UUID) ([]Run
 	return items, nil
 }
 
+const updateRunStepContainerInfo = `-- name: UpdateRunStepContainerInfo :one
+UPDATE run_steps
+SET container_id = COALESCE($2, container_id),
+    log_tail = COALESCE($3, log_tail)
+WHERE id = $1
+RETURNING id, run_id, step_name, step_order, action, status, started_at, completed_at, error_message, container_id, log_tail, created_at
+`
+
+type UpdateRunStepContainerInfoParams struct {
+	ID          uuid.UUID   `json:"id"`
+	ContainerID pgtype.Text `json:"container_id"`
+	LogTail     pgtype.Text `json:"log_tail"`
+}
+
+func (q *Queries) UpdateRunStepContainerInfo(ctx context.Context, arg UpdateRunStepContainerInfoParams) (RunStep, error) {
+	row := q.db.QueryRow(ctx, updateRunStepContainerInfo, arg.ID, arg.ContainerID, arg.LogTail)
+	var i RunStep
+	err := row.Scan(
+		&i.ID,
+		&i.RunID,
+		&i.StepName,
+		&i.StepOrder,
+		&i.Action,
+		&i.Status,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.ErrorMessage,
+		&i.ContainerID,
+		&i.LogTail,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const updateRunStepStatus = `-- name: UpdateRunStepStatus :one
 UPDATE run_steps
 SET status = $2,

--- a/backend/internal/domain/port/run_repository.go
+++ b/backend/internal/domain/port/run_repository.go
@@ -22,4 +22,8 @@ type RunRepository interface {
 	GetRunStep(ctx context.Context, id uuid.UUID) (*model.RunStep, error)
 	ListRunStepsByRun(ctx context.Context, runID uuid.UUID) ([]*model.RunStep, error)
 	UpdateRunStepStatus(ctx context.Context, id uuid.UUID, status model.StepStatus, startedAt, completedAt *time.Time, errorMsg *string) (*model.RunStep, error)
+
+	// UpdateRunStepContainerInfo updates container_id and/or log_tail on a run step
+	// without changing its status. Nil values are ignored (existing values preserved).
+	UpdateRunStepContainerInfo(ctx context.Context, id uuid.UUID, containerID *string, logTail *string) (*model.RunStep, error)
 }

--- a/backend/internal/domain/service/action_registry.go
+++ b/backend/internal/domain/service/action_registry.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"sync"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// Ensure InMemoryActionRegistry implements port.ActionRegistry at compile time.
+var _ port.ActionRegistry = (*InMemoryActionRegistry)(nil)
+
+// InMemoryActionRegistry is a thread-safe in-memory implementation of port.ActionRegistry.
+type InMemoryActionRegistry struct {
+	mu      sync.RWMutex
+	actions map[string]model.Action
+}
+
+// NewActionRegistry creates a new InMemoryActionRegistry.
+func NewActionRegistry() *InMemoryActionRegistry {
+	return &InMemoryActionRegistry{
+		actions: make(map[string]model.Action),
+	}
+}
+
+// Register registers an action by its name.
+// If an action with the same name exists, it is overwritten.
+func (r *InMemoryActionRegistry) Register(action model.Action) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.actions[action.Name()] = action
+}
+
+// Get retrieves an action by name.
+// Returns ACTION_NOT_FOUND error if action is not registered.
+func (r *InMemoryActionRegistry) Get(name string) (model.Action, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	action, ok := r.actions[name]
+	if !ok {
+		return nil, errors.NewNotFound("action", name)
+	}
+	return action, nil
+}

--- a/backend/internal/domain/service/run_service_test.go
+++ b/backend/internal/domain/service/run_service_test.go
@@ -93,6 +93,9 @@ func (m *mockRunRepo) UpdateRunStepStatus(ctx context.Context, id uuid.UUID, sta
 	}
 	return nil, nil
 }
+func (m *mockRunRepo) UpdateRunStepContainerInfo(_ context.Context, id uuid.UUID, _ *string, _ *string) (*model.RunStep, error) {
+	return &model.RunStep{ID: id}, nil
+}
 
 // newMockProjectRepoWithProject creates a mockProjectRepo preloaded with a project.
 func newMockProjectRepoWithProject(project *model.Project) *mockProjectRepo {

--- a/backend/queries/run_steps.sql
+++ b/backend/queries/run_steps.sql
@@ -21,3 +21,10 @@ SET status = $2,
     log_tail = COALESCE(sqlc.narg('log_tail'), log_tail)
 WHERE id = $1
 RETURNING *;
+
+-- name: UpdateRunStepContainerInfo :one
+UPDATE run_steps
+SET container_id = COALESCE(sqlc.narg('container_id'), container_id),
+    log_tail = COALESCE(sqlc.narg('log_tail'), log_tail)
+WHERE id = $1
+RETURNING *;


### PR DESCRIPTION
## Summary
- Implement `AgentRunAction` that orchestrates Claude Code agent execution in Docker containers: fetches story/project, composes scope-aware CLAUDE.md, renders prompt templates, creates/starts containers, streams logs with event forwarding, persists container ID and log tail, and handles cleanup on all code paths (success, failure, cancellation)
- Add `CLAUDEMDComposer` helper that reads and concatenates CLAUDE.md template files based on story scope (backend → base+backend+project, frontend → base+frontend+project, shared/nil → base+project)
- Add `InMemoryActionRegistry` (concrete implementation of `port.ActionRegistry`) for thread-safe action registration and lookup
- Extend `RunRepository` port with `UpdateRunStepContainerInfo` for persisting container_id and log_tail without changing step status
- Add `NewDockerLogStreamerFromHost` convenience constructor for creating LogStreamer from Docker host URL
- Wire `AgentRunAction` into `main.go` ActionRegistry with `EventRepo` as event publisher

## Test plan
- [x] 20 unit tests covering:
  - Happy path (container create → start → stream logs → exit 0)
  - Backend, frontend, and shared/nil scope CLAUDE.md composition
  - Agent failure (non-zero exit code) with log tail persistence
  - Container create failure (early abort, no start called)
  - Context cancellation (cleanup runs)
  - Story not found / project not found (early abort)
  - Missing prompt template (early abort)
  - Cleanup on all failure paths (start failure)
  - CLAUDEMDComposer: all scopes, case insensitivity, missing files, whitespace trimming
- [x] All existing tests pass (`go test ./... -short`)
- [x] golangci-lint passes with zero issues
- [x] `go vet` and `gofmt` clean

Refs: S-3-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)