### PR TITLE
feat(ui): add cost dashboard page

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -37,6 +37,8 @@ tags:
     description: Pipeline configuration endpoints
   - name: hitl
     description: Human-in-the-loop approval endpoints
+  - name: costs
+    description: Cost tracking and observability endpoints
 
 paths:
   # ── Auth ────────────────────────────────────────────────────────────────
@@ -970,6 +972,100 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+
+  # ── Costs ─────────────────────────────────────────────────────────────
+  /projects/{projectId}/costs/summary:
+    get:
+      operationId: getProjectCostSummary
+      summary: Get cost summary for a project
+      tags: [costs]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - name: period
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [7d, 30d]
+            default: 7d
+          description: Time period for cost aggregation
+      responses:
+        "200":
+          description: Cost summary
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CostSummary"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /projects/{projectId}/costs/chart:
+    get:
+      operationId: getProjectCostChart
+      summary: Get daily cost data points for chart rendering
+      tags: [costs]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - name: period
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [7d, 30d]
+            default: 7d
+          description: Time period for cost chart data
+      responses:
+        "200":
+          description: Daily cost data points
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CostDataPoint"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /projects/{projectId}/costs/runs:
+    get:
+      operationId: getProjectCostRuns
+      summary: Get run-level cost breakdown for a project
+      tags: [costs]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - name: period
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [7d, 30d]
+            default: 7d
+          description: Time period for run cost data
+        - $ref: "#/components/parameters/PageParam"
+        - $ref: "#/components/parameters/PerPageParam"
+      responses:
+        "200":
+          description: Paginated list of run cost rows
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data, pagination]
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/RunCostRow"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   /hitl-requests/{hitlRequestId}/reject:
     post:
@@ -2030,6 +2126,86 @@ components:
           minLength: 10
           description: Reason for rejecting the HITL request
 
+
+    # ── Costs ──────────────────────────────────────────────────────────
+    CostSummary:
+      type: object
+      required:
+        - total_cost_usd
+        - period_start
+        - period_end
+        - avg_cost_per_story_usd
+      properties:
+        total_cost_usd:
+          type: number
+          format: double
+          example: 1.2345
+        total_cost_week_usd:
+          type: number
+          format: double
+          example: 0.5678
+        total_cost_month_usd:
+          type: number
+          format: double
+          example: 3.4567
+        avg_cost_per_story_usd:
+          type: number
+          format: double
+          example: 0.1234
+        budget_limit_usd:
+          type: number
+          format: double
+          example: 10.0
+        period_start:
+          type: string
+          format: date-time
+          example: "2026-02-10T00:00:00Z"
+        period_end:
+          type: string
+          format: date-time
+          example: "2026-02-17T00:00:00Z"
+
+    CostDataPoint:
+      type: object
+      required:
+        - date
+        - total_cost_usd
+      properties:
+        date:
+          type: string
+          format: date
+          example: "2026-02-10"
+        total_cost_usd:
+          type: number
+          format: double
+          example: 0.1234
+
+    RunCostRow:
+      type: object
+      required:
+        - run_id
+        - story_key
+        - status
+        - started_at
+        - total_cost_usd
+      properties:
+        run_id:
+          type: string
+          format: uuid
+        story_key:
+          type: string
+          example: S-01
+        status:
+          type: string
+          example: completed
+        started_at:
+          type: string
+          format: date-time
+          example: "2026-02-10T10:30:00Z"
+        total_cost_usd:
+          type: number
+          format: double
+          example: 0.01234
 
     # ── Shared ─────────────────────────────────────────────────────────
     Pagination:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@vue-flow/minimap": "^1.5.4",
         "@vueuse/core": "^14.2.1",
         "ansi-to-html": "^0.7.2",
+        "chart.js": "^4.5.1",
         "date-fns": "^4.1.0",
         "diff2html": "^3.4.56",
         "dompurify": "^3.3.1",
@@ -1544,6 +1545,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@monaco-editor/loader": {
       "version": "1.7.0",
@@ -4234,6 +4241,18 @@
       "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@vue-flow/minimap": "^1.5.4",
     "@vueuse/core": "^14.2.1",
     "ansi-to-html": "^0.7.2",
+    "chart.js": "^4.5.1",
     "date-fns": "^4.1.0",
     "diff2html": "^3.4.56",
     "dompurify": "^3.3.1",

--- a/frontend/src/composables/__tests__/useCosts.spec.ts
+++ b/frontend/src/composables/__tests__/useCosts.spec.ts
@@ -109,7 +109,7 @@ describe('useCosts', () => {
     expect(isLoading.value).toBe(false)
   })
 
-  it('sets error and clears isLoading when API returns an error', async () => {
+  it('sets error and clears isLoading when summary API returns an error', async () => {
     mockGet
       .mockResolvedValueOnce({ data: undefined, error: { code: 'NOT_FOUND', message: 'not found' } })
       .mockResolvedValue({ data: [], error: undefined })
@@ -118,6 +118,32 @@ describe('useCosts', () => {
     await fetchAll()
 
     expect(error.value).toBe('Failed to load cost summary')
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('sets error when chart API returns an error', async () => {
+    mockGet
+      .mockResolvedValueOnce({ data: summaryData, error: undefined })
+      .mockResolvedValueOnce({ data: undefined, error: { code: 'INTERNAL', message: 'chart error' } })
+      .mockResolvedValueOnce({ data: { data: [], pagination: { total: 0, page: 1, per_page: 20 } }, error: undefined })
+
+    const { error, isLoading, fetchAll } = useCosts('proj-1')
+    await fetchAll()
+
+    expect(error.value).toBe('Failed to load cost chart')
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('sets error when runs API returns an error', async () => {
+    mockGet
+      .mockResolvedValueOnce({ data: summaryData, error: undefined })
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValueOnce({ data: undefined, error: { code: 'INTERNAL', message: 'runs error' } })
+
+    const { error, isLoading, fetchAll } = useCosts('proj-1')
+    await fetchAll()
+
+    expect(error.value).toBe('Failed to load cost runs')
     expect(isLoading.value).toBe(false)
   })
 

--- a/frontend/src/composables/__tests__/useCosts.spec.ts
+++ b/frontend/src/composables/__tests__/useCosts.spec.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useCosts } from '../useCosts'
+
+const mockGet = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+  },
+}))
+
+// Suppress onMounted in unit test context — tests call fetchAll directly
+vi.mock('vue', async (importOriginal) => {
+  const vue = await importOriginal<typeof import('vue')>()
+  return { ...vue, onMounted: vi.fn() }
+})
+
+const summaryData = {
+  total_cost_usd: 1.5,
+  total_cost_week_usd: 0.5,
+  total_cost_month_usd: 1.5,
+  avg_cost_per_story_usd: 0.25,
+  budget_limit_usd: 10.0,
+  period_start: '2026-02-10T00:00:00Z',
+  period_end: '2026-02-17T00:00:00Z',
+}
+
+const chartData = [
+  { date: '2026-02-10', total_cost_usd: 0.2 },
+  { date: '2026-02-11', total_cost_usd: 0.3 },
+]
+
+const runsData = [
+  {
+    run_id: 'run-1',
+    story_key: 'S-01',
+    status: 'completed',
+    started_at: '2026-02-10T10:00:00Z',
+    total_cost_usd: 0.01234,
+  },
+]
+
+function mockSuccessResponses() {
+  mockGet
+    .mockResolvedValueOnce({ data: summaryData, error: undefined })
+    .mockResolvedValueOnce({ data: chartData, error: undefined })
+    .mockResolvedValueOnce({
+      data: { data: runsData, pagination: { total: 1, page: 1, per_page: 20 } },
+      error: undefined,
+    })
+}
+
+describe('useCosts', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+  })
+
+  it('starts with default state', () => {
+    const { period, summary, chartData: cd, runs, isLoading, error } = useCosts('p1')
+    expect(period.value).toBe('7d')
+    expect(summary.value).toBeNull()
+    expect(cd.value).toEqual([])
+    expect(runs.value).toEqual([])
+    expect(isLoading.value).toBe(false)
+    expect(error.value).toBeNull()
+  })
+
+  it('fetchAll calls all three endpoints with the current period', async () => {
+    mockSuccessResponses()
+    const { fetchAll } = useCosts('proj-1')
+    await fetchAll()
+
+    expect(mockGet).toHaveBeenCalledTimes(3)
+    expect(mockGet).toHaveBeenCalledWith('/projects/{projectId}/costs/summary', {
+      params: { path: { projectId: 'proj-1' }, query: { period: '7d' } },
+    })
+    expect(mockGet).toHaveBeenCalledWith('/projects/{projectId}/costs/chart', {
+      params: { path: { projectId: 'proj-1' }, query: { period: '7d' } },
+    })
+    expect(mockGet).toHaveBeenCalledWith('/projects/{projectId}/costs/runs', {
+      params: { path: { projectId: 'proj-1' }, query: { period: '7d' } },
+    })
+  })
+
+  it('fetchAll populates summary, chartData and runs on success', async () => {
+    mockSuccessResponses()
+    const { summary, chartData: cd, runs, fetchAll } = useCosts('proj-1')
+    await fetchAll()
+
+    expect(summary.value).toEqual(summaryData)
+    expect(cd.value).toEqual(chartData)
+    expect(runs.value).toEqual(runsData)
+  })
+
+  it('isLoading is true during fetch and false after', async () => {
+    let resolve!: (v: unknown) => void
+    mockGet.mockReturnValueOnce(new Promise((r) => (resolve = r)))
+    mockGet.mockResolvedValue({ data: [], error: undefined })
+
+    const { isLoading, fetchAll } = useCosts('proj-1')
+    expect(isLoading.value).toBe(false)
+
+    const fetchPromise = fetchAll()
+    expect(isLoading.value).toBe(true)
+
+    resolve({ data: summaryData, error: undefined })
+    await fetchPromise
+
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('sets error and clears isLoading when API returns an error', async () => {
+    mockGet
+      .mockResolvedValueOnce({ data: undefined, error: { code: 'NOT_FOUND', message: 'not found' } })
+      .mockResolvedValue({ data: [], error: undefined })
+
+    const { error, isLoading, fetchAll } = useCosts('proj-1')
+    await fetchAll()
+
+    expect(error.value).toBe('Failed to load cost summary')
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('setPeriod updates period and re-fetches with new period', async () => {
+    mockSuccessResponses()
+    // Second call set for 30d
+    mockGet
+      .mockResolvedValueOnce({ data: summaryData, error: undefined })
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValueOnce({ data: { data: [], pagination: { total: 0, page: 1, per_page: 20 } }, error: undefined })
+
+    const { period, setPeriod } = useCosts('proj-1')
+
+    // First fetch (7d)
+    await setPeriod('7d')
+    expect(period.value).toBe('7d')
+    mockGet.mockClear()
+
+    // Second fetch with 30d
+    mockGet
+      .mockResolvedValueOnce({ data: summaryData, error: undefined })
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValueOnce({ data: { data: [], pagination: { total: 0, page: 1, per_page: 20 } }, error: undefined })
+
+    await setPeriod('30d')
+    expect(period.value).toBe('30d')
+
+    expect(mockGet).toHaveBeenCalledWith('/projects/{projectId}/costs/summary', {
+      params: { path: { projectId: 'proj-1' }, query: { period: '30d' } },
+    })
+  })
+
+  it('clears error on successful retry', async () => {
+    // First fetch fails
+    mockGet.mockResolvedValue({ data: undefined, error: { code: 'INTERNAL', message: 'fail' } })
+    const { error, fetchAll } = useCosts('proj-1')
+    await fetchAll()
+    expect(error.value).not.toBeNull()
+
+    // Retry succeeds
+    mockGet.mockReset()
+    mockSuccessResponses()
+    await fetchAll()
+    expect(error.value).toBeNull()
+  })
+})

--- a/frontend/src/composables/useCosts.ts
+++ b/frontend/src/composables/useCosts.ts
@@ -34,6 +34,8 @@ export function useCosts(projectId: string) {
         }),
       ])
       if (sumRes.error) throw new Error('Failed to load cost summary')
+      if (chartRes.error) throw new Error('Failed to load cost chart')
+      if (runsRes.error) throw new Error('Failed to load cost runs')
       summary.value = sumRes.data ?? null
       chartData.value = chartRes.data ?? []
       runs.value = runsRes.data?.data ?? []
@@ -47,7 +49,7 @@ export function useCosts(projectId: string) {
   /** Update the active period and re-fetch all cost data. */
   function setPeriod(p: '7d' | '30d') {
     period.value = p
-    fetchAll()
+    return fetchAll()
   }
 
   onMounted(fetchAll)

--- a/frontend/src/composables/useCosts.ts
+++ b/frontend/src/composables/useCosts.ts
@@ -1,0 +1,56 @@
+import { onMounted, ref } from 'vue'
+import { apiClient } from '@/api/client'
+import type { components } from '@/api/schema'
+
+type CostSummary = components['schemas']['CostSummary']
+type CostDataPoint = components['schemas']['CostDataPoint']
+type RunCostRow = components['schemas']['RunCostRow']
+
+/**
+ * Composable for fetching and managing cost data for a project.
+ * Owns all state: summary, chart data, runs, period, isLoading, error.
+ */
+export function useCosts(projectId: string) {
+  const period = ref<'7d' | '30d'>('7d')
+  const summary = ref<CostSummary | null>(null)
+  const chartData = ref<CostDataPoint[]>([])
+  const runs = ref<RunCostRow[]>([])
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchAll() {
+    isLoading.value = true
+    error.value = null
+    try {
+      const [sumRes, chartRes, runsRes] = await Promise.all([
+        apiClient.GET('/projects/{projectId}/costs/summary', {
+          params: { path: { projectId }, query: { period: period.value } },
+        }),
+        apiClient.GET('/projects/{projectId}/costs/chart', {
+          params: { path: { projectId }, query: { period: period.value } },
+        }),
+        apiClient.GET('/projects/{projectId}/costs/runs', {
+          params: { path: { projectId }, query: { period: period.value } },
+        }),
+      ])
+      if (sumRes.error) throw new Error('Failed to load cost summary')
+      summary.value = sumRes.data ?? null
+      chartData.value = chartRes.data ?? []
+      runs.value = runsRes.data?.data ?? []
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load cost data'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  /** Update the active period and re-fetch all cost data. */
+  function setPeriod(p: '7d' | '30d') {
+    period.value = p
+    fetchAll()
+  }
+
+  onMounted(fetchAll)
+
+  return { period, summary, chartData, runs, isLoading, error, fetchAll, setPeriod }
+}

--- a/frontend/src/features/costs/CostChart.vue
+++ b/frontend/src/features/costs/CostChart.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { format, parseISO } from 'date-fns'
+import Chart from 'primevue/chart'
+import Skeleton from 'primevue/skeleton'
+import type { components } from '@/api/schema'
+
+type CostDataPoint = components['schemas']['CostDataPoint']
+
+const props = defineProps<{
+  data: CostDataPoint[]
+  isLoading: boolean
+}>()
+
+const chartDataset = computed(() => ({
+  labels: props.data.map((d) => format(parseISO(d.date), 'MMM d')),
+  datasets: [
+    {
+      label: 'Daily Cost (USD)',
+      data: props.data.map((d) => d.total_cost_usd),
+      fill: false,
+      tension: 0.3,
+      borderColor: '#6366f1',
+      pointBackgroundColor: '#6366f1',
+    },
+  ],
+}))
+
+const chartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+  },
+  scales: {
+    x: {
+      grid: { display: false },
+    },
+    y: {
+      beginAtZero: true,
+      ticks: {
+        callback: (value: number) => `$${value.toFixed(2)}`,
+      },
+    },
+  },
+}
+</script>
+
+<template>
+  <div class="rounded-lg border border-surface-200 bg-surface-0 p-4">
+    <h3 class="mb-4 font-semibold">Cost Over Time</h3>
+    <Skeleton v-if="isLoading" width="100%" height="16rem" />
+    <div v-else-if="data.length === 0" class="flex flex-col items-center justify-center py-12">
+      <i class="pi pi-chart-line mb-3 text-3xl text-surface-300" />
+      <p class="text-surface-500">No cost data yet</p>
+    </div>
+    <div v-else style="height: 16rem">
+      <Chart type="line" :data="chartDataset" :options="chartOptions" style="height: 100%" />
+    </div>
+  </div>
+</template>

--- a/frontend/src/features/costs/CostSummaryCard.vue
+++ b/frontend/src/features/costs/CostSummaryCard.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import Skeleton from 'primevue/skeleton'
+
+defineProps<{
+  label: string
+  value: string
+  isLoading: boolean
+}>()
+</script>
+
+<template>
+  <div class="rounded-lg border border-surface-200 bg-surface-0 p-4">
+    <p class="mb-1 text-sm text-surface-500">{{ label }}</p>
+    <Skeleton v-if="isLoading" width="6rem" height="1.75rem" />
+    <p v-else class="text-2xl font-bold">{{ value }}</p>
+  </div>
+</template>

--- a/frontend/src/features/costs/RunCostTable.vue
+++ b/frontend/src/features/costs/RunCostTable.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import DataTable from 'primevue/datatable'
+import Column from 'primevue/column'
+import Tag from 'primevue/tag'
+import Skeleton from 'primevue/skeleton'
+import { useRelativeTime } from '@/composables/useRelativeTime'
+import { formatCostUSD } from '@/utils/formatCost'
+import type { components } from '@/api/schema'
+
+type RunCostRow = components['schemas']['RunCostRow']
+
+defineProps<{
+  runs: RunCostRow[]
+  isLoading: boolean
+}>()
+
+const emit = defineEmits<{
+  navigate: [runId: string]
+}>()
+
+/** Maps run status to PrimeVue Tag severity for visual differentiation. */
+function statusSeverity(
+  status: string,
+): 'success' | 'info' | 'warn' | 'danger' | 'secondary' | undefined {
+  switch (status) {
+    case 'completed':
+      return 'success'
+    case 'running':
+      return 'info'
+    case 'failed':
+      return 'danger'
+    case 'cancelled':
+      return 'warn'
+    default:
+      return 'secondary'
+  }
+}
+
+const skeletonRows = [1, 2, 3]
+</script>
+
+<template>
+  <div class="rounded-lg border border-surface-200 bg-surface-0">
+    <div class="border-b border-surface-200 px-4 py-3">
+      <h3 class="font-semibold">Recent Runs</h3>
+    </div>
+
+    <!-- Skeleton loading state -->
+    <div v-if="isLoading" class="divide-y divide-surface-100">
+      <div v-for="n in skeletonRows" :key="n" class="flex items-center gap-4 px-4 py-3">
+        <Skeleton width="4rem" height="1.25rem" />
+        <Skeleton width="5rem" height="1.5rem" class="rounded-full" />
+        <Skeleton width="5rem" height="1.25rem" />
+        <Skeleton width="5rem" height="1.25rem" class="ml-auto" />
+      </div>
+    </div>
+
+    <!-- Empty state -->
+    <div
+      v-else-if="runs.length === 0"
+      class="flex flex-col items-center justify-center py-10"
+    >
+      <i class="pi pi-list mb-3 text-3xl text-surface-300" />
+      <p class="text-surface-500">No runs in this period</p>
+    </div>
+
+    <!-- Data table -->
+    <DataTable
+      v-else
+      :value="runs"
+      row-hover
+      class="cursor-pointer"
+      @row-click="emit('navigate', $event.data.run_id)"
+    >
+      <Column field="story_key" header="Story" />
+      <Column field="status" header="Status">
+        <template #body="{ data: row }">
+          <Tag :value="row.status" :severity="statusSeverity(row.status)" />
+        </template>
+      </Column>
+      <Column field="started_at" header="Started">
+        <template #body="{ data: row }">
+          <RelativeCell :date="row.started_at" />
+        </template>
+      </Column>
+      <Column field="total_cost_usd" header="Cost">
+        <template #body="{ data: row }">
+          {{ formatCostUSD(row.total_cost_usd) }}
+        </template>
+      </Column>
+    </DataTable>
+  </div>
+</template>
+
+<!-- Inline helper to avoid passing composable into template directly -->
+<script lang="ts">
+import { defineComponent, h } from 'vue'
+
+const RelativeCell = defineComponent({
+  props: { date: { type: String, required: true } },
+  setup(props) {
+    const rel = useRelativeTime(props.date)
+    return () => h('span', rel.value ?? props.date)
+  },
+})
+
+export { RelativeCell }
+</script>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -69,6 +69,11 @@ const router = createRouter({
           component: PromptTemplatesView,
         },
         {
+          path: 'costs',
+          name: 'project-costs',
+          component: () => import('@/views/CostDashboardView.vue'),
+        },
+        {
           path: 'templates/new',
           name: 'template-create',
           component: () => import('@/views/TemplateEditorView.vue'),

--- a/frontend/src/utils/formatCost.ts
+++ b/frontend/src/utils/formatCost.ts
@@ -1,0 +1,12 @@
+/**
+ * Formats a numeric USD value as a currency string.
+ * Uses up to 5 decimal places to show small AI usage costs accurately.
+ */
+export function formatCostUSD(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 5,
+  }).format(value)
+}

--- a/frontend/src/views/CostDashboardView.vue
+++ b/frontend/src/views/CostDashboardView.vue
@@ -85,7 +85,7 @@ function budgetPercent(total: number, limit: number): number {
 
       <!-- Budget progress bar -->
       <div
-        v-if="summary && summary.budget_limit_usd && summary.budget_limit_usd > 0"
+        v-if="summary && (summary.budget_limit_usd ?? 0) > 0"
         class="rounded-lg border border-surface-200 bg-surface-0 p-4"
         data-testid="budget-bar"
       >
@@ -93,11 +93,11 @@ function budgetPercent(total: number, limit: number): number {
           <span class="font-medium">Budget usage</span>
           <span class="text-surface-500">
             {{ formatCostUSD(summary.total_cost_usd) }} /
-            {{ formatCostUSD(summary.budget_limit_usd) }} used
+            {{ formatCostUSD(summary.budget_limit_usd ?? 0) }} used
           </span>
         </div>
         <ProgressBar
-          :value="budgetPercent(summary.total_cost_usd, summary.budget_limit_usd)"
+          :value="budgetPercent(summary.total_cost_usd, summary.budget_limit_usd ?? 0)"
           :show-value="false"
         />
       </div>

--- a/frontend/src/views/CostDashboardView.vue
+++ b/frontend/src/views/CostDashboardView.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+import { useRoute, useRouter } from 'vue-router'
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import ProgressBar from 'primevue/progressbar'
+import { useCosts } from '@/composables/useCosts'
+import { formatCostUSD } from '@/utils/formatCost'
+import CostSummaryCard from '@/features/costs/CostSummaryCard.vue'
+import CostChart from '@/features/costs/CostChart.vue'
+import RunCostTable from '@/features/costs/RunCostTable.vue'
+
+const route = useRoute()
+const router = useRouter()
+
+const projectId = route.params.id as string
+const { period, summary, chartData, runs, isLoading, error, fetchAll, setPeriod } =
+  useCosts(projectId)
+
+function onRunNavigate(runId: string) {
+  router.push({ name: 'run-detail', params: { id: runId } })
+}
+
+function budgetPercent(total: number, limit: number): number {
+  if (limit <= 0) return 0
+  return Math.min((total / limit) * 100, 100)
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-6 p-6">
+    <!-- Error state -->
+    <Message
+      v-if="error"
+      severity="error"
+      :closable="false"
+      data-testid="cost-error"
+    >
+      <div class="flex items-center gap-3">
+        <span>{{ error }}</span>
+        <Button label="Retry" severity="secondary" text size="small" @click="fetchAll()" />
+      </div>
+    </Message>
+
+    <template v-if="!error">
+      <!-- Period toggle -->
+      <div class="flex items-center gap-2">
+        <span class="text-sm font-medium text-surface-600">Period:</span>
+        <Button
+          label="7d"
+          size="small"
+          :outlined="period !== '7d'"
+          data-testid="period-7d"
+          @click="setPeriod('7d')"
+        />
+        <Button
+          label="30d"
+          size="small"
+          :outlined="period !== '30d'"
+          data-testid="period-30d"
+          @click="setPeriod('30d')"
+        />
+      </div>
+
+      <!-- Summary cards -->
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <CostSummaryCard
+          label="Total cost this week"
+          :value="summary ? formatCostUSD(summary.total_cost_week_usd ?? 0) : '$0.00'"
+          :is-loading="isLoading"
+          data-testid="card-week"
+        />
+        <CostSummaryCard
+          label="Total cost this month"
+          :value="summary ? formatCostUSD(summary.total_cost_month_usd ?? 0) : '$0.00'"
+          :is-loading="isLoading"
+          data-testid="card-month"
+        />
+        <CostSummaryCard
+          label="Average cost per story"
+          :value="summary ? formatCostUSD(summary.avg_cost_per_story_usd) : '$0.00'"
+          :is-loading="isLoading"
+          data-testid="card-avg"
+        />
+      </div>
+
+      <!-- Budget progress bar -->
+      <div
+        v-if="summary && summary.budget_limit_usd && summary.budget_limit_usd > 0"
+        class="rounded-lg border border-surface-200 bg-surface-0 p-4"
+        data-testid="budget-bar"
+      >
+        <div class="mb-2 flex items-center justify-between text-sm">
+          <span class="font-medium">Budget usage</span>
+          <span class="text-surface-500">
+            {{ formatCostUSD(summary.total_cost_usd) }} /
+            {{ formatCostUSD(summary.budget_limit_usd) }} used
+          </span>
+        </div>
+        <ProgressBar
+          :value="budgetPercent(summary.total_cost_usd, summary.budget_limit_usd)"
+          :show-value="false"
+        />
+      </div>
+
+      <!-- Cost over time chart -->
+      <CostChart :data="chartData" :is-loading="isLoading" data-testid="cost-chart" />
+
+      <!-- Recent runs table -->
+      <RunCostTable
+        :runs="runs"
+        :is-loading="isLoading"
+        data-testid="runs-table"
+        @navigate="onRunNavigate"
+      />
+    </template>
+  </div>
+</template>

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -20,6 +20,7 @@ const tabs = [
   { label: 'Board', icon: 'pi pi-th-large', route: 'project-board' },
   { label: 'Pipeline', icon: 'pi pi-cog', route: 'project-pipeline' },
   { label: 'Templates', icon: 'pi pi-file', route: 'project-templates' },
+  { label: 'Costs', icon: 'pi pi-dollar', route: 'project-costs' },
 ]
 
 const activeIndex = computed(() => {


### PR DESCRIPTION
## Summary
- Adds cost summary/chart/runs API endpoints to openapi.yaml with CostSummary, CostDataPoint, and RunCostRow schemas
- Implements useCosts composable with period toggle (7d/30d), parallel data fetching, and error handling
- Creates CostDashboardView with summary cards, line chart (chart.js via PrimeVue Chart), budget ProgressBar, and run cost DataTable
- Adds Costs tab to ProjectDetailView and project-costs child route to the router
- Adds formatCostUSD utility for consistent cost display

## Test plan
- All 380 unit tests pass including 7 new useCosts tests
- Lint and type-check pass cleanly

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>