### PR TITLE
feat(ui): add story editor with create and edit mode

### DIFF
--- a/frontend/src/composables/__tests__/useStoryEditor.spec.ts
+++ b/frontend/src/composables/__tests__/useStoryEditor.spec.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { setActivePinia, createPinia } from 'pinia'
+import { useStoryEditor } from '../useStoryEditor'
+import type { Story } from '@/stores/stories'
+import { useStoriesStore } from '@/stores/stories'
+
+const mockPut = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: vi.fn(),
+    PUT: (...args: unknown[]) => mockPut(...args),
+    POST: vi.fn(),
+  },
+}))
+
+function makeStory(overrides: Partial<Story> = {}): Story {
+  return {
+    id: 's1',
+    epic_id: 'e1',
+    project_id: 'p1',
+    key: 'S-01',
+    title: 'Test Story',
+    status: 'backlog',
+    objective: 'Build the feature',
+    acceptance_criteria: '- Item 1\n- Item 2',
+    target_files: ['src/foo.ts', 'src/bar.ts'],
+    depends_on: ['S-02'],
+    scope: 'backend',
+    created_at: '2026-01-15T10:00:00Z',
+    updated_at: '2026-01-15T10:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('useStoryEditor', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockPut.mockReset()
+  })
+
+  it('starts with isEditing false', () => {
+    const story = ref<Story | null>(makeStory())
+    const { isEditing } = useStoryEditor('p1', story)
+    expect(isEditing.value).toBe(false)
+  })
+
+  describe('startEdit', () => {
+    it('copies story fields into draftFields and sets isEditing true', () => {
+      const story = ref<Story | null>(makeStory())
+      const { startEdit, isEditing, draftFields } = useStoryEditor('p1', story)
+
+      startEdit()
+
+      expect(isEditing.value).toBe(true)
+      expect(draftFields.value.title).toBe('Test Story')
+      expect(draftFields.value.objective).toBe('Build the feature')
+      expect(draftFields.value.acceptance_criteria).toBe('- Item 1\n- Item 2')
+      expect(draftFields.value.target_files).toEqual(['src/foo.ts', 'src/bar.ts'])
+      expect(draftFields.value.depends_on).toEqual(['S-02'])
+      expect(draftFields.value.scope).toBe('backend')
+    })
+
+    it('deep clones target_files so mutations do not affect original', () => {
+      const story = ref<Story | null>(makeStory({ target_files: ['a.ts'] }))
+      const { startEdit, draftFields } = useStoryEditor('p1', story)
+
+      startEdit()
+      draftFields.value.target_files!.push('b.ts')
+
+      expect(story.value!.target_files).toEqual(['a.ts'])
+    })
+
+    it('clears previous validation errors and api error', () => {
+      const story = ref<Story | null>(makeStory())
+      const { startEdit, validationErrors, apiError } = useStoryEditor('p1', story)
+
+      // Simulate previous errors
+      validationErrors.value = { title: 'Required' }
+      apiError.value = 'Server error'
+
+      startEdit()
+
+      expect(validationErrors.value).toEqual({})
+      expect(apiError.value).toBeNull()
+    })
+
+    it('does nothing when story is null', () => {
+      const story = ref<Story | null>(null)
+      const { startEdit, isEditing } = useStoryEditor('p1', story)
+
+      startEdit()
+
+      expect(isEditing.value).toBe(false)
+    })
+  })
+
+  describe('cancelEdit', () => {
+    it('resets state and sets isEditing false', () => {
+      const story = ref<Story | null>(makeStory())
+      const { startEdit, cancelEdit, isEditing, draftFields, validationErrors, apiError } =
+        useStoryEditor('p1', story)
+
+      startEdit()
+      draftFields.value.title = 'Modified'
+      validationErrors.value = { title: 'Error' }
+      apiError.value = 'API error'
+
+      cancelEdit()
+
+      expect(isEditing.value).toBe(false)
+      expect(draftFields.value).toEqual({})
+      expect(validationErrors.value).toEqual({})
+      expect(apiError.value).toBeNull()
+    })
+  })
+
+  describe('saveEdit', () => {
+    it('calls store.updateStory and sets isEditing false on success', async () => {
+      const story = ref<Story | null>(makeStory())
+      const { startEdit, saveEdit, isEditing } = useStoryEditor('p1', story)
+
+      startEdit()
+
+      const updatedStory = makeStory({ title: 'Updated' })
+      mockPut.mockResolvedValue({ data: updatedStory, error: undefined })
+
+      // Populate store items so updateStory can find the story
+      const store = useStoriesStore()
+      store.items = [makeStory()]
+
+      const result = await saveEdit('s1')
+
+      expect(result).toEqual(updatedStory)
+      expect(isEditing.value).toBe(false)
+    })
+
+    it('sets validation error when title is empty', async () => {
+      const story = ref<Story | null>(makeStory())
+      const { startEdit, saveEdit, validationErrors, isEditing } = useStoryEditor('p1', story)
+
+      startEdit()
+      // Clear the title
+      const { draftFields } = useStoryEditor('p1', story)
+      draftFields.value = { ...draftFields.value }
+
+      // Use the original editor instance
+      const editor = useStoryEditor('p1', story)
+      editor.startEdit()
+      editor.draftFields.value.title = ''
+
+      const result = await editor.saveEdit('s1')
+
+      expect(result).toBeNull()
+      expect(editor.validationErrors.value.title).toBe('Title is required')
+      expect(editor.isEditing.value).toBe(true)
+    })
+
+    it('sets validation error when title is whitespace only', async () => {
+      const story = ref<Story | null>(makeStory())
+      const editor = useStoryEditor('p1', story)
+
+      editor.startEdit()
+      editor.draftFields.value.title = '   '
+
+      const result = await editor.saveEdit('s1')
+
+      expect(result).toBeNull()
+      expect(editor.validationErrors.value.title).toBe('Title is required')
+    })
+
+    it('does not call store when validation fails', async () => {
+      const story = ref<Story | null>(makeStory())
+      const editor = useStoryEditor('p1', story)
+
+      editor.startEdit()
+      editor.draftFields.value.title = ''
+
+      await editor.saveEdit('s1')
+
+      expect(mockPut).not.toHaveBeenCalled()
+    })
+
+    it('populates apiError and keeps isEditing true on API error', async () => {
+      const story = ref<Story | null>(makeStory())
+      const editor = useStoryEditor('p1', story)
+
+      editor.startEdit()
+
+      mockPut.mockResolvedValue({
+        data: undefined,
+        error: { error: { code: 'INTERNAL', message: 'Server error' } },
+      })
+
+      const result = await editor.saveEdit('s1')
+
+      expect(result).toBeNull()
+      expect(editor.apiError.value).toBeTruthy()
+      expect(editor.isEditing.value).toBe(true)
+    })
+
+    it('sets isSaving during save operation', async () => {
+      const story = ref<Story | null>(makeStory())
+      const editor = useStoryEditor('p1', story)
+
+      editor.startEdit()
+
+      const store = useStoriesStore()
+      store.items = [makeStory()]
+
+      let savingDuringCall = false
+      mockPut.mockImplementation(() => {
+        savingDuringCall = editor.isSaving.value
+        return Promise.resolve({ data: makeStory(), error: undefined })
+      })
+
+      await editor.saveEdit('s1')
+
+      expect(savingDuringCall).toBe(true)
+      expect(editor.isSaving.value).toBe(false)
+    })
+  })
+})

--- a/frontend/src/composables/useStoryEditor.ts
+++ b/frontend/src/composables/useStoryEditor.ts
@@ -1,0 +1,72 @@
+import { ref, type Ref } from 'vue'
+import { useStoriesStore, type Story, type UpdateStoryFields } from '@/stores/stories'
+
+/**
+ * Composable for managing inline story edit mode.
+ * Owns all edit-mode state: isEditing, draftFields, validationErrors, apiError, isSaving.
+ */
+export function useStoryEditor(projectId: string, story: Ref<Story | null>) {
+  const store = useStoriesStore()
+  const isEditing = ref(false)
+  const draftFields = ref<UpdateStoryFields>({})
+  const validationErrors = ref<Record<string, string>>({})
+  const apiError = ref<string | null>(null)
+  const isSaving = ref(false)
+
+  /** Enter edit mode by copying story fields into draft */
+  function startEdit() {
+    if (!story.value) return
+    draftFields.value = {
+      title: story.value.title,
+      objective: story.value.objective,
+      acceptance_criteria: story.value.acceptance_criteria,
+      target_files: [...(story.value.target_files ?? [])],
+      depends_on: [...(story.value.depends_on ?? [])],
+      scope: story.value.scope,
+    }
+    validationErrors.value = {}
+    apiError.value = null
+    isEditing.value = true
+  }
+
+  /** Exit edit mode and discard draft changes */
+  function cancelEdit() {
+    isEditing.value = false
+    draftFields.value = {}
+    validationErrors.value = {}
+    apiError.value = null
+  }
+
+  /** Validate and save the draft fields via the store */
+  async function saveEdit(storyId: string): Promise<Story | null> {
+    validationErrors.value = {}
+    if (!draftFields.value.title?.trim()) {
+      validationErrors.value.title = 'Title is required'
+      return null
+    }
+    isSaving.value = true
+    apiError.value = null
+    try {
+      const updated = await store.updateStory(projectId, storyId, draftFields.value)
+      if (updated) {
+        isEditing.value = false
+        return updated
+      }
+      apiError.value = store.error ?? 'Failed to save story'
+      return null
+    } finally {
+      isSaving.value = false
+    }
+  }
+
+  return {
+    isEditing,
+    draftFields,
+    validationErrors,
+    apiError,
+    isSaving,
+    startEdit,
+    cancelEdit,
+    saveEdit,
+  }
+}

--- a/frontend/src/features/board/CreateStoryDialog.vue
+++ b/frontend/src/features/board/CreateStoryDialog.vue
@@ -1,0 +1,247 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useForm } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/zod'
+import { z } from 'zod'
+import Dialog from 'primevue/dialog'
+import InputText from 'primevue/inputtext'
+import Textarea from 'primevue/textarea'
+import Select from 'primevue/select'
+import FloatLabel from 'primevue/floatlabel'
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import { useStoriesStore, type Story } from '@/stores/stories'
+
+const props = defineProps<{
+  visible: boolean
+  projectId: string
+  epicId: string
+}>()
+
+const emit = defineEmits<{
+  'update:visible': [value: boolean]
+  created: [story: Story]
+}>()
+
+const createStorySchema = toTypedSchema(
+  z.object({
+    key: z.string().min(1, 'Key is required').max(50, 'Key must be 50 characters or fewer'),
+    title: z.string().min(1, 'Title is required').max(255, 'Title must be 255 characters or fewer'),
+    objective: z.string().optional().or(z.literal('')),
+    acceptance_criteria: z.string().optional().or(z.literal('')),
+    scope: z.enum(['backend', 'frontend', 'shared']).optional(),
+  }),
+)
+
+const { defineField, handleSubmit, errors, resetForm, validate } = useForm({
+  validationSchema: createStorySchema,
+})
+
+const [key, keyAttrs] = defineField('key')
+const [title, titleAttrs] = defineField('title')
+const [objective, objectiveAttrs] = defineField('objective')
+const [acceptanceCriteria, acceptanceCriteriaAttrs] = defineField('acceptance_criteria')
+const [scope, scopeAttrs] = defineField('scope')
+
+const scopeOptions = [
+  { label: 'Backend', value: 'backend' },
+  { label: 'Frontend', value: 'frontend' },
+  { label: 'Shared', value: 'shared' },
+]
+
+const targetFiles = ref<string[]>([])
+const store = useStoriesStore()
+const apiError = ref<string | null>(null)
+const isSaving = ref(false)
+
+function addFile() {
+  targetFiles.value.push('')
+}
+
+function removeFile(index: number) {
+  targetFiles.value.splice(index, 1)
+}
+
+async function onSubmit() {
+  const { valid } = await validate()
+  if (!valid) return
+
+  await handleSubmit(async (values) => {
+    isSaving.value = true
+    apiError.value = null
+    try {
+      const files = targetFiles.value.filter((f) => f.trim() !== '')
+      const result = await store.createStory(props.projectId, {
+        key: values.key,
+        title: values.title,
+        objective: values.objective || undefined,
+        acceptance_criteria: values.acceptance_criteria || undefined,
+        scope: values.scope as 'backend' | 'frontend' | 'shared' | undefined,
+        epic_id: props.epicId,
+        target_files: files.length > 0 ? files : undefined,
+      })
+      if (result) {
+        emit('created', result)
+        close()
+      } else {
+        apiError.value = store.error ?? 'Failed to create story'
+      }
+    } finally {
+      isSaving.value = false
+    }
+  })()
+}
+
+function close() {
+  resetForm()
+  targetFiles.value = []
+  apiError.value = null
+  emit('update:visible', false)
+}
+</script>
+
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    header="Create Story"
+    class="w-full max-w-lg"
+    @update:visible="close"
+  >
+    <form class="flex flex-col gap-6" @submit.prevent="onSubmit">
+      <Message v-if="apiError" severity="error" :closable="false">
+        {{ apiError }}
+      </Message>
+
+      <div class="flex flex-col gap-2">
+        <FloatLabel>
+          <InputText
+            id="story-key"
+            v-model="key"
+            v-bind="keyAttrs"
+            class="w-full"
+            :invalid="!!errors.key"
+          />
+          <label for="story-key">Key *</label>
+        </FloatLabel>
+        <small v-if="errors.key" class="text-red-500">{{ errors.key }}</small>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <FloatLabel>
+          <InputText
+            id="story-title"
+            v-model="title"
+            v-bind="titleAttrs"
+            class="w-full"
+            :invalid="!!errors.title"
+          />
+          <label for="story-title">Title *</label>
+        </FloatLabel>
+        <small v-if="errors.title" class="text-red-500">{{ errors.title }}</small>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <FloatLabel>
+          <Textarea
+            id="story-objective"
+            v-model="objective"
+            v-bind="objectiveAttrs"
+            class="w-full"
+            rows="3"
+          />
+          <label for="story-objective">Objective</label>
+        </FloatLabel>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <FloatLabel>
+          <Textarea
+            id="story-acceptance-criteria"
+            v-model="acceptanceCriteria"
+            v-bind="acceptanceCriteriaAttrs"
+            class="w-full"
+            rows="4"
+          />
+          <label for="story-acceptance-criteria">Acceptance Criteria</label>
+        </FloatLabel>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <FloatLabel>
+          <Select
+            id="story-scope"
+            v-model="scope"
+            v-bind="scopeAttrs"
+            :options="scopeOptions"
+            option-label="label"
+            option-value="value"
+            class="w-full"
+            show-clear
+          />
+          <label for="story-scope">Scope</label>
+        </FloatLabel>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <div class="flex items-center justify-between">
+          <h3
+            class="m-0"
+            style="
+              font-size: 0.85rem;
+              font-weight: 600;
+              text-transform: uppercase;
+              color: var(--p-text-muted-color);
+            "
+          >
+            Target Files
+          </h3>
+          <Button
+            type="button"
+            icon="pi pi-plus"
+            text
+            severity="secondary"
+            size="small"
+            aria-label="Add file"
+            @click="addFile"
+          />
+        </div>
+        <div
+          v-for="(file, index) in targetFiles"
+          :key="index"
+          class="flex items-center gap-2"
+        >
+          <InputText
+            :model-value="file"
+            class="flex-1"
+            placeholder="path/to/file"
+            style="font-family: monospace; font-size: 0.85rem"
+            @update:model-value="targetFiles[index] = $event as string"
+          />
+          <Button
+            type="button"
+            icon="pi pi-trash"
+            text
+            severity="danger"
+            size="small"
+            aria-label="Remove file"
+            @click="removeFile(index)"
+          />
+        </div>
+      </div>
+    </form>
+
+    <template #footer>
+      <div class="flex justify-end gap-2">
+        <Button label="Cancel" severity="secondary" text @click="close" />
+        <Button
+          label="Create"
+          severity="success"
+          icon="pi pi-check"
+          :loading="isSaving"
+          @click="onSubmit"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>

--- a/frontend/src/features/board/EpicDetailLayout.vue
+++ b/frontend/src/features/board/EpicDetailLayout.vue
@@ -16,6 +16,8 @@ const emit = defineEmits<{
   select: [storyId: string]
   'update:filters': [filters: StoryFilters]
   'launch-click': []
+  'create-story': []
+  'story-updated': [story: Story]
 }>()
 </script>
 
@@ -28,6 +30,7 @@ const emit = defineEmits<{
         :filters="filters"
         @select="emit('select', $event)"
         @update:filters="emit('update:filters', $event)"
+        @create-story="emit('create-story')"
       />
     </div>
     <div class="flex-1 overflow-y-auto border-l border-surface-200">
@@ -38,6 +41,7 @@ const emit = defineEmits<{
         :show-launch-button="true"
         @select-dependency="emit('select', $event)"
         @launch-click="emit('launch-click')"
+        @story-updated="emit('story-updated', $event)"
       />
     </div>
   </div>

--- a/frontend/src/features/board/StoryDetailPanel.vue
+++ b/frontend/src/features/board/StoryDetailPanel.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
+import { computed, toRef } from 'vue'
 import Badge from 'primevue/badge'
 import Tag from 'primevue/tag'
+import Button from 'primevue/button'
 import type { Story } from '@/stores/stories'
 import { renderMarkdown } from '@/utils/renderMarkdown'
 import RunLaunchButton from '@/features/runs/RunLaunchButton.vue'
+import StoryEditorForm from './StoryEditorForm.vue'
+import { useStoryEditor } from '@/composables/useStoryEditor'
 
 const props = defineProps<{
   story: Story | null
@@ -15,7 +19,16 @@ const props = defineProps<{
 const emit = defineEmits<{
   'select-dependency': [storyId: string]
   'launch-click': []
+  'story-updated': [story: Story]
 }>()
+
+const storyRef = toRef(props, 'story')
+const { isEditing, draftFields, validationErrors, apiError, isSaving, startEdit, cancelEdit, saveEdit } =
+  useStoryEditor(props.projectId ?? '', storyRef)
+
+const canEdit = computed(() => {
+  return props.story?.status === 'backlog' || props.story?.status === 'failed'
+})
 
 const severityMap: Record<string, 'secondary' | 'info' | 'success' | 'danger'> = {
   backlog: 'secondary',
@@ -33,6 +46,14 @@ const scopeSeverityMap: Record<string, 'info' | 'warn' | 'secondary'> = {
 function handleDependencyClick(key: string) {
   const match = props.allStories?.find((s) => s.key === key)
   if (match) emit('select-dependency', match.id)
+}
+
+async function handleSave() {
+  if (!props.story) return
+  const updated = await saveEdit(props.story.id)
+  if (updated) {
+    emit('story-updated', updated)
+  }
 }
 </script>
 
@@ -67,116 +88,141 @@ function handleDependencyClick(key: string) {
             :severity="scopeSeverityMap[story.scope] ?? 'secondary'"
           />
         </div>
-        <RunLaunchButton
-          v-if="showLaunchButton"
-          :story-id="story.id"
-          :story-key="story.key"
-          :story-title="story.title"
-          :status="story.status"
-          @launch-click="emit('launch-click')"
-        />
+        <div class="flex items-center gap-2">
+          <Button
+            v-if="canEdit && !isEditing"
+            icon="pi pi-pencil"
+            severity="secondary"
+            text
+            aria-label="Edit story"
+            @click="startEdit"
+          />
+          <RunLaunchButton
+            v-if="showLaunchButton && !isEditing"
+            :story-id="story.id"
+            :story-key="story.key"
+            :story-title="story.title"
+            :status="story.status"
+            @launch-click="emit('launch-click')"
+          />
+        </div>
       </div>
 
-      <h2 class="m-0" style="font-size: 1.25rem; font-weight: 600">{{ story.title }}</h2>
+      <!-- Edit mode -->
+      <StoryEditorForm
+        v-if="isEditing"
+        :model-value="draftFields"
+        :errors="validationErrors"
+        :api-error="apiError"
+        :is-saving="isSaving"
+        @update:model-value="draftFields = $event"
+        @save="handleSave"
+        @cancel="cancelEdit"
+      />
 
-      <div v-if="story.objective" class="flex flex-col gap-1">
-        <h3
-          class="m-0"
-          style="
-            font-size: 0.85rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            color: var(--p-text-muted-color);
-          "
-        >
-          Objective
-        </h3>
-        <!-- eslint-disable-next-line vue/no-v-html -->
-        <div class="prose-content" v-html="renderMarkdown(story.objective)" />
-      </div>
+      <!-- Read mode -->
+      <template v-else>
+        <h2 class="m-0" style="font-size: 1.25rem; font-weight: 600">{{ story.title }}</h2>
 
-      <div v-if="story.acceptance_criteria" class="flex flex-col gap-1">
-        <h3
-          class="m-0"
-          style="
-            font-size: 0.85rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            color: var(--p-text-muted-color);
-          "
-        >
-          Acceptance Criteria
-        </h3>
-        <!-- eslint-disable-next-line vue/no-v-html -->
-        <div class="prose-content" v-html="renderMarkdown(story.acceptance_criteria)" />
-      </div>
-
-      <div
-        v-if="story.target_files && story.target_files.length > 0"
-        class="flex flex-col gap-1"
-      >
-        <h3
-          class="m-0"
-          style="
-            font-size: 0.85rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            color: var(--p-text-muted-color);
-          "
-        >
-          Target Files
-        </h3>
-        <ul class="m-0 pl-5">
-          <li
-            v-for="file in story.target_files"
-            :key="file"
-            style="font-family: monospace; font-size: 0.85rem"
+        <div v-if="story.objective" class="flex flex-col gap-1">
+          <h3
+            class="m-0"
+            style="
+              font-size: 0.85rem;
+              font-weight: 600;
+              text-transform: uppercase;
+              color: var(--p-text-muted-color);
+            "
           >
-            {{ file }}
-          </li>
-        </ul>
-      </div>
+            Objective
+          </h3>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div class="prose-content" v-html="renderMarkdown(story.objective)" />
+        </div>
 
-      <div
-        v-if="story.depends_on && story.depends_on.length > 0"
-        class="flex flex-col gap-1"
-      >
-        <h3
-          class="m-0"
-          style="
-            font-size: 0.85rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            color: var(--p-text-muted-color);
-          "
-        >
-          Dependencies
-        </h3>
-        <ul class="m-0 pl-5">
-          <li
-            v-for="dep in story.depends_on"
-            :key="dep"
-            style="font-family: monospace; font-size: 0.85rem"
+        <div v-if="story.acceptance_criteria" class="flex flex-col gap-1">
+          <h3
+            class="m-0"
+            style="
+              font-size: 0.85rem;
+              font-weight: 600;
+              text-transform: uppercase;
+              color: var(--p-text-muted-color);
+            "
           >
-            <button
-              type="button"
-              style="
-                background: none;
-                border: none;
-                padding: 0;
-                font-family: monospace;
-                font-size: 0.85rem;
-                color: var(--p-primary-color);
-                cursor: pointer;
-                text-decoration: underline;
-              "
-              @click="handleDependencyClick(dep)"
+            Acceptance Criteria
+          </h3>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div class="prose-content" v-html="renderMarkdown(story.acceptance_criteria)" />
+        </div>
+
+        <div
+          v-if="story.target_files && story.target_files.length > 0"
+          class="flex flex-col gap-1"
+        >
+          <h3
+            class="m-0"
+            style="
+              font-size: 0.85rem;
+              font-weight: 600;
+              text-transform: uppercase;
+              color: var(--p-text-muted-color);
+            "
+          >
+            Target Files
+          </h3>
+          <ul class="m-0 pl-5">
+            <li
+              v-for="file in story.target_files"
+              :key="file"
+              style="font-family: monospace; font-size: 0.85rem"
             >
-              {{ dep }}
-            </button>
-          </li>
-        </ul>
-      </div>
+              {{ file }}
+            </li>
+          </ul>
+        </div>
+
+        <div
+          v-if="story.depends_on && story.depends_on.length > 0"
+          class="flex flex-col gap-1"
+        >
+          <h3
+            class="m-0"
+            style="
+              font-size: 0.85rem;
+              font-weight: 600;
+              text-transform: uppercase;
+              color: var(--p-text-muted-color);
+            "
+          >
+            Dependencies
+          </h3>
+          <ul class="m-0 pl-5">
+            <li
+              v-for="dep in story.depends_on"
+              :key="dep"
+              style="font-family: monospace; font-size: 0.85rem"
+            >
+              <button
+                type="button"
+                style="
+                  background: none;
+                  border: none;
+                  padding: 0;
+                  font-family: monospace;
+                  font-size: 0.85rem;
+                  color: var(--p-primary-color);
+                  cursor: pointer;
+                  text-decoration: underline;
+                "
+                @click="handleDependencyClick(dep)"
+              >
+                {{ dep }}
+              </button>
+            </li>
+          </ul>
+        </div>
+      </template>
     </div>
   </div>
 </template>

--- a/frontend/src/features/board/StoryEditorForm.vue
+++ b/frontend/src/features/board/StoryEditorForm.vue
@@ -1,0 +1,177 @@
+<script setup lang="ts">
+import InputText from 'primevue/inputtext'
+import Textarea from 'primevue/textarea'
+import Select from 'primevue/select'
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import FloatLabel from 'primevue/floatlabel'
+import type { UpdateStoryFields } from '@/stores/stories'
+
+const props = defineProps<{
+  modelValue: UpdateStoryFields
+  errors: Record<string, string>
+  apiError: string | null
+  isSaving: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: UpdateStoryFields]
+  save: []
+  cancel: []
+}>()
+
+const scopeOptions = [
+  { label: 'Backend', value: 'backend' },
+  { label: 'Frontend', value: 'frontend' },
+  { label: 'Shared', value: 'shared' },
+]
+
+function updateField<K extends keyof UpdateStoryFields>(key: K, value: UpdateStoryFields[K]) {
+  emit('update:modelValue', { ...props.modelValue, [key]: value })
+}
+
+function addFile() {
+  emit('update:modelValue', {
+    ...props.modelValue,
+    target_files: [...(props.modelValue.target_files ?? []), ''],
+  })
+}
+
+function removeFile(index: number) {
+  const updated = [...(props.modelValue.target_files ?? [])]
+  updated.splice(index, 1)
+  emit('update:modelValue', { ...props.modelValue, target_files: updated })
+}
+
+function updateFile(index: number, value: string) {
+  const updated = [...(props.modelValue.target_files ?? [])]
+  updated[index] = value
+  emit('update:modelValue', { ...props.modelValue, target_files: updated })
+}
+</script>
+
+<template>
+  <form class="flex flex-col gap-4" @submit.prevent="emit('save')">
+    <Message v-if="apiError" severity="error" :closable="false">
+      {{ apiError }}
+    </Message>
+
+    <div class="flex flex-col gap-2">
+      <FloatLabel>
+        <InputText
+          id="story-title"
+          :model-value="modelValue.title"
+          class="w-full"
+          :invalid="!!errors.title"
+          @update:model-value="updateField('title', $event as string)"
+        />
+        <label for="story-title">Title *</label>
+      </FloatLabel>
+      <small v-if="errors.title" class="text-red-500">{{ errors.title }}</small>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <FloatLabel>
+        <Textarea
+          id="story-objective"
+          :model-value="modelValue.objective ?? ''"
+          class="w-full"
+          rows="3"
+          @update:model-value="updateField('objective', $event as string)"
+        />
+        <label for="story-objective">Objective</label>
+      </FloatLabel>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <FloatLabel>
+        <Textarea
+          id="story-acceptance-criteria"
+          :model-value="modelValue.acceptance_criteria ?? ''"
+          class="w-full"
+          rows="4"
+          @update:model-value="updateField('acceptance_criteria', $event as string)"
+        />
+        <label for="story-acceptance-criteria">Acceptance Criteria</label>
+      </FloatLabel>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <FloatLabel>
+        <Select
+          id="story-scope"
+          :model-value="modelValue.scope"
+          :options="scopeOptions"
+          option-label="label"
+          option-value="value"
+          class="w-full"
+          show-clear
+          @update:model-value="updateField('scope', $event)"
+        />
+        <label for="story-scope">Scope</label>
+      </FloatLabel>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <div class="flex items-center justify-between">
+        <h3
+          class="m-0"
+          style="
+            font-size: 0.85rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            color: var(--p-text-muted-color);
+          "
+        >
+          Target Files
+        </h3>
+        <Button
+          type="button"
+          icon="pi pi-plus"
+          text
+          severity="secondary"
+          size="small"
+          aria-label="Add file"
+          @click="addFile"
+        />
+      </div>
+      <div
+        v-for="(file, index) in modelValue.target_files ?? []"
+        :key="index"
+        class="flex items-center gap-2"
+      >
+        <InputText
+          :model-value="file"
+          class="flex-1"
+          placeholder="path/to/file"
+          style="font-family: monospace; font-size: 0.85rem"
+          @update:model-value="updateFile(index, $event as string)"
+        />
+        <Button
+          type="button"
+          icon="pi pi-trash"
+          text
+          severity="danger"
+          size="small"
+          aria-label="Remove file"
+          @click="removeFile(index)"
+        />
+      </div>
+    </div>
+
+    <div class="flex justify-end gap-2 pt-2">
+      <Button
+        type="button"
+        label="Cancel"
+        severity="secondary"
+        text
+        @click="emit('cancel')"
+      />
+      <Button
+        type="submit"
+        label="Save"
+        :loading="isSaving"
+      />
+    </div>
+  </form>
+</template>

--- a/frontend/src/features/board/StoryListPanel.vue
+++ b/frontend/src/features/board/StoryListPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+import Button from 'primevue/button'
 import type { Story, StoryFilters } from '@/stores/stories'
 import StoryStatusCard from './StoryStatusCard.vue'
 import StoryFilterBar from './StoryFilterBar.vue'
@@ -14,6 +15,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   select: [storyId: string]
   'update:filters': [filters: StoryFilters]
+  'create-story': []
 }>()
 
 const selectedIndex = ref(0)
@@ -74,7 +76,16 @@ function handleFilterUpdate(newFilters: StoryFilters) {
 
 <template>
   <div class="flex flex-col gap-3 h-full">
-    <StoryFilterBar :model-value="filters" @update:model-value="handleFilterUpdate" />
+    <div class="flex items-center justify-between">
+      <StoryFilterBar :model-value="filters" @update:model-value="handleFilterUpdate" class="flex-1" />
+      <Button
+        icon="pi pi-plus"
+        severity="secondary"
+        text
+        aria-label="Create story"
+        @click="emit('create-story')"
+      />
+    </div>
     <div
       class="flex flex-col gap-1 overflow-y-auto"
       style="flex: 1; min-height: 0"

--- a/frontend/src/features/board/__tests__/StoryDetailPanel.spec.ts
+++ b/frontend/src/features/board/__tests__/StoryDetailPanel.spec.ts
@@ -1,8 +1,17 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { mount, type VueWrapper } from '@vue/test-utils'
+import { createPinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import StoryDetailPanel from '../StoryDetailPanel.vue'
 import type { Story } from '@/stores/stories'
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: vi.fn(),
+    PUT: vi.fn(),
+    POST: vi.fn(),
+  },
+}))
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let wrapper: VueWrapper<any>
@@ -34,11 +43,14 @@ function mountComponent(props: {
   wrapper = mount(StoryDetailPanel, {
     props,
     global: {
-      plugins: [PrimeVue],
+      plugins: [PrimeVue, createPinia()],
       stubs: {
         RunLaunchButton: {
           template: '<button data-testid="launch-btn">Launch</button>',
           emits: ['launchClick'],
+        },
+        StoryEditorForm: {
+          template: '<div data-testid="editor-form">Editor Form</div>',
         },
       },
     },

--- a/frontend/src/features/board/__tests__/StoryEditorForm.spec.ts
+++ b/frontend/src/features/board/__tests__/StoryEditorForm.spec.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, afterEach, vi, beforeAll } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import StoryEditorForm from '../StoryEditorForm.vue'
+import type { UpdateStoryFields } from '@/stores/stories'
+
+beforeAll(() => {
+  // PrimeVue Select uses matchMedia which is not available in jsdom
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function mountComponent(props: {
+  modelValue: UpdateStoryFields
+  errors?: Record<string, string>
+  apiError?: string | null
+  isSaving?: boolean
+}) {
+  wrapper = mount(StoryEditorForm, {
+    props: {
+      errors: {},
+      apiError: null,
+      isSaving: false,
+      ...props,
+    },
+    global: {
+      plugins: [PrimeVue],
+    },
+  })
+  return wrapper
+}
+
+describe('StoryEditorForm', () => {
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('renders all fields with initial values', () => {
+    mountComponent({
+      modelValue: {
+        title: 'My Story',
+        objective: 'Build it',
+        acceptance_criteria: '- done',
+        scope: 'backend',
+        target_files: ['src/foo.ts'],
+      },
+    })
+
+    expect(wrapper.find('#story-title').exists()).toBe(true)
+    expect(wrapper.find('#story-objective').exists()).toBe(true)
+    expect(wrapper.find('#story-acceptance-criteria').exists()).toBe(true)
+    expect(wrapper.find('#story-scope').exists()).toBe(true)
+  })
+
+  it('shows inline error when errors.title is set', () => {
+    mountComponent({
+      modelValue: { title: '' },
+      errors: { title: 'Title is required' },
+    })
+
+    const errorEl = wrapper.find('.text-red-500')
+    expect(errorEl.exists()).toBe(true)
+    expect(errorEl.text()).toBe('Title is required')
+  })
+
+  it('does not show inline error when no errors', () => {
+    mountComponent({
+      modelValue: { title: 'Valid' },
+      errors: {},
+    })
+
+    expect(wrapper.find('.text-red-500').exists()).toBe(false)
+  })
+
+  it('renders API error Message when apiError is set', () => {
+    mountComponent({
+      modelValue: { title: 'Story' },
+      apiError: 'Server error occurred',
+    })
+
+    expect(wrapper.text()).toContain('Server error occurred')
+  })
+
+  it('does not render API error Message when apiError is null', () => {
+    mountComponent({
+      modelValue: { title: 'Story' },
+      apiError: null,
+    })
+
+    // There should be no error message component rendered
+    const messages = wrapper.findAll('.p-message')
+    expect(messages.length).toBe(0)
+  })
+
+  it('emits save event on form submit', async () => {
+    mountComponent({ modelValue: { title: 'Story' } })
+
+    await wrapper.find('form').trigger('submit.prevent')
+
+    expect(wrapper.emitted('save')).toHaveLength(1)
+  })
+
+  it('emits cancel event when Cancel button is clicked', async () => {
+    mountComponent({ modelValue: { title: 'Story' } })
+
+    const cancelBtn = wrapper.findAll('button').find((b) => b.text().includes('Cancel'))
+    expect(cancelBtn).toBeDefined()
+
+    await cancelBtn!.trigger('click')
+
+    expect(wrapper.emitted('cancel')).toHaveLength(1)
+  })
+
+  it('renders target file inputs for each file', () => {
+    mountComponent({
+      modelValue: {
+        title: 'Story',
+        target_files: ['src/a.ts', 'src/b.ts'],
+      },
+    })
+
+    const fileInputs = wrapper.findAll('input[placeholder="path/to/file"]')
+    expect(fileInputs).toHaveLength(2)
+  })
+
+  it('emits update:modelValue with new file when Add file clicked', async () => {
+    mountComponent({
+      modelValue: {
+        title: 'Story',
+        target_files: ['src/a.ts'],
+      },
+    })
+
+    const addBtn = wrapper.find('[aria-label="Add file"]')
+    expect(addBtn.exists()).toBe(true)
+
+    await addBtn.trigger('click')
+
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeDefined()
+    expect(emitted![0]![0]).toEqual({
+      title: 'Story',
+      target_files: ['src/a.ts', ''],
+    })
+  })
+
+  it('emits update:modelValue with file removed when Remove file clicked', async () => {
+    mountComponent({
+      modelValue: {
+        title: 'Story',
+        target_files: ['src/a.ts', 'src/b.ts'],
+      },
+    })
+
+    const removeButtons = wrapper.findAll('[aria-label="Remove file"]')
+    expect(removeButtons).toHaveLength(2)
+
+    await removeButtons[0]!.trigger('click')
+
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeDefined()
+    expect(emitted![0]![0]).toEqual({
+      title: 'Story',
+      target_files: ['src/b.ts'],
+    })
+  })
+})

--- a/frontend/src/stores/__tests__/stories.spec.ts
+++ b/frontend/src/stores/__tests__/stories.spec.ts
@@ -3,10 +3,14 @@ import { setActivePinia, createPinia } from 'pinia'
 import { useStoriesStore } from '../stories'
 
 const mockGet = vi.fn()
+const mockPut = vi.fn()
+const mockPost = vi.fn()
 
 vi.mock('@/api/client', () => ({
   apiClient: {
     GET: (...args: unknown[]) => mockGet(...args),
+    PUT: (...args: unknown[]) => mockPut(...args),
+    POST: (...args: unknown[]) => mockPost(...args),
   },
 }))
 
@@ -51,6 +55,8 @@ describe('useStoriesStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     mockGet.mockReset()
+    mockPut.mockReset()
+    mockPost.mockReset()
   })
 
   it('starts with default state', () => {
@@ -265,5 +271,102 @@ describe('useStoriesStore', () => {
     expect(store.filters).toEqual({ status: null, search: '' })
     expect(store.error).toBeNull()
     expect(store.isLoading).toBe(false)
+  })
+
+  describe('updateStory', () => {
+    it('updates item in-place on success', async () => {
+      mockGet.mockResolvedValue({
+        data: { data: mockStories },
+        error: undefined,
+      })
+
+      const store = useStoriesStore()
+      await store.fetchStoriesByEpic('p1', 'e1')
+
+      const updatedStory = { ...mockStories[1], title: 'Updated title' }
+      mockPut.mockResolvedValue({ data: updatedStory, error: undefined })
+
+      const result = await store.updateStory('p1', 's2', { title: 'Updated title' })
+
+      expect(result).toEqual(updatedStory)
+      expect(store.items[1]!.title).toBe('Updated title')
+      expect(store.error).toBeNull()
+    })
+
+    it('returns null and sets error on API error', async () => {
+      mockGet.mockResolvedValue({
+        data: { data: mockStories },
+        error: undefined,
+      })
+
+      const store = useStoriesStore()
+      await store.fetchStoriesByEpic('p1', 'e1')
+
+      mockPut.mockResolvedValue({
+        data: undefined,
+        error: { error: { code: 'NOT_FOUND', message: 'Story not found' } },
+      })
+
+      const result = await store.updateStory('p1', 's2', { title: 'Updated' })
+
+      expect(result).toBeNull()
+      expect(store.error).toBe('Story not found')
+    })
+
+    it('returns null and sets error on thrown exception', async () => {
+      const store = useStoriesStore()
+      mockPut.mockRejectedValue(new Error('Network error'))
+
+      const result = await store.updateStory('p1', 's1', { title: 'Updated' })
+
+      expect(result).toBeNull()
+      expect(store.error).toBe('Network error')
+    })
+  })
+
+  describe('createStory', () => {
+    it('pushes new story to items on success', async () => {
+      const store = useStoriesStore()
+      const newStory = {
+        id: 's4',
+        epic_id: 'e1',
+        project_id: 'p1',
+        key: 'S-04',
+        title: 'New story',
+        status: 'backlog',
+        created_at: '2026-01-18T10:00:00Z',
+        updated_at: '2026-01-18T10:00:00Z',
+      }
+      mockPost.mockResolvedValue({ data: newStory, error: undefined })
+
+      const result = await store.createStory('p1', { key: 'S-04', title: 'New story' })
+
+      expect(result).toEqual(newStory)
+      expect(store.items).toHaveLength(1)
+      expect(store.items[0]!.key).toBe('S-04')
+    })
+
+    it('returns null and sets error on API error', async () => {
+      const store = useStoriesStore()
+      mockPost.mockResolvedValue({
+        data: undefined,
+        error: { error: { code: 'CONFLICT', message: 'Key already exists' } },
+      })
+
+      const result = await store.createStory('p1', { key: 'S-01', title: 'Duplicate' })
+
+      expect(result).toBeNull()
+      expect(store.error).toBe('Key already exists')
+    })
+
+    it('returns null and sets error on thrown exception', async () => {
+      const store = useStoriesStore()
+      mockPost.mockRejectedValue(new Error('Network error'))
+
+      const result = await store.createStory('p1', { key: 'S-05', title: 'Story' })
+
+      expect(result).toBeNull()
+      expect(store.error).toBe('Network error')
+    })
   })
 })

--- a/frontend/src/stores/stories.ts
+++ b/frontend/src/stores/stories.ts
@@ -32,6 +32,29 @@ export interface Story {
   updated_at: string
 }
 
+/** Fields for updating an existing story */
+export interface UpdateStoryFields {
+  title?: string
+  objective?: string
+  acceptance_criteria?: string
+  target_files?: string[]
+  depends_on?: string[]
+  scope?: 'backend' | 'frontend' | 'shared'
+  status?: 'backlog' | 'running' | 'done' | 'failed'
+}
+
+/** Fields for creating a new story */
+export interface CreateStoryFields {
+  key: string
+  title: string
+  objective?: string
+  acceptance_criteria?: string
+  target_files?: string[]
+  depends_on?: string[]
+  scope?: 'backend' | 'frontend' | 'shared'
+  epic_id?: string
+}
+
 /** Filter state for the story list */
 export interface StoryFilters {
   status: string | null
@@ -115,6 +138,68 @@ export const useStoriesStore = defineStore('stories', () => {
     error.value = null
   }
 
+  /** Update an existing story via PUT API */
+  async function updateStory(
+    projectId: string,
+    storyId: string,
+    fields: UpdateStoryFields,
+  ): Promise<Story | null> {
+    try {
+      const { data, error: apiError } = await apiClient.PUT(
+        '/projects/{projectId}/stories/{storyId}',
+        {
+          params: { path: { projectId, storyId } },
+          body: fields,
+        },
+      )
+      if (apiError) {
+        const message =
+          (apiError as { error?: { message?: string } })?.error?.message ??
+          'Failed to update story'
+        error.value = message
+        return null
+      }
+      const updated = data as unknown as Story
+      const index = items.value.findIndex((s) => s.id === storyId)
+      if (index !== -1) {
+        items.value[index] = updated
+      }
+      return updated
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to update story'
+      return null
+    }
+  }
+
+  /** Create a new story via POST API */
+  async function createStory(
+    projectId: string,
+    fields: CreateStoryFields,
+  ): Promise<Story | null> {
+    try {
+      const { data, error: apiError } = await apiClient.POST(
+        '/projects/{projectId}/stories',
+        {
+          params: { path: { projectId } },
+          body: fields,
+        },
+      )
+      if (apiError) {
+        const message =
+          (apiError as { error?: { message?: string } })?.error?.message ??
+          'Failed to create story'
+        error.value = message
+        return null
+      }
+      const created = data as unknown as Story
+      items.value.push(created)
+      return created
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to create story'
+      return null
+    }
+  }
+
   /** Reset store state to initial values */
   function reset() {
     items.value = []
@@ -133,6 +218,8 @@ export const useStoriesStore = defineStore('stories', () => {
     filteredStories,
     selectedStory,
     fetchStoriesByEpic,
+    updateStory,
+    createStory,
     setSelectedStory,
     setFilters,
     clearError,

--- a/frontend/src/views/EpicDetailView.vue
+++ b/frontend/src/views/EpicDetailView.vue
@@ -8,6 +8,7 @@ import Skeleton from 'primevue/skeleton'
 import Toast from 'primevue/toast'
 import EpicDetailLayout from '@/features/board/EpicDetailLayout.vue'
 import RunLaunchConfirmDialog from '@/features/runs/RunLaunchConfirmDialog.vue'
+import CreateStoryDialog from '@/features/board/CreateStoryDialog.vue'
 import { useStories } from '@/composables/useStories'
 import { useRunLauncher, ALREADY_RUNNING_ERROR } from '@/composables/useRunLauncher'
 
@@ -33,10 +34,33 @@ const {
 } = useStories(projectId, epicId)
 
 const dialogVisible = ref(false)
+const createDialogVisible = ref(false)
 const { isLoading: launchLoading, error: launchError, launchRun } = useRunLauncher()
 
 function handleLaunchClick() {
   dialogVisible.value = true
+}
+
+function handleCreateStory() {
+  createDialogVisible.value = true
+}
+
+function handleStoryCreated() {
+  toast.add({
+    severity: 'success',
+    summary: 'Story created',
+    detail: 'New story has been created',
+    life: 3000,
+  })
+}
+
+function handleStoryUpdated() {
+  toast.add({
+    severity: 'success',
+    summary: 'Story updated',
+    detail: 'Story has been updated',
+    life: 3000,
+  })
 }
 
 async function handleConfirm() {
@@ -157,6 +181,8 @@ watch(
       @select="selectStory"
       @update:filters="setFilters"
       @launch-click="handleLaunchClick"
+      @create-story="handleCreateStory"
+      @story-updated="handleStoryUpdated"
     />
 
     <RunLaunchConfirmDialog
@@ -167,6 +193,13 @@ watch(
       :loading="launchLoading"
       @confirm="handleConfirm"
       @cancel="dialogVisible = false"
+    />
+
+    <CreateStoryDialog
+      v-model:visible="createDialogVisible"
+      :project-id="projectId"
+      :epic-id="epicId"
+      @created="handleStoryCreated"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Add inline story editing in StoryDetailPanel with edit mode toggle (visible for backlog/failed status)
- Create CreateStoryDialog for new story creation with vee-validate + zod form validation
- Add `useStoryEditor` composable managing edit state (draft fields, validation, API errors, saving state)
- Add `updateStory` and `createStory` store actions calling PUT/POST API endpoints
- Create `StoryEditorForm` component with editable target files list (add/remove controls)
- Wire create-story and story-updated events through EpicDetailLayout to EpicDetailView with toast notifications
- Add Create Story button to StoryListPanel header

## Test plan
- [x] 58 unit tests passing for new and modified code
- [x] 280 total unit tests passing (full suite, no regressions)
- [x] ESLint passes with no warnings
- [x] TypeScript type-check passes (vue-tsc --build)
- [ ] Manual verification: edit mode activates from StoryDetailPanel for backlog/failed stories
- [ ] Manual verification: save/cancel work correctly in edit mode
- [ ] Manual verification: create story dialog opens, validates, and creates stories
- [ ] Manual verification: API error feedback displays inside form/dialog

Refs: S-2-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)