### PR TITLE
feat(ui): add story import from markdown dialog

### DIFF
--- a/frontend/src/composables/__tests__/useStoryImport.spec.ts
+++ b/frontend/src/composables/__tests__/useStoryImport.spec.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useStoryImport } from '../useStoryImport'
+
+const mockPost = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: vi.fn(),
+    PUT: vi.fn(),
+    POST: (...args: unknown[]) => mockPost(...args),
+  },
+}))
+
+/** Captured instance from the most recent FileReader construction */
+let capturedReader: {
+  readAsText: ReturnType<typeof vi.fn>
+  onload: ((e: ProgressEvent) => void) | null
+}
+
+beforeEach(() => {
+  mockPost.mockReset()
+  capturedReader = { readAsText: vi.fn(), onload: null }
+
+  // Use a real function so `new FileReader()` works
+  vi.stubGlobal(
+    'FileReader',
+    function MockFileReader(this: typeof capturedReader) {
+      this.readAsText = vi.fn()
+      this.onload = null
+      // Save a reference so tests can trigger onload
+      capturedReader = this
+    } as unknown as typeof FileReader,
+  )
+})
+
+describe('useStoryImport', () => {
+  describe('selectFile', () => {
+    it('sets fileError when file is not .md', () => {
+      const { selectFile, fileError, fileContent } = useStoryImport()
+
+      selectFile(new File(['content'], 'test.txt', { type: 'text/plain' }))
+
+      expect(fileError.value).toBe('Only .md files are supported')
+      expect(fileContent.value).toBeNull()
+    })
+
+    it('reads content and parses preview for .md file', () => {
+      const { selectFile, fileContent, fileName, parsedPreview } = useStoryImport()
+
+      const mdContent = '---\nkey: S-01\n---\n# My Story\n'
+      selectFile(new File([mdContent], 'stories.md', { type: 'text/markdown' }))
+
+      expect(fileName.value).toBe('stories.md')
+      expect(capturedReader.readAsText).toHaveBeenCalled()
+
+      // Simulate FileReader onload
+      capturedReader.onload!({ target: { result: mdContent } } as unknown as ProgressEvent)
+
+      expect(fileContent.value).toBe(mdContent)
+      expect(parsedPreview.value).toHaveLength(1)
+      expect(parsedPreview.value[0]).toEqual({
+        key: 'S-01',
+        title: 'My Story',
+        scope: undefined,
+        valid: true,
+      })
+    })
+
+    it('clears previous fileError when selecting new file', () => {
+      const { selectFile, fileError } = useStoryImport()
+
+      selectFile(new File([''], 'test.txt', { type: 'text/plain' }))
+      expect(fileError.value).toBe('Only .md files are supported')
+
+      selectFile(new File([''], 'test.md', { type: 'text/markdown' }))
+      expect(fileError.value).toBeNull()
+    })
+  })
+
+  describe('parseMarkdownPreview', () => {
+    it('parses valid story block with key, title, and scope', () => {
+      const { parseMarkdownPreview } = useStoryImport()
+
+      const content = '---\nkey: S-01\nscope: backend\n---\n# Implement login\n'
+      const result = parseMarkdownPreview(content)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({
+        key: 'S-01',
+        title: 'Implement login',
+        scope: 'backend',
+        valid: true,
+      })
+    })
+
+    it('marks story invalid when key is missing', () => {
+      const { parseMarkdownPreview } = useStoryImport()
+
+      const content = '---\nscope: backend\n---\n# Some Title\n'
+      const result = parseMarkdownPreview(content)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({
+        key: '(unknown)',
+        title: 'Some Title',
+        scope: 'backend',
+        valid: false,
+        error: 'Missing key in frontmatter',
+      })
+    })
+
+    it('marks story invalid when H1 title is missing', () => {
+      const { parseMarkdownPreview } = useStoryImport()
+
+      const content = '---\nkey: S-01\n---\nNo heading here\n'
+      const result = parseMarkdownPreview(content)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({
+        key: 'S-01',
+        title: '(no title)',
+        scope: undefined,
+        valid: false,
+        error: 'Missing H1 title in body',
+      })
+    })
+
+    it('parses multiple story blocks', () => {
+      const { parseMarkdownPreview } = useStoryImport()
+
+      const content =
+        '---\nkey: S-01\n---\n# Story One\n---\nkey: S-02\nscope: frontend\n---\n# Story Two\n'
+      const result = parseMarkdownPreview(content)
+
+      expect(result).toHaveLength(2)
+      expect(result[0]!.key).toBe('S-01')
+      expect(result[0]!.title).toBe('Story One')
+      expect(result[0]!.valid).toBe(true)
+      expect(result[1]!.key).toBe('S-02')
+      expect(result[1]!.title).toBe('Story Two')
+      expect(result[1]!.scope).toBe('frontend')
+      expect(result[1]!.valid).toBe(true)
+    })
+
+    it('returns empty array for content with no story blocks', () => {
+      const { parseMarkdownPreview } = useStoryImport()
+
+      const content = 'Just some text without any frontmatter delimiters'
+      const result = parseMarkdownPreview(content)
+
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('importStories', () => {
+    it('sets importResult on success', async () => {
+      const { selectFile, importStories, importResult } = useStoryImport()
+
+      // Set up file content
+      selectFile(new File(['content'], 'test.md'))
+      capturedReader.onload!({
+        target: { result: '---\nkey: S-01\n---\n# Test\n' },
+      } as unknown as ProgressEvent)
+
+      const mockResult = { imported: 2, updated: 1, failed: 0, errors: [] }
+      mockPost.mockResolvedValue({ data: mockResult, error: undefined })
+
+      await importStories('project-123')
+
+      expect(mockPost).toHaveBeenCalledWith('/projects/{projectId}/stories/import', {
+        params: { path: { projectId: 'project-123' } },
+        body: { content: '---\nkey: S-01\n---\n# Test\n' },
+      })
+      expect(importResult.value).toEqual(mockResult)
+    })
+
+    it('sets apiError on API error', async () => {
+      const { selectFile, importStories, importResult, apiError } = useStoryImport()
+
+      selectFile(new File(['content'], 'test.md'))
+      capturedReader.onload!({
+        target: { result: 'content' },
+      } as unknown as ProgressEvent)
+
+      mockPost.mockResolvedValue({
+        data: undefined,
+        error: { error: { code: 'INTERNAL', message: 'Server error' } },
+      })
+
+      await importStories('project-123')
+
+      expect(apiError.value).toBe('Import failed. Please try again.')
+      expect(importResult.value).toBeNull()
+    })
+
+    it('does nothing when fileContent is null', async () => {
+      const { importStories } = useStoryImport()
+
+      await importStories('project-123')
+
+      expect(mockPost).not.toHaveBeenCalled()
+    })
+
+    it('sets isImporting during the request', async () => {
+      const { selectFile, importStories, isImporting } = useStoryImport()
+
+      selectFile(new File(['content'], 'test.md'))
+      capturedReader.onload!({
+        target: { result: 'content' },
+      } as unknown as ProgressEvent)
+
+      let importingDuringCall = false
+      mockPost.mockImplementation(() => {
+        importingDuringCall = isImporting.value
+        return Promise.resolve({ data: { imported: 0, updated: 0, failed: 0, errors: [] }, error: undefined })
+      })
+
+      await importStories('project-123')
+
+      expect(importingDuringCall).toBe(true)
+      expect(isImporting.value).toBe(false)
+    })
+  })
+
+  describe('reset', () => {
+    it('clears all state to initial values', () => {
+      const {
+        fileContent,
+        fileName,
+        parsedPreview,
+        importResult,
+        fileError,
+        apiError,
+        isImporting,
+        reset,
+      } = useStoryImport()
+
+      // Populate state
+      fileContent.value = 'some content'
+      fileName.value = 'test.md'
+      parsedPreview.value = [{ key: 'S-01', title: 'Test', valid: true }]
+      importResult.value = { imported: 1, updated: 0, failed: 0, errors: [] }
+      fileError.value = 'error'
+      apiError.value = 'api error'
+      isImporting.value = true
+
+      reset()
+
+      expect(fileContent.value).toBeNull()
+      expect(fileName.value).toBeNull()
+      expect(parsedPreview.value).toEqual([])
+      expect(importResult.value).toBeNull()
+      expect(fileError.value).toBeNull()
+      expect(apiError.value).toBeNull()
+      expect(isImporting.value).toBe(false)
+    })
+  })
+})

--- a/frontend/src/composables/useStoryImport.ts
+++ b/frontend/src/composables/useStoryImport.ts
@@ -1,0 +1,121 @@
+import { ref } from 'vue'
+import { apiClient } from '@/api/client'
+import type { components } from '@/api/schema'
+
+/** Local preview of a parsed story block */
+export interface ParsedStoryPreview {
+  key: string
+  title: string
+  scope?: string
+  valid: boolean
+  error?: string
+}
+
+/** Import result returned from the backend API */
+export type ImportResult = components['schemas']['ImportStoriesResult']
+
+/**
+ * Composable for importing stories from a markdown file.
+ * Handles file selection, local markdown parsing preview, API import call, and state reset.
+ */
+export function useStoryImport() {
+  const fileContent = ref<string | null>(null)
+  const fileName = ref<string | null>(null)
+  const parsedPreview = ref<ParsedStoryPreview[]>([])
+  const importResult = ref<ImportResult | null>(null)
+  const fileError = ref<string | null>(null)
+  const apiError = ref<string | null>(null)
+  const isImporting = ref(false)
+
+  /**
+   * Parse markdown content into a preview of story blocks.
+   * Splits on `---` delimiters and extracts key/title from frontmatter + H1.
+   */
+  function parseMarkdownPreview(content: string): ParsedStoryPreview[] {
+    const blocks = content.split(/^---$/m).filter((b) => b.trim())
+    const stories: ParsedStoryPreview[] = []
+
+    for (let i = 0; i < blocks.length - 1; i += 2) {
+      const frontmatter = blocks[i]!
+      const body = blocks[i + 1] ?? ''
+
+      const keyMatch = frontmatter.match(/^key:\s*(.+)$/m)
+      const titleMatch = body.match(/^#\s+(.+)$/m)
+      const scopeMatch = frontmatter.match(/^scope:\s*(.+)$/m)
+
+      const key = keyMatch?.[1]?.trim() ?? ''
+      const title = titleMatch?.[1]?.trim() ?? ''
+      const scope = scopeMatch?.[1]?.trim()
+
+      if (!key) {
+        stories.push({ key: '(unknown)', title, scope, valid: false, error: 'Missing key in frontmatter' })
+      } else if (!title) {
+        stories.push({ key, title: '(no title)', scope, valid: false, error: 'Missing H1 title in body' })
+      } else {
+        stories.push({ key, title, scope, valid: true })
+      }
+    }
+    return stories
+  }
+
+  /** Validate and read the selected file */
+  function selectFile(file: File) {
+    fileError.value = null
+    if (!file.name.endsWith('.md')) {
+      fileError.value = 'Only .md files are supported'
+      return
+    }
+    fileName.value = file.name
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      fileContent.value = e.target?.result as string
+      parsedPreview.value = parseMarkdownPreview(fileContent.value)
+    }
+    reader.readAsText(file)
+  }
+
+  /** Send the file content to the backend import endpoint */
+  async function importStories(projectId: string): Promise<void> {
+    if (!fileContent.value) return
+    isImporting.value = true
+    apiError.value = null
+    try {
+      const { data, error } = await apiClient.POST('/projects/{projectId}/stories/import', {
+        params: { path: { projectId } },
+        body: { content: fileContent.value },
+      })
+      if (error) {
+        apiError.value = 'Import failed. Please try again.'
+        return
+      }
+      importResult.value = data as ImportResult
+    } finally {
+      isImporting.value = false
+    }
+  }
+
+  /** Reset all state to initial values */
+  function reset() {
+    fileContent.value = null
+    fileName.value = null
+    parsedPreview.value = []
+    importResult.value = null
+    fileError.value = null
+    apiError.value = null
+    isImporting.value = false
+  }
+
+  return {
+    fileContent,
+    fileName,
+    parsedPreview,
+    importResult,
+    fileError,
+    apiError,
+    isImporting,
+    parseMarkdownPreview,
+    selectFile,
+    importStories,
+    reset,
+  }
+}

--- a/frontend/src/features/board/StoryImportDialog.vue
+++ b/frontend/src/features/board/StoryImportDialog.vue
@@ -1,0 +1,215 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import Dialog from 'primevue/dialog'
+import Button from 'primevue/button'
+import Tag from 'primevue/tag'
+import DataTable from 'primevue/datatable'
+import Column from 'primevue/column'
+import Message from 'primevue/message'
+import { useStoryImport } from '@/composables/useStoryImport'
+
+const props = defineProps<{
+  visible: boolean
+  projectId: string
+}>()
+
+const emit = defineEmits<{
+  'update:visible': [value: boolean]
+  imported: []
+}>()
+
+const {
+  fileContent,
+  fileName,
+  parsedPreview,
+  importResult,
+  fileError,
+  apiError,
+  isImporting,
+  selectFile,
+  importStories,
+  reset,
+} = useStoryImport()
+
+const isDragging = ref(false)
+const fileInputRef = ref<HTMLInputElement | null>(null)
+
+const validStories = computed(() => parsedPreview.value.filter((s) => s.valid))
+const invalidStories = computed(() => parsedPreview.value.filter((s) => !s.valid))
+const validCount = computed(() => validStories.value.length)
+const invalidCount = computed(() => invalidStories.value.length)
+
+function triggerFileInput() {
+  fileInputRef.value?.click()
+}
+
+function handleDrop(event: DragEvent) {
+  isDragging.value = false
+  const file = event.dataTransfer?.files[0]
+  if (file) {
+    selectFile(file)
+  }
+}
+
+function handleFileInput(event: Event) {
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  if (file) {
+    selectFile(file)
+  }
+  target.value = ''
+}
+
+async function handleImport() {
+  await importStories(props.projectId)
+}
+
+function handleImportAnother() {
+  reset()
+}
+
+function handleClose() {
+  if (importResult.value) {
+    emit('imported')
+  }
+  reset()
+  emit('update:visible', false)
+}
+</script>
+
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    header="Import Stories"
+    class="w-full max-w-2xl"
+    @update:visible="handleClose"
+  >
+    <div class="flex flex-col gap-4">
+      <!-- Step 1: Upload zone -->
+      <div v-if="!fileContent && !importResult">
+        <div
+          class="flex flex-col items-center justify-center gap-3 p-8 border-2 border-dashed rounded-lg cursor-pointer"
+          :style="{
+            borderColor: isDragging ? 'var(--p-primary-color)' : 'var(--p-surface-300)',
+            backgroundColor: isDragging ? 'var(--p-primary-50)' : 'transparent',
+          }"
+          data-testid="drop-zone"
+          @click="triggerFileInput"
+          @dragover.prevent
+          @dragenter="isDragging = true"
+          @dragleave="isDragging = false"
+          @drop.prevent="handleDrop"
+        >
+          <i class="pi pi-upload" style="font-size: 2rem; color: var(--p-text-muted-color)" />
+          <p style="color: var(--p-text-muted-color)">
+            Drag & drop a .md file here, or click to browse
+          </p>
+          <p v-if="fileName" class="text-sm font-medium">{{ fileName }}</p>
+        </div>
+        <input
+          ref="fileInputRef"
+          type="file"
+          accept=".md"
+          class="hidden"
+          data-testid="file-input"
+          @change="handleFileInput"
+        />
+        <small v-if="fileError" class="text-red-500" data-testid="file-error">{{
+          fileError
+        }}</small>
+      </div>
+
+      <!-- Step 2: Preview -->
+      <div v-if="fileContent && !importResult">
+        <div class="flex items-center gap-2 mb-4">
+          <Tag :value="`${validCount} stories detected`" severity="info" />
+          <Tag
+            v-if="invalidCount > 0"
+            :value="`${invalidCount} invalid`"
+            severity="warn"
+          />
+        </div>
+
+        <DataTable
+          v-if="validStories.length > 0"
+          :value="validStories"
+          size="small"
+          data-testid="preview-table"
+        >
+          <Column field="key" header="Key" />
+          <Column field="title" header="Title" />
+          <Column field="scope" header="Scope" />
+        </DataTable>
+
+        <div v-if="invalidStories.length > 0" class="mt-4" data-testid="invalid-stories">
+          <h4 class="text-sm font-semibold mb-2" style="color: var(--p-text-muted-color)">
+            Invalid stories
+          </h4>
+          <ul class="list-disc pl-5 text-sm">
+            <li v-for="(story, idx) in invalidStories" :key="idx" class="text-red-500">
+              {{ story.key }}: {{ story.error }}
+            </li>
+          </ul>
+        </div>
+
+        <Message v-if="apiError" severity="error" :closable="false" class="mt-4" data-testid="api-error">
+          {{ apiError }}
+        </Message>
+      </div>
+
+      <!-- Step 3: Result -->
+      <div v-if="importResult" data-testid="import-result">
+        <div class="flex items-center gap-2 mb-4">
+          <Tag :value="`${importResult.imported} created`" severity="success" />
+          <Tag :value="`${importResult.updated} updated`" severity="info" />
+          <Tag
+            v-if="importResult.failed > 0"
+            :value="`${importResult.failed} failed`"
+            severity="danger"
+          />
+        </div>
+
+        <div v-if="importResult.errors.length > 0" class="mt-2" data-testid="import-errors">
+          <h4 class="text-sm font-semibold mb-2" style="color: var(--p-text-muted-color)">
+            Errors
+          </h4>
+          <ul class="list-disc pl-5 text-sm">
+            <li v-for="(err, idx) in importResult.errors" :key="idx" class="text-red-500">
+              {{ err.key }}: {{ err.message }}
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <template #footer>
+      <!-- Step 1 footer: no buttons needed (upload zone is interactive) -->
+
+      <!-- Step 2 footer: Cancel + Import -->
+      <div v-if="fileContent && !importResult" class="flex justify-end gap-2">
+        <Button label="Cancel" severity="secondary" text @click="handleClose" />
+        <Button
+          label="Import"
+          icon="pi pi-upload"
+          :loading="isImporting"
+          :disabled="validCount === 0"
+          data-testid="import-button"
+          @click="handleImport"
+        />
+      </div>
+
+      <!-- Step 3 footer: Import Another + Close -->
+      <div v-if="importResult" class="flex justify-end gap-2">
+        <Button
+          label="Import Another File"
+          severity="secondary"
+          text
+          data-testid="import-another-button"
+          @click="handleImportAnother"
+        />
+        <Button label="Close" data-testid="close-button" @click="handleClose" />
+      </div>
+    </template>
+  </Dialog>
+</template>

--- a/frontend/src/features/board/__tests__/StoryImportDialog.spec.ts
+++ b/frontend/src/features/board/__tests__/StoryImportDialog.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { h, defineComponent } from 'vue'
+import PrimeVue from 'primevue/config'
+import StoryImportDialog from '../StoryImportDialog.vue'
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: vi.fn(),
+    PUT: vi.fn(),
+    POST: vi.fn(),
+  },
+}))
+
+/** Stub Dialog to render inline instead of teleporting */
+const DialogStub = defineComponent({
+  name: 'DialogStub',
+  props: ['visible', 'modal', 'header', 'class'],
+  emits: ['update:visible'],
+  setup(props, { slots, emit }) {
+    return () => {
+      if (!props.visible) return null
+      return h('div', { class: 'p-dialog' }, [
+        h('div', { class: 'p-dialog-header' }, props.header),
+        h('div', { class: 'p-dialog-content' }, slots.default?.()),
+        h('div', { class: 'p-dialog-footer' }, slots.footer?.()),
+      ])
+    }
+  },
+})
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+beforeEach(() => {
+  // Mock FileReader for the composable
+  vi.stubGlobal(
+    'FileReader',
+    function MockFileReader(this: { readAsText: ReturnType<typeof vi.fn>; onload: null }) {
+      this.readAsText = vi.fn()
+      this.onload = null
+    } as unknown as typeof FileReader,
+  )
+})
+
+function mountComponent(props: Partial<{ visible: boolean; projectId: string }> = {}) {
+  wrapper = mount(StoryImportDialog, {
+    props: {
+      visible: true,
+      projectId: 'p1',
+      ...props,
+    },
+    global: {
+      plugins: [PrimeVue],
+      stubs: {
+        Dialog: DialogStub,
+      },
+    },
+  })
+  return wrapper
+}
+
+describe('StoryImportDialog', () => {
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  describe('Step 1: Upload zone', () => {
+    it('renders upload zone when no file is selected', () => {
+      mountComponent()
+      expect(wrapper.find('[data-testid="drop-zone"]').exists()).toBe(true)
+      expect(wrapper.text()).toContain('Drag & drop a .md file here')
+    })
+
+    it('renders file input accepting .md files', () => {
+      mountComponent()
+      const fileInput = wrapper.find('[data-testid="file-input"]')
+      expect(fileInput.exists()).toBe(true)
+      expect(fileInput.attributes('accept')).toBe('.md')
+    })
+
+    it('does not show file error initially', () => {
+      mountComponent()
+      expect(wrapper.find('[data-testid="file-error"]').exists()).toBe(false)
+    })
+
+    it('does not show preview table', () => {
+      mountComponent()
+      expect(wrapper.find('[data-testid="preview-table"]').exists()).toBe(false)
+    })
+
+    it('does not show import result', () => {
+      mountComponent()
+      expect(wrapper.find('[data-testid="import-result"]').exists()).toBe(false)
+    })
+  })
+
+  describe('dialog header', () => {
+    it('has correct header text', () => {
+      mountComponent()
+      expect(wrapper.text()).toContain('Import Stories')
+    })
+  })
+
+  describe('not visible', () => {
+    it('renders nothing when visible is false', () => {
+      mountComponent({ visible: false })
+      expect(wrapper.find('.p-dialog').exists()).toBe(false)
+    })
+  })
+
+  describe('emits', () => {
+    it('emits update:visible false when dialog close is triggered', async () => {
+      mountComponent()
+      const dialog = wrapper.findComponent({ name: 'DialogStub' })
+      await dialog.vm.$emit('update:visible', false)
+      expect(wrapper.emitted('update:visible')).toBeTruthy()
+    })
+  })
+})

--- a/frontend/src/features/board/__tests__/StoryImportDialog.spec.ts
+++ b/frontend/src/features/board/__tests__/StoryImportDialog.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { mount, type VueWrapper } from '@vue/test-utils'
-import { h, defineComponent } from 'vue'
+import { h, defineComponent, ref } from 'vue'
 import PrimeVue from 'primevue/config'
 import StoryImportDialog from '../StoryImportDialog.vue'
 
@@ -10,6 +10,40 @@ vi.mock('@/api/client', () => ({
     PUT: vi.fn(),
     POST: vi.fn(),
   },
+}))
+
+// Mutable state used by composable mock
+const mockState = {
+  fileContent: ref<string | null>(null),
+  fileName: ref<string | null>(null),
+  parsedPreview: ref<{ key: string; title: string; scope?: string; valid: boolean; error?: string }[]>([]),
+  importResult: ref<{ imported: number; updated: number; failed: number; errors: { key: string; message: string; code: string }[] } | null>(null),
+  fileError: ref<string | null>(null),
+  apiError: ref<string | null>(null),
+  isImporting: ref(false),
+}
+
+const mockSelectFile = vi.fn()
+const mockImportStories = vi.fn()
+const mockReset = vi.fn().mockImplementation(() => {
+  mockState.fileContent.value = null
+  mockState.fileName.value = null
+  mockState.parsedPreview.value = []
+  mockState.importResult.value = null
+  mockState.fileError.value = null
+  mockState.apiError.value = null
+  mockState.isImporting.value = false
+})
+const mockParseMarkdownPreview = vi.fn()
+
+vi.mock('@/composables/useStoryImport', () => ({
+  useStoryImport: () => ({
+    ...mockState,
+    selectFile: mockSelectFile,
+    importStories: mockImportStories,
+    reset: mockReset,
+    parseMarkdownPreview: mockParseMarkdownPreview,
+  }),
 }))
 
 /** Stub Dialog to render inline instead of teleporting */
@@ -33,7 +67,26 @@ const DialogStub = defineComponent({
 let wrapper: VueWrapper<any>
 
 beforeEach(() => {
-  // Mock FileReader for the composable
+  // Reset all mock state
+  mockState.fileContent.value = null
+  mockState.fileName.value = null
+  mockState.parsedPreview.value = []
+  mockState.importResult.value = null
+  mockState.fileError.value = null
+  mockState.apiError.value = null
+  mockState.isImporting.value = false
+  vi.clearAllMocks()
+  mockReset.mockImplementation(() => {
+    mockState.fileContent.value = null
+    mockState.fileName.value = null
+    mockState.parsedPreview.value = []
+    mockState.importResult.value = null
+    mockState.fileError.value = null
+    mockState.apiError.value = null
+    mockState.isImporting.value = false
+  })
+
+  // Mock FileReader for any direct usage
   vi.stubGlobal(
     'FileReader',
     function MockFileReader(this: { readAsText: ReturnType<typeof vi.fn>; onload: null }) {
@@ -84,6 +137,14 @@ describe('StoryImportDialog', () => {
       expect(wrapper.find('[data-testid="file-error"]').exists()).toBe(false)
     })
 
+    it('shows file error when fileError is set', async () => {
+      mountComponent()
+      mockState.fileError.value = 'Only .md files are supported'
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('[data-testid="file-error"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="file-error"]').text()).toBe('Only .md files are supported')
+    })
+
     it('does not show preview table', () => {
       mountComponent()
       expect(wrapper.find('[data-testid="preview-table"]').exists()).toBe(false)
@@ -92,6 +153,104 @@ describe('StoryImportDialog', () => {
     it('does not show import result', () => {
       mountComponent()
       expect(wrapper.find('[data-testid="import-result"]').exists()).toBe(false)
+    })
+  })
+
+  describe('Step 2: Preview', () => {
+    beforeEach(() => {
+      mockState.fileContent.value = '---\nkey: S-01\n---\n# Story One\n'
+      mockState.parsedPreview.value = [{ key: 'S-01', title: 'Story One', valid: true }]
+    })
+
+    it('renders preview table when fileContent is set', async () => {
+      mountComponent()
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('[data-testid="drop-zone"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="preview-table"]').exists()).toBe(true)
+    })
+
+    it('disables Import button when all parsed stories are invalid', async () => {
+      mockState.parsedPreview.value = [
+        { key: '(unknown)', title: '(no title)', valid: false, error: 'Missing key in frontmatter' },
+      ]
+      mountComponent()
+      await wrapper.vm.$nextTick()
+      const importButton = wrapper.find('[data-testid="import-button"]')
+      expect(importButton.exists()).toBe(true)
+      expect(importButton.attributes('disabled')).toBeDefined()
+    })
+
+    it('enables Import button when at least one valid story exists', async () => {
+      mountComponent()
+      await wrapper.vm.$nextTick()
+      const importButton = wrapper.find('[data-testid="import-button"]')
+      expect(importButton.exists()).toBe(true)
+      expect(importButton.attributes('disabled')).toBeUndefined()
+    })
+
+    it('shows invalid stories section when invalid stories exist', async () => {
+      mockState.parsedPreview.value = [
+        { key: 'S-01', title: 'Valid', valid: true },
+        { key: '(unknown)', title: '(no title)', valid: false, error: 'Missing key in frontmatter' },
+      ]
+      mountComponent()
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('[data-testid="invalid-stories"]').exists()).toBe(true)
+    })
+
+    it('shows api error message when apiError is set', async () => {
+      mockState.apiError.value = 'Import failed. Please try again.'
+      mountComponent()
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('[data-testid="api-error"]').exists()).toBe(true)
+    })
+  })
+
+  describe('Step 3: Result', () => {
+    beforeEach(() => {
+      mockState.importResult.value = { imported: 3, updated: 1, failed: 0, errors: [] }
+    })
+
+    it('renders summary tags when importResult is set', async () => {
+      mountComponent()
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('[data-testid="import-result"]').exists()).toBe(true)
+      expect(wrapper.text()).toContain('3 created')
+      expect(wrapper.text()).toContain('1 updated')
+    })
+
+    it('does not render upload zone in Step 3', async () => {
+      mountComponent()
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('[data-testid="drop-zone"]').exists()).toBe(false)
+    })
+
+    it('"Import Another File" triggers reset and returns to Step 1', async () => {
+      mountComponent()
+      await wrapper.vm.$nextTick()
+
+      const importAnotherButton = wrapper.find('[data-testid="import-another-button"]')
+      expect(importAnotherButton.exists()).toBe(true)
+      await importAnotherButton.trigger('click')
+      await wrapper.vm.$nextTick()
+
+      expect(mockReset).toHaveBeenCalled()
+      // After reset, importResult is null so Step 1 should be visible
+      expect(wrapper.find('[data-testid="drop-zone"]').exists()).toBe(true)
+    })
+
+    it('"Close" emits imported and update:visible false', async () => {
+      mountComponent()
+      await wrapper.vm.$nextTick()
+
+      const closeButton = wrapper.find('[data-testid="close-button"]')
+      expect(closeButton.exists()).toBe(true)
+      await closeButton.trigger('click')
+
+      expect(wrapper.emitted('imported')).toBeTruthy()
+      expect(wrapper.emitted('update:visible')).toBeTruthy()
+      const updateEvents = wrapper.emitted('update:visible') as unknown[][]
+      expect(updateEvents[0]).toEqual([false])
     })
   })
 

--- a/frontend/src/views/BoardView.vue
+++ b/frontend/src/views/BoardView.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import Button from 'primevue/button'
 import Message from 'primevue/message'
 import Skeleton from 'primevue/skeleton'
 import EpicCardGrid from '@/features/board/EpicCardGrid.vue'
 import BoardEmptyState from '@/features/board/BoardEmptyState.vue'
+import StoryImportDialog from '@/features/board/StoryImportDialog.vue'
 import { useEpics } from '@/composables/useEpics'
 import { useAuthStore } from '@/stores/auth'
 
@@ -17,9 +18,14 @@ const projectId = route.params.id as string
 const { epics, isLoading, error, retry } = useEpics(projectId)
 
 const isAdmin = computed(() => authStore.user?.role === 'admin')
+const importDialogVisible = ref(false)
 
 function handleEpicClick(epicId: string) {
   router.push({ name: 'epic-detail', params: { id: projectId, epicId } })
+}
+
+function handleImported() {
+  retry()
 }
 </script>
 
@@ -27,7 +33,19 @@ function handleEpicClick(epicId: string) {
   <div class="flex flex-col gap-6 p-6">
     <div class="flex items-center justify-between">
       <h1 class="text-2xl font-bold">Story Board</h1>
+      <Button
+        label="Import Stories"
+        icon="pi pi-upload"
+        severity="secondary"
+        @click="importDialogVisible = true"
+      />
     </div>
+
+    <StoryImportDialog
+      v-model:visible="importDialogVisible"
+      :project-id="projectId"
+      @imported="handleImported"
+    />
 
     <div v-if="isLoading && epics.length === 0" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
       <div v-for="n in 6" :key="n" class="flex flex-col gap-3 p-4">


### PR DESCRIPTION
## Summary
- Add "Import Stories" button on the Story Board page that opens a three-step dialog (upload, preview, result)
- Create `useStoryImport` composable with file validation (`.md` only), local markdown preview parsing, API import call (`POST /projects/{projectId}/stories/import`), and full state management
- Create `StoryImportDialog.vue` with drag-and-drop upload zone, DataTable preview of detected stories, invalid story error listing, and import result summary with created/updated/failed counts
- Wire dialog into `BoardView.vue` with automatic epic list refresh on successful import
- Add 13 unit tests for the composable and 8 unit tests for the dialog component

## Test plan
- [x] All 301 unit tests pass (`npm run test:unit -- --run`)
- [x] ESLint passes (`npm run lint`)
- [x] TypeScript type-check passes (`npm run type-check`)
- [ ] Manual verification: open Story Board, click "Import Stories", drag a `.md` file, verify preview, click Import, verify result display
- [ ] Manual verification: attempt importing a non-`.md` file and verify rejection message
- [ ] Manual verification: verify "Import Another File" resets to upload state
- [ ] Manual verification: verify board refreshes after closing import dialog

Refs: S-2-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)