### PR TITLE
feat(ui): add LogViewer component and live log page

### DIFF
--- a/_bmad-output/implementation-artifacts/4-3-logviewer-component-live-log-page.md
+++ b/_bmad-output/implementation-artifacts/4-3-logviewer-component-live-log-page.md
@@ -1,6 +1,6 @@
 # Story 4.3: [FRONT] LogViewer Component + Live Log Page
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -50,61 +50,61 @@ As a user watching a run execute, I want a live log view with ANSI color renderi
 
 ## Tasks / Subtasks
 
-- [ ] [FRONT] Task 1: Install `ansi-to-html` and create `formatLogLine` utility (AC: #1)
-  - [ ] Run `npm install ansi-to-html` in `frontend/`
-  - [ ] Create `frontend/src/utils/formatLogLine.ts` — exports `formatLogLine(raw: string, timestamp: Date): string`
-  - [ ] Uses `new AnsiUp().ansi_to_html(raw)` (or `ansi-to-html` Convert class) for ANSI rendering
-  - [ ] Prepends `HH:MM:SS` timestamp formatted from `timestamp` parameter
-  - [ ] Write unit tests in `frontend/src/utils/__tests__/formatLogLine.spec.ts`
+- [x] [FRONT] Task 1: Install `ansi-to-html` and create `formatLogLine` utility (AC: #1)
+  - [x] Run `npm install ansi-to-html` in `frontend/`
+  - [x] Create `frontend/src/utils/formatLogLine.ts` — exports `formatLogLine(raw: string, timestamp: Date): string`
+  - [x] Uses `ansi-to-html` Convert class for ANSI rendering with XML escaping
+  - [x] Prepends `HH:MM:SS` timestamp formatted from `timestamp` parameter
+  - [x] Write unit tests in `frontend/src/utils/__tests__/formatLogLine.spec.ts`
 
-- [ ] [FRONT] Task 2: Create `useSSE` composable (AC: #4)
-  - [ ] Create `frontend/src/composables/useSSE.ts`
-  - [ ] Uses native `EventSource` API (not `@vueuse/core` `useEventSource` — need explicit named-event support)
-  - [ ] Accepts `projectId: string` and `onEvent: (eventName: string, data: unknown) => void` callback
-  - [ ] Exposes `status: Ref<'connecting' | 'open' | 'closed' | 'error'>`
-  - [ ] Opens connection on call, calls `onEvent` for all message events, closes on `onBeforeUnmount`
-  - [ ] Write unit tests in `frontend/src/composables/__tests__/useSSE.spec.ts` using mock `EventSource`
+- [x] [FRONT] Task 2: Create `useSSE` composable (AC: #4)
+  - [x] Create `frontend/src/composables/useSSE.ts`
+  - [x] Uses native `EventSource` API (not `@vueuse/core` `useEventSource` — need explicit named-event support)
+  - [x] Accepts `projectId: string` and `onEvent: (eventName: string, data: unknown) => void` callback
+  - [x] Exposes `status: Ref<'connecting' | 'open' | 'closed' | 'error'>`
+  - [x] Opens connection on call, calls `onEvent` for all message events, closes on `onBeforeUnmount`
+  - [x] Write unit tests in `frontend/src/composables/__tests__/useSSE.spec.ts` using mock `EventSource`
 
-- [ ] [FRONT] Task 3: Build `LogViewer.vue` shared component (AC: #1, #2, #3)
-  - [ ] Create `frontend/src/ui/composed/LogViewer.vue`
-  - [ ] Props: `lines: LogLine[]` (type `{ text: string; timestamp: Date }`), `status: 'connecting' | 'open' | 'closed' | 'error'`
-  - [ ] Renders lines as `v-html` from `formatLogLine(line.text, line.timestamp)` inside a `<pre>` or fixed-height `<div>` with `overflow-y: auto`
-  - [ ] Toolbar row: connection state badge (PrimeVue Tag severity mapped from status), Clear button, auto-scroll indicator
-  - [ ] Auto-scroll logic: use `useTemplateRef` on the scroll container; on new `lines`, if auto-scroll enabled, scroll to bottom via `scrollTop = scrollHeight`
-  - [ ] Scroll listener: detect user scroll-up → pause; detect near-bottom → resume
+- [x] [FRONT] Task 3: Build `LogViewer.vue` shared component (AC: #1, #2, #3)
+  - [x] Create `frontend/src/ui/composed/LogViewer.vue`
+  - [x] Props: `lines: LogLine[]` (type `{ text: string; timestamp: Date }`), `status: 'connecting' | 'open' | 'closed' | 'error'`
+  - [x] Renders lines as `v-html` from `formatLogLine(line.text, line.timestamp)` inside a fixed-height `<div>` with `overflow-y: auto`
+  - [x] Toolbar row: connection state badge (PrimeVue Tag severity mapped from status), Clear button, auto-scroll indicator
+  - [x] Auto-scroll logic: use `useTemplateRef` on the scroll container; on new `lines`, if auto-scroll enabled, scroll to bottom via `scrollTop = scrollHeight`
+  - [x] Scroll listener: detect user scroll-up → pause; detect near-bottom → resume
 
-- [ ] [FRONT] Task 4: Create `useRunLogs` composable (AC: #4, #5)
-  - [ ] Create `frontend/src/features/runs/composables/useRunLogs.ts`
-  - [ ] Accepts `projectId: string`, `runId: string`
-  - [ ] Uses `useSSE(projectId, onEvent)` internally
-  - [ ] Filters events: only processes events where `eventName === 'log.emitted'` and `payload.run_id === runId`
-  - [ ] Appends to `lines: Ref<LogLine[]>` on matching events
-  - [ ] Exposes `lines`, `sseStatus`, `clearLogs`
+- [x] [FRONT] Task 4: Create `useRunLogs` composable (AC: #4, #5)
+  - [x] Create `frontend/src/features/runs/composables/useRunLogs.ts`
+  - [x] Accepts `projectId: string`, `runId: string`
+  - [x] Uses `useSSE(projectId, onEvent)` internally
+  - [x] Filters events: only processes events where `eventName === 'log.emitted'` and `payload.run_id === runId`
+  - [x] Appends to `lines: Ref<LogLine[]>` on matching events
+  - [x] Exposes `lines`, `sseStatus`, `clearLogs`
 
-- [ ] [FRONT] Task 5: Create `useRunDetail` composable (AC: #5)
-  - [ ] Create `frontend/src/features/runs/composables/useRunDetail.ts`
-  - [ ] Accepts `runId: string`
-  - [ ] Uses `useAsyncAction` to fetch `GET /api/v1/runs/{runId}` (generated type `RunWithSteps`)
-  - [ ] Exposes `run`, `isLoading`, `error`, `fetchRun`, `retry`
-  - [ ] Calls `fetchRun` on mount via `onMounted`
-  - [ ] Write unit tests in `frontend/src/features/runs/__tests__/useRunDetail.spec.ts`
+- [x] [FRONT] Task 5: Create `useRunDetail` composable (AC: #5)
+  - [x] Create `frontend/src/features/runs/composables/useRunDetail.ts`
+  - [x] Accepts `runId: string`
+  - [x] Uses `useAsyncAction` to fetch `GET /api/v1/runs/{runId}` (generated type `RunWithSteps`)
+  - [x] Exposes `run`, `isLoading`, `error`, `fetchRun`, `retry`
+  - [x] Calls `fetchRun` on mount via `onMounted`
+  - [x] Write unit tests in `frontend/src/features/runs/__tests__/useRunDetail.spec.ts`
 
-- [ ] [FRONT] Task 6: Implement `RunDetailView.vue` (AC: #5)
-  - [ ] Replace placeholder content in `frontend/src/views/RunDetailView.vue`
-  - [ ] Extract `runId` from `useRoute().params.id`
-  - [ ] Use `useRunDetail(runId)` for run data; show `Skeleton` on load, `Message` on error
-  - [ ] Render: run ID (monospace), status `Tag`, `ProgressBar :value="run.progress"`, step list via PrimeVue `Timeline`
-  - [ ] Mount `LogViewer` below, wired to `useRunLogs(run.project_id, runId)` — only when `run` is loaded
-  - [ ] Extract `projectId` from `run.project_id` (available after fetch, not from route)
+- [x] [FRONT] Task 6: Implement `RunDetailView.vue` (AC: #5)
+  - [x] Replace placeholder content in `frontend/src/views/RunDetailView.vue`
+  - [x] Extract `runId` from `useRoute().params.id`
+  - [x] Use `useRunDetail(runId)` for run data; show `Skeleton` on load, `Message` on error
+  - [x] Render: run ID (monospace), status `Tag`, `ProgressBar :value="progress"`, step list via PrimeVue `Timeline`
+  - [x] Mount `LogViewer` below, wired to `useRunLogs(run.project_id, runId)` — only when `run` is loaded
+  - [x] Extract `projectId` from `run.project_id` (available after fetch, not from route)
 
-- [ ] [FRONT] Task 7: Wire step status to PrimeVue Timeline in RunDetailView (AC: #5)
-  - [ ] Map step `status` to Timeline marker severity: `completed → success`, `running → info`, `failed → danger`, `pending → secondary`, `cancelled → warn`
-  - [ ] Each Timeline item shows: step name, action, status badge, duration (if `started_at` and `completed_at` available)
-  - [ ] Use `date-fns` `differenceInSeconds` for duration formatting
+- [x] [FRONT] Task 7: Wire step status to PrimeVue Timeline in RunDetailView (AC: #5)
+  - [x] Map step `status` to Timeline marker severity: `completed → success`, `running → info`, `failed → danger`, `pending → secondary`, `cancelled → warn`
+  - [x] Each Timeline item shows: step name, action, status badge, duration (if `started_at` and `completed_at` available)
+  - [x] Use `date-fns` `differenceInSeconds` for duration formatting
 
-- [ ] [FRONT] Task 8: Write unit tests for LogViewer.vue and useRunLogs (AC: #1, #2, #3, #4)
-  - [ ] `frontend/src/ui/composed/__tests__/LogViewer.spec.ts`: renders lines with ANSI HTML; shows "Connecting..." when status is connecting; Clear button empties lines (via emit)
-  - [ ] `frontend/src/features/runs/__tests__/useRunLogs.spec.ts`: mock `useSSE`; assert only `log.emitted` events with matching `run_id` are appended; assert other events are ignored; `clearLogs` resets lines
+- [x] [FRONT] Task 8: Write unit tests for LogViewer.vue and useRunLogs (AC: #1, #2, #3, #4)
+  - [x] `frontend/src/ui/composed/__tests__/LogViewer.spec.ts`: renders lines with ANSI HTML; shows "Connecting..." when status is connecting; Clear button empties lines (via emit)
+  - [x] `frontend/src/features/runs/__tests__/useRunLogs.spec.ts`: mock `useSSE`; assert only `log.emitted` events with matching `run_id` are appended; assert other events are ignored; `clearLogs` resets lines
 
 ## Dev Notes
 
@@ -345,12 +345,48 @@ const stepSeverity: Record<string, string> = {
 - PrimeVue Tag: https://primevue.org/tag/
 - SSE named events via `addEventListener`: https://developer.mozilla.org/en-US/docs/Web/API/EventSource
 
+## File List
+
+| File | Action |
+|------|--------|
+| `frontend/package.json` | modified (added ansi-to-html dependency) |
+| `frontend/package-lock.json` | modified (lockfile update) |
+| `frontend/src/utils/formatLogLine.ts` | new |
+| `frontend/src/utils/__tests__/formatLogLine.spec.ts` | new |
+| `frontend/src/composables/useSSE.ts` | new |
+| `frontend/src/composables/__tests__/useSSE.spec.ts` | new |
+| `frontend/src/ui/composed/LogViewer.vue` | new |
+| `frontend/src/ui/composed/__tests__/LogViewer.spec.ts` | new |
+| `frontend/src/features/runs/composables/useRunLogs.ts` | new |
+| `frontend/src/features/runs/composables/useRunDetail.ts` | new |
+| `frontend/src/features/runs/RunLogViewer.vue` | new |
+| `frontend/src/features/runs/__tests__/useRunLogs.spec.ts` | new |
+| `frontend/src/features/runs/__tests__/useRunDetail.spec.ts` | new |
+| `frontend/src/views/RunDetailView.vue` | modified (replaced placeholder) |
+
 ## Dev Agent Record
 
-(Agent execution logs will be appended here)
+### Implementation Plan
+
+1. Installed `ansi-to-html` dependency and created `formatLogLine` utility with XSS-safe escaping
+2. Created `useSSE` composable with native EventSource, named event listeners for all known event types, and lifecycle cleanup
+3. Built `LogViewer.vue` as a pure display component with auto-scroll, connection status badge, and clear functionality
+4. Created `useRunLogs` composable that filters SSE events by `log.emitted` + `run_id` match
+5. Created `useRunDetail` composable following existing `useStoryDetail` pattern with `useAsyncAction`
+6. Implemented `RunDetailView.vue` with full run detail display: status badge, progress bar (computed from step completion ratio as fallback when `run.progress` not available), step timeline with severity-mapped markers and duration formatting, and live log viewer
+7. Created `RunLogViewer.vue` wrapper component to defer SSE connection until `projectId` is available from loaded run data
+8. All 31 new tests pass (4 formatLogLine, 10 useSSE, 8 LogViewer, 5 useRunLogs, 4 useRunDetail)
+9. Full regression suite: 342 tests pass across 40 files, zero failures
+
+### Completion Notes
+
+- Progress bar computes from step completion ratio as fallback since Story 4-2 (run.progress field) has not landed yet; when it does, the `progress` computed property will use `run.progress` if available
+- Created `RunLogViewer.vue` wrapper to solve the chicken-and-egg problem of needing `projectId` from the run API response before connecting SSE
+- All acceptance criteria satisfied with comprehensive test coverage
 
 ## Change Log
 
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-02-17 | Claude Sonnet 4.5 | Initial story creation |
+| 2026-02-17 | Claude Opus 4.6 | Implementation complete — all 8 tasks done, 31 new tests, full regression green |

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -95,7 +95,7 @@ development_status:
   epic-4: backlog
   4-1-sse-streaming-endpoint: backlog
   4-2-run-progress-tracking-api: backlog
-  4-3-logviewer-component-live-log-page: backlog
+  4-3-logviewer-component-live-log-page: review
   4-4-run-progress-timeline-display: backlog
   epic-4-retrospective: optional
 
@@ -456,7 +456,7 @@ parallel_waves:
         cross_epic_deps: [3-1-runs-runsteps-tables-run-creation-api-state-machine]
       - key: 4-3-logviewer-component-live-log-page
         domain: front
-        status: backlog
+        status: review
         cross_epic_deps: [1-8-app-shell-layout-header-sidebar-status-bar]
       # Epic 5 - HITL Gates
       - key: 5-1-hitl-gate-action-pending-state

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@vue-flow/core": "^1.48.2",
         "@vue-flow/minimap": "^1.5.4",
         "@vueuse/core": "^14.2.1",
+        "ansi-to-html": "^0.7.2",
         "date-fns": "^4.1.0",
         "diff2html": "^3.4.56",
         "dompurify": "^3.3.1",
@@ -3968,6 +3969,30 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-to-html": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.7.2.tgz",
+      "integrity": "sha512-v6MqmEpNlxF+POuyhKkidusCHWWkaLcGRURzivcU3I9tv7k4JVhFcnukrM5Rlk2rUywdZuzYAZ+kbZqWCnfN3g==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^2.2.0"
+      },
+      "bin": {
+        "ansi-to-html": "bin/ansi-to-html"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/ansi-to-html/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/ansis": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "@vue-flow/core": "^1.48.2",
     "@vue-flow/minimap": "^1.5.4",
     "@vueuse/core": "^14.2.1",
+    "ansi-to-html": "^0.7.2",
     "date-fns": "^4.1.0",
     "diff2html": "^3.4.56",
     "dompurify": "^3.3.1",

--- a/frontend/src/composables/__tests__/useSSE.spec.ts
+++ b/frontend/src/composables/__tests__/useSSE.spec.ts
@@ -145,7 +145,7 @@ describe('useSSE', () => {
 
     expect(mockOnBeforeUnmount).toHaveBeenCalledTimes(1)
 
-    const unmountCallback = mockOnBeforeUnmount.mock.calls[0][0]
+    const unmountCallback = mockOnBeforeUnmount.mock.calls[0]![0]
     unmountCallback()
 
     expect(mockInstance.close).toHaveBeenCalledTimes(1)

--- a/frontend/src/composables/__tests__/useSSE.spec.ts
+++ b/frontend/src/composables/__tests__/useSSE.spec.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+type EventSourceHandler = ((event: Event | MessageEvent) => void) | null
+type EventListenerEntry = { type: string; handler: EventListener }
+
+interface MockESInstance {
+  onopen: EventSourceHandler
+  onerror: EventSourceHandler
+  onmessage: EventSourceHandler
+  close: ReturnType<typeof vi.fn>
+  addEventListener: ReturnType<typeof vi.fn>
+  listeners: EventListenerEntry[]
+}
+
+let mockInstance: MockESInstance
+
+class MockEventSource {
+  onopen: EventSourceHandler = null
+  onerror: EventSourceHandler = null
+  onmessage: EventSourceHandler = null
+  close = vi.fn()
+  addEventListener = vi.fn((type: string, handler: EventListener) => {
+    mockInstance.listeners.push({ type, handler })
+  })
+  listeners: EventListenerEntry[] = []
+
+  constructor(public url: string) {
+    mockInstance = this
+  }
+}
+
+const mockOnBeforeUnmount = vi.fn()
+
+vi.mock('vue', async () => {
+  const actual = await vi.importActual<typeof import('vue')>('vue')
+  return {
+    ...actual,
+    onBeforeUnmount: (fn: () => void) => mockOnBeforeUnmount(fn),
+  }
+})
+
+vi.stubGlobal('EventSource', MockEventSource)
+
+describe('useSSE', () => {
+  let useSSE: typeof import('../useSSE').useSSE
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const mod = await import('../useSSE')
+    useSSE = mod.useSSE
+  })
+
+  it('opens EventSource with correct URL', () => {
+    const onEvent = vi.fn()
+    useSSE('proj-123', onEvent)
+
+    expect(mockInstance).toBeDefined()
+    expect((mockInstance as unknown as MockEventSource).url).toBe(
+      '/api/v1/events/stream?project_id=proj-123',
+    )
+  })
+
+  it('starts with connecting status', () => {
+    const onEvent = vi.fn()
+    const { status } = useSSE('proj-123', onEvent)
+
+    expect(status.value).toBe('connecting')
+  })
+
+  it('sets status to open when onopen fires', () => {
+    const onEvent = vi.fn()
+    const { status } = useSSE('proj-123', onEvent)
+
+    mockInstance.onopen!(new Event('open'))
+
+    expect(status.value).toBe('open')
+  })
+
+  it('sets status to error when onerror fires', () => {
+    const onEvent = vi.fn()
+    const { status } = useSSE('proj-123', onEvent)
+
+    mockInstance.onerror!(new Event('error'))
+
+    expect(status.value).toBe('error')
+  })
+
+  it('dispatches parsed JSON on message event', () => {
+    const onEvent = vi.fn()
+    useSSE('proj-123', onEvent)
+
+    mockInstance.onmessage!(
+      new MessageEvent('message', { data: '{"foo":"bar"}' }),
+    )
+
+    expect(onEvent).toHaveBeenCalledWith('message', { foo: 'bar' })
+  })
+
+  it('ignores malformed JSON on message event', () => {
+    const onEvent = vi.fn()
+    useSSE('proj-123', onEvent)
+
+    mockInstance.onmessage!(
+      new MessageEvent('message', { data: 'not-json' }),
+    )
+
+    expect(onEvent).not.toHaveBeenCalled()
+  })
+
+  it('registers listeners for all known named events', () => {
+    const onEvent = vi.fn()
+    useSSE('proj-123', onEvent)
+
+    const registeredTypes = mockInstance.listeners.map((l) => l.type)
+    expect(registeredTypes).toContain('run.started')
+    expect(registeredTypes).toContain('run.completed')
+    expect(registeredTypes).toContain('step.completed')
+    expect(registeredTypes).toContain('step.failed')
+    expect(registeredTypes).toContain('log.emitted')
+    expect(registeredTypes).toContain('hitl.pending')
+  })
+
+  it('dispatches named events with parsed data', () => {
+    const onEvent = vi.fn()
+    useSSE('proj-123', onEvent)
+
+    const logListener = mockInstance.listeners.find(
+      (l) => l.type === 'log.emitted',
+    )
+    logListener!.handler(
+      new MessageEvent('log.emitted', {
+        data: '{"run_id":"r1","line":"hello"}',
+      }),
+    )
+
+    expect(onEvent).toHaveBeenCalledWith('log.emitted', {
+      run_id: 'r1',
+      line: 'hello',
+    })
+  })
+
+  it('registers onBeforeUnmount callback that closes EventSource', () => {
+    const onEvent = vi.fn()
+    useSSE('proj-123', onEvent)
+
+    expect(mockOnBeforeUnmount).toHaveBeenCalledTimes(1)
+
+    const unmountCallback = mockOnBeforeUnmount.mock.calls[0][0]
+    unmountCallback()
+
+    expect(mockInstance.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('sets status to closed when close() is called', () => {
+    const onEvent = vi.fn()
+    const { status, close } = useSSE('proj-123', onEvent)
+
+    close()
+
+    expect(status.value).toBe('closed')
+    expect(mockInstance.close).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/composables/useSSE.ts
+++ b/frontend/src/composables/useSSE.ts
@@ -1,0 +1,57 @@
+import { ref, onBeforeUnmount } from 'vue'
+
+export type SSEStatus = 'connecting' | 'open' | 'closed' | 'error'
+
+/**
+ * Composable that manages an EventSource connection for server-sent events.
+ * Opens a connection to the SSE endpoint filtered by projectId,
+ * dispatches parsed events to the provided callback, and cleans up on unmount.
+ */
+export function useSSE(
+  projectId: string,
+  onEvent: (eventName: string, data: unknown) => void,
+) {
+  const status = ref<SSEStatus>('connecting')
+  const es = new EventSource(`/api/v1/events/stream?project_id=${projectId}`)
+
+  es.onopen = () => {
+    status.value = 'open'
+  }
+  es.onerror = () => {
+    status.value = 'error'
+  }
+  es.onmessage = (e) => {
+    try {
+      onEvent('message', JSON.parse(e.data))
+    } catch {
+      /* ignore malformed JSON */
+    }
+  }
+
+  const knownEvents = [
+    'run.started',
+    'run.completed',
+    'step.completed',
+    'step.failed',
+    'log.emitted',
+    'hitl.pending',
+  ]
+  for (const name of knownEvents) {
+    es.addEventListener(name, (e) => {
+      try {
+        onEvent(name, JSON.parse((e as MessageEvent).data))
+      } catch {
+        /* ignore malformed JSON */
+      }
+    })
+  }
+
+  function close() {
+    es.close()
+    status.value = 'closed'
+  }
+
+  onBeforeUnmount(close)
+
+  return { status, close }
+}

--- a/frontend/src/features/runs/RunLogViewer.vue
+++ b/frontend/src/features/runs/RunLogViewer.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import LogViewer from '@/ui/composed/LogViewer.vue'
+import { useRunLogs } from './composables/useRunLogs'
+
+const props = defineProps<{
+  projectId: string
+  runId: string
+}>()
+
+const { lines, sseStatus, clearLogs } = useRunLogs(props.projectId, props.runId)
+</script>
+
+<template>
+  <LogViewer :lines="lines" :status="sseStatus" @clear="clearLogs" />
+</template>

--- a/frontend/src/features/runs/__tests__/useRunDetail.spec.ts
+++ b/frontend/src/features/runs/__tests__/useRunDetail.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { useRunDetail } from '../composables/useRunDetail'
+
+const mockGet = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+  },
+}))
+
+/** Wraps composable that calls onMounted in a simulated lifecycle */
+function withSetup<T>(composable: () => T): T {
+  let result!: T
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { createApp, defineComponent } = require('vue')
+  const app = createApp(
+    defineComponent({
+      setup() {
+        result = composable()
+        return () => null
+      },
+    }),
+  )
+  app.mount(document.createElement('div'))
+  return result
+}
+
+const mockRun = {
+  id: 'run-1',
+  project_id: 'proj-1',
+  story_id: 'story-1',
+  status: 'running',
+  created_at: '2026-02-17T10:00:00Z',
+  updated_at: '2026-02-17T10:00:00Z',
+  steps: [
+    {
+      id: 'step-1',
+      run_id: 'run-1',
+      step_name: 'dev-story',
+      step_order: 1,
+      action: 'agent_run',
+      status: 'completed',
+      created_at: '2026-02-17T10:00:00Z',
+    },
+    {
+      id: 'step-2',
+      run_id: 'run-1',
+      step_name: 'code-review',
+      step_order: 2,
+      action: 'agent_run',
+      status: 'running',
+      created_at: '2026-02-17T10:01:00Z',
+    },
+  ],
+}
+
+describe('useRunDetail', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+  })
+
+  it('fetches run on mount and populates run.value', async () => {
+    mockGet.mockResolvedValue({ data: mockRun, error: undefined })
+
+    const { run, isLoading } = withSetup(() => useRunDetail('run-1'))
+    await flushPromises()
+
+    expect(run.value).toEqual(mockRun)
+    expect(isLoading.value).toBe(false)
+    expect(mockGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('sets error when API returns error', async () => {
+    mockGet.mockResolvedValue({
+      data: undefined,
+      error: { error: { code: 'NOT_FOUND', message: 'Run not found' } },
+    })
+
+    const { run, error } = withSetup(() => useRunDetail('run-1'))
+    await flushPromises()
+
+    expect(run.value).toBeNull()
+    expect(error.value).toBeInstanceOf(Error)
+    expect(error.value?.message).toBe('Failed to load run')
+  })
+
+  it('retry() re-calls the API', async () => {
+    mockGet.mockResolvedValue({ data: mockRun, error: undefined })
+
+    const { retry } = withSetup(() => useRunDetail('run-1'))
+    await flushPromises()
+
+    expect(mockGet).toHaveBeenCalledTimes(1)
+
+    mockGet.mockClear()
+    mockGet.mockResolvedValue({ data: mockRun, error: undefined })
+
+    await retry()
+    expect(mockGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes isLoading as true during fetch', async () => {
+    let resolvePromise: (value: unknown) => void
+    mockGet.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePromise = resolve
+      }),
+    )
+
+    const { isLoading } = withSetup(() => useRunDetail('run-1'))
+
+    expect(isLoading.value).toBe(true)
+
+    resolvePromise!({ data: mockRun, error: undefined })
+    await flushPromises()
+
+    expect(isLoading.value).toBe(false)
+  })
+})

--- a/frontend/src/features/runs/__tests__/useRunLogs.spec.ts
+++ b/frontend/src/features/runs/__tests__/useRunLogs.spec.ts
@@ -29,8 +29,8 @@ describe('useRunLogs', () => {
     })
 
     expect(lines.value).toHaveLength(1)
-    expect(lines.value[0].text).toBe('hello world')
-    expect(lines.value[0].timestamp).toBeInstanceOf(Date)
+    expect(lines.value[0]!.text).toBe('hello world')
+    expect(lines.value[0]!.timestamp).toBeInstanceOf(Date)
   })
 
   it('ignores log.emitted events with different runId', () => {

--- a/frontend/src/features/runs/__tests__/useRunLogs.spec.ts
+++ b/frontend/src/features/runs/__tests__/useRunLogs.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+let capturedOnEvent: (eventName: string, data: unknown) => void
+const mockStatus = { value: 'open' }
+
+vi.mock('@/composables/useSSE', () => ({
+  useSSE: vi.fn((_projectId: string, onEvent: (eventName: string, data: unknown) => void) => {
+    capturedOnEvent = onEvent
+    return { status: mockStatus }
+  }),
+}))
+
+describe('useRunLogs', () => {
+  let useRunLogs: typeof import('../composables/useRunLogs').useRunLogs
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const mod = await import('../composables/useRunLogs')
+    useRunLogs = mod.useRunLogs
+  })
+
+  it('appends log line when log.emitted event matches runId', () => {
+    const { lines } = useRunLogs('proj-1', 'run-1')
+
+    capturedOnEvent('log.emitted', {
+      run_id: 'run-1',
+      line: 'hello world',
+      timestamp: '2026-02-17T10:30:00Z',
+    })
+
+    expect(lines.value).toHaveLength(1)
+    expect(lines.value[0].text).toBe('hello world')
+    expect(lines.value[0].timestamp).toBeInstanceOf(Date)
+  })
+
+  it('ignores log.emitted events with different runId', () => {
+    const { lines } = useRunLogs('proj-1', 'run-1')
+
+    capturedOnEvent('log.emitted', {
+      run_id: 'run-OTHER',
+      line: 'should be ignored',
+      timestamp: '2026-02-17T10:30:00Z',
+    })
+
+    expect(lines.value).toHaveLength(0)
+  })
+
+  it('ignores events that are not log.emitted', () => {
+    const { lines } = useRunLogs('proj-1', 'run-1')
+
+    capturedOnEvent('run.started', { run_id: 'run-1' })
+    capturedOnEvent('step.completed', { run_id: 'run-1' })
+
+    expect(lines.value).toHaveLength(0)
+  })
+
+  it('clearLogs resets lines to empty', () => {
+    const { lines, clearLogs } = useRunLogs('proj-1', 'run-1')
+
+    capturedOnEvent('log.emitted', {
+      run_id: 'run-1',
+      line: 'line 1',
+      timestamp: '2026-02-17T10:30:00Z',
+    })
+    capturedOnEvent('log.emitted', {
+      run_id: 'run-1',
+      line: 'line 2',
+      timestamp: '2026-02-17T10:30:01Z',
+    })
+
+    expect(lines.value).toHaveLength(2)
+
+    clearLogs()
+
+    expect(lines.value).toHaveLength(0)
+  })
+
+  it('exposes sseStatus from useSSE', () => {
+    const { sseStatus } = useRunLogs('proj-1', 'run-1')
+
+    expect(sseStatus.value).toBe('open')
+  })
+})

--- a/frontend/src/features/runs/composables/useRunDetail.ts
+++ b/frontend/src/features/runs/composables/useRunDetail.ts
@@ -1,0 +1,64 @@
+import { onMounted } from 'vue'
+import { useAsyncAction } from '@/composables/useAsyncAction'
+import { apiClient } from '@/api/client'
+
+/** Run with steps shape matching the API RunWithSteps schema. */
+export interface RunWithSteps {
+  id: string
+  project_id: string
+  story_id: string
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
+  pipeline_config_snapshot?: Record<string, unknown>
+  started_at?: string
+  completed_at?: string
+  error_message?: string
+  created_at: string
+  updated_at: string
+  progress?: number
+  steps: RunStep[]
+}
+
+export interface RunStep {
+  id: string
+  run_id: string
+  step_name: string
+  step_order: number
+  action: string
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
+  started_at?: string
+  completed_at?: string
+  error_message?: string
+  container_id?: string
+  log_tail?: string
+  created_at: string
+}
+
+/**
+ * Composable for fetching a single run by ID with its steps.
+ * Uses useAsyncAction to wrap the API call with loading/error state.
+ */
+export function useRunDetail(runId: string) {
+  const {
+    data: run,
+    isLoading,
+    error,
+    execute,
+  } = useAsyncAction(async () => {
+    const { data, error: apiError } = await apiClient.GET(
+      '/runs/{runId}' as never,
+      {
+        params: { path: { runId } },
+      } as never,
+    )
+    if (apiError) throw new Error('Failed to load run')
+    return data as unknown as RunWithSteps
+  })
+
+  async function fetchRun() {
+    await execute()
+  }
+
+  onMounted(fetchRun)
+
+  return { run, isLoading, error, fetchRun, retry: fetchRun }
+}

--- a/frontend/src/features/runs/composables/useRunLogs.ts
+++ b/frontend/src/features/runs/composables/useRunLogs.ts
@@ -1,0 +1,27 @@
+import { ref } from 'vue'
+import { useSSE } from '@/composables/useSSE'
+import type { LogLine } from '@/ui/composed/LogViewer.vue'
+
+/**
+ * Composable that connects to SSE and collects log lines for a specific run.
+ * Filters only `log.emitted` events matching the given runId.
+ */
+export function useRunLogs(projectId: string, runId: string) {
+  const lines = ref<LogLine[]>([])
+
+  const { status: sseStatus } = useSSE(projectId, (eventName, data) => {
+    if (eventName !== 'log.emitted') return
+    const payload = data as { run_id: string; line: string; timestamp: string }
+    if (payload.run_id !== runId) return
+    lines.value.push({
+      text: payload.line,
+      timestamp: new Date(payload.timestamp),
+    })
+  })
+
+  function clearLogs() {
+    lines.value = []
+  }
+
+  return { lines, sseStatus, clearLogs }
+}

--- a/frontend/src/ui/composed/LogViewer.vue
+++ b/frontend/src/ui/composed/LogViewer.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { ref, watch, nextTick, useTemplateRef } from 'vue'
+import Tag from 'primevue/tag'
+import Button from 'primevue/button'
+import { formatLogLine } from '@/utils/formatLogLine'
+import type { SSEStatus } from '@/composables/useSSE'
+
+/** A single log line with raw text and timestamp. */
+export interface LogLine {
+  text: string
+  timestamp: Date
+}
+
+const props = defineProps<{
+  lines: LogLine[]
+  status: SSEStatus
+}>()
+
+const emit = defineEmits<{
+  clear: []
+}>()
+
+const scrollContainer = useTemplateRef<HTMLElement>('scrollContainer')
+const autoScroll = ref(true)
+
+watch(
+  () => props.lines.length,
+  async () => {
+    if (!autoScroll.value) return
+    await nextTick()
+    if (scrollContainer.value) {
+      scrollContainer.value.scrollTop = scrollContainer.value.scrollHeight
+    }
+  },
+)
+
+function onScroll() {
+  if (!scrollContainer.value) return
+  const { scrollTop, scrollHeight, clientHeight } = scrollContainer.value
+  const distFromBottom = scrollHeight - scrollTop - clientHeight
+  autoScroll.value = distFromBottom < 50
+}
+
+const statusSeverity: Record<SSEStatus, 'info' | 'success' | 'warn' | 'danger'> = {
+  connecting: 'info',
+  open: 'success',
+  closed: 'warn',
+  error: 'danger',
+}
+
+const statusLabel: Record<SSEStatus, string> = {
+  connecting: 'Connecting...',
+  open: 'Live',
+  closed: 'Disconnected',
+  error: 'Error',
+}
+</script>
+
+<template>
+  <div class="flex flex-col border border-surface rounded-lg overflow-hidden">
+    <!-- Toolbar -->
+    <div class="flex items-center justify-between px-3 py-2 bg-surface-50 dark:bg-surface-800 border-b border-surface">
+      <div class="flex items-center gap-2">
+        <Tag :value="statusLabel[status]" :severity="statusSeverity[status]" />
+        <span
+          v-if="!autoScroll"
+          class="text-xs text-surface-500 cursor-pointer hover:text-primary"
+          @click="autoScroll = true"
+        >
+          Auto-scroll paused — click to resume
+        </span>
+      </div>
+      <Button
+        label="Clear"
+        icon="pi pi-trash"
+        severity="secondary"
+        text
+        size="small"
+        @click="emit('clear')"
+      />
+    </div>
+
+    <!-- Log lines -->
+    <div
+      ref="scrollContainer"
+      class="overflow-y-auto font-mono text-sm p-3 bg-surface-900 text-surface-100 min-h-48 max-h-96"
+      @scroll="onScroll"
+    >
+      <div
+        v-for="(line, index) in lines"
+        :key="index"
+        class="log-line whitespace-pre-wrap leading-relaxed"
+        v-html="formatLogLine(line.text, line.timestamp)"
+      />
+      <div v-if="lines.length === 0" class="text-surface-500 text-center py-8">
+        No log output yet
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+:deep(.log-ts) {
+  color: var(--p-surface-400);
+  opacity: 0.7;
+  font-size: 0.8em;
+}
+</style>

--- a/frontend/src/ui/composed/__tests__/LogViewer.spec.ts
+++ b/frontend/src/ui/composed/__tests__/LogViewer.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import LogViewer from '../LogViewer.vue'
+import type { LogLine } from '../LogViewer.vue'
+
+function mountLogViewer(props: { lines: LogLine[]; status: 'connecting' | 'open' | 'closed' | 'error' }) {
+  return mount(LogViewer, {
+    props,
+    global: {
+      plugins: [PrimeVue],
+    },
+  })
+}
+
+describe('LogViewer', () => {
+  it('renders the correct number of log line elements', () => {
+    const lines: LogLine[] = [
+      { text: 'line one', timestamp: new Date('2026-01-01T10:00:00Z') },
+      { text: 'line two', timestamp: new Date('2026-01-01T10:00:01Z') },
+      { text: 'line three', timestamp: new Date('2026-01-01T10:00:02Z') },
+    ]
+
+    const wrapper = mountLogViewer({ lines, status: 'open' })
+    const logLines = wrapper.findAll('.log-line')
+
+    expect(logLines).toHaveLength(3)
+  })
+
+  it('renders ANSI-converted HTML in log lines', () => {
+    const lines: LogLine[] = [
+      { text: '\u001b[32mOK\u001b[0m', timestamp: new Date('2026-01-01T10:00:00Z') },
+    ]
+
+    const wrapper = mountLogViewer({ lines, status: 'open' })
+    const logLine = wrapper.find('.log-line')
+
+    expect(logLine.html()).toContain('OK')
+    expect(logLine.html()).not.toContain('\u001b')
+  })
+
+  it('shows "Connecting..." tag when status is connecting', () => {
+    const wrapper = mountLogViewer({ lines: [], status: 'connecting' })
+
+    expect(wrapper.text()).toContain('Connecting...')
+  })
+
+  it('shows "Live" tag when status is open', () => {
+    const wrapper = mountLogViewer({ lines: [], status: 'open' })
+
+    expect(wrapper.text()).toContain('Live')
+  })
+
+  it('shows "Disconnected" tag when status is closed', () => {
+    const wrapper = mountLogViewer({ lines: [], status: 'closed' })
+
+    expect(wrapper.text()).toContain('Disconnected')
+  })
+
+  it('shows "Error" tag when status is error', () => {
+    const wrapper = mountLogViewer({ lines: [], status: 'error' })
+
+    expect(wrapper.text()).toContain('Error')
+  })
+
+  it('emits clear when Clear button is clicked', async () => {
+    const wrapper = mountLogViewer({ lines: [], status: 'open' })
+    const clearButton = wrapper.find('button')
+
+    await clearButton.trigger('click')
+
+    expect(wrapper.emitted('clear')).toBeTruthy()
+    expect(wrapper.emitted('clear')).toHaveLength(1)
+  })
+
+  it('shows "No log output yet" when lines is empty', () => {
+    const wrapper = mountLogViewer({ lines: [], status: 'open' })
+
+    expect(wrapper.text()).toContain('No log output yet')
+  })
+})

--- a/frontend/src/utils/__tests__/formatLogLine.spec.ts
+++ b/frontend/src/utils/__tests__/formatLogLine.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { formatLogLine } from '../formatLogLine'
+
+describe('formatLogLine', () => {
+  it('converts ANSI green code to HTML span with color style', () => {
+    const raw = '\u001b[32mOK\u001b[0m'
+    const timestamp = new Date('2026-01-01T10:05:03Z')
+    const result = formatLogLine(raw, timestamp)
+
+    expect(result).toContain('<span')
+    expect(result).not.toContain('\u001b')
+    expect(result).toContain('OK')
+  })
+
+  it('prefixes with HH:MM:SS timestamp', () => {
+    const raw = 'hello world'
+    const timestamp = new Date('2026-01-01T10:05:03Z')
+    const result = formatLogLine(raw, timestamp)
+
+    // Timestamp is rendered in local time via getHours/getMinutes/getSeconds
+    const hh = String(timestamp.getHours()).padStart(2, '0')
+    const mm = String(timestamp.getMinutes()).padStart(2, '0')
+    const ss = String(timestamp.getSeconds()).padStart(2, '0')
+    expect(result).toContain(`<span class="log-ts">${hh}:${mm}:${ss}</span>`)
+  })
+
+  it('handles empty string input', () => {
+    const timestamp = new Date('2026-01-01T10:05:03Z')
+    const result = formatLogLine('', timestamp)
+
+    expect(result).toContain('<span class="log-ts">')
+  })
+
+  it('escapes HTML entities in raw text', () => {
+    const raw = '<script>alert("xss")</script>'
+    const timestamp = new Date('2026-01-01T10:05:03Z')
+    const result = formatLogLine(raw, timestamp)
+
+    expect(result).not.toContain('<script>')
+    expect(result).toContain('&lt;script&gt;')
+  })
+})

--- a/frontend/src/utils/formatLogLine.ts
+++ b/frontend/src/utils/formatLogLine.ts
@@ -1,0 +1,12 @@
+import Convert from 'ansi-to-html'
+
+const converter = new Convert({ escapeXML: true })
+
+/** Converts a raw log line (possibly with ANSI codes) to HTML with HH:MM:SS prefix. */
+export function formatLogLine(raw: string, timestamp: Date): string {
+  const hh = String(timestamp.getHours()).padStart(2, '0')
+  const mm = String(timestamp.getMinutes()).padStart(2, '0')
+  const ss = String(timestamp.getSeconds()).padStart(2, '0')
+  const timePrefix = `<span class="log-ts">${hh}:${mm}:${ss}</span> `
+  return timePrefix + converter.toHtml(raw)
+}

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -15,7 +15,8 @@ import type { RunStep } from '@/features/runs/composables/useRunDetail'
 const route = useRoute()
 const runId = computed(() => route.params.id as string)
 
-const { run, isLoading, error, retry } = useRunDetail(runId.value)
+const { run: runRef, isLoading, error, retry } = useRunDetail(runId.value)
+const run = computed(() => runRef.value)
 
 const runStatusSeverity: Record<string, 'info' | 'success' | 'warn' | 'danger' | 'secondary'> = {
   pending: 'secondary',

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -1,5 +1,144 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import Skeleton from 'primevue/skeleton'
+import Message from 'primevue/message'
+import Tag from 'primevue/tag'
+import ProgressBar from 'primevue/progressbar'
+import Timeline from 'primevue/timeline'
+import Button from 'primevue/button'
+import { differenceInSeconds } from 'date-fns'
+import { useRunDetail } from '@/features/runs/composables/useRunDetail'
+import RunLogViewer from '@/features/runs/RunLogViewer.vue'
+import type { RunStep } from '@/features/runs/composables/useRunDetail'
+
+const route = useRoute()
+const runId = computed(() => route.params.id as string)
+
+const { run, isLoading, error, retry } = useRunDetail(runId.value)
+
+const runStatusSeverity: Record<string, 'info' | 'success' | 'warn' | 'danger' | 'secondary'> = {
+  pending: 'secondary',
+  running: 'info',
+  completed: 'success',
+  failed: 'danger',
+  cancelled: 'warn',
+}
+
+const stepSeverity: Record<string, string> = {
+  completed: 'success',
+  running: 'info',
+  failed: 'danger',
+  pending: 'secondary',
+  cancelled: 'warn',
+}
+
+/** Compute progress from completed steps ratio (0-100). */
+const progress = computed(() => {
+  if (!run.value || run.value.steps.length === 0) return 0
+  if (run.value.progress !== undefined) return run.value.progress
+  const completed = run.value.steps.filter(
+    (s) => s.status === 'completed' || s.status === 'failed' || s.status === 'cancelled',
+  ).length
+  return Math.round((completed / run.value.steps.length) * 100)
+})
+
+/** Format step duration from started_at to completed_at. */
+function formatDuration(step: RunStep): string | null {
+  if (!step.started_at) return null
+  const end = step.completed_at ? new Date(step.completed_at) : new Date()
+  const seconds = differenceInSeconds(end, new Date(step.started_at))
+  if (seconds < 60) return `${seconds}s`
+  const mins = Math.floor(seconds / 60)
+  const secs = seconds % 60
+  return `${mins}m ${secs}s`
+}
+</script>
+
 <template>
-  <div class="p-6">
-    <h1 class="text-2xl font-bold">Run Detail</h1>
+  <div class="flex flex-col h-full p-6 gap-6">
+    <!-- Loading state -->
+    <div v-if="isLoading" class="flex flex-col gap-4">
+      <Skeleton width="20rem" height="2rem" />
+      <Skeleton width="100%" height="1rem" />
+      <Skeleton width="100%" height="12rem" />
+    </div>
+
+    <!-- Error state -->
+    <Message v-else-if="error" severity="error" :closable="false">
+      {{ error.message }}
+      <Button label="Retry" icon="pi pi-refresh" text size="small" class="ml-2" @click="retry" />
+    </Message>
+
+    <!-- Run data -->
+    <template v-else-if="run">
+      <!-- Header: Run ID + Status -->
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <h1 class="text-xl font-bold">Run</h1>
+          <code class="text-sm bg-surface-100 dark:bg-surface-800 px-2 py-1 rounded font-mono">
+            {{ run.id }}
+          </code>
+        </div>
+        <Tag :value="run.status" :severity="runStatusSeverity[run.status]" />
+      </div>
+
+      <!-- Progress Bar -->
+      <ProgressBar :value="progress" :show-value="true" />
+
+      <!-- Step Timeline -->
+      <div v-if="run.steps.length > 0">
+        <h2 class="text-lg font-semibold mb-3">Steps</h2>
+        <Timeline :value="run.steps" align="left" class="w-full">
+          <template #marker="{ item }">
+            <Tag
+              :severity="stepSeverity[(item as RunStep).status] ?? 'secondary'"
+              class="w-8 h-8 flex items-center justify-center rounded-full"
+            >
+              <i
+                :class="{
+                  'pi pi-check': (item as RunStep).status === 'completed',
+                  'pi pi-spin pi-spinner': (item as RunStep).status === 'running',
+                  'pi pi-times': (item as RunStep).status === 'failed',
+                  'pi pi-clock': (item as RunStep).status === 'pending',
+                  'pi pi-ban': (item as RunStep).status === 'cancelled',
+                }"
+                class="text-xs"
+              />
+            </Tag>
+          </template>
+          <template #content="{ item }">
+            <div class="flex flex-col gap-1 mb-4">
+              <div class="flex items-center gap-2">
+                <span class="font-medium">{{ (item as RunStep).step_name }}</span>
+                <Tag
+                  :value="(item as RunStep).status"
+                  :severity="stepSeverity[(item as RunStep).status] ?? 'secondary'"
+                  class="text-xs"
+                />
+              </div>
+              <div class="text-sm text-surface-500 flex items-center gap-3">
+                <span>{{ (item as RunStep).action }}</span>
+                <span v-if="formatDuration(item as RunStep)" class="text-surface-400">
+                  {{ formatDuration(item as RunStep) }}
+                </span>
+              </div>
+              <div
+                v-if="(item as RunStep).error_message"
+                class="text-sm text-red-500 mt-1"
+              >
+                {{ (item as RunStep).error_message }}
+              </div>
+            </div>
+          </template>
+        </Timeline>
+      </div>
+
+      <!-- Live Log Viewer -->
+      <div>
+        <h2 class="text-lg font-semibold mb-3">Live Logs</h2>
+        <RunLogViewer :project-id="run.project_id" :run-id="run.id" />
+      </div>
+    </template>
   </div>
 </template>

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -76,7 +76,7 @@ function formatDuration(step: RunStep): string | null {
       <!-- Header: Run ID + Status -->
       <div class="flex items-center justify-between">
         <div class="flex items-center gap-3">
-          <h1 class="text-xl font-bold">Run</h1>
+          <h1 class="text-xl font-bold">Run Detail</h1>
           <code class="text-sm bg-surface-100 dark:bg-surface-800 px-2 py-1 rounded font-mono">
             {{ run.id }}
           </code>

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -58,6 +58,20 @@ function formatDuration(step: RunStep): string | null {
 
 <template>
   <div class="flex flex-col h-full p-6 gap-6">
+    <!-- Page Header — always visible -->
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <h1 class="text-xl font-bold">Run Detail</h1>
+        <code
+          v-if="run"
+          class="text-sm bg-surface-100 dark:bg-surface-800 px-2 py-1 rounded font-mono"
+        >
+          {{ run.id }}
+        </code>
+      </div>
+      <Tag v-if="run" :value="run.status" :severity="runStatusSeverity[run.status]" />
+    </div>
+
     <!-- Loading state -->
     <div v-if="isLoading" class="flex flex-col gap-4">
       <Skeleton width="20rem" height="2rem" />
@@ -73,16 +87,6 @@ function formatDuration(step: RunStep): string | null {
 
     <!-- Run data -->
     <template v-else-if="run">
-      <!-- Header: Run ID + Status -->
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <h1 class="text-xl font-bold">Run Detail</h1>
-          <code class="text-sm bg-surface-100 dark:bg-surface-800 px-2 py-1 rounded font-mono">
-            {{ run.id }}
-          </code>
-        </div>
-        <Tag :value="run.status" :severity="runStatusSeverity[run.status]" />
-      </div>
 
       <!-- Progress Bar -->
       <ProgressBar :value="progress" :show-value="true" />


### PR DESCRIPTION
## Story: 4-3 — [FRONT] LogViewer Component + Live Log Page

### Changes
- Install `ansi-to-html` for ANSI escape code rendering in log output
- Create `formatLogLine` utility converting raw log lines to timestamped HTML
- Create `useSSE` composable managing EventSource connections with named event listeners
- Build `LogViewer.vue` shared component with auto-scroll, connection status badge, and clear functionality
- Create `useRunLogs` composable filtering SSE `log.emitted` events by `run_id`
- Create `useRunDetail` composable for fetching run data with steps via `GET /runs/{runId}`
- Implement `RunDetailView.vue` with PrimeVue Timeline (severity-mapped step markers + duration), ProgressBar, and live log viewer
- Add `RunLogViewer.vue` wrapper for deferred SSE connection (waits for run data to know projectId)

### Acceptance Criteria
- [x] AC1: LogViewer renders ANSI-colored log lines with HH:MM:SS timestamps
- [x] AC2: Auto-scroll follows new lines, pauses on scroll-up (>50px), resumes near bottom
- [x] AC3: Connection state indicator shows Connecting/Live/Disconnected/Error with correct severity
- [x] AC4: useSSE composable manages EventSource lifecycle with named event support
- [x] AC5: RunDetailView shows run info, step timeline, progress bar, and live LogViewer

### Files Changed
| File | Action |
|------|--------|
| `frontend/package.json` | modified (added ansi-to-html) |
| `frontend/src/utils/formatLogLine.ts` | new |
| `frontend/src/utils/__tests__/formatLogLine.spec.ts` | new |
| `frontend/src/composables/useSSE.ts` | new |
| `frontend/src/composables/__tests__/useSSE.spec.ts` | new |
| `frontend/src/ui/composed/LogViewer.vue` | new |
| `frontend/src/ui/composed/__tests__/LogViewer.spec.ts` | new |
| `frontend/src/features/runs/composables/useRunLogs.ts` | new |
| `frontend/src/features/runs/composables/useRunDetail.ts` | new |
| `frontend/src/features/runs/RunLogViewer.vue` | new |
| `frontend/src/features/runs/__tests__/useRunLogs.spec.ts` | new |
| `frontend/src/features/runs/__tests__/useRunDetail.spec.ts` | new |
| `frontend/src/views/RunDetailView.vue` | modified (replaced placeholder) |

### Testing
- All tests passing locally: Yes
- Coverage: 31 new unit tests (4 formatLogLine, 10 useSSE, 8 LogViewer, 5 useRunLogs, 4 useRunDetail)
- Full regression: 342 tests passing across 40 test files

---
*Generated by BMAD Dev Agent*