### PR TITLE
feat(event): add SSE streaming endpoint for real-time project events

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -202,6 +202,9 @@ func run() error {
 		}()
 	}
 
+	// SSE handler for real-time event streaming
+	sseHandler := handler.NewSSEHandler(eventBus, eventRepo, projectUserRepo, logger)
+
 	server := handler.NewServer(authHandler, projectHandler, userHandler, epicHandler, storyHandler, promptTemplateHandler, runHandler, pipelineConfigHandler)
 
 	// Project user handler
@@ -221,6 +224,10 @@ func run() error {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
+
+	// SSE endpoint — registered before oapi-codegen mux to avoid route conflicts.
+	// Auth is applied globally via the Auth middleware on the router.
+	r.Get("/api/v1/events/stream", sseHandler.ServeHTTP)
 
 	handler.HandlerFromMuxWithBaseURL(server, r, "/api/v1")
 

--- a/backend/internal/adapter/postgres/event_repo.go
+++ b/backend/internal/adapter/postgres/event_repo.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -12,6 +13,9 @@ import (
 
 // Ensure EventRepo implements port.EventPublisher at compile time.
 var _ port.EventPublisher = (*EventRepo)(nil)
+
+// Ensure EventRepo implements port.EventRepository at compile time.
+var _ port.EventRepository = (*EventRepo)(nil)
 
 // EventRepo implements port.EventPublisher using sqlc-generated queries.
 type EventRepo struct {
@@ -56,4 +60,31 @@ func (r *EventRepo) Publish(ctx context.Context, event model.Event) error {
 		return apperrors.NewInternal("failed to publish event", err)
 	}
 	return nil
+}
+
+// GetEventsSince returns all events for the project created after the event
+// identified by afterEventID. Returns empty slice if afterEventID is unknown
+// (the subquery returns no rows, so the WHERE clause matches nothing).
+func (r *EventRepo) GetEventsSince(ctx context.Context, projectID uuid.UUID, afterEventID uuid.UUID) ([]*model.Event, error) {
+	rows, err := r.queries.GetEventsSince(ctx, GetEventsSinceParams{
+		ProjectID: projectID,
+		ID:        afterEventID,
+	})
+	if err != nil {
+		return nil, apperrors.NewInternal("failed to query events since", err)
+	}
+
+	events := make([]*model.Event, 0, len(rows))
+	for _, row := range rows {
+		events = append(events, &model.Event{
+			ID:         row.ID,
+			ProjectID:  row.ProjectID,
+			EntityType: row.EntityType,
+			EntityID:   row.EntityID,
+			Action:     row.Action,
+			Payload:    json.RawMessage(row.Payload),
+			CreatedAt:  row.CreatedAt,
+		})
+	}
+	return events, nil
 }

--- a/backend/internal/adapter/postgres/events.sql.go
+++ b/backend/internal/adapter/postgres/events.sql.go
@@ -90,6 +90,49 @@ func (q *Queries) GetEventsByEntityID(ctx context.Context, arg GetEventsByEntity
 	return items, nil
 }
 
+const getEventsSince = `-- name: GetEventsSince :many
+SELECT e.id, e.project_id, e.entity_type, e.entity_id, e.action, e.payload, e.created_at
+FROM events e
+WHERE e.project_id = $1
+  AND e.created_at > (
+      SELECT anchor.created_at FROM events anchor WHERE anchor.id = $2
+  )
+ORDER BY e.created_at ASC
+`
+
+type GetEventsSinceParams struct {
+	ProjectID uuid.UUID `json:"project_id"`
+	ID        uuid.UUID `json:"id"`
+}
+
+func (q *Queries) GetEventsSince(ctx context.Context, arg GetEventsSinceParams) ([]Event, error) {
+	rows, err := q.db.Query(ctx, getEventsSince, arg.ProjectID, arg.ID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Event{}
+	for rows.Next() {
+		var i Event
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.EntityType,
+			&i.EntityID,
+			&i.Action,
+			&i.Payload,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listEventsByProject = `-- name: ListEventsByProject :many
 SELECT id, project_id, entity_type, entity_id, action, payload, created_at FROM events
 WHERE project_id = $1

--- a/backend/internal/api/handler/sse_handler.go
+++ b/backend/internal/api/handler/sse_handler.go
@@ -92,7 +92,6 @@ func (h *SSEHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Set SSE response headers
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
 
 	// Replay missed events if Last-Event-ID is present

--- a/backend/internal/api/handler/sse_handler.go
+++ b/backend/internal/api/handler/sse_handler.go
@@ -1,0 +1,220 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	authmw "github.com/zakari/hopeitworks/backend/internal/api/middleware"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+)
+
+const keepaliveInterval = 30 * time.Second
+
+// SSEHandler serves Server-Sent Events for real-time project event streaming.
+// This is a long-lived HTTP connection — it must NOT go through the oapi-codegen
+// generated mux. Register manually on the chi router.
+//
+// The http.Server.WriteTimeout must be zero or very large for SSE connections;
+// MVP relies on proxy-level timeout.
+type SSEHandler struct {
+	eventSub        port.EventSubscriber
+	eventRepo       port.EventRepository
+	projectUserRepo port.ProjectUserRepository
+	logger          *slog.Logger
+}
+
+// NewSSEHandler creates a new SSEHandler with all required dependencies.
+func NewSSEHandler(
+	eventSub port.EventSubscriber,
+	eventRepo port.EventRepository,
+	projectUserRepo port.ProjectUserRepository,
+	logger *slog.Logger,
+) *SSEHandler {
+	return &SSEHandler{
+		eventSub:        eventSub,
+		eventRepo:       eventRepo,
+		projectUserRepo: projectUserRepo,
+		logger:          logger,
+	}
+}
+
+// ServeHTTP handles SSE streaming requests.
+// Route: GET /api/v1/events/stream?project_id={uuid}
+func (h *SSEHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Parse project_id query param
+	projectIDStr := r.URL.Query().Get("project_id")
+	if projectIDStr == "" {
+		writeBadRequestJSON(w, "missing required query parameter: project_id")
+		return
+	}
+	projectID, err := uuid.Parse(projectIDStr)
+	if err != nil {
+		writeBadRequestJSON(w, "invalid project_id: must be a valid UUID")
+		return
+	}
+
+	// Extract authenticated user from context
+	userID, ok := authmw.UserIDFromContext(r.Context())
+	if !ok {
+		writeUnauthorizedJSON(w)
+		return
+	}
+
+	// Check project membership (admins bypass via middleware, but SSE is registered
+	// without RequireProjectAccess, so we check inline)
+	if !authmw.IsAdmin(r.Context()) {
+		isMember, memberErr := h.projectUserRepo.IsUserInProject(r.Context(), projectID, userID)
+		if memberErr != nil {
+			h.logger.Error("failed to check project membership", "error", memberErr, "project_id", projectID, "user_id", userID)
+			writeInternalErrorJSON(w)
+			return
+		}
+		if !isMember {
+			writeForbiddenJSON(w, "you are not a member of this project")
+			return
+		}
+	}
+
+	// Assert http.Flusher support
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		h.logger.Error("response writer does not support http.Flusher")
+		writeInternalErrorJSON(w)
+		return
+	}
+
+	// Set SSE response headers
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	// Replay missed events if Last-Event-ID is present
+	lastEventID := r.Header.Get("Last-Event-ID")
+	if lastEventID != "" {
+		afterID, parseErr := uuid.Parse(lastEventID)
+		if parseErr == nil {
+			missedEvents, replayErr := h.eventRepo.GetEventsSince(r.Context(), projectID, afterID)
+			if replayErr != nil {
+				h.logger.Error("failed to replay events", "error", replayErr, "last_event_id", lastEventID)
+			} else {
+				for _, event := range missedEvents {
+					if writeErr := writeSSEEvent(w, flusher, *event); writeErr != nil {
+						h.logger.Error("failed to write replay event", "error", writeErr)
+						return
+					}
+				}
+			}
+		}
+	}
+
+	// Subscribe to live events
+	eventCh, cleanup, subErr := h.eventSub.Subscribe(r.Context(), projectID)
+	if subErr != nil {
+		h.logger.Error("failed to subscribe to events", "error", subErr, "project_id", projectID)
+		writeInternalErrorJSON(w)
+		return
+	}
+	defer cleanup()
+
+	h.logger.Info("SSE client connected", "project_id", projectID, "user_id", userID)
+
+	// Streaming loop
+	ticker := time.NewTicker(keepaliveInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case event, ok := <-eventCh:
+			if !ok {
+				// Channel closed, end stream
+				return
+			}
+			if writeErr := writeSSEEvent(w, flusher, event); writeErr != nil {
+				h.logger.Error("failed to write SSE event", "error", writeErr)
+				return
+			}
+
+		case <-ticker.C:
+			// Send keepalive comment to prevent proxy timeout
+			if _, writeErr := fmt.Fprint(w, ": keepalive\n\n"); writeErr != nil {
+				h.logger.Debug("keepalive write failed, client likely disconnected", "error", writeErr)
+				return
+			}
+			flusher.Flush()
+
+		case <-r.Context().Done():
+			h.logger.Info("SSE client disconnected", "project_id", projectID, "user_id", userID)
+			return
+		}
+	}
+}
+
+// writeSSEEvent writes a single SSE frame and flushes the response.
+func writeSSEEvent(w io.Writer, f http.Flusher, event model.Event) error {
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshaling event: %w", err)
+	}
+	_, err = fmt.Fprintf(w, "event: %s\ndata: %s\nid: %s\n\n",
+		event.EventName(), payload, event.ID)
+	if err != nil {
+		return fmt.Errorf("writing SSE frame: %w", err)
+	}
+	f.Flush()
+	return nil
+}
+
+// writeBadRequestJSON writes a 400 error response.
+func writeBadRequestJSON(w http.ResponseWriter, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    "VALIDATION_ERROR",
+			"message": msg,
+		},
+	})
+}
+
+// writeUnauthorizedJSON writes a 401 error response.
+func writeUnauthorizedJSON(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    "UNAUTHORIZED",
+			"message": "authentication required",
+		},
+	})
+}
+
+// writeForbiddenJSON writes a 403 error response.
+func writeForbiddenJSON(w http.ResponseWriter, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    "FORBIDDEN",
+			"message": msg,
+		},
+	})
+}
+
+// writeInternalErrorJSON writes a 500 error response.
+func writeInternalErrorJSON(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    "INTERNAL_ERROR",
+			"message": "an internal error occurred",
+		},
+	})
+}

--- a/backend/internal/api/handler/sse_handler_test.go
+++ b/backend/internal/api/handler/sse_handler_test.go
@@ -1,0 +1,466 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/api/middleware"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+)
+
+// --- Mock EventSubscriber ---
+
+type mockEventSubscriber struct {
+	mu       sync.Mutex
+	channels map[uuid.UUID]chan model.Event
+	subErr   error
+}
+
+func newMockEventSubscriber() *mockEventSubscriber {
+	return &mockEventSubscriber{
+		channels: make(map[uuid.UUID]chan model.Event),
+	}
+}
+
+func (m *mockEventSubscriber) Subscribe(_ context.Context, projectID uuid.UUID) (<-chan model.Event, func(), error) {
+	if m.subErr != nil {
+		return nil, nil, m.subErr
+	}
+	m.mu.Lock()
+	ch := make(chan model.Event, 100)
+	m.channels[projectID] = ch
+	m.mu.Unlock()
+
+	cleanup := func() {
+		m.mu.Lock()
+		delete(m.channels, projectID)
+		m.mu.Unlock()
+	}
+	return ch, cleanup, nil
+}
+
+func (m *mockEventSubscriber) Close() error {
+	return nil
+}
+
+func (m *mockEventSubscriber) send(projectID uuid.UUID, event model.Event) {
+	m.mu.Lock()
+	ch, ok := m.channels[projectID]
+	m.mu.Unlock()
+	if ok {
+		ch <- event
+	}
+}
+
+func (m *mockEventSubscriber) closeChan(projectID uuid.UUID) {
+	m.mu.Lock()
+	ch, ok := m.channels[projectID]
+	m.mu.Unlock()
+	if ok {
+		close(ch)
+	}
+}
+
+// --- Mock EventRepository ---
+
+type mockEventRepository struct {
+	events []*model.Event
+	err    error
+}
+
+func (m *mockEventRepository) GetEventsSince(_ context.Context, _ uuid.UUID, _ uuid.UUID) ([]*model.Event, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.events, nil
+}
+
+// --- Mock ProjectUserRepository for SSE ---
+
+type mockProjectUserRepoForSSE struct {
+	members map[string]bool // key: "projectID:userID"
+	err     error
+}
+
+func newMockProjectUserRepoForSSE() *mockProjectUserRepoForSSE {
+	return &mockProjectUserRepoForSSE{
+		members: make(map[string]bool),
+	}
+}
+
+func (m *mockProjectUserRepoForSSE) key(projectID, userID uuid.UUID) string {
+	return projectID.String() + ":" + userID.String()
+}
+
+func (m *mockProjectUserRepoForSSE) AddUser(_ context.Context, projectID, userID uuid.UUID, role model.ProjectRole) (*model.ProjectUser, error) {
+	m.members[m.key(projectID, userID)] = true
+	return &model.ProjectUser{ProjectID: projectID, UserID: userID, Role: role}, nil
+}
+
+func (m *mockProjectUserRepoForSSE) RemoveUser(_ context.Context, projectID, userID uuid.UUID) error {
+	delete(m.members, m.key(projectID, userID))
+	return nil
+}
+
+func (m *mockProjectUserRepoForSSE) ListMembers(_ context.Context, _ uuid.UUID) ([]*model.ProjectMember, error) {
+	return nil, nil
+}
+
+func (m *mockProjectUserRepoForSSE) IsUserInProject(_ context.Context, projectID, userID uuid.UUID) (bool, error) {
+	if m.err != nil {
+		return false, m.err
+	}
+	return m.members[m.key(projectID, userID)], nil
+}
+
+func (m *mockProjectUserRepoForSSE) ListProjectsByUser(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Project, error) {
+	return nil, nil
+}
+
+func (m *mockProjectUserRepoForSSE) CountProjectsByUser(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+
+// --- Test helpers ---
+
+func newTestSSEHandler(sub *mockEventSubscriber, repo *mockEventRepository, puRepo *mockProjectUserRepoForSSE) *SSEHandler {
+	logger := slog.Default()
+	return NewSSEHandler(sub, repo, puRepo, logger)
+}
+
+func makeAuthenticatedRequest(method, url string, userID uuid.UUID, role model.Role) *http.Request {
+	req := httptest.NewRequest(method, url, nil)
+	ctx := middleware.SetUserContext(req.Context(), userID, role)
+	return req.WithContext(ctx)
+}
+
+// --- Tests ---
+
+func TestSSEHandler_MissingProjectID(t *testing.T) {
+	sub := newMockEventSubscriber()
+	repo := &mockEventRepository{}
+	puRepo := newMockProjectUserRepoForSSE()
+	h := newTestSSEHandler(sub, repo, puRepo)
+
+	userID := uuid.New()
+	req := makeAuthenticatedRequest(http.MethodGet, "/api/v1/events/stream", userID, model.RoleUser)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d. Body: %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+
+	var errResp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+	errObj, ok := errResp["error"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected error object in response")
+	}
+	if errObj["code"] != "VALIDATION_ERROR" {
+		t.Errorf("expected error code VALIDATION_ERROR, got %v", errObj["code"])
+	}
+}
+
+func TestSSEHandler_InvalidProjectID(t *testing.T) {
+	sub := newMockEventSubscriber()
+	repo := &mockEventRepository{}
+	puRepo := newMockProjectUserRepoForSSE()
+	h := newTestSSEHandler(sub, repo, puRepo)
+
+	userID := uuid.New()
+	req := makeAuthenticatedRequest(http.MethodGet, "/api/v1/events/stream?project_id=not-a-uuid", userID, model.RoleUser)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+	}
+}
+
+func TestSSEHandler_Unauthenticated(t *testing.T) {
+	sub := newMockEventSubscriber()
+	repo := &mockEventRepository{}
+	puRepo := newMockProjectUserRepoForSSE()
+	h := newTestSSEHandler(sub, repo, puRepo)
+
+	projectID := uuid.New()
+	// No user in context
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/events/stream?project_id="+projectID.String(), nil)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d. Body: %s", http.StatusUnauthorized, rec.Code, rec.Body.String())
+	}
+}
+
+func TestSSEHandler_NonMember(t *testing.T) {
+	sub := newMockEventSubscriber()
+	repo := &mockEventRepository{}
+	puRepo := newMockProjectUserRepoForSSE()
+	h := newTestSSEHandler(sub, repo, puRepo)
+
+	projectID := uuid.New()
+	userID := uuid.New()
+	// User is NOT a member of the project
+
+	req := makeAuthenticatedRequest(http.MethodGet, "/api/v1/events/stream?project_id="+projectID.String(), userID, model.RoleUser)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected status %d, got %d. Body: %s", http.StatusForbidden, rec.Code, rec.Body.String())
+	}
+}
+
+func TestSSEHandler_ReceivesLiveEvent(t *testing.T) {
+	sub := newMockEventSubscriber()
+	repo := &mockEventRepository{}
+	puRepo := newMockProjectUserRepoForSSE()
+	h := newTestSSEHandler(sub, repo, puRepo)
+
+	projectID := uuid.New()
+	userID := uuid.New()
+	puRepo.members[puRepo.key(projectID, userID)] = true
+
+	req := makeAuthenticatedRequest(http.MethodGet, "/api/v1/events/stream?project_id="+projectID.String(), userID, model.RoleUser)
+
+	// Use a cancellable context so we can stop the handler
+	ctx, cancel := context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	eventID := uuid.New()
+	entityID := uuid.New()
+	testEvent := model.Event{
+		ID:         eventID,
+		ProjectID:  projectID,
+		EntityType: "run",
+		EntityID:   entityID,
+		Action:     "started",
+		Payload:    json.RawMessage(`{"key":"value"}`),
+		CreatedAt:  time.Now().UTC(),
+	}
+
+	// Run handler in a goroutine
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Wait for subscription to be established
+	waitForSubscription(t, sub, projectID)
+
+	// Send an event
+	sub.send(projectID, testEvent)
+
+	// Give handler time to process the event
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel context to stop the handler
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+
+	// Verify SSE headers
+	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("expected Content-Type text/event-stream, got %s", ct)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("expected Cache-Control no-cache, got %s", cc)
+	}
+	if xab := rec.Header().Get("X-Accel-Buffering"); xab != "no" {
+		t.Errorf("expected X-Accel-Buffering no, got %s", xab)
+	}
+
+	// Verify SSE frame contains correct event
+	if !strings.Contains(body, "event: run.started") {
+		t.Errorf("expected body to contain 'event: run.started', got: %s", body)
+	}
+	if !strings.Contains(body, "id: "+eventID.String()) {
+		t.Errorf("expected body to contain event ID, got: %s", body)
+	}
+	if !strings.Contains(body, `"key":"value"`) {
+		t.Errorf("expected body to contain payload, got: %s", body)
+	}
+}
+
+func TestSSEHandler_ReplayEvents(t *testing.T) {
+	sub := newMockEventSubscriber()
+	puRepo := newMockProjectUserRepoForSSE()
+
+	projectID := uuid.New()
+	userID := uuid.New()
+	puRepo.members[puRepo.key(projectID, userID)] = true
+
+	// Create two replay events
+	event1 := &model.Event{
+		ID:         uuid.New(),
+		ProjectID:  projectID,
+		EntityType: "step",
+		EntityID:   uuid.New(),
+		Action:     "completed",
+		Payload:    json.RawMessage(`{"step":1}`),
+		CreatedAt:  time.Now().UTC().Add(-2 * time.Second),
+	}
+	event2 := &model.Event{
+		ID:         uuid.New(),
+		ProjectID:  projectID,
+		EntityType: "run",
+		EntityID:   uuid.New(),
+		Action:     "failed",
+		Payload:    json.RawMessage(`{"step":2}`),
+		CreatedAt:  time.Now().UTC().Add(-1 * time.Second),
+	}
+	repo := &mockEventRepository{events: []*model.Event{event1, event2}}
+
+	h := newTestSSEHandler(sub, repo, puRepo)
+
+	lastEventID := uuid.New()
+	req := makeAuthenticatedRequest(http.MethodGet, "/api/v1/events/stream?project_id="+projectID.String(), userID, model.RoleUser)
+	req.Header.Set("Last-Event-ID", lastEventID.String())
+
+	ctx, cancel := context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Wait for subscription to be established
+	waitForSubscription(t, sub, projectID)
+
+	// Cancel context to stop the handler
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+
+	// Both replay events should appear before any live events
+	if !strings.Contains(body, "event: step.completed") {
+		t.Errorf("expected replay event step.completed in body, got: %s", body)
+	}
+	if !strings.Contains(body, "event: run.failed") {
+		t.Errorf("expected replay event run.failed in body, got: %s", body)
+	}
+	if !strings.Contains(body, "id: "+event1.ID.String()) {
+		t.Errorf("expected event1 ID in body, got: %s", body)
+	}
+	if !strings.Contains(body, "id: "+event2.ID.String()) {
+		t.Errorf("expected event2 ID in body, got: %s", body)
+	}
+
+	// Verify replay order: step.completed appears before run.failed
+	idx1 := strings.Index(body, "event: step.completed")
+	idx2 := strings.Index(body, "event: run.failed")
+	if idx1 >= idx2 {
+		t.Errorf("expected step.completed before run.failed in replay, body: %s", body)
+	}
+}
+
+func TestSSEHandler_AdminBypassesProjectCheck(t *testing.T) {
+	sub := newMockEventSubscriber()
+	repo := &mockEventRepository{}
+	puRepo := newMockProjectUserRepoForSSE()
+	h := newTestSSEHandler(sub, repo, puRepo)
+
+	projectID := uuid.New()
+	userID := uuid.New()
+	// User is NOT a member, but is admin
+	req := makeAuthenticatedRequest(http.MethodGet, "/api/v1/events/stream?project_id="+projectID.String(), userID, model.RoleAdmin)
+
+	ctx, cancel := context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Wait for subscription to be established
+	waitForSubscription(t, sub, projectID)
+
+	cancel()
+	<-done
+
+	// Should NOT be 403 — admin bypasses membership check
+	if rec.Code == http.StatusForbidden {
+		t.Errorf("admin should bypass project membership check, got 403")
+	}
+}
+
+func TestSSEHandler_ChannelClosed(t *testing.T) {
+	sub := newMockEventSubscriber()
+	repo := &mockEventRepository{}
+	puRepo := newMockProjectUserRepoForSSE()
+	h := newTestSSEHandler(sub, repo, puRepo)
+
+	projectID := uuid.New()
+	userID := uuid.New()
+	puRepo.members[puRepo.key(projectID, userID)] = true
+
+	req := makeAuthenticatedRequest(http.MethodGet, "/api/v1/events/stream?project_id="+projectID.String(), userID, model.RoleUser)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Wait for subscription to be established
+	waitForSubscription(t, sub, projectID)
+
+	// Close the channel to simulate EventBus shutdown
+	sub.closeChan(projectID)
+
+	// Handler should exit gracefully
+	select {
+	case <-done:
+		// Good — handler returned
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not exit after channel closed")
+	}
+}
+
+// waitForSubscription polls until the mock subscriber has a channel for the project.
+func waitForSubscription(t *testing.T, sub *mockEventSubscriber, projectID uuid.UUID) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		sub.mu.Lock()
+		_, ok := sub.channels[projectID]
+		sub.mu.Unlock()
+		if ok {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for subscription to be established")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}

--- a/backend/internal/api/handler/sse_handler_test.go
+++ b/backend/internal/api/handler/sse_handler_test.go
@@ -267,15 +267,17 @@ func TestSSEHandler_ReceivesLiveEvent(t *testing.T) {
 	// Wait for subscription to be established
 	waitForSubscription(t, sub, projectID)
 
-	// Send an event
+	// Send an event then close the channel so the handler processes it and exits naturally.
 	sub.send(projectID, testEvent)
+	sub.closeChan(projectID)
 
-	// Give handler time to process the event
-	time.Sleep(50 * time.Millisecond)
-
-	// Cancel context to stop the handler
-	cancel()
-	<-done
+	// Wait for handler to finish (channel closed causes it to return)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not exit after channel closed")
+	}
+	cancel() // release context resources
 
 	body := rec.Body.String()
 

--- a/backend/internal/domain/port/event_repository.go
+++ b/backend/internal/domain/port/event_repository.go
@@ -1,0 +1,15 @@
+package port
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+)
+
+// EventRepository defines read access to persisted events.
+type EventRepository interface {
+	// GetEventsSince returns all events for the project created after the event
+	// identified by afterEventID. Returns empty slice if afterEventID is unknown.
+	GetEventsSince(ctx context.Context, projectID uuid.UUID, afterEventID uuid.UUID) ([]*model.Event, error)
+}

--- a/backend/queries/events.sql
+++ b/backend/queries/events.sql
@@ -13,3 +13,12 @@ LIMIT $2 OFFSET $3;
 SELECT * FROM events
 WHERE entity_type = $1 AND entity_id = $2
 ORDER BY created_at ASC;
+
+-- name: GetEventsSince :many
+SELECT e.*
+FROM events e
+WHERE e.project_id = $1
+  AND e.created_at > (
+      SELECT anchor.created_at FROM events anchor WHERE anchor.id = $2
+  )
+ORDER BY e.created_at ASC;


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/events/stream?project_id={uuid}` SSE endpoint for real-time project event streaming
- Implement Last-Event-ID replay to deliver missed events on reconnection
- Add 30-second keepalive heartbeats to prevent proxy timeouts
- Enforce authentication (401) and project membership (403) authorization
- Clean up subscriptions on client disconnect without goroutine leaks

## Changes

### New files
- `backend/internal/domain/port/event_repository.go` — EventRepository port with `GetEventsSince` method
- `backend/internal/api/handler/sse_handler.go` — SSEHandler with streaming loop, replay, keepalive, and auth
- `backend/internal/api/handler/sse_handler_test.go` — 7 unit tests covering error cases, live events, replay, admin bypass, and channel closure

### Modified files
- `backend/queries/events.sql` — Added `GetEventsSince` sqlc query
- `backend/internal/adapter/postgres/events.sql.go` — Regenerated sqlc output
- `backend/internal/adapter/postgres/event_repo.go` — Added `GetEventsSince` method implementing EventRepository port
- `backend/cmd/api/main.go` — Wire SSEHandler and register route

## Test plan

- [x] Missing `project_id` query param returns 400
- [x] Invalid `project_id` UUID returns 400
- [x] Unauthenticated request (no user in context) returns 401
- [x] Non-member user returns 403
- [x] Admin bypasses project membership check
- [x] Connected client receives live SSE events with correct frame format
- [x] Last-Event-ID header triggers replay of missed events before live stream
- [x] Channel closure causes handler to exit gracefully
- [x] All existing tests continue to pass
- [x] golangci-lint passes clean

Refs: S-4-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)