### PR TITLE
feat(dag): add DAG builder with topological sort

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -425,6 +425,52 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /projects/{projectId}/epics/{epicId}/dag:
+    get:
+      operationId: getEpicDAG
+      summary: Get the DAG visualization for an epic's stories
+      tags: [epics]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/EpicIdPath"
+      responses:
+        "200":
+          description: DAG nodes and edges
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpicDAGResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          description: Cycle detected in story dependencies
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /projects/{projectId}/epics/{epicId}/runs:
+    post:
+      operationId: launchEpicRun
+      summary: Launch a batch run for all stories in an epic (async)
+      tags: [epics]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/EpicIdPath"
+      responses:
+        "202":
+          description: Epic run scheduling accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpicRunAccepted"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   # ── Stories ──────────────────────────────────────────────────────────
   /projects/{projectId}/stories:
     get:
@@ -1240,6 +1286,60 @@ components:
             $ref: "#/components/schemas/Epic"
         pagination:
           $ref: "#/components/schemas/Pagination"
+
+    EpicDAGNode:
+      type: object
+      required: [id, key, title, status, layer]
+      properties:
+        id:
+          type: string
+          format: uuid
+        key:
+          type: string
+        title:
+          type: string
+        status:
+          type: string
+        layer:
+          type: integer
+          description: Zero-based execution layer index
+
+    EpicDAGEdge:
+      type: object
+      required: [source, target]
+      properties:
+        source:
+          type: string
+          description: Source story key (dependency)
+        target:
+          type: string
+          description: Target story key (dependent)
+
+    EpicDAGResponse:
+      type: object
+      required: [nodes, edges]
+      properties:
+        nodes:
+          type: array
+          items:
+            $ref: "#/components/schemas/EpicDAGNode"
+        edges:
+          type: array
+          items:
+            $ref: "#/components/schemas/EpicDAGEdge"
+
+    EpicRunAccepted:
+      type: object
+      required: [epic_run_id, status, stories_count]
+      properties:
+        epic_run_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [scheduling]
+        stories_count:
+          type: integer
 
     # ── Story ───────────────────────────────────────────────────────────
     Story:

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -94,12 +94,15 @@ func run() error {
 	// Epic service
 	epicRepo := pgadapter.NewEpicRepo(queries)
 	epicService := service.NewEpicService(epicRepo)
-	epicHandler := handler.NewEpicHandler(epicService)
 
 	// Story service
 	storyRepo := pgadapter.NewStoryRepo(queries)
 	storyService := service.NewStoryService(storyRepo)
 	storyHandler := handler.NewStoryHandler(storyService)
+
+	// Scheduler service (DAG computation, pure domain service)
+	schedulerService := service.NewSchedulerService()
+	epicHandler := handler.NewEpicHandler(epicService, schedulerService, storyRepo)
 
 	// Prompt template service
 	promptTemplateRepo := pgadapter.NewPromptTemplateRepo(queries)

--- a/backend/internal/api/handler/epic_handler.go
+++ b/backend/internal/api/handler/epic_handler.go
@@ -6,18 +6,21 @@ import (
 
 	"github.com/zakari/hopeitworks/backend/internal/api/middleware"
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
 	"github.com/zakari/hopeitworks/backend/internal/domain/service"
 	"github.com/zakari/hopeitworks/backend/pkg/errors"
 )
 
 // EpicHandler implements epic-related HTTP handlers.
 type EpicHandler struct {
-	service *service.EpicService
+	service   *service.EpicService
+	scheduler *service.SchedulerService
+	storyRepo port.StoryRepository
 }
 
 // NewEpicHandler creates a new EpicHandler.
-func NewEpicHandler(svc *service.EpicService) *EpicHandler {
-	return &EpicHandler{service: svc}
+func NewEpicHandler(svc *service.EpicService, scheduler *service.SchedulerService, storyRepo port.StoryRepository) *EpicHandler {
+	return &EpicHandler{service: svc, scheduler: scheduler, storyRepo: storyRepo}
 }
 
 // ListEpics handles GET /projects/{projectId}/epics.
@@ -142,6 +145,51 @@ func (h *EpicHandler) DeleteEpic(w http.ResponseWriter, r *http.Request, _ Proje
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetEpicDAG handles GET /projects/{projectId}/epics/{epicId}/dag.
+func (h *EpicHandler) GetEpicDAG(w http.ResponseWriter, r *http.Request, _ ProjectIdPath, epicID EpicIdPath) {
+	stories, err := h.storyRepo.ListByEpic(r.Context(), epicID, 500, 0)
+	if err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+
+	storyValues := make([]model.Story, len(stories))
+	for i, s := range stories {
+		storyValues[i] = *s
+	}
+
+	dag, err := h.scheduler.BuildDAG(storyValues)
+	if err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toEpicDAGResponse(dag))
+}
+
+// toEpicDAGResponse converts a DAGResult to the API EpicDAGResponse type.
+func toEpicDAGResponse(dag model.DAGResult) EpicDAGResponse {
+	nodes := make([]EpicDAGNode, 0)
+	edges := make([]EpicDAGEdge, 0)
+
+	for layer, group := range dag.Groups {
+		for _, s := range group {
+			nodes = append(nodes, EpicDAGNode{
+				Id:     s.ID,
+				Key:    s.Key,
+				Title:  s.Title,
+				Status: s.Status,
+				Layer:  layer,
+			})
+			for _, dep := range s.DependsOn {
+				edges = append(edges, EpicDAGEdge{Source: dep, Target: s.Key})
+			}
+		}
+	}
+
+	return EpicDAGResponse{Nodes: nodes, Edges: edges}
 }
 
 // toAPIEpic converts a domain Epic to the API Epic type.

--- a/backend/internal/api/handler/epic_handler_test.go
+++ b/backend/internal/api/handler/epic_handler_test.go
@@ -82,11 +82,31 @@ func (m *mockEpicRepo) Delete(_ context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// errorStoryRepo is a mock that always returns an error on ListByEpic.
+type errorStoryRepo struct {
+	mockStoryRepo
+	listByEpicErr error
+}
+
+func (m *errorStoryRepo) ListByEpic(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Story, error) {
+	return nil, m.listByEpicErr
+}
+
 func setupEpicHandler() (*EpicHandler, *mockEpicRepo) {
 	repo := newMockEpicRepo()
+	storyRepo := newMockStoryRepo()
 	svc := service.NewEpicService(repo)
-	handler := NewEpicHandler(svc)
-	return handler, repo
+	scheduler := service.NewSchedulerService()
+	h := NewEpicHandler(svc, scheduler, storyRepo)
+	return h, repo
+}
+
+func setupEpicHandlerWithStoryRepo(storyRepo port.StoryRepository) (*EpicHandler, *mockEpicRepo) {
+	epicRepo := newMockEpicRepo()
+	svc := service.NewEpicService(epicRepo)
+	scheduler := service.NewSchedulerService()
+	h := NewEpicHandler(svc, scheduler, storyRepo)
+	return h, epicRepo
 }
 
 func TestCreateEpic_AdminOnly(t *testing.T) {
@@ -449,5 +469,149 @@ func TestDeleteEpic_NotFound(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestGetEpicDAG_NoDeps(t *testing.T) {
+	projectID := uuid.New()
+	epicID := uuid.New()
+
+	storyRepo := newMockStoryRepo()
+	storyRepo.stories[uuid.New()] = &model.Story{ID: uuid.New(), ProjectID: projectID, EpicID: &epicID, Key: "S-01", Title: "Story 1", Status: "backlog"}
+	storyRepo.stories[uuid.New()] = &model.Story{ID: uuid.New(), ProjectID: projectID, EpicID: &epicID, Key: "S-02", Title: "Story 2", Status: "backlog"}
+	storyRepo.stories[uuid.New()] = &model.Story{ID: uuid.New(), ProjectID: projectID, EpicID: &epicID, Key: "S-03", Title: "Story 3", Status: "backlog"}
+
+	h, _ := setupEpicHandlerWithStoryRepo(storyRepo)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+projectID.String()+"/epics/"+epicID.String()+"/dag", nil)
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleUser)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.GetEpicDAG(rec, req, projectID, epicID)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp EpicDAGResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp.Nodes) != 3 {
+		t.Errorf("expected 3 nodes, got %d", len(resp.Nodes))
+	}
+	for _, node := range resp.Nodes {
+		if node.Layer != 0 {
+			t.Errorf("expected all nodes in layer 0, got node %s in layer %d", node.Key, node.Layer)
+		}
+	}
+	if len(resp.Edges) != 0 {
+		t.Errorf("expected 0 edges, got %d", len(resp.Edges))
+	}
+}
+
+func TestGetEpicDAG_WithDeps(t *testing.T) {
+	projectID := uuid.New()
+	epicID := uuid.New()
+
+	storyRepo := newMockStoryRepo()
+	storyRepo.stories[uuid.New()] = &model.Story{ID: uuid.New(), ProjectID: projectID, EpicID: &epicID, Key: "S-01", Title: "Story 1", Status: "backlog"}
+	storyRepo.stories[uuid.New()] = &model.Story{ID: uuid.New(), ProjectID: projectID, EpicID: &epicID, Key: "S-02", Title: "Story 2", Status: "backlog", DependsOn: []string{"S-01"}}
+	storyRepo.stories[uuid.New()] = &model.Story{ID: uuid.New(), ProjectID: projectID, EpicID: &epicID, Key: "S-03", Title: "Story 3", Status: "backlog", DependsOn: []string{"S-01"}}
+
+	h, _ := setupEpicHandlerWithStoryRepo(storyRepo)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+projectID.String()+"/epics/"+epicID.String()+"/dag", nil)
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleUser)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.GetEpicDAG(rec, req, projectID, epicID)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp EpicDAGResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp.Nodes) != 3 {
+		t.Errorf("expected 3 nodes, got %d", len(resp.Nodes))
+	}
+
+	// S-01 should be layer 0, S-02 and S-03 should be layer 1
+	layerMap := make(map[string]int)
+	for _, node := range resp.Nodes {
+		layerMap[node.Key] = node.Layer
+	}
+	if layerMap["S-01"] != 0 {
+		t.Errorf("expected S-01 in layer 0, got %d", layerMap["S-01"])
+	}
+	if layerMap["S-02"] != 1 {
+		t.Errorf("expected S-02 in layer 1, got %d", layerMap["S-02"])
+	}
+	if layerMap["S-03"] != 1 {
+		t.Errorf("expected S-03 in layer 1, got %d", layerMap["S-03"])
+	}
+
+	if len(resp.Edges) != 2 {
+		t.Errorf("expected 2 edges, got %d", len(resp.Edges))
+	}
+}
+
+func TestGetEpicDAG_CycleReturns422(t *testing.T) {
+	projectID := uuid.New()
+	epicID := uuid.New()
+
+	storyRepo := newMockStoryRepo()
+	storyRepo.stories[uuid.New()] = &model.Story{ID: uuid.New(), ProjectID: projectID, EpicID: &epicID, Key: "S-01", Title: "Story 1", Status: "backlog", DependsOn: []string{"S-02"}}
+	storyRepo.stories[uuid.New()] = &model.Story{ID: uuid.New(), ProjectID: projectID, EpicID: &epicID, Key: "S-02", Title: "Story 2", Status: "backlog", DependsOn: []string{"S-01"}}
+
+	h, _ := setupEpicHandlerWithStoryRepo(storyRepo)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+projectID.String()+"/epics/"+epicID.String()+"/dag", nil)
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleUser)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.GetEpicDAG(rec, req, projectID, epicID)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp Error
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+
+	if resp.Error.Code != "DAG_CYCLE_DETECTED" {
+		t.Errorf("expected error code DAG_CYCLE_DETECTED, got %s", resp.Error.Code)
+	}
+}
+
+func TestGetEpicDAG_StoryRepoError(t *testing.T) {
+	projectID := uuid.New()
+	epicID := uuid.New()
+
+	errRepo := &errorStoryRepo{
+		mockStoryRepo: *newMockStoryRepo(),
+		listByEpicErr: errors.NewNotFound("epic", epicID),
+	}
+	h, _ := setupEpicHandlerWithStoryRepo(errRepo)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+projectID.String()+"/epics/"+epicID.String()+"/dag", nil)
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleUser)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.GetEpicDAG(rec, req, projectID, epicID)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d. Body: %s", rec.Code, rec.Body.String())
 	}
 }

--- a/backend/internal/api/handler/gen_server.go
+++ b/backend/internal/api/handler/gen_server.go
@@ -56,6 +56,11 @@ const (
 	EpicStatusInProgress EpicStatus = "in_progress"
 )
 
+// Defines values for EpicRunAcceptedStatus.
+const (
+	Scheduling EpicRunAcceptedStatus = "scheduling"
+)
+
 // Defines values for PipelineStepActionType.
 const (
 	PipelineStepActionTypeCustom    PipelineStepActionType = "custom"
@@ -233,11 +238,47 @@ type Epic struct {
 // EpicStatus defines model for Epic.Status.
 type EpicStatus string
 
+// EpicDAGEdge defines model for EpicDAGEdge.
+type EpicDAGEdge struct {
+	// Source Source story key (dependency)
+	Source string `json:"source"`
+
+	// Target Target story key (dependent)
+	Target string `json:"target"`
+}
+
+// EpicDAGNode defines model for EpicDAGNode.
+type EpicDAGNode struct {
+	Id  openapi_types.UUID `json:"id"`
+	Key string             `json:"key"`
+
+	// Layer Zero-based execution layer index
+	Layer  int    `json:"layer"`
+	Status string `json:"status"`
+	Title  string `json:"title"`
+}
+
+// EpicDAGResponse defines model for EpicDAGResponse.
+type EpicDAGResponse struct {
+	Edges []EpicDAGEdge `json:"edges"`
+	Nodes []EpicDAGNode `json:"nodes"`
+}
+
 // EpicList defines model for EpicList.
 type EpicList struct {
 	Data       []Epic     `json:"data"`
 	Pagination Pagination `json:"pagination"`
 }
+
+// EpicRunAccepted defines model for EpicRunAccepted.
+type EpicRunAccepted struct {
+	EpicRunId    openapi_types.UUID    `json:"epic_run_id"`
+	Status       EpicRunAcceptedStatus `json:"status"`
+	StoriesCount int                   `json:"stories_count"`
+}
+
+// EpicRunAcceptedStatus defines model for EpicRunAccepted.Status.
+type EpicRunAcceptedStatus string
 
 // Error defines model for Error.
 type Error struct {
@@ -821,6 +862,12 @@ type ServerInterface interface {
 	// Update an epic
 	// (PUT /projects/{projectId}/epics/{epicId})
 	UpdateEpic(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, epicId EpicIdPath)
+	// Get the DAG visualization for an epic's stories
+	// (GET /projects/{projectId}/epics/{epicId}/dag)
+	GetEpicDAG(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, epicId EpicIdPath)
+	// Launch a batch run for all stories in an epic (async)
+	// (POST /projects/{projectId}/epics/{epicId}/runs)
+	LaunchEpicRun(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, epicId EpicIdPath)
 	// Get the pipeline configuration for a project
 	// (GET /projects/{projectId}/pipeline)
 	GetPipelineConfig(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath)
@@ -974,6 +1021,18 @@ func (_ Unimplemented) GetEpic(w http.ResponseWriter, r *http.Request, projectId
 // Update an epic
 // (PUT /projects/{projectId}/epics/{epicId})
 func (_ Unimplemented) UpdateEpic(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, epicId EpicIdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get the DAG visualization for an epic's stories
+// (GET /projects/{projectId}/epics/{epicId}/dag)
+func (_ Unimplemented) GetEpicDAG(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, epicId EpicIdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Launch a batch run for all stories in an epic (async)
+// (POST /projects/{projectId}/epics/{epicId}/runs)
+func (_ Unimplemented) LaunchEpicRun(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, epicId EpicIdPath) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1548,6 +1607,86 @@ func (siw *ServerInterfaceWrapper) UpdateEpic(w http.ResponseWriter, r *http.Req
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.UpdateEpic(w, r, projectId, epicId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetEpicDAG operation middleware
+func (siw *ServerInterfaceWrapper) GetEpicDAG(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "epicId" -------------
+	var epicId EpicIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "epicId", chi.URLParam(r, "epicId"), &epicId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "epicId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetEpicDAG(w, r, projectId, epicId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// LaunchEpicRun operation middleware
+func (siw *ServerInterfaceWrapper) LaunchEpicRun(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "epicId" -------------
+	var epicId EpicIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "epicId", chi.URLParam(r, "epicId"), &epicId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "epicId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.LaunchEpicRun(w, r, projectId, epicId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2568,6 +2707,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Put(options.BaseURL+"/projects/{projectId}/epics/{epicId}", wrapper.UpdateEpic)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/projects/{projectId}/epics/{epicId}/dag", wrapper.GetEpicDAG)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/projects/{projectId}/epics/{epicId}/runs", wrapper.LaunchEpicRun)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/projects/{projectId}/pipeline", wrapper.GetPipelineConfig)
 	})
 	r.Group(func(r chi.Router) {
@@ -2640,83 +2785,89 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+w9aW8buZJ/hehdYGcAyWo5dmbGn16Omff8NpMYdozB2zxDoLtLEp+7yQ7JjqM1DOx/",
-	"2H+4v2TBo2/2IVmHZzKfEks8inWxqlhVevACFieMApXCO3vwEsxxDBK4/uvnhATn4QWWS/VXCCLgJJGE",
-	"Ue9Mf4eur8/feiOPqA8SNWzkURyDd+aBnuqNPA6fU8Ih9M4kT2HkiWAJMVbrzRmPsfTOvDQlaqRcJWqm",
-	"kJzQhff4OPLa9r4EwVIeQMf+5Kl7X+AFXChsNLdXXyGaxrfAs80/p8BXxe4JXoBX3i+EOU4j6Z1NR15M",
-	"KInTWP/f7kuohAVwszHwjr3PJcQCJcCR3cO5PfBZOwjH/siL8VcLg+/3Q8TZvyCQbdSwX3cQI8kWeCJN",
-	"LlPayhIp7QCAq4lP3PyKcfl61UKWXwhEIZIMCcYlul21EEZ9O9PfOujiBRywhHCGpRsAyfiq7fz6yw4M",
-	"CDP5iTj4CHESYQkdrBAnEkk7rAMema/0JJAe1WSRMCpAa6zXOLyEzykIqf4KGJVA9X9xkkQkwArOyb+E",
-	"AvahtM2/c5h7Z96/TQptODHfisnPnDNutqoe9jUOEbebPY68N4zOIxLsYeNc/QV2S/QdHC2OUJiarQBB",
-	"jEn0vYLqF8ZvSRgC3T1Y+VZojHAYE4pwEIAQKCfv48h7z+QvLKXhHrFEmURzvefjyLumOJVLxsl/wx5g",
-	"qOymvrYz1IJvtLSra7TEsQlnCXBJDDdXFnvw4CuOkwiyy3fOOFLLA5UWbDQHLFMOwtMa/h3QhZLSY18p",
-	"+ZroZJJYXvZaAEevKkvWVjo91bdF9vfUsayQWKaiqtlucXAXsYU38oCqe+ZT6RNCZwlnCw5CgR0yCt6N",
-	"S/cUSuKTAb0YxW7V9aKFUCPV3kjr4/UVEvq/yN5Y1dNPh+Lx1xW6cC3Qj761zxknMlPKrcdtAvjWUAad",
-	"q79joBKZpdandqbHZyVBKvb5B0sR5oBItg+hC6SvIvTwoP+d3cHq8fHo6Mjr30p/8JCzUL6ovkGkvmc5",
-	"fCFwr9YCru2fIBWSxQqHBVTliQPw7ziknddOmcuUtpIjIQlEhOrV5mTRHCAkJPo/RBl7ze9xkHFuKy8O",
-	"OpZdx3UK+wHmHK8a0w18rmmGpCQcZk1U17QzRw38tGNZGz2teFa3TyIxDWAWcCKBE+zEWQgJ0FDMDEpz",
-	"nLfwX4aTkXZxhp115N3BqioZV2N/WpW2U5duMScmX8AJkQhYVSSUVgWqIJhzzarqv2KJFZJvOnV11/Wm",
-	"0Xxlhio8YL4AOZuTCMR6GJNERjVNVGigiC0IzbyauhbqZh6F3Wx1F7eo67LJHyVzuwLSsX/8cuxPx9PT",
-	"j1P/7IV/5vv/pTCa0TjEEsaSGM3QZKbNr+zGYoa5ijV++MGHH098fwzHP92OT6bhyRj/MH05Pjl5+fL0",
-	"9OTE932/DGkbNw69+RsT7bU4qwP28uV2ACv4caidUMBQjHQsq5RLwFIb5ehl9jdm6OPIS5Nw20xSY16j",
-	"8wrEjjL1bJFRA39UdRNL8LVx/jvitIGwxBXp7TRwlQA5BDrBC0JxxuxdK1wUI+sI0JBU1nKeRNvYjWOA",
-	"++OAhXUOv/r5cvb+w8fZLx+u3791i67EJDJXRxgSBQmOLkrLGue0AVkMQiit1RSoeyKX6PwtwrfB9PhF",
-	"yRHp4wkNfrFyEx+18QYLLrSdxwnjUjE1AdF6VZaMt5oThe9RjPldyO4psqPMsf7x6td3SN8yMZYSuDXr",
-	"biMW3IkBBzQbDgBZaBfCSXcxmIGLNVfWWWsy8xyTyDiFVRy815E+xOb6iAQEkksskRmOJFPWLeMlYzKP",
-	"nY0881X3qhTuoxWyUp3t4VzNCnvXYnZIDup3d7BCOOKAwxWCr0RICL/3nGG+ilLK4C42zRE0ypDfTbzV",
-	"z92iWT3BrzhYEgpjBSi+jQDpPZAVhDZ7yhUDUwf+LsYrdAsI4kSuEJnrDwOWRqEWQvXNV8lxUEVGsXxJ",
-	"pKtb/C2NMa0DWR4yzFTJ1h8ZbLgQ+U6ZQ60CqwM8VY2TCuB/sX8eBSwu30ZmuOtCx0LcM167zgUEKYeL",
-	"vwgxLa+SD+47ZLZdPsF1wIvK3VFzker6dOoShzzMXR557LuGSiZxFV8nx71CYCaNsmh+vp3zNNZpedPi",
-	"0+3ecqr7jJ23sYX2SkLiUoXdVs/xFqyeisFjgO81ZipQt3jFs+4oQS06IJVwrR0kGHk4lWyGk4SzL1Xu",
-	"m+NIFDbCLWMRYOoy5X/8cTt0j1kIUfm8QYTTEMYsScX4ZPxSnc58IhilIMcn49PisyUmd+n4ZPyievbm",
-	"GgNciE6E6fjMLGERCVZ9zHmpxl6YoU5juRK+MATPEFEjTW1jJ1PZQN2B3UNH5LHXHdyW7ugJYDaDEvcU",
-	"eEOTnZ5uB5o9eVyWifKzrOdXWexswbXK8HxY76oaSd6TMOxKJ64V7957jGObEfODxMgPGhRpC8WvLb4l",
-	"dt+OFJfl57DCfAkL5efxnXsPTUH7O6aA3jJY/yFpU0+ktOyPa/slo/YXtrIV0kBgjL/OlDhl+Mydj0pm",
-	"TSmxxumUGNukLrKUUX0x0bHyt1OuTZ3oHq9EVUIrA7rPXQa3sq3z4Cl1Oe1q10Lmhyn46q0xbI52qWcl",
-	"B7zl2ujVs7VnpJmgOBFLJteO7+VR52a6C/AAqMQLQGyOchwh7c+g7/z/+5//nfr+9yP9Vaq+wRLplCCk",
-	"jn/ktSZiOfmlejMNCabzdbHfDMAnQEP15cjjKaXmf/lJy0GhANMAosi8NBVsWsxvCcsPPE31ztnKlVJ6",
-	"c8xj7aUnhnUulMuUbuEWUaJ34KsjpV3etVMeN9QNjEpMCkfieSmPiC1m0l6STWc2pX8gGYRk1pI1YL9l",
-	"PARe+ro1Zhx6OW7KC1eWybMOSjJXonQLT/5G5PIqi3DhKPow984+DZGl/tSKnjXcEbKBCRE3Wdbm5skJ",
-	"m0jBPhIa1st7qGfFkc8pWK+GhMrJmRP7XEZoFgExSY0jdDX2p997o2buxJrJEuvent9qbsVOrtpyhoZb",
-	"8nuv2PLDfEOcssf/8vlfuGwonTdQHnXqGlU8Bebj3Ba8Vcc9TxU19BSZCoU6D43VbzduPf8WjAyjkA5r",
-	"ZuRn+cCvCF1E4KrxkCmnAuVDdfJMpP6jLGgCYoQYR0JPN6P0iDtYoYixuzTRThQMuCoKzKoLYwDucr1+",
-	"tWauaz+9Cym81uKwWX7wtX0Frr5MbpQSbFfS6UvvzXW+cULw5sm/DQ4ycFVf3VrxtM3HscG5kBbCTVOR",
-	"e0k4XZeEWZ3OJlR87DrgZjnIJbDiRG7IW93B1GyLvB7FjtpHuvFgBP5+klj/oMmo/bmmLZS7FuvFWCnc",
-	"j/XH2wq0XsVE11StKTScRRVC6WIdZYAJ4ENZVwDf0yvRtoLVu3qv7AyCr4376iEP+PiS4dG68Bru9Qx2",
-	"xSNbsFc1qx3SXFWqCYKUE7m6UitmEXF2R+BV6iqD/PtvH5Fkd0CRUN4XFghTtJQy+UCjFTJvGsgskFVH",
-	"5n9l9ZFqekEpnJD/hJUpMSN0zrKkTWwyF+ykv7EEzuVvjN8J9BFw7DlqFrVORq8uzrW1LJeAyrMy3zvG",
-	"FC+M76huTsVER/+kH5dEICL0LGt42xo7NkeSp3KZL6o2UAByHMijf6qTRCQAKqAE7q/nHxUX8cg78xR2",
-	"xNlkwhKgZs0jxhcTO0lM1NhCaVdO+uri3Bt5X4ALc0b/aHrk6/sqAYoT4p15L478oxeaznKpqTfBqVxO",
-	"tFus2ZMZNlVMqtngPPTOTAretRFDW+j5moWrrZUNVlL8HqusKXkK9eLWY9/f2t5GqpoVixomJFJduTlP",
-	"lQZYAg5tQ4ArkOM3hlMbTJ/zt+L+nJ0LaBqlu48j78SftgGan3zSLKK00uidfboZeSKNY8xXBnZEqJI1",
-	"nehK6AJlShQvhNa2Slxv1Bo5A7BUdnIAS2XOAhVanDRR8I4tFhAilsoSBiOtrTY8aeVsal0lW0HKuZLM",
-	"nsOZa2kBjnP9FeQbs4j7bLvnszelM6As834LePorVHAUrcr1NhD24Yzbp/N2lsge13eoF+rv94NUw3Tn",
-	"JNMlDRmCIKyy+I7VhN/PFKXSfz3lp/4pecl+l1bJqIEwonDfwUD27hStUqeMoYts0KjSa6UlQlUMmRQ9",
-	"QdqCVOXB5R4iA8aXe1s83uxQHZTz5hwsZi01CE2gj81RjtRt6FC1Jo6iYtGCjvlHN8q0dEp+pbZ8R6Lv",
-	"rF/fs/znGYkO+ljz0LoB3qay+TQ6GiRZeSzlyzZJWRbLyQMJH40+isDkOFbp+1Z/XtB3Pfm0LVEc0nPS",
-	"3jLHgBJuiBQ16aR/Ut5yo4pFc1yEuzE4ajUgto8of58s/DSb42moV0ZKjnd0u0K6S45bFaUO7FdCy08j",
-	"wPZVmDPuvWfvZgD9s7K2vamwp7GMwWqftFb1Xd5263ECCQm6DZOf9Yi1rZJKa7AhlskfwozJy6oH2TAa",
-	"+aZq1uQ8BHl5+VZMGrO+7i2QK5XmbgXDGGboM3R0zfcT+eFml1ZS+Wl0zyaSqYdv0l6/ku7dOFKTXvRP",
-	"KlqBbeYfue0vxUw66uLQTBmjdaulyYNpFjnAONsGT/arkVLby2HmnCb702259Wn4dOuPagI6lUOb4fcc",
-	"iODvR5QPbiQa8jRMxJIGb7cPD0SnXVmUa6v7PfHIQQzJHauKp90Pma3aqlta74OsZqMrcF2rtN+GhbIr",
-	"L6QKqctWtCOQqVFJuX2lPJC6kUtAiROkqnVZdj7s8LEZ3u+0bp96O3Nhncll+/ZkN+ShP6RacmmZ7fBs",
-	"q0biKe32my9TKl6vNo3F7NN/3qWqy+qfBvnDGqfbcn7VYq2U1jv1ObqXKX3Wfm6pl+ie3VxdQ+PorJzS",
-	"wzi5myuL6pNBpi54SvtYp1UxZH26unTDVd7L61lH1Wov8yyO8ViAmlGWWpOeCQJJhuYkksCVW2KLdGxG",
-	"98gmuH/f1v8+b2nY+t47au/qJZnO7Edpgr7jtjwgS0NSg9p2NcUn7VvuUjE2Kx0GqcisfVtR4WDb62lM",
-	"HESEtLbN4HIEG1liKqoto1gesWWHVqgyoelTyabO4jkr5UrW9p7Vsq1CafKREZVvK/5oqwjdAciC3/r0",
-	"+MQ2cWzN+6l0pXymrOls9rlnh8XVvdPBqmYY4nqAUSAJ8LGhps0sQpiGeR/I4sXkebJ0hUNfp9GdbQta",
-	"qEzO4qKXqrOH6mac+2B/22VA/HwrenXAO1zpl2qGRdCN5vp9htCNCmq55dqiWM+DEv6+7qTDZ1vk9lMl",
-	"kF4xSNqjVgej1q5iW+ubL3tjlT/j6W3x9A5FM/ySyCNamZlT8/60bSWUNWWahmgn2WYTQCJQCJx8gdBc",
-	"Zzr4Zjb7D1EPw5nrm35OIVULihUNEHyFIFVbHaGswPvE/wmRuakp0QyQdatemroZrEsOFRgjdOL71bFE",
-	"5MNDRkGNOKmOYLwBFxFFK3ZTm1Jz3XFKg+UWwkJP1s9bDeUUTVS6YzqGbhmhMgr+KZAlV1gziJKRZiSp",
-	"7K6vEU7KSpR7s8dLxdbimw03O/o3Ds0mL/8+4fai0PWF298e9MBxAcGAfPNyZ8nnHBNxtwLYf/Z6pROn",
-	"MwO08iOV31a8pMapbZETB5/2667JQ/GznsNS7bfI2v36qfbrpYNT9Sv4+p36qDWy92mkjqT/Z0Yy/4Ca",
-	"41nUEFQgctQSOK6bzpqCw9N3hzUJm95Ph+SyPx1i2VEMMVyrqftLmeGTB/1z4I9dSWabOH/Fr5PvOtWi",
-	"15Oziqnktx9QRynfSOslAw6RAmU/+OLwjtoDFj0pOJvF6CoO+J/pN09Jv+lweVNhK8NbaXitR3ybRdF5",
-	"o5xB5DO4PMizVl5AnVpqZaQ2f5doPbDY1jZR2GGl7bXpL/G7tNlrrQYyJLdb51tGp7+flhJPt6L3SR1z",
-	"p+m2JXVjuyBQh4X9dBrtyjwut7N7Jt2INH98K5nMrQJf605S7T326UZxhQD+JeOlKgpfXZyjL1N0iwWg",
-	"BOt2gabj1gQnZPJlqpnK7tiYW/2paqBhwoipJbWpdbr9STNnT9Ot1EPMMTO7xtpaI3TPLrUFcRbjdc82",
-	"dSiOvcvh/O4lrBHVFy3qPUXVSWnLfuxeJnsG7DhQNTHeBUo9J/7x5vH/AwAA//8gp24xHYwAAA==",
+	"H4sIAAAAAAAC/+x9624bObLwqxD9fcAmgGRJjpyZ8a91LjPrPTMZw44x2M0aAt1dkrjuJjskO47WMHDe",
+	"4bzheZIDXvrOvkjWxTOZX4klXop1Y1WxqvTg+SyKGQUqhXf64MWY4wgkcP3X+5j458EFlkv1VwDC5ySW",
+	"hFHvVH+Hrq/P33kDj6gPYjVs4FEcgXfqgZ7qDTwOnxPCIfBOJU9g4Al/CRFW680Zj7D0Tr0kIWqkXMVq",
+	"ppCc0IX3+Djwmva+BMES7kPL/uSpe1/gBVwobNS3V18hmkS3wNPNPyfAV/nuMV6AV9wvgDlOQumdTgZe",
+	"RCiJkkj/3+5LqIQFcLMx8Ja9zyVEAsXAkd3DuT3wWTMIx+OBF+GvFobxuBsizv4Nvmyihv26hRhxusAT",
+	"aXKZ0EaWSGgLAFxNfOLmV4zLN6sGsvxIIAyQZEgwLtHtqoEw6tuZ/tZBF8/ngCUEMyzdAEjGV03n11+2",
+	"YECYyU/EwUeI4hBLaGGFKJZI2mEt8MhspSeB9Kgmi5hRAVpjvcHBJXxOQEj1l8+oBKr/i+M4JD5WcI7+",
+	"LRSwD4Vt/j+HuXfq/b9Rrg1H5lsxes8542ar8mHf4ABxu9njwHvL6Dwk/h42ztSfb7dEL+BocYSCxGwF",
+	"CCJMwpcKqh8ZvyVBAHT3YGVboSHCQUQowr4PQqCMvI8D7wOTP7KEBnvEEmUSzfWejwPvmuJELhkn/4E9",
+	"wFDaTX1tZ6gF32ppV9dogWNjzmLgkhhuLi324MFXHMUhpJfvnHGklgcqLdhoDlgmHISnNfzPQBdKSo/H",
+	"SslXRCeVxOKy1wI4OistWVnp5ETfFunfE8eyQmKZiLJmu8X+XcgW3sADqu6ZT4VPCJ3FnC04CAV2wCh4",
+	"Ny7dkyuJTwb0fBS7VdeLFkKNVHsjrY/XMyT0f5G9scqnn/TF4y8rdOFaoBt9a58zimWqlBuPWwfwnaEM",
+	"Old/R0AlMkutT+1Uj88KgpTv8w+WIMwBkXQfQhdIX0Xo4UH/O7uD1ePj0dGR172V/uAhY6FsUX2DSH3P",
+	"cvhC4F6tBVzbP34iJIsUDnOoihN74N9xSDuvmTKXCW0kR0xiCAnVq83Joj5ASIj1f4gy9urfYz/l3EZe",
+	"7HUsu47rFPYDzDle1aYb+FzTDElJ0M+aKK9pZw5q+GnGsjZ6GvGsbp9YYurDzOdEAifYibMAYqCBmBmU",
+	"Zjhv4L8UJwPt4vQ768C7g1VZMq6G40lZ2k5cusWcmHwBJ0TCZ2WRUFoVqIJgzjWrqv+KJVZIvmnV1W3X",
+	"m0bzlRmq8ID5AuRsTkIQ62FMEhlWNFGugUK2IDT1aqpaqJ15FHbT1V3coq7LOn8UzO0SSMfj49fD8WQ4",
+	"Ofk4GZ++Gp+Ox/9UGE1pHGAJQ0mMZqgz0+ZXdm0xw1z5Gt99N4bvp+PxEI5/uB1OJ8F0iL+bvB5Op69f",
+	"n5xMp+PxeFyEtIkb+978tYn2WpxVAXv9ejuA5fzY107IYchHOpZVysVniY1ydDL7WzP0ceAlcbBtJqkw",
+	"r9F5OWIHqXq2yKiAPyi7iQX4mjj/3dlP74MFOO4ZbR87fEljN5t7+g5W6IVRkUD91UsXfo1GqC/0UX/u",
+	"Wki+7L4RDHTZ6i3H+8ACx/HWU821z0O8Al4/0z+Bs+EtFhAg+Ap+ooVYj0WEBvDVq4dQinxdx12qE3tw",
+	"SVHPFfjDQNqCn0vrItdxBMGiosRb/ZwCNznUO2XB+otp2nVZHGblgQW36aQ/E6exjyVeCyjX0WK8IBSn",
+	"Wr1thYt8ZPUUGpLSWk0nuUzombZejJNaoZmyO3hC+9oedaWqYA2SUH1/06AuCQijcQqsWYwJFs9VBKii",
+	"tvJlnEfVfnP9gO6PfSvlhVvr6v3l7MOvH2c//nr94Z37OpaYhMYcDAKikI7Di8KyJuBUgywCIfDCdUne",
+	"E7lE5+8QvvUnx68KwYUufabBz1eu46OKVY0FF9rOo5hxeWXQ22j+FhyySmAE36MI87uA3VNkR5lj/ePs",
+	"l5+RthwjLCVwq7lvQ+bfiR4HNBv2AFnosICT7v0VSL7mygZg6nI7xyQ0MlTGwQcdvUdsjiyXIrnEEpnh",
+	"SDLlsTIuncrcfNW+KoX7cIXsTZ3u4VzNXuBti9khGagv1FWKQw44WCH4SoSE4KU36BLTDO580wxBgxT5",
+	"7cRbvW8XzfIJfsH+klAYKkDxbQhI74GsIDRdxK64trYdIrxCt4AgiuUKkbn+0GdJGGghVN98lRz7ZWTk",
+	"yxdEurzF35II0yqQxSH93I90/YHBhguRPysXp1FgddC2rHESAfyv9s8jn0VFC9MMdxnpWIh7xismugA/",
+	"4XDxVyEmxVWywV2HTLfLJrgOeFG6Jithj6o+nbjEIXu6Ko48HruGSiZxGV/T404hMJMG6Qtdtp3zNDYQ",
+	"8bYhTrN7b6gaB2o1PCy0VxJilyps92SOt+DJlJwYA3yng1KCuiHSNWuP/FUiflIJ19qBv4GHE8lmOI45",
+	"+1LmvjkORW4j3DIWAqYu9/z777dD94gFEBbP64c4CWDI4kQMp8PX6nTmE8EoBTmcDk/yz5aY3CXD6fBV",
+	"+ez1NXqEBVoRpmOus5iFxF91MeelGnthhjpdm1JI0hA8RUSFNJWNnUxlg+8HDvk4XhM6Qzzb0h0djxL1",
+	"QOM9BV7TZCcn24FmT1EUy0TZWdaLlVjsbMGLTPF8WEey/Dq0J2HYlU5c6w1r73HLbb6CHeTd66CBzqbn",
+	"tbXFt8Du25HiovwcVpgvYaH8PL5z76EuaH/HFNA7Bus/Dm/qiRSW/X5tv2TQ/GpetEJqCIzw15kSpxSf",
+	"mfNRypYrJMs5nRJjm1RFljKqLyY6VP52wrWpE97jlShLaGlA+7mL4Ja2dR48oS6nXe2ay3w/BV++NfrN",
+	"0S71rOCAN1wbnXq28jQ8ExTHYsnk2vG97CWpnsIG3Acq8QIQm6MMR0j7M+jF+H//+38m4/HLgf4qUd9g",
+	"iXSaH1LHP/Iakyud/FK+mfrEcvm62K/Hf2Oggfpy4PGEUvO/7KTFoJCPqQ9haF6PczbN5zc8tfU8TfnO",
+	"2cqVUsgjyALRhWfDdS6Uy4Ru4RZRonfgqyOhbd61Ux431A2MSkxyR+J5KY+QLWbSXpJ1Z3at95TnLoMQ",
+	"zxoygey3jAfmcbMrZhx4GW6KC5eWyTKJCjJXoHQDT/5G5PIqjXDhMPx17p1+6iNL3elSHWu4I2Q9k5xu",
+	"0kzszROONpGCfSQprfdgXs10JZ+TNGeABMrJmRP7XEZoGgExicoDdDUcT156g3o+1JoJUOvent9qvtRO",
+	"rtqGbIR1rthisk1NnNKEnuL5X7lsKJ0LVBx14hqVPwVm49wWvFXHHU8VFfTk2Ue5Og+M1W83bjz/FowM",
+	"o5AOa2ZkZ/mVXxG6CMFVtyUTTgXKhuqEuFD9R1nQBMQAMY6Enm5G6RF3sEIhY3dJrJ0o6HFV5JhVF0YP",
+	"3GV6/WrN/PVueudSeK3FYbOc/2v7Clx+mdwozd+upFMSP5jrfOMk/80T+mscZOAqv7o14mmbj2O985st",
+	"hJuWF3SScLIuCdPau02o+Nh2wM3qCgpgRbHckLfag6npFlmNmR21jxKC3gj8/SSm/0ETzLvzxxsody3W",
+	"i7FSuB/qj7cVaL2KiK6TXFNoOAtLhNIFeMoAE6XU0FYECOB7eiXaVrB6V++VrUHwtXFfPuQBH19SPFoX",
+	"XsO9nsGueGQL9qpmtUOaq0o1gZ9wIldXasU0Is7uCJwlrtLmv//2EUl2BxQJ5X1hgTBFSynjX2m4QuZN",
+	"A5kF0orn7K+05llNzymFY/JfsDJlo4TOWZq0iU3mgp30NxbDufyN8TuBPgKOPEcdstbJ6OziXFvLcgmo",
+	"OCv1vSNM8cL4jurmVEx09C/6cUkEIkLPsoa3rZtlcyR5IpfZomoDBSDHvjz6lzpJSHyweeUW3F/OPyou",
+	"4qF36insiNPRiMVAzZpHjC9GdpIYqbG50i6d9Ozi3Bt4X4ALc8bx0eRorO+rGCiOiXfqvToaH73SdJZL",
+	"Tb0RTuRypN1izZ7MsKliUs0G54F3alLwro0Y2uLtNyxYba0UuJTi91hmTckTqBasH4/HW9vbSFW9ClnD",
+	"hESiq7HnidIAS8CBbfJxBXL41nBqjekz/lbcn7FzDk2tHP9x4E3HkyZAs5OP6oXRVhq90083A08kUYT5",
+	"ysCOCFWyphNdCV2gVInihdDaVonrjVojYwCWyFYOYInMWKBEi2kdBT+zxQICxBJZwGCotdWGJy2dTa2r",
+	"ZMtPOFeS2XE4cy3ZYpvyuX4C+dYs4j7b7vnsbeEMKM283wKefoISjsJVsYYOgi6ccft03swS6eP6DvVC",
+	"9f2+l2qY7JxkuqQhRRAEZRbfsZoYdzNFoZ2HnvJD95SsDUebVkmpgTCicN/CQPbuFI1Sp4yhi3TQoNQ/",
+	"qSFClQ8Z5X1+moJUxcHFvkA9xhf71Tze7FAdFPPmHCxmLTUITKCPzVGG1G3oULUmDsN80ZyO2Uc3yrR0",
+	"Sn6pX8SORN/Zk2LP8p9lJDroY81D6wZ4m8rm0+hokGTlsZAvWydlUSxHDyR4NPooBJPjWKbvO/15Tt/1",
+	"5NO2OXJIz7S5DZYBJdgQKWrStHtS1kanjEVzXITbMThoNCC2j6jxPln4aTbH01CvjJQM7+h2hXTnK7cq",
+	"ShzYL4WWn0aA7aswZ9x7z95ND/qnZW17U2FPYxmD1S5pLeu7rJXe4whi4rcbJu/1iLWtklK7vz6WyR/C",
+	"jMkqyHvZMBr5pmrW5Dz4WcuIrZg0Zn3dLyRTKvXdcoYxzNBl6Ojy9ifyw80uraTi0+ieTSRT+l+nvX4l",
+	"3btxpCa96p6Ut/fbzD9y21+KmXTUxaGZUkZrV0ujB9MAtodxtg2e7FYjhVa2/cw5Tfan23Lr0/Dp1h/V",
+	"BHQqhybD7zkQYbwfUT64kWjIUzMRCxq82T48EJ12ZVGure73xCMHMSR3rCqedj+ktmqjbul5H4wCvGgL",
+	"YduuQH8sXVRsweRguXdnPyHd4QhhGiDT42hP2mngTY+Pd98H9+3KD0FpXvCVEU2oNWOzvmJEHdkZ9FfI",
+	"+UJEgkPyH9sxTxnFhg//Ioq9VTbkSJ5Q0fJchBPqL21TpkOz5fFW2bLYZapJE/KEorxdFMLZ+APcnoYU",
+	"CKNbLP2lBk3zQhhmrXHsU6GC/AUWK+q/XIcx0vKyNgVVaQqyDWdqVwGTMqQut9aOQKacLuE2oeJAlpES",
+	"99gJUtkRLsZJ7PChGd4dX9s+9XYWbXPmwe476LYhD/0hLSiXQbQdnm3USOnd1Bjiu0yoeLPaNGy8z1Df",
+	"LlVdWqrZK3SncbqtOJ1arJHSeqeumNwWzIqdhuQKrcz3HJHT5X6OH3ZI6GHicZsri/LrZqouMgOmmXUa",
+	"FUNq9rbphqvMNH7WDwAVV4FFER4KUDOKUmsyyUEgydCchBI4ul2l9YS2+GRga3FeNv38TtaatDE1ZdDc",
+	"gFAyXYSEkhi94LaSKc2YVIOadjV1cs1b7lIx1ouyeqnI1JzOi7FsJ1CNicMY/wq0FC7HuwiLTfMHyyiW",
+	"R2yFtBWqVGi6VLIpCXvOSrlUYLJntWwL5up8ZETl23oqsQXP7reSnN+69PjI9pttDEOUGug+U9Z09iXe",
+	"s8PiajTsYFUzDHE9wCiQGPjQUNMmQZponG1Zmz/uPk+WLnHomyS8sx2Mc5XJWZS3fXa2e96Mcx/sT8v1",
+	"eOrbil7tkTJQ+KG8fo99VzYa+Xt87TMqqOGWa4piPQ9KjPd1Jx0+MSyzn0pvfiWDpDlqdTBq7Sq2tb75",
+	"sjdW+fPpr+npr0XR9L8kaq8tFe9P21ZCWVOmv5F2km3iE8QCBcDJFwjMdaaDb2azv4hqGM5c3/RzAola",
+	"UKyon/9iyxFKe1FMxz8gMjflb5oB0sb6S1Pih3V1tAJjgKbjcXksEdnwgFFQI6blEYzX4CIi/9UIU0bn",
+	"enHay2tTh37eaign7/fUHtMxdMt+WsdS8E+BdLyDOSJJRXd9jXBS2k2hs9Cl0BdCfLPhZker2b6FL8Wf",
+	"R95eFLq6cPPbgx44zCHoURpTbIL7nGMi7q4l+y+0KTUNdiarl34j+9uKl1Q4tSly4uDTbt01esh/Vbxf",
+	"VdAWWbtbP1V+PL13VVEJX79TH7VC9i6N1FKf9MxINj6g5ngW5U4liBxlT47rprX86fD03WH51Kb30yG5",
+	"7E+HWLbUbfXXaur+Umb46IEn1F5QTXpuE+fvUq26ezXVx5Oziqngtx9QRynfSOslAw6RAqW/TeXwjpoD",
+	"Fh0pOJvF6EoO+J/pN09Jv2lxeRNhm1g00vBaj/g2+zdkPb16kc/g8iDPWlmvh8RSKyW1+btA6559AWy/",
+	"lx02Bbg2rXB+lzZ7pStKiuRm63zL6Bzvp/vN063ofVLH3Gm6w1LV2M4J1GJhP51GuzKPi503n0njNM0f",
+	"30omc6PAVxopldskfrpRXCGAf0l5qYzCs4tz9GWCbrEAFGPd2dQ0BxzhmIy+TDRT2R1rc/MuX+YlIIgZ",
+	"MWXvNrVOd2qq5+xpuhXaHTpmptdYUxeX9tmFDkbOuuH22aYOxbF3MZzfvoQ1orqiRZ2nKDspTdmP7cuk",
+	"z4AtByonxrtAqebEP948/l8AAAD//w4FG4OclAAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/backend/internal/api/handler/helpers.go
+++ b/backend/internal/api/handler/helpers.go
@@ -52,7 +52,7 @@ func mapCategoryToStatus(cat errors.ErrorCategory) int {
 	case errors.CategoryForbidden:
 		return http.StatusForbidden
 	case errors.CategoryInvalidState:
-		return http.StatusConflict
+		return http.StatusUnprocessableEntity
 	default:
 		return http.StatusInternalServerError
 	}

--- a/backend/internal/api/handler/server.go
+++ b/backend/internal/api/handler/server.go
@@ -111,6 +111,16 @@ func (s *Server) DeleteEpic(w http.ResponseWriter, r *http.Request, projectID Pr
 	s.epics.DeleteEpic(w, r, projectID, epicID)
 }
 
+// GetEpicDAG delegates to EpicHandler.
+func (s *Server) GetEpicDAG(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, epicID EpicIdPath) {
+	s.epics.GetEpicDAG(w, r, projectID, epicID)
+}
+
+// LaunchEpicRun delegates to EpicHandler (stub — not yet implemented).
+func (s *Server) LaunchEpicRun(w http.ResponseWriter, _ *http.Request, _ ProjectIdPath, _ EpicIdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // ListStories delegates to StoryHandler.
 func (s *Server) ListStories(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, params ListStoriesParams) {
 	s.stories.ListStories(w, r, projectID, params)

--- a/backend/internal/domain/model/dag.go
+++ b/backend/internal/domain/model/dag.go
@@ -1,0 +1,8 @@
+package model
+
+// DAGResult holds the result of a topological sort on stories.
+// Groups are execution layers: all stories in Groups[i] can run concurrently,
+// and all must complete before any story in Groups[i+1] starts.
+type DAGResult struct {
+	Groups [][]Story
+}

--- a/backend/internal/domain/service/scheduler_service.go
+++ b/backend/internal/domain/service/scheduler_service.go
@@ -1,0 +1,159 @@
+package service
+
+import (
+	"sort"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// SchedulerService provides DAG computation for story execution ordering.
+type SchedulerService struct{}
+
+// NewSchedulerService creates a new SchedulerService.
+func NewSchedulerService() *SchedulerService {
+	return &SchedulerService{}
+}
+
+// BuildDAG computes topological execution layers for the given stories.
+// Returns DAGResult with Groups where each group can run in parallel.
+// Returns DAG_CYCLE_DETECTED DomainError if a cycle is found.
+func (s *SchedulerService) BuildDAG(stories []model.Story) (model.DAGResult, error) {
+	if len(stories) == 0 {
+		return model.DAGResult{Groups: [][]model.Story{}}, nil
+	}
+
+	// Index stories by key
+	byKey := make(map[string]*model.Story, len(stories))
+	keys := make([]string, 0, len(stories))
+	for i := range stories {
+		byKey[stories[i].Key] = &stories[i]
+		keys = append(keys, stories[i].Key)
+	}
+
+	// Build adjacency list and in-degree map from explicit DependsOn edges
+	adj := make(map[string][]string)    // dep → []dependents
+	inDegree := make(map[string]int)    // story key → in-degree
+	edgeSet := make(map[[2]string]bool) // track existing edges to avoid duplicates
+
+	for _, key := range keys {
+		inDegree[key] = 0
+	}
+
+	for _, story := range stories {
+		for _, dep := range story.DependsOn {
+			if _, ok := byKey[dep]; !ok {
+				continue // skip unknown keys (AC6)
+			}
+			edge := [2]string{dep, story.Key}
+			if edgeSet[edge] {
+				continue
+			}
+			edgeSet[edge] = true
+			adj[dep] = append(adj[dep], story.Key)
+			inDegree[story.Key]++
+		}
+	}
+
+	// Add implicit file-conflict edges
+	addFileConflictEdges(stories, byKey, adj, inDegree, edgeSet)
+
+	// Kahn's algorithm: process zero-in-degree nodes layer by layer
+	var groups [][]model.Story
+	processed := 0
+
+	for processed < len(stories) {
+		// Collect all nodes with zero in-degree
+		var zeroKeys []string
+		for _, key := range keys {
+			if inDegree[key] == 0 {
+				zeroKeys = append(zeroKeys, key)
+			}
+		}
+
+		if len(zeroKeys) == 0 {
+			return model.DAGResult{}, errors.NewInvalidState(
+				"DAG_CYCLE_DETECTED",
+				"cycle detected in story dependencies",
+			)
+		}
+
+		// Sort for deterministic output within a layer
+		sort.Strings(zeroKeys)
+
+		group := make([]model.Story, 0, len(zeroKeys))
+		for _, key := range zeroKeys {
+			group = append(group, *byKey[key])
+			// Remove this node: set in-degree to -1 so it's skipped in future iterations
+			inDegree[key] = -1
+			for _, dependent := range adj[key] {
+				inDegree[dependent]--
+			}
+		}
+
+		groups = append(groups, group)
+		processed += len(group)
+	}
+
+	return model.DAGResult{Groups: groups}, nil
+}
+
+// addFileConflictEdges adds implicit directed edges between stories that share target files.
+// For each file with multiple stories, edges go from lexicographically smaller keys to larger keys.
+func addFileConflictEdges(
+	stories []model.Story,
+	byKey map[string]*model.Story,
+	adj map[string][]string,
+	inDegree map[string]int,
+	edgeSet map[[2]string]bool,
+) {
+	// Build file → story keys index
+	fileIndex := make(map[string][]string)
+	for _, story := range stories {
+		for _, f := range story.TargetFiles {
+			fileIndex[f] = append(fileIndex[f], story.Key)
+		}
+	}
+
+	// For each file with >1 story, create chain edges in sorted key order
+	for _, storyKeys := range fileIndex {
+		if len(storyKeys) < 2 {
+			continue
+		}
+		sort.Strings(storyKeys)
+		// Deduplicate keys for the same file
+		unique := dedup(storyKeys)
+		for i := 0; i < len(unique)-1; i++ {
+			src := unique[i]
+			dst := unique[i+1]
+			// Only check stories that are in our input
+			if _, ok := byKey[src]; !ok {
+				continue
+			}
+			if _, ok := byKey[dst]; !ok {
+				continue
+			}
+			edge := [2]string{src, dst}
+			if edgeSet[edge] {
+				continue // skip if explicit edge already exists
+			}
+			edgeSet[edge] = true
+			adj[src] = append(adj[src], dst)
+			inDegree[dst]++
+		}
+	}
+}
+
+// dedup returns a new slice with duplicates removed, preserving order.
+func dedup(sorted []string) []string {
+	if len(sorted) == 0 {
+		return sorted
+	}
+	result := []string{sorted[0]}
+	for i := 1; i < len(sorted); i++ {
+		if sorted[i] != sorted[i-1] {
+			result = append(result, sorted[i])
+		}
+	}
+	return result
+}

--- a/backend/internal/domain/service/scheduler_service_test.go
+++ b/backend/internal/domain/service/scheduler_service_test.go
@@ -1,0 +1,174 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+func newStory(key string, dependsOn []string, targetFiles []string) model.Story {
+	return model.Story{
+		ID:          uuid.New(),
+		ProjectID:   uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		Key:         key,
+		Title:       "Story " + key,
+		DependsOn:   dependsOn,
+		TargetFiles: targetFiles,
+		Status:      model.StoryStatusBacklog,
+	}
+}
+
+func extractKeys(groups [][]model.Story) [][]string {
+	result := make([][]string, len(groups))
+	for i, group := range groups {
+		keys := make([]string, len(group))
+		for j, s := range group {
+			keys[j] = s.Key
+		}
+		result[i] = keys
+	}
+	return result
+}
+
+func TestBuildDAG(t *testing.T) {
+	svc := NewSchedulerService()
+
+	tests := []struct {
+		name       string
+		stories    []model.Story
+		wantGroups [][]string
+		wantErr    string
+	}{
+		{
+			name:       "empty input",
+			stories:    []model.Story{},
+			wantGroups: [][]string{},
+		},
+		{
+			name:       "single story no deps",
+			stories:    []model.Story{newStory("S-01", nil, nil)},
+			wantGroups: [][]string{{"S-01"}},
+		},
+		{
+			name: "two independent stories",
+			stories: []model.Story{
+				newStory("S-01", nil, nil),
+				newStory("S-02", nil, nil),
+			},
+			wantGroups: [][]string{{"S-01", "S-02"}},
+		},
+		{
+			name: "linear chain A→B→C",
+			stories: []model.Story{
+				newStory("S-01", nil, nil),
+				newStory("S-02", []string{"S-01"}, nil),
+				newStory("S-03", []string{"S-02"}, nil),
+			},
+			wantGroups: [][]string{{"S-01"}, {"S-02"}, {"S-03"}},
+		},
+		{
+			name: "diamond A→B, A→C, B→D, C→D",
+			stories: []model.Story{
+				newStory("S-01", nil, nil),
+				newStory("S-02", []string{"S-01"}, nil),
+				newStory("S-03", []string{"S-01"}, nil),
+				newStory("S-04", []string{"S-02", "S-03"}, nil),
+			},
+			wantGroups: [][]string{{"S-01"}, {"S-02", "S-03"}, {"S-04"}},
+		},
+		{
+			name: "cycle of two A↔B",
+			stories: []model.Story{
+				newStory("S-01", []string{"S-02"}, nil),
+				newStory("S-02", []string{"S-01"}, nil),
+			},
+			wantErr: "DAG_CYCLE_DETECTED",
+		},
+		{
+			name: "cycle of three A→B→C→A",
+			stories: []model.Story{
+				newStory("S-01", []string{"S-03"}, nil),
+				newStory("S-02", []string{"S-01"}, nil),
+				newStory("S-03", []string{"S-02"}, nil),
+			},
+			wantErr: "DAG_CYCLE_DETECTED",
+		},
+		{
+			name: "unknown dep key ignored",
+			stories: []model.Story{
+				newStory("S-01", nil, nil),
+				newStory("S-02", []string{"GHOST-99"}, nil),
+			},
+			wantGroups: [][]string{{"S-01", "S-02"}},
+		},
+		{
+			name: "file conflict implicit edge",
+			stories: []model.Story{
+				newStory("S-02", nil, []string{"shared.go"}),
+				newStory("S-01", nil, []string{"shared.go"}),
+			},
+			wantGroups: [][]string{{"S-01"}, {"S-02"}},
+		},
+		{
+			name: "combined explicit and file conflict",
+			stories: []model.Story{
+				newStory("S-01", nil, []string{"main.go"}),
+				newStory("S-02", []string{"S-01"}, []string{"main.go"}),
+				newStory("S-03", nil, nil),
+			},
+			wantGroups: [][]string{{"S-01", "S-03"}, {"S-02"}},
+		},
+		{
+			name: "file conflict with three stories on same file",
+			stories: []model.Story{
+				newStory("S-03", nil, []string{"config.yaml"}),
+				newStory("S-01", nil, []string{"config.yaml"}),
+				newStory("S-02", nil, []string{"config.yaml"}),
+			},
+			wantGroups: [][]string{{"S-01"}, {"S-02"}, {"S-03"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := svc.BuildDAG(tt.stories)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error with code %s, got nil", tt.wantErr)
+				}
+				domainErr, ok := err.(*errors.DomainError)
+				if !ok {
+					t.Fatalf("expected *errors.DomainError, got %T", err)
+				}
+				if domainErr.Code != tt.wantErr {
+					t.Errorf("expected error code %s, got %s", tt.wantErr, domainErr.Code)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			gotGroups := extractKeys(result.Groups)
+			if len(gotGroups) != len(tt.wantGroups) {
+				t.Fatalf("expected %d groups, got %d: %v", len(tt.wantGroups), len(gotGroups), gotGroups)
+			}
+
+			for i, wantGroup := range tt.wantGroups {
+				if len(gotGroups[i]) != len(wantGroup) {
+					t.Errorf("group %d: expected %d stories, got %d: %v", i, len(wantGroup), len(gotGroups[i]), gotGroups[i])
+					continue
+				}
+				for j, wantKey := range wantGroup {
+					if gotGroups[i][j] != wantKey {
+						t.Errorf("group %d, position %d: expected %s, got %s", i, j, wantKey, gotGroups[i][j])
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `SchedulerService` with Kahn's algorithm for topological sort of story dependencies
- Support explicit `DependsOn` edges, implicit file-conflict edges, cycle detection (`DAG_CYCLE_DETECTED`), and unknown dependency key handling
- Add `GET /projects/{projectId}/epics/{epicId}/dag` endpoint returning `{ nodes, edges }` for DAG visualization
- Add stub `POST /projects/{projectId}/epics/{epicId}/runs` endpoint (202 response, implementation deferred)
- Add `DAGResult` domain model, `EpicDAGNode`/`EpicDAGEdge`/`EpicDAGResponse`/`EpicRunAccepted` OpenAPI schemas
- Map `CategoryInvalidState` to HTTP 422 instead of 409 for cycle errors
- Wire `SchedulerService` and `StoryRepository` into `EpicHandler`

## Test plan

- [x] 11 table-driven unit tests for `SchedulerService.BuildDAG` covering: empty input, single story, independent stories, linear chain, diamond, cycle of 2, cycle of 3, unknown dep key, file conflict, combined explicit + implicit, three-way file conflict
- [x] 4 handler tests for `GetEpicDAG`: no deps (all layer 0), with deps (correct layers/edges), cycle returns 422, story repo error returns 404
- [x] All existing epic handler tests still pass
- [x] `go vet ./...` passes
- [x] `go test ./... -short` passes (all packages green)
- [x] `go build ./...` compiles successfully

Refs: S-7-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)