### PR TITLE
chore(ci): add per-phase model overrides to pipeline scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,15 @@ Stories are implemented via Docker containers running Claude Code agents. **Neve
 | Script | Purpose |
 |--------|---------|
 | `scripts/bmad-dev.sh` | Launch dev agent containers (clone mode or interactive) |
-| `scripts/pipeline.sh` | Runs inside container: dev-story (Opus) → code-review (Sonnet) → merge-story (Sonnet) |
+| `scripts/pipeline.sh` | Runs inside container: dev-story → code-review → merge-story |
+
+### Default models per phase
+
+| Phase | Default model | Override flag |
+|-------|--------------|---------------|
+| `dev-story` | `opus` | `--dev=MODEL` |
+| `code-review` | `sonnet` | `--review=MODEL` |
+| `merge-story` | `opus` | `--merge=MODEL` |
 
 ### Usage
 
@@ -260,6 +268,10 @@ Stories are implemented via Docker containers running Claude Code agents. **Neve
 ./scripts/bmad-dev.sh --story <story-key> --phase dev-story
 ./scripts/bmad-dev.sh --story <story-key> --phase code-review
 ./scripts/bmad-dev.sh --story <story-key> --phase merge-story
+
+# Override models per phase (reduce cost or test with lighter models)
+./scripts/bmad-dev.sh --story <story-key> --pipeline --dev=sonnet
+./scripts/bmad-dev.sh --wave <N> --pipeline --dev=sonnet --review=haiku --merge=sonnet
 
 # Monitor running containers
 ./scripts/bmad-dev.sh --status

--- a/scripts/bmad-dev.sh
+++ b/scripts/bmad-dev.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # BMAD Dev Agent Launcher
 #
 # Story lifecycle: dev-story (Opus) → code-review (Sonnet) → merge-story (Opus)
+# Model overrides: --dev=MODEL --review=MODEL --merge=MODEL (default: opus/sonnet/opus)
 # Branching: develop (clone) → feat/story-key (PR targets wave-X)
 #
 # Usage:
@@ -29,12 +30,22 @@ set -euo pipefail
 #   # Monitoring
 #   ./scripts/bmad-dev.sh --status
 #
+#   # Use personal or professional subscription
+#   ./scripts/bmad-dev.sh --story 1-1 --pipeline --perso
+#   ./scripts/bmad-dev.sh --wave 1 --pipeline --pro
+#
+#   # Override models per phase
+#   ./scripts/bmad-dev.sh --story 1-1 --pipeline --dev=sonnet
+#   ./scripts/bmad-dev.sh --wave 1 --pipeline --dev=sonnet --review=haiku --merge=sonnet
+#
 #   # Force rebuild
 #   ./scripts/bmad-dev.sh --build
 #
 # Required env vars:
-#   CLAUDE_CODE_OAUTH_TOKEN - OAuth token for Claude Code
-#   GITHUB_TOKEN            - GitHub token for gh CLI
+#   CLAUDE_CODE_OAUTH_TOKEN      - Default OAuth token for Claude Code
+#   CLAUDE_CODE_OAUTH_TOKEN_PERSO - Personal subscription token (used with --perso)
+#   CLAUDE_CODE_OAUTH_TOKEN_PRO   - Professional subscription token (used with --pro)
+#   GITHUB_TOKEN                  - GitHub token for gh CLI
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
@@ -56,7 +67,11 @@ PHASE=""
 PIPELINE=false
 SETUP=false
 STATUS=false
+SUB_MODE=""
 CLAUDE_ARGS=()
+MODEL_DEV="opus"
+MODEL_REVIEW="sonnet"
+MODEL_MERGE="opus"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -68,6 +83,11 @@ while [[ $# -gt 0 ]]; do
         --no-merge)  SKIP_MERGE=true; shift ;;
         --setup)     SETUP=true; shift ;;
         --status)    STATUS=true; shift ;;
+        --perso)     SUB_MODE="perso"; shift ;;
+        --pro)       SUB_MODE="pro"; shift ;;
+        --dev=*)     MODEL_DEV="${1#--dev=}"; shift ;;
+        --review=*)  MODEL_REVIEW="${1#--review=}"; shift ;;
+        --merge=*)   MODEL_MERGE="${1#--merge=}"; shift ;;
         -p|--prompt) CLAUDE_ARGS+=("-p" "$2"); shift 2 ;;
         --model)     CLAUDE_ARGS+=("--model" "$2"); shift 2 ;;
         *)           CLAUDE_ARGS+=("$1"); shift ;;
@@ -85,10 +105,10 @@ get_workflow() {
 }
 get_model() {
     case "$1" in
-        dev-story)    echo "opus" ;;
-        code-review)  echo "sonnet" ;;
-        merge-story)  echo "opus" ;;
-        *)            echo "opus" ;;
+        dev-story)    echo "$MODEL_DEV" ;;
+        code-review)  echo "$MODEL_REVIEW" ;;
+        merge-story)  echo "$MODEL_MERGE" ;;
+        *)            echo "$MODEL_DEV" ;;
     esac
 }
 
@@ -96,11 +116,36 @@ get_model() {
 # HELPERS
 # ============================================================
 
+resolve_token() {
+    case "$SUB_MODE" in
+        perso)
+            if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN_PERSO:-}" ]]; then
+                echo -e "${RED}Error: CLAUDE_CODE_OAUTH_TOKEN_PERSO is not set${NC}"
+                exit 1
+            fi
+            CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN_PERSO"
+            export CLAUDE_CODE_OAUTH_TOKEN
+            ;;
+        pro)
+            if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN_PRO:-}" ]]; then
+                echo -e "${RED}Error: CLAUDE_CODE_OAUTH_TOKEN_PRO is not set${NC}"
+                exit 1
+            fi
+            CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN_PRO"
+            export CLAUDE_CODE_OAUTH_TOKEN
+            ;;
+    esac
+}
+
 check_token() {
+    resolve_token
     if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
-        echo -e "${RED}Error: CLAUDE_CODE_OAUTH_TOKEN is not set${NC}"
+        echo -e "${RED}Error: CLAUDE_CODE_OAUTH_TOKEN is not set (use --perso or --pro, or set CLAUDE_CODE_OAUTH_TOKEN)${NC}"
         exit 1
     fi
+    local label="default"
+    [[ -n "$SUB_MODE" ]] && label="$SUB_MODE"
+    echo -e "${CYAN}Subscription: ${label}${NC}"
 }
 
 get_repo_url() {
@@ -214,6 +259,9 @@ run_clone() {
         -e "CLONE_BRANCH=develop" \
         -e "BASE_BRANCH=${merge_target}" \
         -e "STORY_BRANCH=${story_key}" \
+        -e "MODEL_DEV=${MODEL_DEV}" \
+        -e "MODEL_REVIEW=${MODEL_REVIEW}" \
+        -e "MODEL_MERGE=${MODEL_MERGE}" \
         "${extra_env[@]+"${extra_env[@]}"}" \
         "$IMAGE_NAME" \
         --dangerously-skip-permissions \

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 # BMAD Story Pipeline - runs inside a container
-# Chains: dev-story (opus) → code-review (sonnet) → merge-story (opus)
+# Chains: dev-story → code-review → merge-story
+# Models: MODEL_DEV (default: opus), MODEL_REVIEW (default: sonnet), MODEL_MERGE (default: opus)
 #
 # Each phase runs Claude Code with the appropriate workflow.
 # If a phase fails (non-zero exit), the pipeline stops.
@@ -17,6 +18,9 @@ set -euo pipefail
 STORY_KEY="${STORY_KEY:-unknown}"
 BASE_BRANCH="${BASE_BRANCH:-main}"
 SKIP_MERGE="${SKIP_MERGE:-false}"
+MODEL_DEV="${MODEL_DEV:-opus}"
+MODEL_REVIEW="${MODEL_REVIEW:-sonnet}"
+MODEL_MERGE="${MODEL_MERGE:-opus}"
 LOG_PREFIX="[pipeline:${STORY_KEY}]"
 
 log() { echo "$LOG_PREFIX $1"; }
@@ -34,14 +38,14 @@ Feature branch: feat/${STORY_KEY}
 Base branch: ${BASE_BRANCH}
 IMPORTANT: Do NOT ask questions. Act autonomously. Pick story ${STORY_KEY} automatically."
 
-# Phase 1: Dev Story (Opus)
-log "=== Phase 1/3: dev-story (opus) ==="
+# Phase 1: Dev Story
+log "=== Phase 1/3: dev-story ($MODEL_DEV) ==="
 DEV_PROMPT="${STORY_CONTEXT}
 Execute /bmad-bmm-dev-story for story ${STORY_KEY}.
 The story file is at _bmad-output/implementation-artifacts/${STORY_KEY}.md
 Work on branch feat/${STORY_KEY}. Commit and push all code. Create a PR targeting ${BASE_BRANCH}."
 
-if echo "$DEV_PROMPT" | claude --dangerously-skip-permissions --model opus "$@"; then
+if echo "$DEV_PROMPT" | claude --dangerously-skip-permissions --model "$MODEL_DEV" "$@"; then
     log "✅ dev-story complete"
 else
     log "❌ dev-story failed (exit $?)"
@@ -50,14 +54,14 @@ fi
 
 log ""
 
-# Phase 2: Code Review (Sonnet)
-log "=== Phase 2/3: code-review (sonnet) ==="
+# Phase 2: Code Review
+log "=== Phase 2/3: code-review ($MODEL_REVIEW) ==="
 REVIEW_PROMPT="${STORY_CONTEXT}
 Execute /bmad-bmm-code-review for story ${STORY_KEY}.
 The story file is at _bmad-output/implementation-artifacts/${STORY_KEY}.md
 Review ALL code changes on branch feat/${STORY_KEY} vs ${BASE_BRANCH}. Fix any issues found. Push fixes and ensure CI is green."
 
-if echo "$REVIEW_PROMPT" | claude --dangerously-skip-permissions --model sonnet "$@"; then
+if echo "$REVIEW_PROMPT" | claude --dangerously-skip-permissions --model "$MODEL_REVIEW" "$@"; then
     log "✅ code-review complete"
 else
     log "❌ code-review failed (exit $?)"
@@ -70,12 +74,12 @@ log ""
 if [ "$SKIP_MERGE" = "true" ]; then
     log "=== Phase 3/3: merge-story SKIPPED (SKIP_MERGE=true) ==="
 else
-    log "=== Phase 3/3: merge-story (opus) ==="
+    log "=== Phase 3/3: merge-story ($MODEL_MERGE) ==="
     MERGE_PROMPT="${STORY_CONTEXT}
 Execute /bmad-bmm-merge-story for story ${STORY_KEY}.
 Merge the PR for feat/${STORY_KEY} into ${BASE_BRANCH} via squash merge. Ensure CI is green before merging."
 
-    if echo "$MERGE_PROMPT" | claude --dangerously-skip-permissions --model opus "$@"; then
+    if echo "$MERGE_PROMPT" | claude --dangerously-skip-permissions --model "$MODEL_MERGE" "$@"; then
         log "✅ merge-story complete"
     else
         log "❌ merge-story failed (exit $?)"


### PR DESCRIPTION
## Summary
- Ajout des flags `--dev=MODEL`, `--review=MODEL`, `--merge=MODEL` sur `bmad-dev.sh`
- Les overrides sont passés en env vars au container Docker
- `pipeline.sh` lit `MODEL_DEV/REVIEW/MERGE` depuis l'env (fallback sur les defaults opus/sonnet/opus)
- CLAUDE.md mis à jour avec le tableau des modèles et les exemples d'usage

## Test plan
- [ ] `./scripts/bmad-dev.sh --story X --pipeline --dev=sonnet` lance le container avec `MODEL_DEV=sonnet`
- [ ] Sans override, les defaults opus/sonnet/opus s'appliquent

🤖 Generated with [Claude Code](https://claude.com/claude-code)