### PR TITLE
feat(pipeline): add pipeline validation stories and integration tests

### DIFF
--- a/backend/internal/integration/pipeline_validation_test.go
+++ b/backend/internal/integration/pipeline_validation_test.go
@@ -28,6 +28,11 @@ func testProjectStoriesPath() string {
 	return filepath.Join(filepath.Dir(filename), "..", "..", "..", "test-project", "stories", "todo-stories.md")
 }
 
+const (
+	scopeBackend  = "backend"
+	scopeFrontend = "frontend"
+)
+
 // noopAction implements model.Action for integration tests.
 // It succeeds immediately without performing real work.
 type noopAction struct {
@@ -138,16 +143,16 @@ func TestIntegration_PipelineValidation_StoryImport(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetByKey(TODO-1) error = %v", err)
 		}
-		if story1.Scope == nil || *story1.Scope != "backend" {
-			t.Errorf("TODO-1 scope: expected %q, got %v", "backend", story1.Scope)
+		if story1.Scope == nil || *story1.Scope != scopeBackend {
+			t.Errorf("TODO-1 scope: expected %q, got %v", scopeBackend, story1.Scope)
 		}
 
 		story5, err := storyRepo.GetByKey(ctx, projectID, "TODO-5")
 		if err != nil {
 			t.Fatalf("GetByKey(TODO-5) error = %v", err)
 		}
-		if story5.Scope == nil || *story5.Scope != "frontend" {
-			t.Errorf("TODO-5 scope: expected %q, got %v", "frontend", story5.Scope)
+		if story5.Scope == nil || *story5.Scope != scopeFrontend {
+			t.Errorf("TODO-5 scope: expected %q, got %v", scopeFrontend, story5.Scope)
 		}
 	})
 
@@ -211,7 +216,7 @@ func TestIntegration_PipelineValidation_RunCreation(t *testing.T) {
 	// Create a story
 	storyRepo := postgres.NewStoryRepo(queries)
 	storySvc := service.NewStoryService(storyRepo)
-	scope := "backend"
+	scope := scopeBackend
 	story, err := storySvc.Create(ctx, service.CreateStoryParams{
 		ProjectID: projectID,
 		Key:       "TODO-1",
@@ -360,7 +365,7 @@ func TestIntegration_PipelineValidation_Execution(t *testing.T) {
 	// Create story
 	storyRepo := postgres.NewStoryRepo(queries)
 	storySvc := service.NewStoryService(storyRepo)
-	scope := "backend"
+	scope := scopeBackend
 	story, err := storySvc.Create(ctx, service.CreateStoryParams{
 		ProjectID: projectID,
 		Key:       "TODO-1",

--- a/backend/internal/integration/pipeline_validation_test.go
+++ b/backend/internal/integration/pipeline_validation_test.go
@@ -1,0 +1,640 @@
+// Package integration contains end-to-end integration tests that validate the
+// full pipeline flow against a real Postgres database via testcontainers.
+// These tests cover story import, run creation, pipeline execution, and state
+// transitions using the reference test-project stories.
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/adapter/markdown"
+	"github.com/zakari/hopeitworks/backend/internal/adapter/postgres"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+	"github.com/zakari/hopeitworks/backend/internal/testutil"
+)
+
+// testProjectStoriesPath returns the path to test-project/stories/todo-stories.md.
+func testProjectStoriesPath() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "..", "..", "..", "test-project", "stories", "todo-stories.md")
+}
+
+// noopAction implements model.Action for integration tests.
+// It succeeds immediately without performing real work.
+type noopAction struct {
+	name string
+}
+
+func (a *noopAction) Name() string { return a.name }
+func (a *noopAction) Execute(_ context.Context, _ *model.RunContext) error {
+	return nil
+}
+
+// TestIntegration_PipelineValidation_StoryImport validates that stories from
+// the test-project markdown can be imported into the system via the StoryService.
+func TestIntegration_PipelineValidation_StoryImport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db := testutil.SetupTestDB(t)
+	defer db.Cleanup()
+
+	ctx := context.Background()
+	queries := postgres.New(db.Pool)
+	storyRepo := postgres.NewStoryRepo(queries)
+	storySvc := service.NewStoryService(storyRepo)
+
+	projectID := testutil.CreateProject(t, db.Pool)
+
+	// Read the reference stories markdown
+	storiesPath := testProjectStoriesPath()
+	content, err := os.ReadFile(storiesPath)
+	if err != nil {
+		t.Fatalf("failed to read test-project stories: %v", err)
+	}
+
+	// Parse stories from markdown
+	parsed := markdown.ParseStoryMarkdown(string(content))
+	if len(parsed) == 0 {
+		t.Fatal("expected at least 1 parsed story, got 0")
+	}
+
+	// Import stories into the system
+	inputs := make([]service.ImportStoryInput, 0, len(parsed))
+	for _, p := range parsed {
+		inputs = append(inputs, service.ImportStoryInput{
+			Key:                p.Key,
+			Title:              p.Title,
+			Epic:               p.Epic,
+			DependsOn:          p.DependsOn,
+			Scope:              p.Scope,
+			Status:             p.Status,
+			AcceptanceCriteria: p.AcceptanceCriteria,
+			ParseError:         p.ParseError,
+		})
+	}
+
+	result, err := storySvc.Import(ctx, projectID, inputs)
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+
+	t.Run("all 5 stories imported successfully", func(t *testing.T) {
+		if result.Imported != 5 {
+			t.Errorf("expected 5 imported stories, got %d", result.Imported)
+		}
+		if result.Failed != 0 {
+			t.Errorf("expected 0 failures, got %d: %v", result.Failed, result.Errors)
+		}
+	})
+
+	t.Run("stories retrievable by key", func(t *testing.T) {
+		expectedKeys := []string{"TODO-1", "TODO-2", "TODO-3", "TODO-4", "TODO-5"}
+		for _, key := range expectedKeys {
+			story, err := storyRepo.GetByKey(ctx, projectID, key)
+			if err != nil {
+				t.Errorf("GetByKey(%q) error = %v", key, err)
+				continue
+			}
+			if story.Key != key {
+				t.Errorf("expected key %q, got %q", key, story.Key)
+			}
+			if story.Status != model.StoryStatusBacklog {
+				t.Errorf("story %s: expected status %q, got %q", key, model.StoryStatusBacklog, story.Status)
+			}
+		}
+	})
+
+	t.Run("story dependencies preserved", func(t *testing.T) {
+		story3, err := storyRepo.GetByKey(ctx, projectID, "TODO-3")
+		if err != nil {
+			t.Fatalf("GetByKey(TODO-3) error = %v", err)
+		}
+		if len(story3.DependsOn) != 1 || story3.DependsOn[0] != "TODO-1" {
+			t.Errorf("TODO-3 depends_on: expected [TODO-1], got %v", story3.DependsOn)
+		}
+
+		story5, err := storyRepo.GetByKey(ctx, projectID, "TODO-5")
+		if err != nil {
+			t.Fatalf("GetByKey(TODO-5) error = %v", err)
+		}
+		if len(story5.DependsOn) != 2 {
+			t.Errorf("TODO-5 depends_on: expected 2 deps, got %v", story5.DependsOn)
+		}
+	})
+
+	t.Run("story scopes preserved", func(t *testing.T) {
+		story1, err := storyRepo.GetByKey(ctx, projectID, "TODO-1")
+		if err != nil {
+			t.Fatalf("GetByKey(TODO-1) error = %v", err)
+		}
+		if story1.Scope == nil || *story1.Scope != "backend" {
+			t.Errorf("TODO-1 scope: expected %q, got %v", "backend", story1.Scope)
+		}
+
+		story5, err := storyRepo.GetByKey(ctx, projectID, "TODO-5")
+		if err != nil {
+			t.Fatalf("GetByKey(TODO-5) error = %v", err)
+		}
+		if story5.Scope == nil || *story5.Scope != "frontend" {
+			t.Errorf("TODO-5 scope: expected %q, got %v", "frontend", story5.Scope)
+		}
+	})
+
+	t.Run("re-import updates existing stories", func(t *testing.T) {
+		result2, err := storySvc.Import(ctx, projectID, inputs)
+		if err != nil {
+			t.Fatalf("second Import() error = %v", err)
+		}
+		if result2.Updated != 5 {
+			t.Errorf("expected 5 updated stories, got %d", result2.Updated)
+		}
+		if result2.Imported != 0 {
+			t.Errorf("expected 0 new imports on re-import, got %d", result2.Imported)
+		}
+	})
+}
+
+// TestIntegration_PipelineValidation_RunCreation validates that a run can
+// be created from a pipeline config and story, with correct steps.
+func TestIntegration_PipelineValidation_RunCreation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db := testutil.SetupTestDB(t)
+	defer db.Cleanup()
+
+	ctx := context.Background()
+	queries := postgres.New(db.Pool)
+
+	projectID := testutil.CreateProject(t, db.Pool)
+
+	// Create pipeline config
+	pipelineYAML := `steps:
+  - id: "step-implement"
+    name: "implement"
+    action_type: "implement"
+    model: "claude-opus-4-6"
+    auto_approve: false
+    retry_policy:
+      max_retries: 0
+      retry_type: "none"
+  - id: "step-review"
+    name: "review"
+    action_type: "review"
+    model: "claude-sonnet-4-20250514"
+    auto_approve: true
+    retry_policy:
+      max_retries: 1
+      retry_type: "on-failure"
+  - id: "step-merge"
+    name: "merge"
+    action_type: "merge"
+    auto_approve: true
+    retry_policy:
+      max_retries: 0
+      retry_type: "none"`
+
+	testutil.UpsertPipelineConfig(t, db.Pool, projectID, pipelineYAML)
+
+	// Create a story
+	storyRepo := postgres.NewStoryRepo(queries)
+	storySvc := service.NewStoryService(storyRepo)
+	scope := "backend"
+	story, err := storySvc.Create(ctx, service.CreateStoryParams{
+		ProjectID: projectID,
+		Key:       "TODO-1",
+		Title:     "Add create todo endpoint",
+		Scope:     &scope,
+		Status:    model.StoryStatusBacklog,
+	})
+	if err != nil {
+		t.Fatalf("Create story error = %v", err)
+	}
+
+	// Create run service dependencies
+	runRepo := postgres.NewRunRepo(queries)
+	projectRepo := postgres.NewProjectRepo(queries)
+	pipelineConfigRepo := postgres.NewPipelineConfigRepo(queries)
+	mockJobQueue := &noopJobQueue{}
+
+	runSvc := service.NewRunService(runRepo, projectRepo, storyRepo, pipelineConfigRepo, mockJobQueue)
+
+	// Launch run
+	run, err := runSvc.LaunchRun(ctx, projectID, story.ID)
+	if err != nil {
+		t.Fatalf("LaunchRun() error = %v", err)
+	}
+
+	t.Run("run created with pending status", func(t *testing.T) {
+		if run.Status != model.RunStatusPending {
+			t.Errorf("expected run status %q, got %q", model.RunStatusPending, run.Status)
+		}
+		if run.ProjectID != projectID {
+			t.Errorf("expected project_id %v, got %v", projectID, run.ProjectID)
+		}
+		if run.StoryID != story.ID {
+			t.Errorf("expected story_id %v, got %v", story.ID, run.StoryID)
+		}
+	})
+
+	t.Run("run has 3 steps in correct order", func(t *testing.T) {
+		if len(run.Steps) != 3 {
+			t.Fatalf("expected 3 steps, got %d", len(run.Steps))
+		}
+
+		expectedSteps := []struct {
+			name   string
+			action string
+			order  int
+		}{
+			{"implement", "implement", 0},
+			{"review", "review", 1},
+			{"merge", "merge", 2},
+		}
+
+		for i, expected := range expectedSteps {
+			step := run.Steps[i]
+			if step.StepName != expected.name {
+				t.Errorf("step %d: expected name %q, got %q", i, expected.name, step.StepName)
+			}
+			if step.Action != expected.action {
+				t.Errorf("step %d: expected action %q, got %q", i, expected.action, step.Action)
+			}
+			if step.StepOrder != expected.order {
+				t.Errorf("step %d: expected order %d, got %d", i, expected.order, step.StepOrder)
+			}
+			if step.Status != model.StepStatusPending {
+				t.Errorf("step %d: expected status %q, got %q", i, model.StepStatusPending, step.Status)
+			}
+		}
+	})
+
+	t.Run("pipeline config snapshot persisted", func(t *testing.T) {
+		if len(run.PipelineConfigSnapshot) == 0 {
+			t.Fatal("expected pipeline config snapshot to be non-empty")
+		}
+		var snapshot model.PipelineConfigYAML
+		if err := json.Unmarshal(run.PipelineConfigSnapshot, &snapshot); err != nil {
+			t.Fatalf("failed to unmarshal config snapshot: %v", err)
+		}
+		if len(snapshot.Steps) != 3 {
+			t.Errorf("expected 3 steps in snapshot, got %d", len(snapshot.Steps))
+		}
+	})
+
+	t.Run("run retrievable by ID", func(t *testing.T) {
+		retrieved, err := runSvc.GetRun(ctx, run.ID)
+		if err != nil {
+			t.Fatalf("GetRun() error = %v", err)
+		}
+		if retrieved.ID != run.ID {
+			t.Errorf("expected run ID %v, got %v", run.ID, retrieved.ID)
+		}
+		if len(retrieved.Steps) != 3 {
+			t.Errorf("expected 3 steps, got %d", len(retrieved.Steps))
+		}
+	})
+
+	t.Run("duplicate launch blocked for active run", func(t *testing.T) {
+		_, err := runSvc.LaunchRun(ctx, projectID, story.ID)
+		if err == nil {
+			t.Fatal("expected error for duplicate launch, got nil")
+		}
+	})
+}
+
+// TestIntegration_PipelineValidation_Execution validates the full pipeline
+// execution flow: run transitions, step transitions, and events.
+func TestIntegration_PipelineValidation_Execution(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db := testutil.SetupTestDB(t)
+	defer db.Cleanup()
+
+	ctx := context.Background()
+	queries := postgres.New(db.Pool)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	projectID := testutil.CreateProject(t, db.Pool)
+
+	// Create pipeline config with 3 steps
+	pipelineYAML := `steps:
+  - id: "step-implement"
+    name: "implement"
+    action_type: "implement"
+    auto_approve: false
+    retry_policy:
+      max_retries: 0
+      retry_type: "none"
+  - id: "step-review"
+    name: "review"
+    action_type: "review"
+    auto_approve: true
+    retry_policy:
+      max_retries: 0
+      retry_type: "none"
+  - id: "step-merge"
+    name: "merge"
+    action_type: "merge"
+    auto_approve: true
+    retry_policy:
+      max_retries: 0
+      retry_type: "none"`
+
+	testutil.UpsertPipelineConfig(t, db.Pool, projectID, pipelineYAML)
+
+	// Create story
+	storyRepo := postgres.NewStoryRepo(queries)
+	storySvc := service.NewStoryService(storyRepo)
+	scope := "backend"
+	story, err := storySvc.Create(ctx, service.CreateStoryParams{
+		ProjectID: projectID,
+		Key:       "TODO-1",
+		Title:     "Add create todo endpoint",
+		Scope:     &scope,
+		Status:    model.StoryStatusBacklog,
+	})
+	if err != nil {
+		t.Fatalf("Create story error = %v", err)
+	}
+
+	// Create run
+	runRepo := postgres.NewRunRepo(queries)
+	projectRepo := postgres.NewProjectRepo(queries)
+	pipelineConfigRepo := postgres.NewPipelineConfigRepo(queries)
+	mockQueue := &noopJobQueue{}
+	runSvc := service.NewRunService(runRepo, projectRepo, storyRepo, pipelineConfigRepo, mockQueue)
+
+	run, err := runSvc.LaunchRun(ctx, projectID, story.ID)
+	if err != nil {
+		t.Fatalf("LaunchRun() error = %v", err)
+	}
+
+	// Setup action registry with noop actions
+	actionReg := service.NewActionRegistry()
+	actionReg.Register(&noopAction{name: "implement"})
+	actionReg.Register(&noopAction{name: "review"})
+	actionReg.Register(&noopAction{name: "merge"})
+
+	// Setup event publisher
+	eventRepo := postgres.NewEventRepo(queries)
+
+	// Create pipeline executor
+	executor := service.NewPipelineExecutor(runRepo, actionReg, eventRepo, logger)
+
+	// Execute the pipeline
+	err = executor.ExecuteRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("ExecuteRun() error = %v", err)
+	}
+
+	t.Run("run completed successfully", func(t *testing.T) {
+		completedRun, err := runSvc.GetRun(ctx, run.ID)
+		if err != nil {
+			t.Fatalf("GetRun() error = %v", err)
+		}
+		if completedRun.Status != model.RunStatusCompleted {
+			t.Errorf("expected run status %q, got %q", model.RunStatusCompleted, completedRun.Status)
+		}
+		if completedRun.StartedAt == nil {
+			t.Error("expected started_at to be set")
+		}
+		if completedRun.CompletedAt == nil {
+			t.Error("expected completed_at to be set")
+		}
+	})
+
+	t.Run("all steps completed", func(t *testing.T) {
+		completedRun, err := runSvc.GetRun(ctx, run.ID)
+		if err != nil {
+			t.Fatalf("GetRun() error = %v", err)
+		}
+		for _, step := range completedRun.Steps {
+			if step.Status != model.StepStatusCompleted {
+				t.Errorf("step %q: expected status %q, got %q", step.StepName, model.StepStatusCompleted, step.Status)
+			}
+			if step.StartedAt == nil {
+				t.Errorf("step %q: expected started_at to be set", step.StepName)
+			}
+			if step.CompletedAt == nil {
+				t.Errorf("step %q: expected completed_at to be set", step.StepName)
+			}
+		}
+	})
+
+	t.Run("events published for all steps", func(t *testing.T) {
+		events, err := queries.ListEventsByProject(ctx, postgres.ListEventsByProjectParams{
+			ProjectID: projectID,
+			Limit:     100,
+			Offset:    0,
+		})
+		if err != nil {
+			t.Fatalf("ListEventsByProject() error = %v", err)
+		}
+
+		// Events are returned in created_at DESC order.
+		// Expected events (8 total):
+		// run.started, 3x(step.started + step.completed), run.completed
+		if len(events) < 8 {
+			t.Fatalf("expected at least 8 events, got %d", len(events))
+		}
+
+		// Verify most recent event (index 0, DESC order) is run.completed
+		if events[0].EntityType != "run" || events[0].Action != "completed" {
+			t.Errorf("most recent event: expected run.completed, got %s.%s", events[0].EntityType, events[0].Action)
+		}
+
+		// Verify oldest event (last index, DESC order) is run.started
+		last := events[len(events)-1]
+		if last.EntityType != "run" || last.Action != "started" {
+			t.Errorf("oldest event: expected run.started, got %s.%s", last.EntityType, last.Action)
+		}
+
+		// Count step events
+		var stepStarted, stepCompleted int
+		for _, e := range events {
+			switch {
+			case e.EntityType == "step" && e.Action == "started":
+				stepStarted++
+			case e.EntityType == "step" && e.Action == "completed":
+				stepCompleted++
+			}
+		}
+		if stepStarted != 3 {
+			t.Errorf("expected 3 step.started events, got %d", stepStarted)
+		}
+		if stepCompleted != 3 {
+			t.Errorf("expected 3 step.completed events, got %d", stepCompleted)
+		}
+	})
+}
+
+// TestIntegration_PipelineValidation_FullFlow validates the complete pipeline
+// flow from story import through execution, mimicking the reference test project
+// end-to-end validation scenario.
+func TestIntegration_PipelineValidation_FullFlow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db := testutil.SetupTestDB(t)
+	defer db.Cleanup()
+
+	ctx := context.Background()
+	queries := postgres.New(db.Pool)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// 1. Setup: create project with pipeline config
+	projectID := testutil.CreateProject(t, db.Pool)
+
+	pipelineYAML := `steps:
+  - id: "step-implement"
+    name: "implement"
+    action_type: "implement"
+    auto_approve: false
+    retry_policy:
+      max_retries: 0
+      retry_type: "none"
+  - id: "step-review"
+    name: "review"
+    action_type: "review"
+    auto_approve: true
+    retry_policy:
+      max_retries: 0
+      retry_type: "none"`
+
+	testutil.UpsertPipelineConfig(t, db.Pool, projectID, pipelineYAML)
+
+	// 2. Import stories from test-project markdown
+	storyRepo := postgres.NewStoryRepo(queries)
+	storySvc := service.NewStoryService(storyRepo)
+
+	storiesPath := testProjectStoriesPath()
+	content, err := os.ReadFile(storiesPath)
+	if err != nil {
+		t.Fatalf("failed to read test-project stories: %v", err)
+	}
+
+	parsed := markdown.ParseStoryMarkdown(string(content))
+	inputs := make([]service.ImportStoryInput, 0, len(parsed))
+	for _, p := range parsed {
+		inputs = append(inputs, service.ImportStoryInput{
+			Key:                p.Key,
+			Title:              p.Title,
+			Epic:               p.Epic,
+			DependsOn:          p.DependsOn,
+			Scope:              p.Scope,
+			Status:             p.Status,
+			AcceptanceCriteria: p.AcceptanceCriteria,
+			ParseError:         p.ParseError,
+		})
+	}
+
+	importResult, err := storySvc.Import(ctx, projectID, inputs)
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+	if importResult.Failed > 0 {
+		t.Fatalf("story import had %d failures: %v", importResult.Failed, importResult.Errors)
+	}
+
+	// 3. Verify stories exist
+	stories, err := storyRepo.ListByProject(ctx, projectID, 100, 0)
+	if err != nil {
+		t.Fatalf("ListByProject() error = %v", err)
+	}
+	if len(stories) != 5 {
+		t.Fatalf("expected 5 stories after import, got %d", len(stories))
+	}
+
+	// 4. Pick a story without dependencies (TODO-1) and launch a run
+	story1, err := storyRepo.GetByKey(ctx, projectID, "TODO-1")
+	if err != nil {
+		t.Fatalf("GetByKey(TODO-1) error = %v", err)
+	}
+
+	runRepo := postgres.NewRunRepo(queries)
+	projectRepo := postgres.NewProjectRepo(queries)
+	pipelineConfigRepo := postgres.NewPipelineConfigRepo(queries)
+	mockQueue := &noopJobQueue{}
+
+	runSvc := service.NewRunService(runRepo, projectRepo, storyRepo, pipelineConfigRepo, mockQueue)
+
+	run, err := runSvc.LaunchRun(ctx, projectID, story1.ID)
+	if err != nil {
+		t.Fatalf("LaunchRun() error = %v", err)
+	}
+
+	// 5. Setup action registry with noop actions and execute
+	actionReg := service.NewActionRegistry()
+	actionReg.Register(&noopAction{name: "implement"})
+	actionReg.Register(&noopAction{name: "review"})
+
+	eventRepo := postgres.NewEventRepo(queries)
+	executor := service.NewPipelineExecutor(runRepo, actionReg, eventRepo, logger)
+
+	err = executor.ExecuteRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("ExecuteRun() error = %v", err)
+	}
+
+	// 6. Verify final state
+	completedRun, err := runSvc.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+
+	if completedRun.Status != model.RunStatusCompleted {
+		t.Fatalf("expected run status %q, got %q", model.RunStatusCompleted, completedRun.Status)
+	}
+
+	for _, step := range completedRun.Steps {
+		if step.Status != model.StepStatusCompleted {
+			t.Errorf("step %q: expected %q, got %q", step.StepName, model.StepStatusCompleted, step.Status)
+		}
+	}
+
+	// 7. Verify events were generated
+	events, err := queries.ListEventsByProject(ctx, postgres.ListEventsByProjectParams{
+		ProjectID: projectID,
+		Limit:     100,
+		Offset:    0,
+	})
+	if err != nil {
+		t.Fatalf("ListEventsByProject() error = %v", err)
+	}
+
+	// run.started + 2*(step.started + step.completed) + run.completed = 6
+	if len(events) < 6 {
+		t.Errorf("expected at least 6 events, got %d", len(events))
+	}
+
+	t.Logf("Full pipeline validation passed: %d stories imported, run completed with %d steps, %d events generated",
+		importResult.Imported, len(completedRun.Steps), len(events))
+}
+
+// noopJobQueue implements port.JobQueue for integration tests.
+// It records enqueued runs without executing them (execution is done
+// directly via PipelineExecutor in these tests).
+type noopJobQueue struct {
+	enqueuedRunIDs []uuid.UUID
+}
+
+func (q *noopJobQueue) EnqueueExecuteRun(_ context.Context, runID uuid.UUID) error {
+	q.enqueuedRunIDs = append(q.enqueuedRunIDs, runID)
+	return nil
+}

--- a/backend/internal/testutil/factory.go
+++ b/backend/internal/testutil/factory.go
@@ -1,0 +1,67 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// CreateProject inserts a minimal project row and returns its ID.
+func CreateProject(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	return CreateProjectWithName(t, pool, "test-project-"+uuid.New().String()[:8])
+}
+
+// CreateProjectWithName inserts a project with a specific name and returns its ID.
+func CreateProjectWithName(t *testing.T, pool *pgxpool.Pool, name string) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+
+	projectID := uuid.New()
+	_, err := pool.Exec(ctx,
+		`INSERT INTO projects (id, name, git_provider, agent_runtime, repo_url)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		projectID, name, "github", "docker", "https://github.com/test/test-project",
+	)
+	if err != nil {
+		t.Fatalf("failed to create test project: %v", err)
+	}
+	return projectID
+}
+
+// CreateEpic inserts a minimal epic row and returns its ID.
+func CreateEpic(t *testing.T, pool *pgxpool.Pool, projectID uuid.UUID, name string) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+
+	epicID := uuid.New()
+	_, err := pool.Exec(ctx,
+		`INSERT INTO epics (id, project_id, name, status)
+		 VALUES ($1, $2, $3, $4)`,
+		epicID, projectID, name, "backlog",
+	)
+	if err != nil {
+		t.Fatalf("failed to create test epic: %v", err)
+	}
+	return epicID
+}
+
+// UpsertPipelineConfig inserts or updates a pipeline config for a project.
+func UpsertPipelineConfig(t *testing.T, pool *pgxpool.Pool, projectID uuid.UUID, configYAML string) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+
+	configID := uuid.New()
+	_, err := pool.Exec(ctx,
+		`INSERT INTO pipeline_configs (id, project_id, config_yaml, version)
+		 VALUES ($1, $2, $3, 1)
+		 ON CONFLICT (project_id) DO UPDATE SET config_yaml = EXCLUDED.config_yaml, version = pipeline_configs.version + 1`,
+		configID, projectID, configYAML,
+	)
+	if err != nil {
+		t.Fatalf("failed to upsert pipeline config: %v", err)
+	}
+	return configID
+}

--- a/backend/internal/testutil/testdb.go
+++ b/backend/internal/testutil/testdb.go
@@ -1,0 +1,108 @@
+// Package testutil provides shared test infrastructure for integration tests.
+// It includes helpers for spinning up testcontainers-based Postgres instances,
+// applying migrations, and creating test data factories.
+package testutil
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// TestDB holds a shared test database context for integration tests.
+type TestDB struct {
+	Pool       *pgxpool.Pool
+	ConnString string
+	Cleanup    func()
+}
+
+// SetupTestDB spins up a Postgres container, creates a connection pool,
+// and applies all migrations. Call Cleanup() when done.
+func SetupTestDB(t *testing.T) *TestDB {
+	t.Helper()
+
+	ctx := context.Background()
+
+	pgContainer, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("testdb"),
+		tcpostgres.WithUsername("test"),
+		tcpostgres.WithPassword("test"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(30*time.Second),
+		),
+	)
+	if err != nil {
+		t.Fatalf("failed to start postgres container: %v", err)
+	}
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("failed to get connection string: %v", err)
+	}
+
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Fatalf("failed to create pool: %v", err)
+	}
+
+	applyMigrations(t, pool)
+
+	return &TestDB{
+		Pool:       pool,
+		ConnString: connStr,
+		Cleanup: func() {
+			pool.Close()
+			if err := pgContainer.Terminate(ctx); err != nil {
+				t.Logf("failed to terminate container: %v", err)
+			}
+		},
+	}
+}
+
+// applyMigrations reads and applies all .up.sql migration files.
+func applyMigrations(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+
+	migrationsDir := migrationsPath()
+	entries, err := os.ReadDir(migrationsDir)
+	if err != nil {
+		t.Fatalf("failed to read migrations dir %s: %v", migrationsDir, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".sql" {
+			continue
+		}
+		if len(entry.Name()) > 7 && entry.Name()[len(entry.Name())-7:] != ".up.sql" {
+			continue
+		}
+
+		sqlBytes, err := os.ReadFile(filepath.Join(migrationsDir, entry.Name()))
+		if err != nil {
+			t.Fatalf("failed to read migration %s: %v", entry.Name(), err)
+		}
+
+		_, err = pool.Exec(ctx, string(sqlBytes))
+		if err != nil {
+			t.Fatalf("failed to apply migration %s: %v", entry.Name(), err)
+		}
+	}
+}
+
+// migrationsPath returns the absolute path to the backend/migrations directory.
+func migrationsPath() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "..", "..", "migrations")
+}

--- a/test-project/README.md
+++ b/test-project/README.md
@@ -1,0 +1,105 @@
+# Test Project — Pipeline Validation Reference
+
+This directory contains a reference todo application used to validate the
+hopeitworks pipeline end-to-end. It provides sample stories, seed data, and
+a known-good baseline for integration testing.
+
+## Structure
+
+```
+test-project/
+├── README.md             # This file
+└── stories/
+    └── todo-stories.md   # 5 sample stories in frontmatter markdown format
+```
+
+## Sample Stories
+
+The `stories/todo-stories.md` file contains 5 stories in standard frontmatter
+format:
+
+| Key    | Title                               | Scope    | Dependencies     |
+|--------|-------------------------------------|----------|------------------|
+| TODO-1 | Add create todo endpoint            | backend  | none             |
+| TODO-2 | Add list todos endpoint             | backend  | none             |
+| TODO-3 | Add update todo endpoint            | backend  | TODO-1           |
+| TODO-4 | Add delete todo endpoint            | backend  | TODO-1           |
+| TODO-5 | Add todo list UI with toggle        | frontend | TODO-2, TODO-3   |
+
+These stories exercise:
+- Multiple scopes (backend, frontend)
+- Dependency chains (linear and diamond)
+- Standard YAML frontmatter parsing
+
+## Pipeline Validation Flow
+
+The integration test suite in `backend/internal/integration/` validates the
+full pipeline using these stories:
+
+### Test: Story Import (`TestIntegration_PipelineValidation_StoryImport`)
+
+1. Reads `test-project/stories/todo-stories.md`
+2. Parses markdown into story blocks via the markdown adapter
+3. Imports stories into Postgres via `StoryService.Import()`
+4. Verifies all 5 stories created with correct keys, scopes, dependencies
+5. Verifies re-import updates existing stories (idempotent)
+
+### Test: Run Creation (`TestIntegration_PipelineValidation_RunCreation`)
+
+1. Creates a project with a 3-step pipeline config (implement, review, merge)
+2. Creates a story and launches a run via `RunService.LaunchRun()`
+3. Verifies run created in `pending` status with 3 steps in correct order
+4. Verifies pipeline config snapshot persisted as JSON
+5. Verifies duplicate launch is blocked for active runs
+
+### Test: Pipeline Execution (`TestIntegration_PipelineValidation_Execution`)
+
+1. Sets up project, story, pipeline config, and run
+2. Registers noop actions in the `ActionRegistry`
+3. Executes the pipeline via `PipelineExecutor.ExecuteRun()`
+4. Verifies run transitions: `pending` -> `running` -> `completed`
+5. Verifies all steps transition: `pending` -> `running` -> `completed`
+6. Verifies events published to the events table (run.started, step.started/completed, run.completed)
+
+### Test: Full Flow (`TestIntegration_PipelineValidation_FullFlow`)
+
+End-to-end validation combining all the above:
+1. Creates a project with pipeline config
+2. Imports all 5 stories from test-project markdown
+3. Picks TODO-1 (no dependencies) and launches a run
+4. Executes the pipeline with noop actions
+5. Verifies final state: run completed, all steps completed, events generated
+
+## Running the Tests
+
+```bash
+# From the backend directory:
+
+# Run only pipeline validation integration tests
+go test ./internal/integration/ -v -run TestIntegration_PipelineValidation
+
+# Run all integration tests (skip unit tests)
+go test ./... -run TestIntegration
+
+# Run unit tests only (skips integration tests)
+go test ./... -short
+```
+
+## Test Infrastructure
+
+The integration tests use:
+- **testcontainers-go**: Ephemeral Postgres 16 containers
+- **Real migrations**: All `.up.sql` files applied automatically
+- **Real adapters**: Postgres repositories, event publisher
+- **Mock actions**: Noop actions that succeed immediately (no Docker/agent containers)
+- **Shared testutil**: `backend/internal/testutil/` provides `SetupTestDB`, `CreateProject`, and other factories
+
+## Design Decisions
+
+- **Noop actions instead of real containers**: Integration tests validate the
+  pipeline orchestration logic (state machine, events, step ordering) against
+  real Postgres without requiring Docker-in-Docker for agent containers.
+- **testcontainers for isolation**: Each test gets a fresh Postgres instance
+  with all migrations applied, ensuring tests are independent and deterministic.
+- **Shared testutil package**: Test helpers extracted to `backend/internal/testutil/`
+  for reuse across integration test suites.

--- a/test-project/stories/todo-stories.md
+++ b/test-project/stories/todo-stories.md
@@ -1,0 +1,88 @@
+---
+key: TODO-1
+epic: Todo App
+depends_on: []
+scope: backend
+status: backlog
+---
+# Add create todo endpoint
+
+**Given** the API is running
+**When** I send a POST to /api/todos with a valid title
+**Then** a new todo is created with status "pending"
+
+**Given** the API is running
+**When** I send a POST to /api/todos without a title
+**Then** I receive a 400 validation error
+
+---
+key: TODO-2
+epic: Todo App
+depends_on: []
+scope: backend
+status: backlog
+---
+# Add list todos endpoint
+
+**Given** todos exist in the database
+**When** I send a GET to /api/todos
+**Then** I receive a paginated list of todos
+
+**Given** no todos exist
+**When** I send a GET to /api/todos
+**Then** I receive an empty list with total count 0
+
+---
+key: TODO-3
+epic: Todo App
+depends_on:
+  - TODO-1
+scope: backend
+status: backlog
+---
+# Add update todo endpoint
+
+**Given** a todo exists
+**When** I send a PUT to /api/todos/:id with updated fields
+**Then** the todo is updated and returned
+
+**Given** I want to mark a todo as complete
+**When** I send a PUT with completed=true
+**Then** the todo status changes to "done"
+
+---
+key: TODO-4
+epic: Todo App
+depends_on:
+  - TODO-1
+scope: backend
+status: backlog
+---
+# Add delete todo endpoint
+
+**Given** a todo exists
+**When** I send a DELETE to /api/todos/:id
+**Then** the todo is removed from the database
+
+**Given** a todo does not exist
+**When** I send a DELETE to /api/todos/:id
+**Then** I receive a 404 error
+
+---
+key: TODO-5
+epic: Todo App
+depends_on:
+  - TODO-2
+  - TODO-3
+scope: frontend
+status: backlog
+---
+# Add todo list UI with completion toggle
+
+**Given** I am on the todo list page
+**When** the page loads
+**Then** I see all todos with their status
+
+**Given** a todo is displayed
+**When** I click the completion toggle
+**Then** the todo status is updated via API


### PR DESCRIPTION
## Summary
- Add 5 reference todo app stories in `test-project/stories/todo-stories.md` with standard YAML frontmatter (keys, dependencies, scopes)
- Add shared `backend/internal/testutil/` package with testcontainers-based Postgres setup, migration runner, and test data factories
- Add pipeline validation integration test suite (`backend/internal/integration/`) covering story import, run creation, pipeline execution, and state transitions against real Postgres
- Add `test-project/README.md` documenting the validation flow and how to run tests

## Test plan
- [x] All unit tests pass (`go test ./... -short`)
- [x] Integration tests compile (`go test -c ./internal/integration/`)
- [x] New code passes `go vet` and `gofmt`
- [ ] Integration tests pass in CI with Docker available (`go test ./internal/integration/ -v -run TestIntegration_PipelineValidation`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)