### PR TITLE
feat(pipeline): add circuit breaker for consecutive pipeline failures

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -812,6 +812,27 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  # ── Circuit Breaker ─────────────────────────────────────────────────
+  /projects/{id}/circuit-breaker/reset:
+    post:
+      operationId: resetCircuitBreaker
+      summary: Reset the circuit breaker for a project
+      description: >
+        Resets the circuit breaker state (count=0, active=false) so that
+        pipeline runs can be attempted again. Admin-only endpoint.
+      tags: [projects]
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "204":
+          description: Circuit breaker reset successfully
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   # ── Pipeline Configs ─────────────────────────────────────────────────
   /projects/{projectId}/pipeline:
     get:
@@ -1064,6 +1085,9 @@ components:
         - id
         - name
         - owner_id
+        - circuit_breaker_count
+        - circuit_breaker_active
+        - circuit_breaker_max
         - created_at
         - updated_at
       properties:
@@ -1081,6 +1105,18 @@ components:
           type: string
           format: uuid
           example: 550e8400-e29b-41d4-a716-446655440000
+        circuit_breaker_count:
+          type: integer
+          description: Number of consecutive pipeline failures
+          example: 0
+        circuit_breaker_active:
+          type: boolean
+          description: Whether the circuit breaker is currently tripped
+          example: false
+        circuit_breaker_max:
+          type: integer
+          description: Threshold for consecutive failures before tripping
+          example: 3
         created_at:
           type: string
           format: date-time

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -89,7 +89,14 @@ func run() error {
 	// Project service (with pipeline config seeding on creation)
 	projectService := service.NewProjectService(projectRepo)
 	projectService.SetPipelineConfigService(pipelineConfigService)
-	projectHandler := handler.NewProjectHandler(projectService, projectUserService)
+
+	// Event publisher (for persisting events to DB) — needed by circuit breaker
+	eventRepo := pgadapter.NewEventRepo(queries)
+
+	// Circuit breaker service
+	circuitBreakerService := service.NewCircuitBreakerService(projectRepo, eventRepo, logger)
+
+	projectHandler := handler.NewProjectHandler(projectService, projectUserService, circuitBreakerService)
 
 	// Epic service
 	epicRepo := pgadapter.NewEpicRepo(queries)
@@ -127,6 +134,7 @@ func run() error {
 	// Pipeline executor (will be used by River workers)
 	// NOTE: event publisher and action registry wiring deferred to later story
 	pipelineExecutor := service.NewPipelineExecutor(runRepo, nil, nil, logger)
+	pipelineExecutor.SetCircuitBreaker(circuitBreakerService)
 
 	// River job queue for async pipeline execution
 	workers := river.NewWorkers()
@@ -152,9 +160,6 @@ func run() error {
 	if err != nil {
 		logger.Warn("docker container manager unavailable, timeout enforcer and orphan cleaner disabled", "error", err)
 	}
-
-	// Event publisher (for persisting events to DB)
-	eventRepo := pgadapter.NewEventRepo(queries)
 
 	// Action registry
 	actionReg := service.NewActionRegistry()

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -190,6 +190,12 @@ func (m *mockProjectRepo) Update(_ context.Context, p *model.Project) (*model.Pr
 	return p, nil
 }
 func (m *mockProjectRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
+func (m *mockProjectRepo) IncrementCircuitBreakerCount(_ context.Context, _ uuid.UUID) (*model.Project, error) {
+	return &model.Project{}, nil
+}
+func (m *mockProjectRepo) ResetCircuitBreaker(_ context.Context, _ uuid.UUID) (*model.Project, error) {
+	return &model.Project{}, nil
+}
 
 type mockRunRepo struct {
 	updateRunStepContainerInfoFn func(ctx context.Context, id uuid.UUID, containerID *string, logTail *string) (*model.RunStep, error)

--- a/backend/internal/adapter/postgres/models.go
+++ b/backend/internal/adapter/postgres/models.go
@@ -41,18 +41,21 @@ type PipelineConfig struct {
 }
 
 type Project struct {
-	ID           uuid.UUID      `json:"id"`
-	Name         string         `json:"name"`
-	Description  pgtype.Text    `json:"description"`
-	OwnerID      pgtype.UUID    `json:"owner_id"`
-	RepoUrl      pgtype.Text    `json:"repo_url"`
-	GitProvider  string         `json:"git_provider"`
-	GitTokenEnv  pgtype.Text    `json:"git_token_env"`
-	AgentRuntime string         `json:"agent_runtime"`
-	DefaultModel pgtype.Text    `json:"default_model"`
-	MaxBudget    pgtype.Numeric `json:"max_budget"`
-	CreatedAt    time.Time      `json:"created_at"`
-	UpdatedAt    time.Time      `json:"updated_at"`
+	ID                   uuid.UUID      `json:"id"`
+	Name                 string         `json:"name"`
+	Description          pgtype.Text    `json:"description"`
+	OwnerID              pgtype.UUID    `json:"owner_id"`
+	RepoUrl              pgtype.Text    `json:"repo_url"`
+	GitProvider          string         `json:"git_provider"`
+	GitTokenEnv          pgtype.Text    `json:"git_token_env"`
+	AgentRuntime         string         `json:"agent_runtime"`
+	DefaultModel         pgtype.Text    `json:"default_model"`
+	MaxBudget            pgtype.Numeric `json:"max_budget"`
+	CreatedAt            time.Time      `json:"created_at"`
+	UpdatedAt            time.Time      `json:"updated_at"`
+	CircuitBreakerCount  int32          `json:"circuit_breaker_count"`
+	CircuitBreakerActive bool           `json:"circuit_breaker_active"`
+	CircuitBreakerMax    int32          `json:"circuit_breaker_max"`
 }
 
 type ProjectUser struct {

--- a/backend/internal/adapter/postgres/project_repo.go
+++ b/backend/internal/adapter/postgres/project_repo.go
@@ -119,15 +119,43 @@ func (r *ProjectRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// IncrementCircuitBreakerCount increments the circuit breaker failure count for a project.
+// If the count reaches the max threshold, the circuit breaker is activated.
+func (r *ProjectRepo) IncrementCircuitBreakerCount(ctx context.Context, id uuid.UUID) (*model.Project, error) {
+	row, err := r.queries.IncrementCircuitBreakerCount(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperrors.NewNotFound("project", id)
+		}
+		return nil, apperrors.NewInternal("failed to increment circuit breaker count", err)
+	}
+	return toDomainProject(row), nil
+}
+
+// ResetCircuitBreaker resets the circuit breaker state for a project.
+func (r *ProjectRepo) ResetCircuitBreaker(ctx context.Context, id uuid.UUID) (*model.Project, error) {
+	row, err := r.queries.ResetCircuitBreaker(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperrors.NewNotFound("project", id)
+		}
+		return nil, apperrors.NewInternal("failed to reset circuit breaker", err)
+	}
+	return toDomainProject(row), nil
+}
+
 // toDomainProject maps a sqlc-generated Project to a domain Project.
 func toDomainProject(p Project) *model.Project {
 	project := &model.Project{
-		ID:           p.ID,
-		Name:         p.Name,
-		GitProvider:  p.GitProvider,
-		AgentRuntime: p.AgentRuntime,
-		CreatedAt:    p.CreatedAt,
-		UpdatedAt:    p.UpdatedAt,
+		ID:                   p.ID,
+		Name:                 p.Name,
+		GitProvider:          p.GitProvider,
+		AgentRuntime:         p.AgentRuntime,
+		CircuitBreakerCount:  int(p.CircuitBreakerCount),
+		CircuitBreakerActive: p.CircuitBreakerActive,
+		CircuitBreakerMax:    int(p.CircuitBreakerMax),
+		CreatedAt:            p.CreatedAt,
+		UpdatedAt:            p.UpdatedAt,
 	}
 	if p.Description.Valid {
 		project.Description = &p.Description.String

--- a/backend/internal/adapter/postgres/project_users.sql.go
+++ b/backend/internal/adapter/postgres/project_users.sql.go
@@ -112,7 +112,7 @@ func (q *Queries) ListProjectUsers(ctx context.Context, projectID uuid.UUID) ([]
 }
 
 const listProjectsByUser = `-- name: ListProjectsByUser :many
-SELECT p.id, p.name, p.description, p.owner_id, p.repo_url, p.git_provider, p.git_token_env, p.agent_runtime, p.default_model, p.max_budget, p.created_at, p.updated_at FROM projects p
+SELECT p.id, p.name, p.description, p.owner_id, p.repo_url, p.git_provider, p.git_token_env, p.agent_runtime, p.default_model, p.max_budget, p.created_at, p.updated_at, p.circuit_breaker_count, p.circuit_breaker_active, p.circuit_breaker_max FROM projects p
 INNER JOIN project_users pu ON pu.project_id = p.id
 WHERE pu.user_id = $1
 ORDER BY p.created_at DESC
@@ -147,6 +147,9 @@ func (q *Queries) ListProjectsByUser(ctx context.Context, arg ListProjectsByUser
 			&i.MaxBudget,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.CircuitBreakerCount,
+			&i.CircuitBreakerActive,
+			&i.CircuitBreakerMax,
 		); err != nil {
 			return nil, err
 		}

--- a/backend/internal/adapter/postgres/projects.sql.go
+++ b/backend/internal/adapter/postgres/projects.sql.go
@@ -26,7 +26,7 @@ func (q *Queries) CountProjects(ctx context.Context) (int64, error) {
 const createProject = `-- name: CreateProject :one
 INSERT INTO projects (name, description, owner_id, repo_url, git_provider, git_token_env, agent_runtime, default_model, max_budget)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-RETURNING id, name, description, owner_id, repo_url, git_provider, git_token_env, agent_runtime, default_model, max_budget, created_at, updated_at
+RETURNING id, name, description, owner_id, repo_url, git_provider, git_token_env, agent_runtime, default_model, max_budget, created_at, updated_at, circuit_breaker_count, circuit_breaker_active, circuit_breaker_max
 `
 
 type CreateProjectParams struct {
@@ -67,6 +67,9 @@ func (q *Queries) CreateProject(ctx context.Context, arg CreateProjectParams) (P
 		&i.MaxBudget,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.CircuitBreakerCount,
+		&i.CircuitBreakerActive,
+		&i.CircuitBreakerMax,
 	)
 	return i, err
 }
@@ -80,8 +83,33 @@ func (q *Queries) DeleteProject(ctx context.Context, id uuid.UUID) error {
 	return err
 }
 
+const getCircuitBreakerState = `-- name: GetCircuitBreakerState :one
+SELECT id, circuit_breaker_count, circuit_breaker_active, circuit_breaker_max
+FROM projects
+WHERE id = $1
+`
+
+type GetCircuitBreakerStateRow struct {
+	ID                   uuid.UUID `json:"id"`
+	CircuitBreakerCount  int32     `json:"circuit_breaker_count"`
+	CircuitBreakerActive bool      `json:"circuit_breaker_active"`
+	CircuitBreakerMax    int32     `json:"circuit_breaker_max"`
+}
+
+func (q *Queries) GetCircuitBreakerState(ctx context.Context, id uuid.UUID) (GetCircuitBreakerStateRow, error) {
+	row := q.db.QueryRow(ctx, getCircuitBreakerState, id)
+	var i GetCircuitBreakerStateRow
+	err := row.Scan(
+		&i.ID,
+		&i.CircuitBreakerCount,
+		&i.CircuitBreakerActive,
+		&i.CircuitBreakerMax,
+	)
+	return i, err
+}
+
 const getProject = `-- name: GetProject :one
-SELECT id, name, description, owner_id, repo_url, git_provider, git_token_env, agent_runtime, default_model, max_budget, created_at, updated_at FROM projects WHERE id = $1
+SELECT id, name, description, owner_id, repo_url, git_provider, git_token_env, agent_runtime, default_model, max_budget, created_at, updated_at, circuit_breaker_count, circuit_breaker_active, circuit_breaker_max FROM projects WHERE id = $1
 `
 
 func (q *Queries) GetProject(ctx context.Context, id uuid.UUID) (Project, error) {
@@ -100,12 +128,50 @@ func (q *Queries) GetProject(ctx context.Context, id uuid.UUID) (Project, error)
 		&i.MaxBudget,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.CircuitBreakerCount,
+		&i.CircuitBreakerActive,
+		&i.CircuitBreakerMax,
+	)
+	return i, err
+}
+
+const incrementCircuitBreakerCount = `-- name: IncrementCircuitBreakerCount :one
+UPDATE projects
+SET circuit_breaker_count = circuit_breaker_count + 1,
+    circuit_breaker_active = CASE
+        WHEN circuit_breaker_count + 1 >= circuit_breaker_max THEN true
+        ELSE circuit_breaker_active
+    END,
+    updated_at = now()
+WHERE id = $1
+RETURNING id, name, description, owner_id, repo_url, git_provider, git_token_env, agent_runtime, default_model, max_budget, created_at, updated_at, circuit_breaker_count, circuit_breaker_active, circuit_breaker_max
+`
+
+func (q *Queries) IncrementCircuitBreakerCount(ctx context.Context, id uuid.UUID) (Project, error) {
+	row := q.db.QueryRow(ctx, incrementCircuitBreakerCount, id)
+	var i Project
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Description,
+		&i.OwnerID,
+		&i.RepoUrl,
+		&i.GitProvider,
+		&i.GitTokenEnv,
+		&i.AgentRuntime,
+		&i.DefaultModel,
+		&i.MaxBudget,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.CircuitBreakerCount,
+		&i.CircuitBreakerActive,
+		&i.CircuitBreakerMax,
 	)
 	return i, err
 }
 
 const listProjects = `-- name: ListProjects :many
-SELECT id, name, description, owner_id, repo_url, git_provider, git_token_env, agent_runtime, default_model, max_budget, created_at, updated_at FROM projects ORDER BY created_at DESC LIMIT $1 OFFSET $2
+SELECT id, name, description, owner_id, repo_url, git_provider, git_token_env, agent_runtime, default_model, max_budget, created_at, updated_at, circuit_breaker_count, circuit_breaker_active, circuit_breaker_max FROM projects ORDER BY created_at DESC LIMIT $1 OFFSET $2
 `
 
 type ListProjectsParams struct {
@@ -135,6 +201,9 @@ func (q *Queries) ListProjects(ctx context.Context, arg ListProjectsParams) ([]P
 			&i.MaxBudget,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.CircuitBreakerCount,
+			&i.CircuitBreakerActive,
+			&i.CircuitBreakerMax,
 		); err != nil {
 			return nil, err
 		}
@@ -144,6 +213,38 @@ func (q *Queries) ListProjects(ctx context.Context, arg ListProjectsParams) ([]P
 		return nil, err
 	}
 	return items, nil
+}
+
+const resetCircuitBreaker = `-- name: ResetCircuitBreaker :one
+UPDATE projects
+SET circuit_breaker_count = 0,
+    circuit_breaker_active = false,
+    updated_at = now()
+WHERE id = $1
+RETURNING id, name, description, owner_id, repo_url, git_provider, git_token_env, agent_runtime, default_model, max_budget, created_at, updated_at, circuit_breaker_count, circuit_breaker_active, circuit_breaker_max
+`
+
+func (q *Queries) ResetCircuitBreaker(ctx context.Context, id uuid.UUID) (Project, error) {
+	row := q.db.QueryRow(ctx, resetCircuitBreaker, id)
+	var i Project
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Description,
+		&i.OwnerID,
+		&i.RepoUrl,
+		&i.GitProvider,
+		&i.GitTokenEnv,
+		&i.AgentRuntime,
+		&i.DefaultModel,
+		&i.MaxBudget,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.CircuitBreakerCount,
+		&i.CircuitBreakerActive,
+		&i.CircuitBreakerMax,
+	)
+	return i, err
 }
 
 const updateProject = `-- name: UpdateProject :one
@@ -159,7 +260,7 @@ SET name = COALESCE($1, name),
     max_budget = COALESCE($9, max_budget),
     updated_at = now()
 WHERE id = $10
-RETURNING id, name, description, owner_id, repo_url, git_provider, git_token_env, agent_runtime, default_model, max_budget, created_at, updated_at
+RETURNING id, name, description, owner_id, repo_url, git_provider, git_token_env, agent_runtime, default_model, max_budget, created_at, updated_at, circuit_breaker_count, circuit_breaker_active, circuit_breaker_max
 `
 
 type UpdateProjectParams struct {
@@ -202,6 +303,9 @@ func (q *Queries) UpdateProject(ctx context.Context, arg UpdateProjectParams) (P
 		&i.MaxBudget,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.CircuitBreakerCount,
+		&i.CircuitBreakerActive,
+		&i.CircuitBreakerMax,
 	)
 	return i, err
 }

--- a/backend/internal/api/handler/gen_server.go
+++ b/backend/internal/api/handler/gen_server.go
@@ -318,12 +318,20 @@ type PipelineStepModel string
 
 // Project defines model for Project.
 type Project struct {
-	CreatedAt   time.Time          `json:"created_at"`
-	Description *string            `json:"description,omitempty"`
-	Id          openapi_types.UUID `json:"id"`
-	Name        string             `json:"name"`
-	OwnerId     openapi_types.UUID `json:"owner_id"`
-	UpdatedAt   time.Time          `json:"updated_at"`
+	// CircuitBreakerActive Whether the circuit breaker is currently tripped
+	CircuitBreakerActive bool `json:"circuit_breaker_active"`
+
+	// CircuitBreakerCount Number of consecutive pipeline failures
+	CircuitBreakerCount int `json:"circuit_breaker_count"`
+
+	// CircuitBreakerMax Threshold for consecutive failures before tripping
+	CircuitBreakerMax int                `json:"circuit_breaker_max"`
+	CreatedAt         time.Time          `json:"created_at"`
+	Description       *string            `json:"description,omitempty"`
+	Id                openapi_types.UUID `json:"id"`
+	Name              string             `json:"name"`
+	OwnerId           openapi_types.UUID `json:"owner_id"`
+	UpdatedAt         time.Time          `json:"updated_at"`
 }
 
 // ProjectList defines model for ProjectList.
@@ -800,6 +808,9 @@ type ServerInterface interface {
 	// Update a project
 	// (PUT /projects/{id})
 	UpdateProject(w http.ResponseWriter, r *http.Request, id IdPath)
+	// Reset the circuit breaker for a project
+	// (POST /projects/{id}/circuit-breaker/reset)
+	ResetCircuitBreaker(w http.ResponseWriter, r *http.Request, id IdPath)
 	// List epics for a project with story counts
 	// (GET /projects/{projectId}/epics)
 	ListEpics(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, params ListEpicsParams)
@@ -938,6 +949,12 @@ func (_ Unimplemented) GetProject(w http.ResponseWriter, r *http.Request, id IdP
 // Update a project
 // (PUT /projects/{id})
 func (_ Unimplemented) UpdateProject(w http.ResponseWriter, r *http.Request, id IdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Reset the circuit breaker for a project
+// (POST /projects/{id}/circuit-breaker/reset)
+func (_ Unimplemented) ResetCircuitBreaker(w http.ResponseWriter, r *http.Request, id IdPath) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1333,6 +1350,37 @@ func (siw *ServerInterfaceWrapper) UpdateProject(w http.ResponseWriter, r *http.
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.UpdateProject(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ResetCircuitBreaker operation middleware
+func (siw *ServerInterfaceWrapper) ResetCircuitBreaker(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id IdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ResetCircuitBreaker(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2547,6 +2595,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Put(options.BaseURL+"/projects/{id}", wrapper.UpdateProject)
 	})
 	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/projects/{id}/circuit-breaker/reset", wrapper.ResetCircuitBreaker)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/projects/{projectId}/epics", wrapper.ListEpics)
 	})
 	r.Group(func(r chi.Router) {
@@ -2634,82 +2685,86 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x9eW8bObL4VyH69wPeDCBZkmNnZvzX5ppd78skhh1jsC9rCHR3SeK6RXZIdhw9w9/9",
-	"gUcf7GYfknV4JvNXYolHsS5WFatKD0HIlgmjQKUIzh6CBHO8BAlc//UuIeF5dIHlQv0VgQg5SSRhNDjT",
-	"36Hr6/O3wSAg6oNEDRsEFC8hOAtATw0GAYcvKeEQBWeSpzAIRLiAJVbrzRhfYhmcBWlK1Ei5StRMITmh",
-	"8+DxcRA07X0JgqU8hJb9yVP3vsBzuFDYqG+vvkI0Xd4Czzb/kgJfFbsneA5Beb8IZjiNZXA2GQRLQsky",
-	"Xer/230JlTAHbjYG3rL3uYSlQAlwZPfwbg982gzC8XgQLPE3C8N43A0RZ/+BUDZRw37dQowkW+CJNLlM",
-	"aSNLpLQFAK4mPnHzK8bl61UDWX4lEEdIMiQYl+h21UAY9e1Uf+uhSxBywBKiKZZ+ACTjq6bz6y9bMCDM",
-	"5Cfi4BMskxhLaGGFZSKRtMNa4JH5Sk8C6VFNFgmjArTGeo2jS/iSgpDqr5BRCVT/FydJTEKs4Bz9Ryhg",
-	"H0rb/H8Os+As+H+jQhuOzLdi9I5zxs1W7mFf4whxu9njIHjD6Cwm4R42ztVfaLdEP8DR/AhFqdkKECwx",
-	"iX9UUP3K+C2JIqC7ByvfCg0RjpaEIhyGIATKyfs4CD4w+StLabRHLFEm0Uzv+TgIrilO5YJx8r+wBxic",
-	"3dTXdoZa8I2WdnWNljg24SwBLonhZmexhwC+4WUSQ3b5zhhHanmg0oKNZoBlykEEWsO/BzpXUno8Vkq+",
-	"IjqZJJaXvRbA0StnycpKp6f6tsj+nniWFRLLVLia7RaHdzGbB4MAqLpnPpc+IXSacDbnIBTYEaMQ3Ph0",
-	"T6EkPhvQi1HsVl0vWgg1Uu2NtD5eXyGh/4vsjeWeftIXj7+t0IVvgW70rX3OZSIzpdx43DqAbw1l0Ln6",
-	"ewlUIrPU+tTO9Pi0JEjFPv9iKcIcEMn2IXSO9FWEHh70v9M7WD0+Hh0dBd1b6Q8echbKF9U3iNT3LIev",
-	"BO7VWsC1/ROmQrKlwmEBVXliD/x7DmnnNVPmMqWN5EhIAjGherUZmdcHCAmJ/g9Rxl79exxmnNvIi72O",
-	"ZdfxncJ+gDnHq9p0A59vmiEpifpZE+6aduaghp9mLGujpxHP6vZJJKYhTENOJHCCvTiLIAEaialBaY7z",
-	"Bv7LcDLQLk6/sw6CO1i5knE1HE9caTv16RZzYvIVvBCJkLkiobQqUAXBjGtWVf8VC6yQfNOqq9uuN43m",
-	"KzNU4QHzOcjpjMQg1sOYJDKuaKJCA8VsTmjm1VS1UDvzKOxmq/u4RV2Xdf4omdsOSMfj45fD8WQ4Of00",
-	"GZ+9GJ+Nx/+jMJrROMIShpIYzVBnps2v7NpihrmKNX76aQw/n4zHQzj+5XZ4MolOhvinycvhycnLl6en",
-	"Jyfj8XhchrSJG/ve/LWJ9lqcVgF7+XI7gBX82NdOKGAoRnqWVcolZKmNcnQy+xsz9HEQpEm0bSapMK/R",
-	"eQViB5l6tsiogD9w3cQSfE2c/554bSAssSO9rQauEiCPQCd4TijOmL1thYtiZBUBGhJnLe9JtI1dOwb4",
-	"Pw5ZVOXwq3eX0w8fP01//Xj94a1fdCUmsbk6oogoSHB8UVrWOKc1yJYghNJadYG6J3KBzt8ifBtOjl+U",
-	"HJEuntDgFyvX8VEZb7DgQ9v5MmFcKqYmIBqvypLxVnGi8D1aYn4XsXuK7ChzrH+9+u090rfMEksJ3Jp1",
-	"tzEL70SPA5oNe4AstAvhpbvozcDFmivrrNWZeYZJbJxCFwcfdKQPsZk+IgGB5AJLZIYjyZR1y3jJmMxj",
-	"Z4PAfNW+KoX7eIWsVGd7eFezwt62mB2Sg/rDHawQjjngaIXgGxESoh8Db5jPUUoZ3MWmOYIGGfLbibd6",
-	"1y6a7gl+w+GCUBgqQPFtDEjvgawgNNlTvhiYOvAPS7xCt4BgmcgVIjP9YcjSONJCqL75JjkOXWQUy5dE",
-	"2t3iH+kS0yqQ5SH9TJVs/YHBhg+R75U51CiwOsDjapxUAP+b/fMoZMvybWSG+y50LMQ945XrXECYcrj4",
-	"mxCT8ir54K5DZtvlE3wHvHDujoqLVNWnE5845GHu8sjjsW+oZBK7+Do57hQCM2mQRfPz7bynsU7Lmwaf",
-	"bveWU9VnbL2NLbRXEhKfKmy3eo63YPU4Bo8BvtOYcaBu8Iqn7VGCSnRAKuFaO0gwCHAq2RQnCWdfXe6b",
-	"4VgUNsItYzFg6jPlf/55O3Rfsgji8nnDGKcRDFmSiuHJ8KU6nflEMEpBDk+Gp8VnC0zu0uHJ8IV79voa",
-	"PVyIVoTp+Mw0YTEJV13MeanGXpihXmPZCV8YgmeIqJCmsrGXqWyg7sDuoSfy2OkObkt3dAQw60GJewq8",
-	"pslOT7cDzZ48LstE+VnW86ssdrbgWmV4Pqx35UaS9yQMu9KJa8W79x7j2GbE/CAx8oMGRZpC8WuLb4nd",
-	"tyPFZfk5rDBfwlz5eXzn3kNd0P6JKaC3DNZ/SNrUEykt+/Pafsmg+YWtbIXUELjE36ZKnDJ85s6Hk1lT",
-	"SqzxOiXGNqmKLGVUX0x0qPztlGtTJ77HK+FKqDOg/dxlcJ1tvQdPqc9pV7sWMt9Pwbu3Rr852qWelhzw",
-	"hmujU89WnpGmguJELJhcO77nXgh9Yth83UPX494J0Eh9OQh4Sqn5X06EciwmxDSEODYPPAV3FPMbouE9",
-	"T+Oq+q1o8tJTXx7iXkd5X6Z0CxpbsfmB1XRK2zxZL+9vKIeMSkwKo/15CWrM5lNpL6S645jSP5HgQTJt",
-	"eKG33zIeAS993RifjYIcN+WFnWXyF36/oDXw5O9ELq6yaBKO44+z4OxzH1nqTmPoWMMfjeqZfHCTZUhu",
-	"ngiwiRTsI3lgvRyDagYa+ZKC9SBIpByKGbFPU4Rm0QaTQDhAV8Px5MdgUM9TWDMxYd0r83vNY9jJ/VrO",
-	"htjwii0/gtfEKXtoL5//hc++1W/05VGnvlHFs1s+zm8tW3Xc8SxQQU+RFVCo88hY2HbjxvNvwcgwCumw",
-	"ZkZ+lo/8itB5DL56CplyKlA+VCeqxOo/X1JQbsMAMY6Enm5G6RF3sEIxY3dpoh0W6HFVFJhVF0YP3OV6",
-	"/WrNvNJuehdSeK3FYbNc3Gv74uq+Am6UfmtX0qlCH8x1vnHy7eaJtjUOMnC5L1yNeNrmQ1TvvEML4aZp",
-	"v50knKxLwqwmZhMqPrYdcLN83xJYy0RuyFvtgctsi7z2w47aR2pvbwT+cRJG/6SJn915nQ2UuxbrxTMp",
-	"3A/1x9sKal4tia5fWlNoOIsdQunCGGWACeB9WVcA39OLzLYCw7t6G2wNOK+Ne/eQB3zoyPBoXXgN93oG",
-	"u+KRLdirmtUOaa4q1QRhyolcXakVs+gzuyPwKvWVHP7z909IsjugSCjvCwuEKVpImXyk8QqZ9wNkFsgq",
-	"EfO/slpENb2gFE7If8PKlHMROmNZgiQ2WQJ20j9YAufyd8bvBPoEeBl46gO1TkavLs61tSwXgMqzMt97",
-	"iSmeG99R3ZyKiY7+TT8tiEBE6FnW8Lb1bGyGJE/lIl9UbaAA5DiUR/9WJ4lJCFRACdzfzj8pLuJxcBYo",
-	"7Iiz0YglQM2aR4zPR3aSGKmxhdJ2Tvrq4jwYBF+BC3PG8dHkaKzvqwQoTkhwFrw4Gh+90HSWC029EU7l",
-	"YqTdYs2ezLCpYlLNBudRcGbS3a6NGNqiytcsWm2tRM9Jp3t0WVPyFKqFpMfj8db2NlJVrw7UMCGR6irJ",
-	"Wao0wAJwZIvvr0AO3xhOrTF9zt+K+3N2LqCplck+DoKT8aQJ0Pzko3rBopXG4OzzzSAQ6XKJ+crAjghV",
-	"sqaTSgmdo0yJ4rnQ2laJ641aI2cAlspWDmCpzFnAocVJHQXv2XwOEWKpLGEw1tpqw5M6Z1PrKtkKU86V",
-	"ZHYczlxLc/Cc6+8g35hF/GfbPZ+9KZ0BZVnuW8DT38HBUbwq17ZA1IUzbp+pm1kie8jeoV6ovpX3Ug2T",
-	"nZNMlw9kCILIZfEdq4lxN1OUyuz1lF+6p+Tl8W1aJaMGwojCfQsD2btTNEqdMoYuskEDp69JQ4SqGDIq",
-	"+m80BanKg8v9OnqML/eReLzZoToo56h5WMxaahCZQB+boRyp29Chak0cx8WiBR3zj26UaemVfKeOe0ei",
-	"760V37P859l/HvpY89C6AcGmsvk0OhokWXks5abWSVkWy9EDiR6NPorB5BO69H2rPy/ou5582vYjHuk5",
-	"aW5PY0CJNkSKmnTSPSlvb+Fi0RwX4XYMDhoNiO0jarxPFn6azfE01CsjJcc7ul0h3ZHGr4pSD/ad0PLT",
-	"CLB9FeaNe+/Zu+lB/6yEbG8q7GksY7DaJa2uvstbXD2OICFhu2HyTo9Y2ypx2nD1sUz+FGZMXsLcy4bR",
-	"yDcVqibnIcxLubdi0pj1dR1/rlTquxUMY5ihy9DR9dVP5IebXVpJ5afRPZtIpva8Tnv9Srp340hNetE9",
-	"qWi7tZl/5Le/FDPpqItHM2WM1q6WRg+mMWMP42wbPNmtRkotJvuZc5rsT7fl1qfh060/qgnoVQ5Nht9z",
-	"IMJ4P6J8cCPRkKdmIpY0eLN9eCA67cqiXFvd74lHDmJI7lhVPO1+yGzVRt3SeB9k9RFtgetKVfs2LJRd",
-	"eSEupD5b0Y5Aph4k5faV8kDqRi4AJV6QXOuy7HzY4UMzvNtp3T71dubCepPL9u3JbshDf0q15NMy2+HZ",
-	"Ro3EU9ruN1+mVLxebRqL2af/vEtVl9U/9fKHNU635fyqxRoprXfqcnQvU/qs/dxS3849u7m6hsbTxTil",
-	"h3FyN1cW7pNBpi54SrtYp1ExZD2x2nTDVd4361lH1Sov82y5xEMBakZZak16JggkGZqRWAJXbokt0rEZ",
-	"3QOb4P5jU6/5vH1g43vvoLmDlmQ6sx+lCfqB2/KALA1JDWra1RSfNG+5S8VYr3TopSKzVmlFhYNtZacx",
-	"cRAR0to2g8sTbGSJqV62jGJ5xJYdWqHKhKZLJZs6i+eslJ2s7T2rZVuFUucjIyrfV/zRVhH6A5AFv3Xp",
-	"8ZFtmNiY9+N0gHymrOltrLlnh8XXKdPDqmYY4nqAUSAJ8KGhps0sQphGec/F4sXkebK0w6Gv0/jOtuAs",
-	"VCZny6Jvqbdf6Wac+2B/R6VH/HwrerXHO1zpV2H6RdCN5vpjhtCNCmq45ZqiWM+DEuN93UmHz7bI7Scn",
-	"kO4YJM1Rq4NRa1exrfXNl72xyl/x9KZ4eoui6X9J5BGtzMypeH/athLKmjJNQ7STbLMJIBEoAk6+QmSu",
-	"Mx18M5v9l6iG4cz1Tb+kkKoFxYqGCL5BmKqtjlBW4H0y/gWRmakp0QyQdYZemLoZrEsOFRgDdDIeu2OJ",
-	"yIdHjIIaceKOYLwGFxFF23NTm1Jx3XFKw8UWwkJP1s9bDeUUTVTaYzqGbhmhMgr+JZAlV1gziJKReiSp",
-	"7K6vEU7KSpQ7s8dLxdbiuw03e3ol9s0mL/8W4Pai0NWFm98e9MBhAUGPfPNyF8fnHBPxtwLYf/a60/XS",
-	"mwHq/CDk9xUvqXBqU+TEw6fdumv0UPyEZr9U+y2ydrd+qvxSaO9UfQdff1AftUL2Lo3UkvT/zEg2PqDm",
-	"eBY1BA5EnloCz3XTWlNwePrusCZh0/vpkFz2l0MsW4oh+ms1dX8pM3z0oH96+7EtyWwT56/4JfBdp1p0",
-	"enJWMZX89gPqKOUbab1kwCFSoOzHVTzeUXPAoiMFZ7MYneOA/5V+85T0mxaXNxW2MryRhtd6xPdZFJ03",
-	"yulFPoPLgzxr5QXUqaVWRmrzd4nWPYttbROFHVbaXpv+En9Im73SaiBDcrN1vmV0jvfTUuLpVvQ+qWPu",
-	"NN22pGpsFwRqsbCfTqNdmcfldnbPpBuR5o/vJZO5UeAr3Unc3mOfbxRXCOBfM15yUfjq4hx9naBbLAAl",
-	"WLcLNB23Rjgho68TzVR2x9pc92ehgUYJI6aW1KbW6fYn9Zw9TbdSDzHPzOwaa2qN0D671BbEW4zXPtvU",
-	"oXj2Lofz25ewRlRXtKjzFK6T0pT92L5M9gzYciA3Md4HSjUn/vHm8f8CAAD//6I23z2JiwAA",
+	"H4sIAAAAAAAC/+w9aW8bObJ/hej3gDcBJEty7MyMgQU2cTK73pdJDDvGYF/WEOjuksR1N9kh2XH0DP/3",
+	"BY++2Yduz2Q+JZZ4FOtiVbGq9Oj5LIoZBSqFd/boxZjjCCRw/de7mPgXwSWWC/VXAMLnJJaEUe9Mf4du",
+	"bi7eegOPqA9iNWzgURyBd+aBnuoNPA5fEsIh8M4kT2DgCX8BEVbrzRiPsPTOvCQhaqRcxmqmkJzQuff0",
+	"NPCa9r4CwRLuQ8v+ZNO9L/EcLhU26turrxBNojvg6eZfEuDLfPcYz8Er7hfADCeh9M4mAy8ilERJpP9v",
+	"9yVUwhy42Rh4y94XEiKBYuDI7uHcHvi0GYTj8cCL8DcLw3jcDRFn/wZfNlHDft1CjDhdYEOaXCW0kSUS",
+	"2gIAVxM33Pyacflm2UCWXwiEAZIMCcYluls2EEZ9O9XfOuji+RywhGCKpRsAyfiy6fz6yxYMCDN5Qxx8",
+	"gigOsYQWVohiiaQd1gKPzFbaCKQnNVnEjArQGusNDq7gSwJCqr98RiVQ/V8cxyHxsYJz9G+hgH0sbPPf",
+	"HGbemfdfo1wbjsy3YvSOc8bNVuXDvsEB4nazp4F3zugsJP4eNs7Un2+3RD/A0fwIBYnZChBEmIQvFFS/",
+	"MH5HggDo7sHKtkJDhIOIUIR9H4RAGXmfBt4HJn9hCQ32iCXKJJrpPZ8G3g3FiVwwTv4f9gBDaTf1tZ2h",
+	"FjzX0q6u0QLHxpzFwCUx3Fxa7NGDbziKQ0gv3xnjSC0PVFqw0QywTDgIT2v490DnSkqPx0rJV0QnlcTi",
+	"sjcCOHpdWrKy0umpvi3SvyeOZYXEMhFlzXaH/fuQzb2BB1TdM58LnxA6jTmbcxAK7IBR8G5duidXEp8N",
+	"6PkodqeuFy2EGqn2Rlodr6+R0P9F9sYqn37SF4+/LtGla4Fu9K18ziiWqVJuPG4dwLeGMuhC/R0Blcgs",
+	"tTq1Uz0+LQhSvs8/WYIwB0TSfQidI30VocdH/e/0HpZPT0dHR173VvqDx4yFskX1DSL1PcvhK4EHtRZw",
+	"bf/4iZAsUjjMoSpO7IF/xyHtvGbKXCW0kRwxiSEkVK82I/P6ACEh1v8hytirf4/9lHMbebHXsew6rlPY",
+	"DzDneFmbbuBzTTMkJUE/a6K8pp05qOGnGcva6GnEs7p9YompD1OfEwmcYCfOAoiBBmJqUJrhvIH/UpwM",
+	"tIvT76wD7x6WZcm4Ho4nZWk7dekWc2LyFZwQCZ+VRUJpVaAKghnXrKr+KxZYIfm2VVe3XW8azddmqMID",
+	"5nOQ0xkJQayGMUlkWNFEuQYK2ZzQ1KupaqF25lHYTVd3cYu6Luv8UTC3SyAdj49fDceT4eT002R89nJ8",
+	"Nh7/n8JoSuMASxhKYjRDnZnWv7Jrixnmytf48ccx/HQyHg/h+Oe74ckkOBniHyevhicnr16dnp6cjMfj",
+	"cRHSJm7se/PXJtprcVoF7NWr7QCW82NfOyGHIR/pWFYpF58lNsrRyeznZujTwEviYNtMUmFeo/NyxA5S",
+	"9WyRUQF/UHYTC/A1cf574rSBsMQl6W01cJUAOQQ6xnNCccrsbStc5iOrCNCQlNZynkTb2LVjgPtjnwVV",
+	"Dr9+dzX98PHT9JePNx/eukVXYhKaqyMIiIIEh5eFZY1zWoMsAiGU1qoL1AORC3TxFuE7f3L8suCIdPGE",
+	"Bj9fuY6PyniDBRfaLqKYcamYmoBovCoLxlvFicIPKML8PmAPFNlR5lj/fP3re6RvmQhLCdyadXch8+9F",
+	"jwOaDXuALLQL4aS76M3A+ZpL66zVmXmGSWicwjIOPuhIH2IzfUQCAskFlsgMR5Ip65bxgjGZxc4Gnvmq",
+	"fVUKD+ESWalO93CuZoW9bTE7JAP1h3tYIhxywMESwTciJAQvPGeYr6SUUrjzTTMEDVLktxNv+a5dNMsn",
+	"+BX7C0JhqADFdyEgvQeygtBkT7liYOrAP0R4ie4AQRTLJSIz/aHPkjDQQqi++SY59svIyJcviHR5i78n",
+	"EaZVIItD+pkq6foDgw0XIt8rc6hRYHWAp6xxEgH8r/bPI59FxdvIDHdd6FiIB8Yr17kAP+Fw+VchJsVV",
+	"ssFdh0y3yya4DnhZujsqLlJVn05c4pCFuYsjj8euoZJJXMbXyXGnEJhJgzSan23nPI11Ws4bfLrdW05V",
+	"n7H1NrbQXkuIXaqw3eo53oLVUzJ4DPCdxkwJ6gaveNoeJahEB6QSrpWDBAMPJ5JNcRxz9rXMfTMcitxG",
+	"uGMsBExdpvxPP22H7hELICye1w9xEsCQxYkYngxfqdOZTwSjFOTwZHiaf7bA5D4Zngxfls9eX6OHC9GK",
+	"MB2fmcYsJP6yizmv1NhLM9RpLJfCF4bgKSIqpKls7GQqG6ir31OE+wmR0zsO+B74FGd+ePlK+G0BcgEc",
+	"yQUgOwfZOYgI5CecA5XhEklO4tjcn53sUt1cG/9t977PqNLaCkSUBlC0iWJ9y2xLp3qsbhfhb/XNPi04",
+	"iAULA+3GFjdM90F3MGMczEkV5Qv7vnTuu1cX3BHd7XS5t6WfO4LE9cDPAwVeuy1OT7cDzZ68Wiuo2Vma",
+	"+HrQJGxuzlzNBbZI3oIXnJLrsI5wOei/p7DWrq6vlZ4m9h6O2ubjxkGeMw4av2p6NVlZfAvsvh0pLsrP",
+	"YYX5CubKJec7d/TqgvYPTAG9ZbD6m9+6TmNh2Z9WdiEHzY+hRYOxhsAIf5sqcUrxmfmJpSSoQg6U00Ay",
+	"ZmRVZCmj+n6jQ2sBKfszfMBLUZbQ0oD2cxfBLW3rPHhCXfEVtWsu8/0UfPnW6DdHRz+mhVhJw7XRqWcr",
+	"L35TQXEsFkyuHIotXwh9nhv4qoeuP1HEQANj7PKEUvO/jAjFsJmPqQ9haN7icu7I5zc8XPQ8TVnVb0WT",
+	"F15ls9eIVZT3VUK3oLEVmx9YTSe0Lejg5P015ZBRiUlu+z8vQQ3ZfCrthVT38RP6BxI8iKcNyRT2W8YD",
+	"4IWvG0PpgZfhprhwaZksGcMtaA08+RuRi+s08IfD8OPMO/vcR5a6M0461nAHDnvmidymyazr52ysIwX7",
+	"yPNYLR2kmixIviRgPQgSKIdiRuwrIqFp0MLkeg7Q9XA8eVEMsKQpJSvmkKx6ZX6vKSc7uV+LiStrXrHF",
+	"fIWaOKU5EcXzOwNxOp2iOOrUNSp/IW0PJ6bquOMFp4KePIEjV+eBsbDtxo3n34KRYRTSYc2M7Cwf+TWh",
+	"8xBcpS8y4VSgbKgOxobqP18SUG7DADGOhJ5uRukR97BEIWP3SawdFuhxVeSYVRdGD9xlev16xRTgbnrn",
+	"UnijxWG9tOkb+zhefrBdK1ParqSzuj6Y63ztPOn1c6JrHGTgKj9GNuJpm2+GvVNELYTrZmh3knCyKgnT",
+	"8qV1qPjUdsD1UrMLYEWxXJO32gOX6RZZmY4dtY8s7N4I/P3k9v5Bc3S7U3AbKHcjVotnUngY6o+3FdS8",
+	"joguNVtRaDgLS4TSNUzKABPA+7KuAL6nF5ltBYZ39cTYGnBeGfflQx7woSPFo3XhNdyrGeyKR7Zgr2pW",
+	"O6S5qlQT+AkncnmtVkyjz+yewOvEVR36j98+IcnugSKhvC8sEKZoIWX8kYZLZN4PkFkgLRrN/krLRtX0",
+	"nFI4Jv8LS1N5R+iMpbms2CR02El/ZzFcyN8YvxfoE+DIc5Ryap2MXl9eaGtZLgAVZ6W+d4QpnhvfUd2c",
+	"iomO/kU/LYhAROhZ1vC2pYdshiRP5CJbVG2gAOTYl0f/UicJiQ9UQAHcXy8+KS7ioXfmKeyIs9GIxUDN",
+	"mkeMz0d2khipsbnSLp309eWFN/C+AhfmjOOjydFY31cxUBwT78x7eTQ+eqnpLBeaeiOcyMVIu8WaPZlh",
+	"U8Wkmg0uAu/MZCbeGDG09a9vWLDcWjVlKfPxqcyakidQrfk9Ho+3treRqnohp4YJiUQXtM4SpQEWgAPb",
+	"J+Ea5PDccGqN6TP+VtyfsXMOTa2i+WngnYwnTYBmJx/Va0utNHpnn28HnkiiCPOlgR0RqmRN5/8SOkep",
+	"EsVzobWtEtdbtUbGACyRrRzAEpmxQIkWJ3UUvGfzOQSIJbKAwVBrqzVPWjqbWlcnX5lMq67DmWtpDo5z",
+	"/Q3kuVnEfbbd89l54QwoLUjYAp7+BiUchctiGRIEXTjj9pm6mSXSh+wd6oXqW3kv1TDZOcl0pUeKIAjK",
+	"LL5jNTHuZopCRwQ95efuKVkngzatklIDYUThoYWB7N0pGqVOGUOX6aBBqQVNQ4QqHzLKW6U0BamKg4ut",
+	"VXqML7b8eLrdoToo5qg5WMxaahCYQB+boQyp29Chak0chvmiOR2zj26VaemU/FLJ/Y5E31nWv2f5z7L/",
+	"HPSx5qF1A7x1ZXMzOhokWXkspLjWSVkUy9EjCZ6MPgrB5BOW6ftWf57TdzX5tJ1iHNJz0txJyIASrIkU",
+	"Nemke1LWiaSMRXNchNsxOGg0ILaPqPE+WXgzm2Mz1CsjJcM7ulsi3TzIrYoSB/ZLoeXNCLB9FeaMe+/Z",
+	"u+lB/7Tab28qbDOWMVjtktaavhvZtPKhTStXG0HJ4an1EgIpnCUeQioAftCJ7H8ZD5DJXP+Lrux4gQQz",
+	"xaJZSQZPqEA+pugOEJYSolhd63iOCT1Cr4OI0CFTZiDQIGaE2iBB1dYWIM8NHG8MGLvVy+eVM2tsbcOX",
+	"U5Nedk/Km1htyC4ac04y6s4Mq3BR1tPuaQQx8dvN23d6xMq2banvXh/79g9hDGc9C3pZwhr5piTdZM74",
+	"We+GrRjGZv0Sezh2yxnGMEOXuawbKmzID7e7tLWLD+x7NrRNs4k67fVb+95N7PVU1MpettuKV8ykY3cO",
+	"zZQyWrtaGj2aTqw9TPxt8GS3Gin0lO13+Wiyb+4R7POaSX0IqgnoVA5N7sNzIMJ4P6J8cFfDkKfmaBQ0",
+	"eLOXcSA67covWVnd74lHDuKO7FhVbHY/pB5Po25pvA9SH6Tt+aPSxmIbFsqufNkypC5bMfW5TFVRwu1b",
+	"94HUjfI6YidIzc6HHT40w7tDH9un3s4CIc4UxX3HQ9bkoT+kWnJpme3wbKNG4glt95uvEireLNeN6O3T",
+	"f96lqkur6Hr5wxqn23J+dbSqidJ6py5H9yqhz9rPLTTq3bObqyuxHG3LE3oYJ3d9ZVF+eCpEOrtYp1Ex",
+	"pE3w2nTDddYo71lH1SqRVBZFeChAzShKrUnyBYEkQzMSSuDKLbGlXrYuYGDLJF40/bhE1i+0MWtg0Nwy",
+	"TzJdH4KSGP3AbZFJmsymBjXtakqYmrfcpWKs18v0UpFpb8S8Tsb2rtSYOIgIaW2bwuUINrLY1MBbRrE8",
+	"YotXrVClQtOlkk21znNWyqXc/z2rZVvLVOcjIyrfV/zR1qK6A5A5v3Xp8ZHtkNqYPVZq+fpMWdPZSXfP",
+	"DourNa6DVc0wxPUAo0Bi4ENDTftshzANsiar+YvJ82TpEoe+ScJ723M3V5mcRXmjYmeD4vU499H+cFKP",
+	"+PlW9GqPd7jCz0D1i6AbzfX7DKEbFdRwyzVFsZ4HJcb7upMOn7OT2U+lQHrJIGmOWh2MWruKba1uvuyN",
+	"Vf6MpzfF01sUTf9LIotoudOIjG0llDVlWs9oJ9lmE0AsUACcfIXAXGc6+GY2+x9RDcOZ65t+SSBRC4ol",
+	"9RF80w1ZGT1CaZuAk/HPiMxMZZJmgLQV/MJUX5lsJQXGAJ2Mx+WxRGTDA0ZBjTgpj2C8BhcR+e8cuJKX",
+	"3uOE+osthIU21s9bDeXkrXjaYzqGbimhUgr+KZAFV1gziJKReiSp6K6vEE5KC907axAKJfviuw03Ozpu",
+	"9q1JKP745/ai0NWF25L1olgOcwh6VC0Ue4E+55iIu6HE/msgSr1TnXnEpV+A/b7iJRVObYqcOPi0W3eN",
+	"HvPfzO1XsLFF1u7WT5WfBu5d8FHC1+/UR62QvUsjtZSOPDOSjQ+oOZ5FJUoJIkdFiuO6aa1MOTx9d1jZ",
+	"su79dEgu+9Mhli0lNf21mrq/lBk+etS/tf/UlmS2jvOX//T/rlMtOj05q5gKfvsBdZTyjbReMuAQKVD6",
+	"a0oO76g5YNGRgrNejK7kgP+ZfrNJ+k2Ly5sI21+gkYY3esT3WVqftVvqRT6Dy4M8a2Vl+ImlVkpq83eB",
+	"1j1Ltm0rjh3WBd6YLiW/S5u90rAiRXKzdb5ldI7305hkcyt6n9Qxd5puflM1tnMCtVjYm9NoV+ZxsSni",
+	"M+lppfnje8lkbhT4So+bcge7z7eKKwTwrykvlVH4+vICfZ2gOywAxVg3nTR920Y4JqOvE81Udsfa3PLv",
+	"wKcF3yJPrdNNdOo5e5puhU50jpnpNdbUYKN9dqG5jLMYr322qUNx7F0M57cvYY2ormhR5ynKTkpT9mP7",
+	"MukzYMuByonxLlCqOfFPt0//CQAA//9mDD+jeo8AAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/backend/internal/api/handler/helpers.go
+++ b/backend/internal/api/handler/helpers.go
@@ -61,11 +61,14 @@ func mapCategoryToStatus(cat errors.ErrorCategory) int {
 // toAPIProject converts a domain Project to the API Project type.
 func toAPIProject(p *model.Project) Project {
 	proj := Project{
-		Id:        p.ID,
-		Name:      p.Name,
-		OwnerId:   uuid.Nil,
-		CreatedAt: p.CreatedAt,
-		UpdatedAt: p.UpdatedAt,
+		Id:                   p.ID,
+		Name:                 p.Name,
+		OwnerId:              uuid.Nil,
+		CircuitBreakerCount:  p.CircuitBreakerCount,
+		CircuitBreakerActive: p.CircuitBreakerActive,
+		CircuitBreakerMax:    p.CircuitBreakerMax,
+		CreatedAt:            p.CreatedAt,
+		UpdatedAt:            p.UpdatedAt,
 	}
 	if p.Description != nil {
 		proj.Description = p.Description

--- a/backend/internal/api/handler/project_handler.go
+++ b/backend/internal/api/handler/project_handler.go
@@ -12,13 +12,14 @@ import (
 
 // ProjectHandler implements project-related HTTP handlers.
 type ProjectHandler struct {
-	service     *service.ProjectService
-	userService *service.ProjectUserService
+	service        *service.ProjectService
+	userService    *service.ProjectUserService
+	circuitBreaker *service.CircuitBreakerService
 }
 
 // NewProjectHandler creates a new ProjectHandler.
-func NewProjectHandler(svc *service.ProjectService, userSvc *service.ProjectUserService) *ProjectHandler {
-	return &ProjectHandler{service: svc, userService: userSvc}
+func NewProjectHandler(svc *service.ProjectService, userSvc *service.ProjectUserService, cbSvc *service.CircuitBreakerService) *ProjectHandler {
+	return &ProjectHandler{service: svc, userService: userSvc, circuitBreaker: cbSvc}
 }
 
 // checkProjectAccess verifies the current user has access to the given project.
@@ -167,6 +168,22 @@ func (h *ProjectHandler) DeleteProject(w http.ResponseWriter, r *http.Request, i
 	}
 
 	if err := h.service.Delete(r.Context(), id); err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ResetCircuitBreaker handles POST /projects/{id}/circuit-breaker/reset.
+// Only admin users can reset the circuit breaker.
+func (h *ProjectHandler) ResetCircuitBreaker(w http.ResponseWriter, r *http.Request, id IdPath) {
+	if !middleware.IsAdmin(r.Context()) {
+		writeErrorResponse(w, errors.NewForbidden("Admin access required"))
+		return
+	}
+
+	if err := h.circuitBreaker.Reset(r.Context(), id); err != nil {
 		writeErrorResponse(w, err)
 		return
 	}

--- a/backend/internal/api/handler/project_handler_test.go
+++ b/backend/internal/api/handler/project_handler_test.go
@@ -70,6 +70,14 @@ func (m *mockProjectRepo) Delete(_ context.Context, id uuid.UUID) error {
 	return nil
 }
 
+func (m *mockProjectRepo) IncrementCircuitBreakerCount(_ context.Context, _ uuid.UUID) (*model.Project, error) {
+	return &model.Project{}, nil
+}
+
+func (m *mockProjectRepo) ResetCircuitBreaker(_ context.Context, _ uuid.UUID) (*model.Project, error) {
+	return &model.Project{}, nil
+}
+
 // mockProjectUserRepoForHandler is a mock implementation of port.ProjectUserRepository for handler tests.
 type mockProjectUserRepoForHandler struct {
 	assignments map[string]model.ProjectRole // key: "projectID:userID"
@@ -167,7 +175,7 @@ func setupHandler() (*ProjectHandler, *mockProjectRepo) {
 	puRepo := newMockProjectUserRepoForHandler()
 	userRepo := newMockUserRepoForHandler()
 	puSvc := service.NewProjectUserService(puRepo, repo, userRepo)
-	handler := NewProjectHandler(svc, puSvc)
+	handler := NewProjectHandler(svc, puSvc, nil)
 	return handler, repo
 }
 
@@ -306,7 +314,7 @@ func TestListProjects_NonAdmin_ReturnsAssigned(t *testing.T) {
 	puRepo := newMockProjectUserRepoForHandler()
 	userRepo := newMockUserRepoForHandler()
 	puSvc := service.NewProjectUserService(puRepo, repo, userRepo)
-	h := NewProjectHandler(svc, puSvc)
+	h := NewProjectHandler(svc, puSvc, nil)
 
 	userID := uuid.New()
 

--- a/backend/internal/api/handler/run_handler_test.go
+++ b/backend/internal/api/handler/run_handler_test.go
@@ -157,6 +157,12 @@ func (m *runHandlerProjectRepo) Update(_ context.Context, p *model.Project) (*mo
 	return p, nil
 }
 func (m *runHandlerProjectRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
+func (m *runHandlerProjectRepo) IncrementCircuitBreakerCount(_ context.Context, _ uuid.UUID) (*model.Project, error) {
+	return &model.Project{}, nil
+}
+func (m *runHandlerProjectRepo) ResetCircuitBreaker(_ context.Context, _ uuid.UUID) (*model.Project, error) {
+	return &model.Project{}, nil
+}
 
 // runHandlerJobQueue is a minimal mock of port.JobQueue.
 type runHandlerJobQueue struct {

--- a/backend/internal/domain/model/project.go
+++ b/backend/internal/domain/model/project.go
@@ -8,17 +8,20 @@ import (
 
 // Project represents a project in the domain.
 type Project struct {
-	ID                  uuid.UUID
-	Name                string
-	Description         *string
-	OwnerID             *uuid.UUID
-	RepoURL             *string
-	GitProvider         string
-	GitTokenEnv         *string
-	AgentRuntime        string
-	DefaultModel        *string
-	MaxBudget           *float64
-	MaxContainerTimeout *time.Duration
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
+	ID                   uuid.UUID
+	Name                 string
+	Description          *string
+	OwnerID              *uuid.UUID
+	RepoURL              *string
+	GitProvider          string
+	GitTokenEnv          *string
+	AgentRuntime         string
+	DefaultModel         *string
+	MaxBudget            *float64
+	MaxContainerTimeout  *time.Duration
+	CircuitBreakerCount  int
+	CircuitBreakerActive bool
+	CircuitBreakerMax    int
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
 }

--- a/backend/internal/domain/port/project_repository.go
+++ b/backend/internal/domain/port/project_repository.go
@@ -15,4 +15,11 @@ type ProjectRepository interface {
 	Count(ctx context.Context) (int64, error)
 	Update(ctx context.Context, project *model.Project) (*model.Project, error)
 	Delete(ctx context.Context, id uuid.UUID) error
+
+	// IncrementCircuitBreakerCount increments the failure count for a project.
+	// If the count reaches the configured max, the circuit breaker is activated.
+	IncrementCircuitBreakerCount(ctx context.Context, id uuid.UUID) (*model.Project, error)
+
+	// ResetCircuitBreaker resets the circuit breaker state (count=0, active=false).
+	ResetCircuitBreaker(ctx context.Context, id uuid.UUID) (*model.Project, error)
 }

--- a/backend/internal/domain/service/circuit_breaker_service.go
+++ b/backend/internal/domain/service/circuit_breaker_service.go
@@ -1,0 +1,158 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// CircuitBreakerService manages circuit breaker state for projects.
+// When consecutive run failures exceed a threshold, the circuit breaker trips
+// and blocks new pipeline runs until an admin resets it.
+type CircuitBreakerService struct {
+	projectRepo port.ProjectRepository
+	eventPub    port.EventPublisher
+	logger      *slog.Logger
+}
+
+// NewCircuitBreakerService creates a new CircuitBreakerService.
+func NewCircuitBreakerService(
+	projectRepo port.ProjectRepository,
+	eventPub port.EventPublisher,
+	logger *slog.Logger,
+) *CircuitBreakerService {
+	return &CircuitBreakerService{
+		projectRepo: projectRepo,
+		eventPub:    eventPub,
+		logger:      logger,
+	}
+}
+
+// CheckCircuitBreaker verifies that the circuit breaker is not active for a project.
+// Returns a CIRCUIT_BREAKER_OPEN error if the circuit breaker is active.
+func (s *CircuitBreakerService) CheckCircuitBreaker(ctx context.Context, projectID uuid.UUID) error {
+	project, err := s.projectRepo.GetByID(ctx, projectID)
+	if err != nil {
+		return err
+	}
+
+	if project.CircuitBreakerActive {
+		return &errors.DomainError{
+			Category: errors.CategoryValidation,
+			Code:     "CIRCUIT_BREAKER_OPEN",
+			Message:  "circuit breaker is active for this project — all pipeline runs are paused",
+		}
+	}
+
+	return nil
+}
+
+// RecordFailure increments the circuit breaker failure count for a project.
+// If the threshold is reached, the circuit breaker trips and an event is published.
+func (s *CircuitBreakerService) RecordFailure(ctx context.Context, projectID uuid.UUID) error {
+	project, err := s.projectRepo.IncrementCircuitBreakerCount(ctx, projectID)
+	if err != nil {
+		return err
+	}
+
+	s.logger.Info("circuit breaker failure recorded",
+		"project_id", projectID,
+		"count", project.CircuitBreakerCount,
+		"max", project.CircuitBreakerMax,
+		"active", project.CircuitBreakerActive,
+	)
+
+	if project.CircuitBreakerActive {
+		s.logger.Warn("circuit breaker triggered",
+			"project_id", projectID,
+			"count", project.CircuitBreakerCount,
+		)
+		s.publishCircuitBreakerEvent(ctx, project, "triggered")
+	}
+
+	return nil
+}
+
+// RecordSuccess resets the circuit breaker failure count on a successful run.
+// This prevents stale failure counts from tripping the breaker later.
+func (s *CircuitBreakerService) RecordSuccess(ctx context.Context, projectID uuid.UUID) error {
+	project, err := s.projectRepo.GetByID(ctx, projectID)
+	if err != nil {
+		return err
+	}
+
+	// Only reset if there are pending failure counts
+	if project.CircuitBreakerCount > 0 {
+		if _, err := s.projectRepo.ResetCircuitBreaker(ctx, projectID); err != nil {
+			return err
+		}
+		s.logger.Info("circuit breaker count reset on success",
+			"project_id", projectID,
+		)
+	}
+
+	return nil
+}
+
+// Reset resets the circuit breaker for a project. Only admins should call this.
+func (s *CircuitBreakerService) Reset(ctx context.Context, projectID uuid.UUID) error {
+	project, err := s.projectRepo.GetByID(ctx, projectID)
+	if err != nil {
+		return err
+	}
+
+	if !project.CircuitBreakerActive && project.CircuitBreakerCount == 0 {
+		return nil // nothing to reset
+	}
+
+	project, err = s.projectRepo.ResetCircuitBreaker(ctx, projectID)
+	if err != nil {
+		return err
+	}
+
+	s.logger.Info("circuit breaker reset by admin",
+		"project_id", projectID,
+	)
+
+	s.publishCircuitBreakerEvent(ctx, project, "reset")
+
+	return nil
+}
+
+// publishCircuitBreakerEvent publishes a circuit breaker event.
+func (s *CircuitBreakerService) publishCircuitBreakerEvent(ctx context.Context, project *model.Project, action string) {
+	payload, err := json.Marshal(map[string]any{
+		"project_id": project.ID.String(),
+		"count":      project.CircuitBreakerCount,
+		"max":        project.CircuitBreakerMax,
+	})
+	if err != nil {
+		s.logger.Error("failed to marshal circuit breaker event payload",
+			"project_id", project.ID,
+			"error", err,
+		)
+		return
+	}
+
+	event := model.Event{
+		ID:         uuid.New(),
+		ProjectID:  project.ID,
+		EntityType: "circuit_breaker",
+		EntityID:   project.ID,
+		Action:     action,
+		Payload:    payload,
+	}
+
+	if err := s.eventPub.Publish(ctx, event); err != nil {
+		s.logger.Error("failed to publish circuit breaker event",
+			"project_id", project.ID,
+			"action", action,
+			"error", err,
+		)
+	}
+}

--- a/backend/internal/domain/service/circuit_breaker_service_test.go
+++ b/backend/internal/domain/service/circuit_breaker_service_test.go
@@ -1,0 +1,407 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+const circuitBreakerOpenCode = "CIRCUIT_BREAKER_OPEN"
+
+// cbMockProjectRepo is a mock implementation of port.ProjectRepository for circuit breaker tests.
+type cbMockProjectRepo struct {
+	mu       sync.Mutex
+	projects map[uuid.UUID]*model.Project
+}
+
+func newCBMockProjectRepo() *cbMockProjectRepo {
+	return &cbMockProjectRepo{
+		projects: make(map[uuid.UUID]*model.Project),
+	}
+}
+
+func (m *cbMockProjectRepo) Create(_ context.Context, project *model.Project) (*model.Project, error) {
+	project.ID = uuid.New()
+	m.projects[project.ID] = project
+	return project, nil
+}
+
+func (m *cbMockProjectRepo) GetByID(_ context.Context, id uuid.UUID) (*model.Project, error) {
+	p, ok := m.projects[id]
+	if !ok {
+		return nil, errors.NewNotFound("project", id)
+	}
+	cp := *p
+	return &cp, nil
+}
+
+func (m *cbMockProjectRepo) List(_ context.Context, _, _ int32) ([]*model.Project, error) {
+	return nil, nil
+}
+
+func (m *cbMockProjectRepo) Count(_ context.Context) (int64, error) {
+	return int64(len(m.projects)), nil
+}
+
+func (m *cbMockProjectRepo) Update(_ context.Context, project *model.Project) (*model.Project, error) {
+	m.projects[project.ID] = project
+	return project, nil
+}
+
+func (m *cbMockProjectRepo) Delete(_ context.Context, id uuid.UUID) error {
+	delete(m.projects, id)
+	return nil
+}
+
+func (m *cbMockProjectRepo) IncrementCircuitBreakerCount(_ context.Context, id uuid.UUID) (*model.Project, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	p, ok := m.projects[id]
+	if !ok {
+		return nil, errors.NewNotFound("project", id)
+	}
+	p.CircuitBreakerCount++
+	if p.CircuitBreakerCount >= p.CircuitBreakerMax {
+		p.CircuitBreakerActive = true
+	}
+	cp := *p
+	return &cp, nil
+}
+
+func (m *cbMockProjectRepo) ResetCircuitBreaker(_ context.Context, id uuid.UUID) (*model.Project, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	p, ok := m.projects[id]
+	if !ok {
+		return nil, errors.NewNotFound("project", id)
+	}
+	p.CircuitBreakerCount = 0
+	p.CircuitBreakerActive = false
+	cp := *p
+	return &cp, nil
+}
+
+// cbMockEventPublisher is a mock for EventPublisher in circuit breaker tests.
+type cbMockEventPublisher struct {
+	mu     sync.Mutex
+	events []model.Event
+}
+
+func newCBMockEventPublisher() *cbMockEventPublisher {
+	return &cbMockEventPublisher{}
+}
+
+func (p *cbMockEventPublisher) Publish(_ context.Context, event model.Event) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.events = append(p.events, event)
+	return nil
+}
+
+func (p *cbMockEventPublisher) getEvents() []model.Event {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	result := make([]model.Event, len(p.events))
+	copy(result, p.events)
+	return result
+}
+
+func newTestProject(id uuid.UUID, maxFailures int) *model.Project {
+	return &model.Project{
+		ID:                   id,
+		Name:                 "test-project",
+		CircuitBreakerCount:  0,
+		CircuitBreakerActive: false,
+		CircuitBreakerMax:    maxFailures,
+	}
+}
+
+func TestCircuitBreakerService_CheckCircuitBreaker_Closed(t *testing.T) {
+	repo := newCBMockProjectRepo()
+	eventPub := newCBMockEventPublisher()
+	svc := NewCircuitBreakerService(repo, eventPub, testLogger())
+
+	projectID := uuid.New()
+	repo.projects[projectID] = newTestProject(projectID, 3)
+
+	err := svc.CheckCircuitBreaker(context.Background(), projectID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestCircuitBreakerService_CheckCircuitBreaker_Open(t *testing.T) {
+	repo := newCBMockProjectRepo()
+	eventPub := newCBMockEventPublisher()
+	svc := NewCircuitBreakerService(repo, eventPub, testLogger())
+
+	projectID := uuid.New()
+	p := newTestProject(projectID, 3)
+	p.CircuitBreakerActive = true
+	p.CircuitBreakerCount = 3
+	repo.projects[projectID] = p
+
+	err := svc.CheckCircuitBreaker(context.Background(), projectID)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != circuitBreakerOpenCode {
+		t.Errorf("expected code CIRCUIT_BREAKER_OPEN, got %s", domainErr.Code)
+	}
+}
+
+func TestCircuitBreakerService_CheckCircuitBreaker_ProjectNotFound(t *testing.T) {
+	repo := newCBMockProjectRepo()
+	eventPub := newCBMockEventPublisher()
+	svc := NewCircuitBreakerService(repo, eventPub, testLogger())
+
+	err := svc.CheckCircuitBreaker(context.Background(), uuid.New())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Category != errors.CategoryNotFound {
+		t.Errorf("expected not_found category, got %s", domainErr.Category)
+	}
+}
+
+func TestCircuitBreakerService_RecordFailure_IncrementsBelowThreshold(t *testing.T) {
+	repo := newCBMockProjectRepo()
+	eventPub := newCBMockEventPublisher()
+	svc := NewCircuitBreakerService(repo, eventPub, testLogger())
+
+	projectID := uuid.New()
+	repo.projects[projectID] = newTestProject(projectID, 3)
+
+	err := svc.RecordFailure(context.Background(), projectID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if repo.projects[projectID].CircuitBreakerCount != 1 {
+		t.Errorf("expected count 1, got %d", repo.projects[projectID].CircuitBreakerCount)
+	}
+	if repo.projects[projectID].CircuitBreakerActive {
+		t.Error("circuit breaker should not be active after 1 failure")
+	}
+
+	// No event should be published when below threshold
+	events := eventPub.getEvents()
+	if len(events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(events))
+	}
+}
+
+func TestCircuitBreakerService_RecordFailure_TripsAtThreshold(t *testing.T) {
+	repo := newCBMockProjectRepo()
+	eventPub := newCBMockEventPublisher()
+	svc := NewCircuitBreakerService(repo, eventPub, testLogger())
+
+	projectID := uuid.New()
+	p := newTestProject(projectID, 3)
+	p.CircuitBreakerCount = 2 // one more failure will trip it
+	repo.projects[projectID] = p
+
+	err := svc.RecordFailure(context.Background(), projectID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if repo.projects[projectID].CircuitBreakerCount != 3 {
+		t.Errorf("expected count 3, got %d", repo.projects[projectID].CircuitBreakerCount)
+	}
+	if !repo.projects[projectID].CircuitBreakerActive {
+		t.Error("circuit breaker should be active after reaching threshold")
+	}
+
+	// circuit_breaker.triggered event should be published
+	events := eventPub.getEvents()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].EventName() != "circuit_breaker.triggered" {
+		t.Errorf("expected circuit_breaker.triggered event, got %s", events[0].EventName())
+	}
+}
+
+func TestCircuitBreakerService_RecordSuccess_ResetsCount(t *testing.T) {
+	repo := newCBMockProjectRepo()
+	eventPub := newCBMockEventPublisher()
+	svc := NewCircuitBreakerService(repo, eventPub, testLogger())
+
+	projectID := uuid.New()
+	p := newTestProject(projectID, 3)
+	p.CircuitBreakerCount = 2 // some failures recorded
+	repo.projects[projectID] = p
+
+	err := svc.RecordSuccess(context.Background(), projectID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if repo.projects[projectID].CircuitBreakerCount != 0 {
+		t.Errorf("expected count 0, got %d", repo.projects[projectID].CircuitBreakerCount)
+	}
+	if repo.projects[projectID].CircuitBreakerActive {
+		t.Error("circuit breaker should not be active after success")
+	}
+}
+
+func TestCircuitBreakerService_RecordSuccess_NoopWhenCountZero(t *testing.T) {
+	repo := newCBMockProjectRepo()
+	eventPub := newCBMockEventPublisher()
+	svc := NewCircuitBreakerService(repo, eventPub, testLogger())
+
+	projectID := uuid.New()
+	repo.projects[projectID] = newTestProject(projectID, 3)
+
+	err := svc.RecordSuccess(context.Background(), projectID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Count should still be zero (no reset call needed)
+	if repo.projects[projectID].CircuitBreakerCount != 0 {
+		t.Errorf("expected count 0, got %d", repo.projects[projectID].CircuitBreakerCount)
+	}
+}
+
+func TestCircuitBreakerService_Reset(t *testing.T) {
+	repo := newCBMockProjectRepo()
+	eventPub := newCBMockEventPublisher()
+	svc := NewCircuitBreakerService(repo, eventPub, testLogger())
+
+	projectID := uuid.New()
+	p := newTestProject(projectID, 3)
+	p.CircuitBreakerCount = 3
+	p.CircuitBreakerActive = true
+	repo.projects[projectID] = p
+
+	err := svc.Reset(context.Background(), projectID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if repo.projects[projectID].CircuitBreakerCount != 0 {
+		t.Errorf("expected count 0, got %d", repo.projects[projectID].CircuitBreakerCount)
+	}
+	if repo.projects[projectID].CircuitBreakerActive {
+		t.Error("circuit breaker should not be active after reset")
+	}
+
+	// circuit_breaker.reset event should be published
+	events := eventPub.getEvents()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].EventName() != "circuit_breaker.reset" {
+		t.Errorf("expected circuit_breaker.reset event, got %s", events[0].EventName())
+	}
+}
+
+func TestCircuitBreakerService_Reset_NoopWhenAlreadyClear(t *testing.T) {
+	repo := newCBMockProjectRepo()
+	eventPub := newCBMockEventPublisher()
+	svc := NewCircuitBreakerService(repo, eventPub, testLogger())
+
+	projectID := uuid.New()
+	repo.projects[projectID] = newTestProject(projectID, 3)
+
+	err := svc.Reset(context.Background(), projectID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// No events should be published since there was nothing to reset
+	events := eventPub.getEvents()
+	if len(events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(events))
+	}
+}
+
+func TestCircuitBreakerService_Reset_ProjectNotFound(t *testing.T) {
+	repo := newCBMockProjectRepo()
+	eventPub := newCBMockEventPublisher()
+	svc := NewCircuitBreakerService(repo, eventPub, testLogger())
+
+	err := svc.Reset(context.Background(), uuid.New())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Category != errors.CategoryNotFound {
+		t.Errorf("expected not_found category, got %s", domainErr.Category)
+	}
+}
+
+func TestCircuitBreakerService_FullLifecycle(t *testing.T) {
+	repo := newCBMockProjectRepo()
+	eventPub := newCBMockEventPublisher()
+	svc := NewCircuitBreakerService(repo, eventPub, testLogger())
+
+	projectID := uuid.New()
+	repo.projects[projectID] = newTestProject(projectID, 3)
+
+	ctx := context.Background()
+
+	// 1. Circuit breaker starts closed
+	if err := svc.CheckCircuitBreaker(ctx, projectID); err != nil {
+		t.Fatalf("step 1: expected circuit breaker closed, got %v", err)
+	}
+
+	// 2. Record 3 failures to trip the breaker
+	for i := 0; i < 3; i++ {
+		if err := svc.RecordFailure(ctx, projectID); err != nil {
+			t.Fatalf("step 2: failure %d: %v", i+1, err)
+		}
+	}
+
+	// 3. Circuit breaker should now be open
+	err := svc.CheckCircuitBreaker(ctx, projectID)
+	if err == nil {
+		t.Fatal("step 3: expected circuit breaker open, got nil")
+	}
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("step 3: expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != circuitBreakerOpenCode {
+		t.Errorf("step 3: expected code CIRCUIT_BREAKER_OPEN, got %s", domainErr.Code)
+	}
+
+	// 4. Reset the circuit breaker
+	if err := svc.Reset(ctx, projectID); err != nil {
+		t.Fatalf("step 4: %v", err)
+	}
+
+	// 5. Circuit breaker should be closed again
+	if err := svc.CheckCircuitBreaker(ctx, projectID); err != nil {
+		t.Fatalf("step 5: expected circuit breaker closed after reset, got %v", err)
+	}
+
+	// 6. A success resets the count
+	if err := svc.RecordFailure(ctx, projectID); err != nil {
+		t.Fatalf("step 6a: %v", err)
+	}
+	if err := svc.RecordSuccess(ctx, projectID); err != nil {
+		t.Fatalf("step 6b: %v", err)
+	}
+	if repo.projects[projectID].CircuitBreakerCount != 0 {
+		t.Errorf("step 6: expected count 0, got %d", repo.projects[projectID].CircuitBreakerCount)
+	}
+}

--- a/backend/internal/domain/service/pipeline_executor.go
+++ b/backend/internal/domain/service/pipeline_executor.go
@@ -17,10 +17,11 @@ import (
 
 // PipelineExecutor orchestrates sequential execution of pipeline steps.
 type PipelineExecutor struct {
-	runRepo   port.RunRepository
-	actionReg port.ActionRegistry
-	eventPub  port.EventPublisher
-	logger    *slog.Logger
+	runRepo        port.RunRepository
+	actionReg      port.ActionRegistry
+	eventPub       port.EventPublisher
+	circuitBreaker *CircuitBreakerService
+	logger         *slog.Logger
 }
 
 // NewPipelineExecutor creates a new pipeline executor.
@@ -38,12 +39,35 @@ func NewPipelineExecutor(
 	}
 }
 
+// SetCircuitBreaker configures the circuit breaker service for the executor.
+func (e *PipelineExecutor) SetCircuitBreaker(cb *CircuitBreakerService) {
+	e.circuitBreaker = cb
+}
+
 // ExecuteRun executes all steps of a run sequentially.
 // Steps execute in step_order sequence. Execution stops on first failure or cancellation.
+// The circuit breaker is checked before execution and updated after completion/failure.
 func (e *PipelineExecutor) ExecuteRun(ctx context.Context, runID uuid.UUID) error {
 	// 1. Verify run exists
-	if _, err := e.runRepo.GetRun(ctx, runID); err != nil {
+	run, err := e.runRepo.GetRun(ctx, runID)
+	if err != nil {
 		return err
+	}
+
+	// 2. Check circuit breaker before starting
+	if e.circuitBreaker != nil {
+		if err := e.circuitBreaker.CheckCircuitBreaker(ctx, run.ProjectID); err != nil {
+			e.logger.Warn("circuit breaker open, aborting run",
+				"run_id", runID,
+				"project_id", run.ProjectID,
+			)
+			errMsg := err.Error()
+			failedAt := time.Now()
+			if _, updateErr := e.runRepo.UpdateRunStatus(ctx, runID, model.RunStatusFailed, nil, &failedAt, &errMsg); updateErr != nil {
+				e.logger.Error("failed to update run status after circuit breaker check", "error", updateErr)
+			}
+			return err
+		}
 	}
 
 	steps, err := e.runRepo.ListRunStepsByRun(ctx, runID)
@@ -56,9 +80,9 @@ func (e *PipelineExecutor) ExecuteRun(ctx context.Context, runID uuid.UUID) erro
 		return cmp.Compare(a.StepOrder, b.StepOrder)
 	})
 
-	// 2. Transition run to "running", publish run.started
+	// 3. Transition run to "running", publish run.started
 	now := time.Now()
-	run, err := e.runRepo.UpdateRunStatus(ctx, runID, model.RunStatusRunning, &now, nil, nil)
+	run, err = e.runRepo.UpdateRunStatus(ctx, runID, model.RunStatusRunning, &now, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -69,7 +93,7 @@ func (e *PipelineExecutor) ExecuteRun(ctx context.Context, runID uuid.UUID) erro
 		"started_at": now.Format(time.RFC3339),
 	})
 
-	// 3. Execute each step in order
+	// 4. Execute each step in order
 	metadata := make(map[string]any)
 	for i := range steps {
 		step := steps[i]
@@ -84,11 +108,17 @@ func (e *PipelineExecutor) ExecuteRun(ctx context.Context, runID uuid.UUID) erro
 
 		if err := e.executeStep(ctx, run, step, metadata); err != nil {
 			e.handleStepFailure(ctx, run, step, err)
+			// Record failure in circuit breaker
+			if e.circuitBreaker != nil {
+				if cbErr := e.circuitBreaker.RecordFailure(ctx, run.ProjectID); cbErr != nil {
+					e.logger.Error("failed to record circuit breaker failure", "error", cbErr)
+				}
+			}
 			return err
 		}
 	}
 
-	// 4. All steps completed — mark run as completed
+	// 5. All steps completed — mark run as completed
 	completedAt := time.Now()
 	if _, err := e.runRepo.UpdateRunStatus(ctx, runID, model.RunStatusCompleted, nil, &completedAt, nil); err != nil {
 		return err
@@ -99,6 +129,13 @@ func (e *PipelineExecutor) ExecuteRun(ctx context.Context, runID uuid.UUID) erro
 		"status":       string(model.RunStatusCompleted),
 		"completed_at": completedAt.Format(time.RFC3339),
 	})
+
+	// Reset circuit breaker count on success
+	if e.circuitBreaker != nil {
+		if cbErr := e.circuitBreaker.RecordSuccess(ctx, run.ProjectID); cbErr != nil {
+			e.logger.Error("failed to record circuit breaker success", "error", cbErr)
+		}
+	}
 
 	return nil
 }

--- a/backend/internal/domain/service/pipeline_executor_test.go
+++ b/backend/internal/domain/service/pipeline_executor_test.go
@@ -788,3 +788,103 @@ func TestActionRegistry_RegisterOverwrites(t *testing.T) {
 		t.Errorf("expected action2 error, got %v", execErr)
 	}
 }
+
+func TestExecuteRun_CircuitBreakerBlocksExecution(t *testing.T) {
+	f := newExecutorTestFixture(1)
+	f.registerSuccessActions()
+
+	// Set up circuit breaker that is already open
+	cbRepo := newCBMockProjectRepo()
+	p := &model.Project{
+		ID:                   f.projectID,
+		CircuitBreakerCount:  3,
+		CircuitBreakerActive: true,
+		CircuitBreakerMax:    3,
+	}
+	cbRepo.projects[f.projectID] = p
+
+	cbEventPub := newCBMockEventPublisher()
+	cbSvc := NewCircuitBreakerService(cbRepo, cbEventPub, testLogger())
+	f.executor.SetCircuitBreaker(cbSvc)
+
+	err := f.executor.ExecuteRun(context.Background(), f.runID)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected *errors.DomainError, got %T", err)
+	}
+	if domainErr.Code != circuitBreakerOpenCode {
+		t.Errorf("expected code CIRCUIT_BREAKER_OPEN, got %s", domainErr.Code)
+	}
+
+	// Run should be marked as failed
+	if len(f.runStatusCalls) != 1 {
+		t.Fatalf("expected 1 run status update, got %d", len(f.runStatusCalls))
+	}
+	if f.runStatusCalls[0].Status != model.RunStatusFailed {
+		t.Errorf("expected run status failed, got %s", f.runStatusCalls[0].Status)
+	}
+}
+
+func TestExecuteRun_CircuitBreakerRecordsFailure(t *testing.T) {
+	f := newExecutorTestFixture(1)
+
+	// Register action that fails
+	f.actionReg.Register(&mockAction{
+		name: f.steps[0].Action,
+		executeFn: func(_ context.Context, _ *model.RunContext) error {
+			return fmt.Errorf("build failed")
+		},
+	})
+
+	cbRepo := newCBMockProjectRepo()
+	p := &model.Project{
+		ID:                   f.projectID,
+		CircuitBreakerCount:  0,
+		CircuitBreakerActive: false,
+		CircuitBreakerMax:    3,
+	}
+	cbRepo.projects[f.projectID] = p
+
+	cbEventPub := newCBMockEventPublisher()
+	cbSvc := NewCircuitBreakerService(cbRepo, cbEventPub, testLogger())
+	f.executor.SetCircuitBreaker(cbSvc)
+
+	_ = f.executor.ExecuteRun(context.Background(), f.runID)
+
+	// Verify circuit breaker count was incremented
+	if cbRepo.projects[f.projectID].CircuitBreakerCount != 1 {
+		t.Errorf("expected circuit breaker count 1, got %d", cbRepo.projects[f.projectID].CircuitBreakerCount)
+	}
+}
+
+func TestExecuteRun_CircuitBreakerRecordsSuccess(t *testing.T) {
+	f := newExecutorTestFixture(1)
+	f.registerSuccessActions()
+
+	cbRepo := newCBMockProjectRepo()
+	p := &model.Project{
+		ID:                   f.projectID,
+		CircuitBreakerCount:  2,
+		CircuitBreakerActive: false,
+		CircuitBreakerMax:    3,
+	}
+	cbRepo.projects[f.projectID] = p
+
+	cbEventPub := newCBMockEventPublisher()
+	cbSvc := NewCircuitBreakerService(cbRepo, cbEventPub, testLogger())
+	f.executor.SetCircuitBreaker(cbSvc)
+
+	err := f.executor.ExecuteRun(context.Background(), f.runID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Verify circuit breaker count was reset to 0
+	if cbRepo.projects[f.projectID].CircuitBreakerCount != 0 {
+		t.Errorf("expected circuit breaker count 0, got %d", cbRepo.projects[f.projectID].CircuitBreakerCount)
+	}
+}

--- a/backend/internal/domain/service/project_service_test.go
+++ b/backend/internal/domain/service/project_service_test.go
@@ -64,6 +64,14 @@ func (m *mockProjectRepo) Delete(_ context.Context, id uuid.UUID) error {
 	return nil
 }
 
+func (m *mockProjectRepo) IncrementCircuitBreakerCount(_ context.Context, _ uuid.UUID) (*model.Project, error) {
+	return &model.Project{}, nil
+}
+
+func (m *mockProjectRepo) ResetCircuitBreaker(_ context.Context, _ uuid.UUID) (*model.Project, error) {
+	return &model.Project{}, nil
+}
+
 func TestProjectService_Create(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/backend/migrations/000013_add_circuit_breaker_to_projects.down.sql
+++ b/backend/migrations/000013_add_circuit_breaker_to_projects.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE projects
+    DROP COLUMN IF EXISTS circuit_breaker_max,
+    DROP COLUMN IF EXISTS circuit_breaker_active,
+    DROP COLUMN IF EXISTS circuit_breaker_count;

--- a/backend/migrations/000013_add_circuit_breaker_to_projects.up.sql
+++ b/backend/migrations/000013_add_circuit_breaker_to_projects.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE projects
+    ADD COLUMN circuit_breaker_count  INT     NOT NULL DEFAULT 0,
+    ADD COLUMN circuit_breaker_active BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN circuit_breaker_max    INT     NOT NULL DEFAULT 3;

--- a/backend/queries/projects.sql
+++ b/backend/queries/projects.sql
@@ -29,3 +29,27 @@ RETURNING *;
 
 -- name: DeleteProject :exec
 DELETE FROM projects WHERE id = $1;
+
+-- name: IncrementCircuitBreakerCount :one
+UPDATE projects
+SET circuit_breaker_count = circuit_breaker_count + 1,
+    circuit_breaker_active = CASE
+        WHEN circuit_breaker_count + 1 >= circuit_breaker_max THEN true
+        ELSE circuit_breaker_active
+    END,
+    updated_at = now()
+WHERE id = $1
+RETURNING *;
+
+-- name: ResetCircuitBreaker :one
+UPDATE projects
+SET circuit_breaker_count = 0,
+    circuit_breaker_active = false,
+    updated_at = now()
+WHERE id = $1
+RETURNING *;
+
+-- name: GetCircuitBreakerState :one
+SELECT id, circuit_breaker_count, circuit_breaker_active, circuit_breaker_max
+FROM projects
+WHERE id = $1;


### PR DESCRIPTION
## Summary
- Add project-level circuit breaker that tracks consecutive pipeline run failures and blocks new runs when a configurable threshold (default 3) is reached
- Integrate circuit breaker check/record into `PipelineExecutor` — checks before run start, records failure on step failure, resets count on success
- Add admin-only `POST /projects/{id}/circuit-breaker/reset` endpoint to manually reset a tripped circuit breaker
- Add DB migration for `circuit_breaker_count`, `circuit_breaker_active`, `circuit_breaker_max` columns on projects table

## Changes
- **Migration**: `000013_add_circuit_breaker_to_projects` — adds 3 columns with defaults
- **Domain model**: `Project` gains `CircuitBreakerCount`, `CircuitBreakerActive`, `CircuitBreakerMax` fields
- **Port**: `ProjectRepository` gains `IncrementCircuitBreakerCount` and `ResetCircuitBreaker` methods
- **Service**: New `CircuitBreakerService` with `CheckCircuitBreaker`, `RecordFailure`, `RecordSuccess`, `Reset`
- **PipelineExecutor**: Enhanced with optional circuit breaker integration via `SetCircuitBreaker`
- **API**: New `resetCircuitBreaker` endpoint, Project schema updated with circuit breaker fields
- **OpenAPI**: Updated spec with circuit breaker fields and reset endpoint

## Test plan
- [x] 11 unit tests for `CircuitBreakerService` (check, record-failure, record-success, reset, full lifecycle)
- [x] 3 integration tests for executor + circuit breaker (blocks when open, records failure, records success)
- [x] All existing tests pass (mock implementations updated)
- [x] golangci-lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)