### PR TITLE
feat(ui): add notification settings page

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1204,6 +1204,121 @@ paths:
         "409":
           $ref: "#/components/responses/Conflict"
 
+  # ── Notification Configs ─────────────────────────────────────────────
+  /projects/{projectId}/notifications:
+    get:
+      operationId: listNotificationConfigs
+      summary: List notification configs for a project
+      tags: [notifications]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+      responses:
+        "200":
+          description: List of notification configs
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - pagination
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/NotificationConfig"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    post:
+      operationId: createNotificationConfig
+      summary: Create a notification config
+      tags: [notifications]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateNotificationConfigRequest"
+      responses:
+        "201":
+          description: Notification config created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationConfig"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /projects/{projectId}/notifications/{notificationId}:
+    put:
+      operationId: updateNotificationConfig
+      summary: Update a notification config
+      tags: [notifications]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/NotificationIdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateNotificationConfigRequest"
+      responses:
+        "200":
+          description: Notification config updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationConfig"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    delete:
+      operationId: deleteNotificationConfig
+      summary: Delete a notification config
+      tags: [notifications]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/NotificationIdPath"
+      responses:
+        "204":
+          description: Notification config deleted
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /projects/{projectId}/notifications/{notificationId}/test:
+    post:
+      operationId: testNotificationConfig
+      summary: Send a test notification
+      tags: [notifications]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/NotificationIdPath"
+      responses:
+        "204":
+          description: Test notification sent
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
 # ── Components ──────────────────────────────────────────────────────────
 components:
   securitySchemes:
@@ -2184,6 +2299,99 @@ components:
         pagination:
           $ref: "#/components/schemas/Pagination"
 
+
+    # ── Notification Config ───────────────────────────────────────────
+    NotificationConfig:
+      type: object
+      required:
+        - id
+        - project_id
+        - channel_type
+        - config
+        - events_filter
+        - enabled
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        project_id:
+          type: string
+          format: uuid
+        channel_type:
+          type: string
+          enum: [discord, webhook]
+          example: discord
+        config:
+          type: object
+          required:
+            - url
+          properties:
+            url:
+              type: string
+              format: uri
+              example: "https://discord.com/api/webhooks/123/abc"
+        events_filter:
+          type: array
+          items:
+            type: string
+          example: ["run.completed", "run.failed"]
+        enabled:
+          type: boolean
+          example: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    CreateNotificationConfigRequest:
+      type: object
+      required:
+        - channel_type
+        - config
+        - events_filter
+        - enabled
+      properties:
+        channel_type:
+          type: string
+          enum: [discord, webhook]
+        config:
+          type: object
+          required:
+            - url
+          properties:
+            url:
+              type: string
+              format: uri
+        events_filter:
+          type: array
+          items:
+            type: string
+        enabled:
+          type: boolean
+          default: true
+
+    UpdateNotificationConfigRequest:
+      type: object
+      properties:
+        channel_type:
+          type: string
+          enum: [discord, webhook]
+        config:
+          type: object
+          properties:
+            url:
+              type: string
+              format: uri
+        events_filter:
+          type: array
+          items:
+            type: string
+        enabled:
+          type: boolean
 
     # ── HITL Request ──────────────────────────────────────────────────
     HITLRequest:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1019,6 +1019,22 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /projects/{projectId}/notifications/{notificationId}/test:
+    post:
+      operationId: testNotificationConfig
+      summary: Send a test notification
+      tags: [notifications]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/NotificationIdPath"
+      responses:
+        "204":
+          description: Test notification sent
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   # ── HITL Requests ───────────────────────────────────────────────────
   /hitl-requests/by-step/{stepId}:
     get:
@@ -1203,121 +1219,6 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
-
-  # ── Notification Configs ─────────────────────────────────────────────
-  /projects/{projectId}/notifications:
-    get:
-      operationId: listNotificationConfigs
-      summary: List notification configs for a project
-      tags: [notifications]
-      parameters:
-        - $ref: "#/components/parameters/ProjectIdPath"
-      responses:
-        "200":
-          description: List of notification configs
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - data
-                  - pagination
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/NotificationConfig"
-                  pagination:
-                    $ref: "#/components/schemas/Pagination"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-
-    post:
-      operationId: createNotificationConfig
-      summary: Create a notification config
-      tags: [notifications]
-      parameters:
-        - $ref: "#/components/parameters/ProjectIdPath"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateNotificationConfigRequest"
-      responses:
-        "201":
-          description: Notification config created
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/NotificationConfig"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-
-  /projects/{projectId}/notifications/{notificationId}:
-    put:
-      operationId: updateNotificationConfig
-      summary: Update a notification config
-      tags: [notifications]
-      parameters:
-        - $ref: "#/components/parameters/ProjectIdPath"
-        - $ref: "#/components/parameters/NotificationIdPath"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/UpdateNotificationConfigRequest"
-      responses:
-        "200":
-          description: Notification config updated
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/NotificationConfig"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-
-    delete:
-      operationId: deleteNotificationConfig
-      summary: Delete a notification config
-      tags: [notifications]
-      parameters:
-        - $ref: "#/components/parameters/ProjectIdPath"
-        - $ref: "#/components/parameters/NotificationIdPath"
-      responses:
-        "204":
-          description: Notification config deleted
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-
-  /projects/{projectId}/notifications/{notificationId}/test:
-    post:
-      operationId: testNotificationConfig
-      summary: Send a test notification
-      tags: [notifications]
-      parameters:
-        - $ref: "#/components/parameters/ProjectIdPath"
-        - $ref: "#/components/parameters/NotificationIdPath"
-      responses:
-        "204":
-          description: Test notification sent
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
 
 # ── Components ──────────────────────────────────────────────────────────
 components:
@@ -2303,35 +2204,25 @@ components:
     # ── Notification Config ───────────────────────────────────────────
     NotificationConfig:
       type: object
-      required:
-        - id
-        - project_id
-        - channel_type
-        - config
-        - events_filter
-        - enabled
-        - created_at
-        - updated_at
+      required: [id, project_id, channel_type, config, events_filter, enabled, created_at, updated_at]
       properties:
         id:
           type: string
           format: uuid
+          example: 770e8400-e29b-41d4-a716-446655440000
         project_id:
           type: string
           format: uuid
+          example: 660e8400-e29b-41d4-a716-446655440000
         channel_type:
           type: string
           enum: [discord, webhook]
           example: discord
         config:
           type: object
-          required:
-            - url
-          properties:
-            url:
-              type: string
-              format: uri
-              example: "https://discord.com/api/webhooks/123/abc"
+          additionalProperties:
+            type: string
+          example: {"url": "https://discord.com/api/webhooks/..."}
         events_filter:
           type: array
           items:
@@ -2343,55 +2234,65 @@ components:
         created_at:
           type: string
           format: date-time
+          example: "2026-01-15T10:30:00Z"
         updated_at:
           type: string
           format: date-time
+          example: "2026-01-15T10:30:00Z"
 
     CreateNotificationConfigRequest:
       type: object
-      required:
-        - channel_type
-        - config
-        - events_filter
-        - enabled
+      required: [channel_type, config, events_filter]
       properties:
         channel_type:
           type: string
           enum: [discord, webhook]
+          example: discord
         config:
           type: object
-          required:
-            - url
-          properties:
-            url:
-              type: string
-              format: uri
+          additionalProperties:
+            type: string
+          example: {"url": "https://discord.com/api/webhooks/..."}
         events_filter:
           type: array
           items:
             type: string
+          example: ["run.completed", "run.failed"]
         enabled:
           type: boolean
           default: true
+          example: true
 
     UpdateNotificationConfigRequest:
       type: object
+      required: [channel_type, config, events_filter, enabled]
       properties:
         channel_type:
           type: string
           enum: [discord, webhook]
+          example: discord
         config:
           type: object
-          properties:
-            url:
-              type: string
-              format: uri
+          additionalProperties:
+            type: string
+          example: {"url": "https://discord.com/api/webhooks/..."}
         events_filter:
           type: array
           items:
             type: string
+          example: ["run.completed", "run.failed"]
         enabled:
           type: boolean
+          example: true
+
+    NotificationConfigList:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/NotificationConfig"
 
     # ── HITL Request ──────────────────────────────────────────────────
     HITLRequest:
@@ -2588,99 +2489,6 @@ components:
             details:
               type: object
               additionalProperties: true
-
-    # ── Notification Config ─────────────────────────────────────────────
-    NotificationConfig:
-      type: object
-      required: [id, project_id, channel_type, config, events_filter, enabled, created_at, updated_at]
-      properties:
-        id:
-          type: string
-          format: uuid
-          example: 770e8400-e29b-41d4-a716-446655440000
-        project_id:
-          type: string
-          format: uuid
-          example: 660e8400-e29b-41d4-a716-446655440000
-        channel_type:
-          type: string
-          enum: [discord, webhook]
-          example: discord
-        config:
-          type: object
-          additionalProperties:
-            type: string
-          example: {"url": "https://discord.com/api/webhooks/..."}
-        events_filter:
-          type: array
-          items:
-            type: string
-          example: ["run.completed", "run.failed"]
-        enabled:
-          type: boolean
-          example: true
-        created_at:
-          type: string
-          format: date-time
-          example: "2026-01-15T10:30:00Z"
-        updated_at:
-          type: string
-          format: date-time
-          example: "2026-01-15T10:30:00Z"
-
-    NotificationConfigList:
-      type: object
-      required: [data]
-      properties:
-        data:
-          type: array
-          items:
-            $ref: "#/components/schemas/NotificationConfig"
-
-    CreateNotificationConfigRequest:
-      type: object
-      required: [channel_type, config, events_filter]
-      properties:
-        channel_type:
-          type: string
-          enum: [discord, webhook]
-          example: discord
-        config:
-          type: object
-          additionalProperties:
-            type: string
-          example: {"url": "https://discord.com/api/webhooks/..."}
-        events_filter:
-          type: array
-          items:
-            type: string
-          example: ["run.completed", "run.failed"]
-        enabled:
-          type: boolean
-          default: true
-          example: true
-
-    UpdateNotificationConfigRequest:
-      type: object
-      required: [channel_type, config, events_filter, enabled]
-      properties:
-        channel_type:
-          type: string
-          enum: [discord, webhook]
-          example: discord
-        config:
-          type: object
-          additionalProperties:
-            type: string
-          example: {"url": "https://discord.com/api/webhooks/..."}
-        events_filter:
-          type: array
-          items:
-            type: string
-          example: ["run.completed", "run.failed"]
-        enabled:
-          type: boolean
-          example: true
 
   responses:
     BadRequest:

--- a/backend/internal/api/handler/gen_server.go
+++ b/backend/internal/api/handler/gen_server.go
@@ -121,6 +121,12 @@ const (
 	RunStatusRunning   RunStatus = "running"
 )
 
+// Defines values for RunStepRetryType.
+const (
+	Full        RunStepRetryType = "full"
+	Incremental RunStepRetryType = "incremental"
+)
+
 // Defines values for RunStepStatus.
 const (
 	RunStepStatusCancelled       RunStepStatus = "cancelled"
@@ -195,6 +201,41 @@ const (
 	UserRoleAdmin UserRole = "admin"
 	UserRoleUser  UserRole = "user"
 )
+
+// Defines values for GetProjectCostChartParamsPeriod.
+const (
+	GetProjectCostChartParamsPeriodN30d GetProjectCostChartParamsPeriod = "30d"
+	GetProjectCostChartParamsPeriodN7d  GetProjectCostChartParamsPeriod = "7d"
+)
+
+// Defines values for GetProjectCostRunsParamsPeriod.
+const (
+	GetProjectCostRunsParamsPeriodN30d GetProjectCostRunsParamsPeriod = "30d"
+	GetProjectCostRunsParamsPeriodN7d  GetProjectCostRunsParamsPeriod = "7d"
+)
+
+// Defines values for GetProjectCostSummaryParamsPeriod.
+const (
+	N30d GetProjectCostSummaryParamsPeriod = "30d"
+	N7d  GetProjectCostSummaryParamsPeriod = "7d"
+)
+
+// CostDataPoint defines model for CostDataPoint.
+type CostDataPoint struct {
+	Date         openapi_types.Date `json:"date"`
+	TotalCostUsd float64            `json:"total_cost_usd"`
+}
+
+// CostSummary defines model for CostSummary.
+type CostSummary struct {
+	AvgCostPerStoryUsd float64   `json:"avg_cost_per_story_usd"`
+	BudgetLimitUsd     *float64  `json:"budget_limit_usd,omitempty"`
+	PeriodEnd          time.Time `json:"period_end"`
+	PeriodStart        time.Time `json:"period_start"`
+	TotalCostMonthUsd  *float64  `json:"total_cost_month_usd,omitempty"`
+	TotalCostUsd       float64   `json:"total_cost_usd"`
+	TotalCostWeekUsd   *float64  `json:"total_cost_week_usd,omitempty"`
+}
 
 // CreateEpicRequest defines model for CreateEpicRequest.
 type CreateEpicRequest struct {
@@ -441,12 +482,14 @@ type PipelineStepModel string
 
 // Project defines model for Project.
 type Project struct {
-	CreatedAt   time.Time          `json:"created_at"`
-	Description *string            `json:"description,omitempty"`
-	Id          openapi_types.UUID `json:"id"`
-	Name        string             `json:"name"`
-	OwnerId     openapi_types.UUID `json:"owner_id"`
-	UpdatedAt   time.Time          `json:"updated_at"`
+	// CircuitBreakerActive Whether the circuit breaker is active, pausing all pipeline runs
+	CircuitBreakerActive *bool              `json:"circuit_breaker_active,omitempty"`
+	CreatedAt            time.Time          `json:"created_at"`
+	Description          *string            `json:"description,omitempty"`
+	Id                   openapi_types.UUID `json:"id"`
+	Name                 string             `json:"name"`
+	OwnerId              openapi_types.UUID `json:"owner_id"`
+	UpdatedAt            time.Time          `json:"updated_at"`
 }
 
 // ProjectList defines model for ProjectList.
@@ -517,6 +560,15 @@ type Run struct {
 // RunStatus defines model for Run.Status.
 type RunStatus string
 
+// RunCostRow defines model for RunCostRow.
+type RunCostRow struct {
+	RunId        openapi_types.UUID `json:"run_id"`
+	StartedAt    time.Time          `json:"started_at"`
+	Status       string             `json:"status"`
+	StoryKey     string             `json:"story_key"`
+	TotalCostUsd float64            `json:"total_cost_usd"`
+}
+
 // RunList defines model for RunList.
 type RunList struct {
 	Data       []Run      `json:"data"`
@@ -532,12 +584,24 @@ type RunStep struct {
 	ErrorMessage *string            `json:"error_message,omitempty"`
 	Id           openapi_types.UUID `json:"id"`
 	LogTail      *string            `json:"log_tail,omitempty"`
-	RunId        openapi_types.UUID `json:"run_id"`
-	StartedAt    *time.Time         `json:"started_at,omitempty"`
-	Status       RunStepStatus      `json:"status"`
-	StepName     string             `json:"step_name"`
-	StepOrder    int                `json:"step_order"`
+
+	// ParentStepId ID of the original step this is a retry of; null for root steps
+	ParentStepId *openapi_types.UUID `json:"parent_step_id"`
+
+	// RetryCount Which retry attempt this is (1-based); null for root steps
+	RetryCount *int `json:"retry_count"`
+
+	// RetryType Retry strategy used for this attempt; null for root steps
+	RetryType *RunStepRetryType  `json:"retry_type"`
+	RunId     openapi_types.UUID `json:"run_id"`
+	StartedAt *time.Time         `json:"started_at,omitempty"`
+	Status    RunStepStatus      `json:"status"`
+	StepName  string             `json:"step_name"`
+	StepOrder int                `json:"step_order"`
 }
+
+// RunStepRetryType Retry strategy used for this attempt; null for root steps
+type RunStepRetryType string
 
 // RunStepStatus defines model for RunStep.Status.
 type RunStepStatus string
@@ -755,6 +819,39 @@ type ListProjectsParams struct {
 	// SortBy Field to sort by
 	SortBy *SortByParam `form:"sort_by,omitempty" json:"sort_by,omitempty"`
 }
+
+// GetProjectCostChartParams defines parameters for GetProjectCostChart.
+type GetProjectCostChartParams struct {
+	// Period Time period for cost chart data
+	Period *GetProjectCostChartParamsPeriod `form:"period,omitempty" json:"period,omitempty"`
+}
+
+// GetProjectCostChartParamsPeriod defines parameters for GetProjectCostChart.
+type GetProjectCostChartParamsPeriod string
+
+// GetProjectCostRunsParams defines parameters for GetProjectCostRuns.
+type GetProjectCostRunsParams struct {
+	// Period Time period for run cost data
+	Period *GetProjectCostRunsParamsPeriod `form:"period,omitempty" json:"period,omitempty"`
+
+	// Page Page number
+	Page *PageParam `form:"page,omitempty" json:"page,omitempty"`
+
+	// PerPage Items per page
+	PerPage *PerPageParam `form:"per_page,omitempty" json:"per_page,omitempty"`
+}
+
+// GetProjectCostRunsParamsPeriod defines parameters for GetProjectCostRuns.
+type GetProjectCostRunsParamsPeriod string
+
+// GetProjectCostSummaryParams defines parameters for GetProjectCostSummary.
+type GetProjectCostSummaryParams struct {
+	// Period Time period for cost aggregation
+	Period *GetProjectCostSummaryParamsPeriod `form:"period,omitempty" json:"period,omitempty"`
+}
+
+// GetProjectCostSummaryParamsPeriod defines parameters for GetProjectCostSummary.
+type GetProjectCostSummaryParamsPeriod string
 
 // ListEpicsParams defines parameters for ListEpics.
 type ListEpicsParams struct {
@@ -976,6 +1073,18 @@ type ServerInterface interface {
 	// Update a project
 	// (PUT /projects/{id})
 	UpdateProject(w http.ResponseWriter, r *http.Request, id IdPath)
+	// Reset circuit breaker for a project
+	// (POST /projects/{id}/circuit-breaker/reset)
+	ResetCircuitBreaker(w http.ResponseWriter, r *http.Request, id IdPath)
+	// Get daily cost data points for chart rendering
+	// (GET /projects/{projectId}/costs/chart)
+	GetProjectCostChart(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, params GetProjectCostChartParams)
+	// Get run-level cost breakdown for a project
+	// (GET /projects/{projectId}/costs/runs)
+	GetProjectCostRuns(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, params GetProjectCostRunsParams)
+	// Get cost summary for a project
+	// (GET /projects/{projectId}/costs/summary)
+	GetProjectCostSummary(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, params GetProjectCostSummaryParams)
 	// List epics for a project with story counts
 	// (GET /projects/{projectId}/epics)
 	ListEpics(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, params ListEpicsParams)
@@ -1009,6 +1118,9 @@ type ServerInterface interface {
 	// Update a notification config
 	// (PUT /projects/{projectId}/notifications/{notificationId})
 	UpdateNotificationConfig(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, notificationId NotificationIdPath)
+	// Send a test notification
+	// (POST /projects/{projectId}/notifications/{notificationId}/test)
+	TestNotificationConfig(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, notificationId NotificationIdPath)
 	// Get the pipeline configuration for a project
 	// (GET /projects/{projectId}/pipeline)
 	GetPipelineConfig(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath)
@@ -1159,6 +1271,30 @@ func (_ Unimplemented) UpdateProject(w http.ResponseWriter, r *http.Request, id 
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Reset circuit breaker for a project
+// (POST /projects/{id}/circuit-breaker/reset)
+func (_ Unimplemented) ResetCircuitBreaker(w http.ResponseWriter, r *http.Request, id IdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get daily cost data points for chart rendering
+// (GET /projects/{projectId}/costs/chart)
+func (_ Unimplemented) GetProjectCostChart(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, params GetProjectCostChartParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get run-level cost breakdown for a project
+// (GET /projects/{projectId}/costs/runs)
+func (_ Unimplemented) GetProjectCostRuns(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, params GetProjectCostRunsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get cost summary for a project
+// (GET /projects/{projectId}/costs/summary)
+func (_ Unimplemented) GetProjectCostSummary(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, params GetProjectCostSummaryParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // List epics for a project with story counts
 // (GET /projects/{projectId}/epics)
 func (_ Unimplemented) ListEpics(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, params ListEpicsParams) {
@@ -1222,6 +1358,12 @@ func (_ Unimplemented) DeleteNotificationConfig(w http.ResponseWriter, r *http.R
 // Update a notification config
 // (PUT /projects/{projectId}/notifications/{notificationId})
 func (_ Unimplemented) UpdateNotificationConfig(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, notificationId NotificationIdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Send a test notification
+// (POST /projects/{projectId}/notifications/{notificationId}/test)
+func (_ Unimplemented) TestNotificationConfig(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, notificationId NotificationIdPath) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1720,6 +1862,179 @@ func (siw *ServerInterfaceWrapper) UpdateProject(w http.ResponseWriter, r *http.
 	handler.ServeHTTP(w, r)
 }
 
+// ResetCircuitBreaker operation middleware
+func (siw *ServerInterfaceWrapper) ResetCircuitBreaker(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id IdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ResetCircuitBreaker(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetProjectCostChart operation middleware
+func (siw *ServerInterfaceWrapper) GetProjectCostChart(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetProjectCostChartParams
+
+	// ------------- Optional query parameter "period" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "period", r.URL.Query(), &params.Period)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "period", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProjectCostChart(w, r, projectId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetProjectCostRuns operation middleware
+func (siw *ServerInterfaceWrapper) GetProjectCostRuns(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetProjectCostRunsParams
+
+	// ------------- Optional query parameter "period" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "period", r.URL.Query(), &params.Period)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "period", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "page" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "page", r.URL.Query(), &params.Page)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "page", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "per_page" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "per_page", r.URL.Query(), &params.PerPage)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "per_page", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProjectCostRuns(w, r, projectId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetProjectCostSummary operation middleware
+func (siw *ServerInterfaceWrapper) GetProjectCostSummary(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetProjectCostSummaryParams
+
+	// ------------- Optional query parameter "period" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "period", r.URL.Query(), &params.Period)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "period", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProjectCostSummary(w, r, projectId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListEpics operation middleware
 func (siw *ServerInterfaceWrapper) ListEpics(w http.ResponseWriter, r *http.Request) {
 
@@ -2142,6 +2457,46 @@ func (siw *ServerInterfaceWrapper) UpdateNotificationConfig(w http.ResponseWrite
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.UpdateNotificationConfig(w, r, projectId, notificationId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// TestNotificationConfig operation middleware
+func (siw *ServerInterfaceWrapper) TestNotificationConfig(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "notificationId" -------------
+	var notificationId NotificationIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "notificationId", chi.URLParam(r, "notificationId"), &notificationId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "notificationId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.TestNotificationConfig(w, r, projectId, notificationId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -3159,6 +3514,18 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Put(options.BaseURL+"/projects/{id}", wrapper.UpdateProject)
 	})
 	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/projects/{id}/circuit-breaker/reset", wrapper.ResetCircuitBreaker)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/projects/{projectId}/costs/chart", wrapper.GetProjectCostChart)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/projects/{projectId}/costs/runs", wrapper.GetProjectCostRuns)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/projects/{projectId}/costs/summary", wrapper.GetProjectCostSummary)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/projects/{projectId}/epics", wrapper.ListEpics)
 	})
 	r.Group(func(r chi.Router) {
@@ -3190,6 +3557,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Put(options.BaseURL+"/projects/{projectId}/notifications/{notificationId}", wrapper.UpdateNotificationConfig)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/projects/{projectId}/notifications/{notificationId}/test", wrapper.TestNotificationConfig)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/projects/{projectId}/pipeline", wrapper.GetPipelineConfig)
@@ -3264,102 +3634,114 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x96W4jOZLwqxD5fcBWAZIluVzV3f41rqO7PVvdbdhlNGZqDIHOpCSOU2Q2ySyX1jCw",
-	"77BvuE+y4JGZZCbz0uk6ftmSeAQjgsG4GHwIQrpMKEFE8OD0IUggg0skEFOf3iU4PI8uoFjITxHiIcOJ",
-	"wJQEp+o3cH19/jYYBFh+kchmg4DAJQpOA6S6BoOAob9SzFAUnAqWokHAwwVaQjnejLIlFMFpkKZYthSr",
-	"RPbkgmEyDx4fB8Gv5x/eX6K/UsRFHRiyCWC6TQM4CyzifKQNoaoD5RJxmrIQNYCBN537dyrwDIdQTlkH",
-	"h90GhJTM8LwBJOKMuCF4F3COLiQLVaGSPwGSLm8RywD5K0VsVUCSwDkK7PkiNINpLILTySBYYoKX6VL9",
-	"b+bFRKA5YnpixBrmPhdoyUGCGDBzeKdHbFoPwvF4ECzhZwPDeNwOEaP/RmEt35qfGwiTZANsSJPLtJZT",
-	"LlPSAABLN2eIK8rE61UNWX7GKI6AoIBTJsDtqoYw8tep+tVDlyBkCAoUTaHwAyBQ0rR8LlDSgAOuum+K",
-	"BEHZqg4I9WMjBKrzhiB8QMskhgI1sOMyEUCYZg3wiHykjUB6lJ15QglH6qh5DSMjn+WnkBKBiPoXJkls",
-	"xNPo31wC+2BN8/8ZmgWnwf8bFcfYSP/KR+8Yo0xP5S72NYyyIyN4HARvKJnFONzDxPkJEZopwTN0ND8C",
-	"UaqnQgAtIY6fS6h+puwWRxEiuwcrnwoMAYyWmAAYhohzkJNXnzw/05REe8QSoQLM1JyPg+CawFQsKMP/",
-	"hfYAgzOb/Nn0kAO+URJH6j8WxyaMJogJrLnZGewhQJ/hMolRpjXNKANyeEREdkzPEBQpQzxQp8x7ROZy",
-	"lx6P5UFT2jrZTrSHveaIgTNnyNJIL1+qEyv7PPEMywUUKXel6y0M72I6DwYBIvKs+2h9g8k0YXTOEJdg",
-	"R5Sg4MYnewoh8VGDXrSit/KIU5tQIdVWXd4ozaUWxeECEoLiqR7pIYcvwjykTIqce3S7oPROTldgqvi5",
-	"sn6tKimGiiIsQYDxhTNnpUs+7kOQsljqmUIk/HQ0MtMchXQ5ggkeGVj46OjoSHasrB8ReBtrzs6xr2Vq",
-	"Pof+aHreUhojSFTXT5KnpzMcC8Qcvvgoz3AJQxIjgZTATsnRDGI5080gwFIv8i7MfAEZg6sKER3U53gr",
-	"A1JPZaP79N89Z4Crf4HRjVwen3TdLb+twIVvgPZN0o+b9aGaHb21y60C+FZzADiXn5eICKCH6r+ns9N6",
-	"aonLYp5/0BRAhgDO5sFkDpTCAR4e1N/pHVo9PkqmbZ+qtBHzQZWeIJRGx9AnjO7lWIgpTTtMuaBLd4va",
-	"HTvg37NI06+eMpcpqSVHghMUY6JGM/LAbSB1QvVPvn3c32GYcW4tL3ZalhnHt4rG7anh83XTJMVRN53R",
-	"HdP0HFTwU49lpdrW4lnqGImAJETTkGGBGIZenEUoQSTiU43SriJroDwQ3dY6CO7Qyt0ZV8PxxN1tL32y",
-	"Ra8Yf0JeiHhI3S0hz05EJAQzplhV/ssXkGlx3HAiNykxCs1XuqnEA2RzJKQURrwfxgQWcUkSFRIopnNM",
-	"Mvu5LIWamUdiNxvdxy1SKfIc8IVh54B0PD5+NRxPhpOXHybj0xfj0/H4nxKjGY0jKNBQYC0Zqsy0vmJW",
-	"GUwzVzHGDz+M0Y8n4/EQHf90OzyZRCdD+MPk1fDk5NWrly9PTsbj8diGtI4bu+p3lY7mWJyWAXv1ajuA",
-	"FfzYVRssYChaeoaVwiWkqXFCtjL7G930cRCkSbRtJikxr5Z5BWIHmXg2yCiBP3AdEhZ8dZz/9uyXd9Ec",
-	"ec4ZZQV5PAbaOtLn9B1agWdaRCISrp4Hg6oUq258JSKqI39Q3/tGFpWBj9vPDA1/Pl0DAn6nkQcBGwrv",
-	"SsMYrrSC7K76n4jR4S3kKALoMwpTte9VW4BJhD7bKx9XfX3OtujC7t3FbAfOtGWrxZN6qQ0YvzTOlyrW",
-	"UTQvHRyNFrTFwZ4jhdCo/2CKG9q0HD3ywIBbt9L32GtgQAF7AeVbWgLnmMDsJGka4aJoWV6FgsQZq24l",
-	"lyk5UxqTNhJLNJO6DktJRfL/9NOuJL9cXJTG8ndHzlvf14h6jLiWlg6oL71edBtX9iJL4rcY0os+5eWp",
-	"Is3/dWhkkXX6Xr27nP7+x4fpz39c//7Wr1YIiGNe7ztwbPcCsiXiHM59h/09Fgtw/hbA23By/MJyhbVJ",
-	"BQV+MXIVH2WsKiz40GZF39q0s47KF57NbEO07HLDM4wiIFsB0wrMGF0CsUAAzuVHlkq9h6RxDG8rLpFi",
-	"ork0BnN7NEcsTBJGP8G4Xpdr3QeuhtXanCFlH1AyZQgaz2Qr9AxxGn9qxm2HQaSlvZ1BWM1y2/vnEqkd",
-	"UymZSsO1a/uqQJKKipY6ms7a36UIoM2rghGKpp5x+8BgPCTd1A/dvMVkVG22qiHYmC3WZ0PvTmtvH0vM",
-	"WhveJyzOlwll4krL4nqpUbf5L+E9WEJ2F9F7km9+JQP/cfbbe6DM5SUUAjGjnd7GNLzjHaShnrADyFz5",
-	"XL2HRHcNphhzZWILVcXB+F+rcXsVHAd0BsyRBsQCCqCbA0EBVoMHPhVU/9Q8KkH38QoYOmZzeEczVkvT",
-	"YKZJDuozaS7AmCEYrQD6jLlA0fOg9UzP4S4mzRE0yJDfTLzVu+Zz3F3BbzBcYIKGElApu4CaA5hTs862",
-	"8IVslX20hCtwiwBaJmIF8Ex9GdI0jtSJLX/5LBgMXWQUw1vnfymtJV1CUgbSbtLN55KNP9DY8CHyvRQn",
-	"tRtWxSNdSZRyxP5mPh6FdGmrj7q579yEnN9TVtJOOQpThi7+xvnEHiVv3LbIbLq8g2+B1ZjSVx9M2onr",
-	"zIpQPYGQ1O68b7t2oh3CZdUtYlfQuJ8Xq7rDtmB2e7Ztm0tAje8D8MIx1UvhnrL9NfGdiHlymN3y2OsN",
-	"ElRAV2SeHLeeg7rTIMuBy6fzrsYEYOqE2e69wOX4V6Pzw0B7JVDi28bN2+F4C9vB2Qka+FaWdqCuifBN",
-	"myOepUinkOdr74DnIICpoFNj0TgYmsGYe4Vvme4//rgdui9phGJ7vWEM0wgNaZLy4cnwlVyd/oZTQpAY",
-	"ngxfFt8tIL5LhyfDF+7aq2N0CIc0IkzFmqcJjXG4amPOS9n2Qjf1SlEnFJuJT42IEmlKE3uZyiQdHDjU",
-	"5cmiaA1tbUt2tCRjVAOs9yR3PxR9Xr78oo5iw0T5WvqdrgY7WzhSMzwf1pntZsXsaTPsSib2yt3Zu6q5",
-	"zeyfg+T7HDTAW5dW1Hv7Wuy+nV1s75/DbuZLNMdcILZzB0J1o/0dEgTeUtQ/KW5dZ4Q17I+9XROD+mzB",
-	"S+Wkbgy3FOGDcq60/F4lrphYA5mreIl9L6qUuzdug91M5ge1UJgqQC7h56nc+RnpczvJuTpj3Zzx2k9a",
-	"jSpLF0KJOkPJcAZxnDKllcX3cMVdYeI0aF6mDa4zrXfhKfG5GI0bo1cYbJ3QmXIATi134doBLDd7b8oJ",
-	"TPiCit6hyzzZp3qXBLEQEQHnCNAZyHGkrtpw8Gz8v//9P5Px+PlA/ZTKX6AA6s4PkMs/CmpvWnn5pWdI",
-	"jgvI+mK/KdjEUkL0f7ZTK3dhh5CEKI57RaA6J2mWj8etnH5Wqmce/LEyu/qcfZcp2cKBJ7fegU+5lDQ5",
-	"Arz7cU3ZQImAuLB5npbwiOl8Ksx5vkmw92B7cBDcQyzPyGmeC9ArMFyTv21+pSzS3u62oFcWli0isnlO",
-	"YT5Mnv/dPQZ7mZI/sVhcZf45GMd/zILTj122V3uSe8sYfv9ex9T0m+yW5Ppp4mslpOwhtbxfEmMlJeav",
-	"NMv0xJE00WbYJAdhkvlv9CXCAbgajifd8j+bcxD6Hqjfapb7Tk7fmnzOPqeunSJd2U5ZXqq9/hc+tUpl",
-	"cLck6Nm5DM0pspmEbgm0lNBTJNEWEj7ShkARMfSvfwt6hxZIh9U88rX8wa4wmcfIZwKKlBEO8qbKGozl",
-	"P1KpxogPAGWAq+66lWpxh1YgpvQuTZRdhTocFQVm5YHRAXe5XL/qebe0nd7FLrxW22G9+7jXJo3FTa1Y",
-	"6wquGUldJPldH+drX8Bd/7JthYM0XN8v1j6NtIW1btIWi7ipJbAbFK4l7jZjt52vHRoI173127pHJ333",
-	"aFZ8ZZ1t+ti0wPWu+1pgLROxpvBo9vVnU+QFPkyrfdzs7YzAL+e+6Fd677P9WmcN5a55vxAAQfdD9fW2",
-	"4gBXS6yK1PTcNIzGDqFU9ROpYXPn9lQjAjhiewpibiuWsqtwemOMpjfu3UUeMDaY4dH4aBTc/SwyySNb",
-	"MEgUqx3SHpGiCYUpw2J1JUfMoiD0DqOz1FdX6u9/fgCC3iECuDSvIQeQAKnL/UHiFdAhN6AHyMpN5Z+y",
-	"glOye0EpmOD/RCtdsweTGc2uFUCdWGM6/UoTdC7+pOyOgw8ILgNPESglk8HZxbkyh1TQzOqVOVeWkMC5",
-	"dg7Ik1My0dG/yIcF5gBz1ctYVqZoEZ0BwVKxyAeVE0gAGQzF0b/kSmIcInP10oD72/kHyUWOpksTRPSY",
-	"R5TNR6YTH8m2hdB2Vnp2cR4Mgk+Icb3G8dHkaKzOqwQRmODgNHhxND56oegsFop6I5iKxUj5PRR7Us2m",
-	"kkmzmoCnOkn8Wm9DE1R8TaPV1uowOUnojy5rSmW9XC3seDze2tx6V1VLQCmYAE9VKaxZKiXAAsHIlMa8",
-	"QmL4RnNqhelz/pbcn7NzAU2lFtrjIDgZT+oAzVc+qlalMrsxOP14Mwh4ulxCttKwA0zkXlNXMTCZg0yI",
-	"wjlX0lZu1xs5Rs4ANBWNHEBTkbOAQ4uTKgre0/kcRYCmwsJgrKTVmit11ibHlXsrTBmTO7NlcfpYMlfe",
-	"3XX9gsQbPYh/bbvnszfWGkB2kXQLePoFOTiKV3ZpCxS14YyZzI56lshyP3YoF8rpJZ1Ew2TnJFM3dDME",
-	"ochl8R2LiXE7U1i1FFWXn9q75DUQm6RKRg0AAUH3DQy0wCIeGn7go9vVkAuUjB50Mc3Hpr1oJcG8Xim3",
-	"w8CpSVzjoCyajKyCn483O9zOdrqOh0WcusSb7WrZ6aS9U16g0S8GHIBUoRvATP1Ti4iScl4iPjgVlLvS",
-	"sDf1qhWfvxPREBG6JLxdAVWitS/lRtZdAr9cP9MNvlIy5pfD15Wmuyf9WjI75xVDvhK/rMMpOqOwSQEo",
-	"5y1ui092oUmUYd2zmdGHR/OqBV8rj2pqdGJRY4fz2hPnPebiImvUlwGLovF1EU27sV1kvkN7u/j5TuWf",
-	"fUXEw1vG64MiHRWmM5AjdRv2mBwTxnExaEHH/Kubx0GNEHFKwu7IjPCWnd2zLZFfvvHQx7iajEtxf7ve",
-	"oaNGktHtrathVVLa23L0gLU2GKEY6es8Ln3fqu8L+vbbn/Xaw0n9mwoalOggmppeLoDNGBzUKs/bR9R4",
-	"nyx8eCU589uW9WNXFKUe7Dth6s0IsH0R5o2h71mF6UD/rIjL01VcHJbRWG3bra68y99leRyhBIfNisk7",
-	"1aK3VuK8HdNFM/kq1Ji8YGMnHUYhX9eI0gmyYV4VdisqjR5fe0oyoVKdrWAYzQxtio6qJrkhP9zsUkuy",
-	"8+j2rCLpSptV2quUur0rR7LTi/ZOxTstG9pEjv4lmUlFcDySKWO0ZrE0etBPsHVQzrbBk+1ixHpMrps6",
-	"p8i+uS7Xn4aba39EEdArHOoUv6dAhPF+tvLBlURNnoqKaEnwev3wQHTalUbZW9zviUcOokjuWFRsdj5k",
-	"umqtbOl4HowiOG8K35gi3F+XLLIrnntY7u3ZL1q3U1XFASQR0HXF9+dNPT7e/atmb1ZhjKT4Vd5lqV9o",
-	"XTZ/PwDLJXvDh8UTA2DOYLIAz96e/fJcq8cbcyRLCW9IPYEpCRemBvqh2fJ4q2xpF3Wvk4QqSpsXVQcw",
-	"b3+A01OTAkBwC0W4UKApDojjvBCsSTuSkD+DfEXC530Yw36Nttmyrt5o4Vuxq3YkhGpqJPryzox9S6rP",
-	"+B5GZVIA+aBxjWOLzC4V20xiT6XHp2wg11+l2rO57KuQWWUn32vQB7Gl12fAwjL2rKUrD3YTOaMH9z3s",
-	"Dtbz9tm3/YzyPAPezab2ccOTCJd4SNssUOottCdFkF3ZbRtKofETkEJfaqygH6vWyp2sElOTLVYq9fuE",
-	"9ZsSpD4PvmlhUJYycw/lgDmRiRek2iMlaz7MtLG2UOL2qbezwKL3+vC+44tr8tBX6SzyyZ7t8GytRMrM",
-	"8Fqb6zIl/PVq3Qj5PqOauxR1WVWzTlFKhdNthSTlYLWUVjO12Vpb8KDs1LiyHmbeszWlymBVKXqZki/X",
-	"XEL3hbjIfTX1rFMrGLK3gppkw1X+ntCTznUoOUTpcgmHHMke9q7VF/ARB4ICXYQD3K6yOlumKMvA1Kh5",
-	"nl1cVSUsi3urxQOFtTd6BvUvCwmqivOANAHPmKnwk100lY3qZjXvedVOuUvBWC1W1ElEZp7DokiReeJL",
-	"YeJwLq8MLk8KCE10FRvDKIZHTOVAs6myTdMmknWppKcslJ26HHsWy6aQVJWP9Fb5trJCTCFAf1pIwW9t",
-	"cnxkHpKrjbg4L+M9Udb0Pji4Z4PF94Kgh1V1M8BUAy1AEsSGmprm7qiOOZq36Io8tqfJ0g6Hvk7jO/M0",
-	"YSEyGV0W7zl633Fcj3P1uwSd/LJbkasdsiM1QD18sFcm5volJjZpEVRzytV5sZ4GJcb7OpMOnwOf609O",
-	"epOjkNR7rQ5GrV35tvqrL3tjle9ZTnVZTg2CpvshUUksKVl/SrfiUpvSdb+VkWxyvFHCQYQY/oSi4hVy",
-	"M9l/8LIbTh/f5K8UpXJAviIhQJ9RmMqpjkBWo/Vk/BPAM101SDFA9mLuQldGgqqonARjAE7GY7ct5nnz",
-	"iBIkW5y4LSirwIV58Xa8rj7kS67ZS2JNi3zeqiunqIPe7NPRdMsIlVHw+4b0pPx4PEm2ud7DnZQVoWy9",
-	"02uV0+TfrLvZ84BU1zu+y0SAAtnb8kKXB66PPaiGwwKCDreA7aetnrJPxF/sdf93ip2nwLz38mxafWP+",
-	"khKn1nlOPHzaLrtGD9m/5x0vQG+Rtdvl04ccuH4XqB18faE2aonsbRKp4Sr2EyPZ+ICS40nc7HYg8tzw",
-	"9hw3jTe9D0/fHd4UX/d8OiSXfTeIRcMV9e5STZ5fUg0fPbCUtNRrW8f4u0zJPsRUF0vOCCbLbj+gjJK2",
-	"kZJLGhwsOMhenPdYR/UOi5YUnPV8dI4B/j39ZpP0mwaTN+Wm9mctDa9Vi2+zVFVeCr0T+TQuDxLWysta",
-	"pYZaGan1Z4vWHUsgmTK5O6x/dK0rCH+ROnupmGyG5HrtfMvoHO+naPDmWvQ+qaPPNFWYuqxsFwRq0LA3",
-	"p9Gu1GP7wZInUm9e8ce3kslcu+FL9afd1yU+3kiu4Ih9ynjJReHZxTn4NAG3kCOQQPUgjH5TQT0V9mmi",
-	"mMrMWOlbFEfXkYAooVhX+DGpdarAdTVnT9HNeiXC0zM7xuoK1jX3too1ekukNPfWV249c9vu/OYhjBLV",
-	"5i1qXYVrpNRlPzYPk4UBGxbkJsb7QCnnxFcH+zVdQjLEZCgWaBhTmoDswWDfgKpcaXUQz6WnBqjci0OP",
-	"N4//FwAA///nZIcXnLUAAA==",
+	"H4sIAAAAAAAC/+w97W4bOZKvQvQdcAkgWbJjJzO+P+s4M7Pey2QMO8FgdzYQqG5K4rpF9pBsOzrDwL3D",
+	"veE9yYEf3U12s7/06UwGCBBL4kexqlisKlYVH4OQLhNKEBE8OH8MEsjgEgnE1KcfEhxeRddQLOSnCPGQ",
+	"4URgSoJz9Rv49OnqXTAIsPwikc0GAYFLFJwHSHUNBgFDv6eYoSg4FyxFg4CHC7SEcrwZZUsogvMgTbFs",
+	"KVaJ7MkFw2QePD0Ngr9efXx/g35PERd1YMgmgOk2DeAssIjzkTaEqg6UG8RpykLUAAbedO4PVOAZDqGc",
+	"sg4Ouw0IKZnheQNIxBlxQ/Cu4RxdSxaqQiV/AiRdThHLAPk9RWxVQJLAOQrs+SI0g2ksgvPjQbDEBC/T",
+	"pfrbzIuJQHPE9MSINcx9JdCSgwQxYObwTo/YpB6Ek/EgWMIvBobxuB0iRv+Fwlq+NT83ECbJBtiQJjdp",
+	"LafcpKQBAJZuzhC3lIm3qxqy/IhRHAFBAadMgOmqhjDy14n61UOXIGQIChRNoPADIFDStHwuUNKAA666",
+	"b4oEQdmqDgj1YyMEqvOGIHxEyySGAjWw4zIRQJhmDfCIfKSNQHqSnXlCCUfqqHkLIyOf5aeQEoGI+hMm",
+	"SWzE0+hfXAL7aE3z7wzNgvPg30bFMTbSv/LRD4xRpqdyF/sWRtmRETwNgktKZjEO9zBxfkKEZkrwAh3N",
+	"j0CU6qkQQEuI45cSqh8pm+IoQmT3YOVTgSGA0RITAMMQcQ5y8uqT50eakmiPWCJUgJma82kQfCIwFQvK",
+	"8H+jPcDgzCZ/Nj3kgJeUi3dQwGuK9fwJowliAmtOjqBA8n/0BS6TWDL9yfjk9XB8MjweB4NiY6h2lY0x",
+	"CAQVMJ6ElItJyiNnpPHR8cmrU3sMmk5jaxRzvurdlW3N3/Kp3JE/593oVJ40ei9wcZsul5CtqiuD93Pd",
+	"Wx6VSi6tD+EgmKbRHIlJjJe4utLjcacxEsQwjSaIRDUYf/NxPD5X//5Rxv1Q4KWXAGZQLiATdYRcY1gL",
+	"+0tKxKKy5ldHp2ev33RadwOPHB+dvDo96zvKA0J3HmKevX7zXX92K0FXwqhDtUEdU3mZUx310vCwjorS",
+	"5rN3sU06Za7MKANyXyMiMv14hqBIGeKBUu/eIzKXx+PJWGp4FRLqI9Ae9hNHDFw4Q5ZGOjtTqmL2+dgz",
+	"LBdQpNxVa6YwvIvpPBgEiEgl8zfrG0wmCaNzhrgEO6IEWeiyDn2bJgr0eqTaNsOlMhlqURwuICEonuiR",
+	"HnP4IsxDyiRJH9B0QemdnK7AVPFzZf3aRlESJoqwBAHG186clS75uI9BymJp4AmR8PPRyExzFNLlCCZ4",
+	"ZGDho6OjI8Xz5fUjAqexPlJy7GtlJp9DfzQ9p5TGCBLV9V4eJpMZjgViDl/8JpVnCUMSI4GUppSSoxnE",
+	"cqbPgwBLg8S7MPMFZAyuKkR0UJ/jrQxIPZWN0dF/91wArv4Exihxefy46275eQWufQO0b5J+3Ky12Uzn",
+	"rV1uFcB3mgPAlfy8REQAPVT/PZ2pyRNLTynm+TtNAWQI4GweTOZACT/w+KiF4B1aPT1Jpm2fqrQR80GV",
+	"gi6UKcXQPUYPcizElIkbplzQpbtF7Y4d8O9ZpOlXT5mblNSSI8EJijFRoxl54DaQxpj6I98+Jf0kzDi3",
+	"lhc7LcuM41tF4/bU8Pm6aZLiqJux5o5peg4q+KnHsrIpa/EslftEQBKiSciwQAxDL84ilCAS8YlGaVeR",
+	"NVCuv25rHQR3aOXujNvh+NjdbWc+2aJXjO+RFyIeUndLyLNTqxszplhV/skXkKHIc3TaJ3KT9aDQfKub",
+	"SjxAJhXaGY4R74cxgUVckkSFBIrpHJPMcVWWQs3MI7Gbje7jFqkUeQ74wqPi0X6Ph8dnH4/H56/6ab+b",
+	"KGaVwXBJ3X/zZoy+Ox2Ph+jk++nw9Dg6HcI3x6+Hp6evX5+dnZ6Ox2PH9Krjxq76XdVk0KfapAzY69fb",
+	"Aazgx67aYAFD0dIzrBQuIU2N97+V2S9106dBkCbRtpmkxLxa5hWIHWTi2SCjBP7A9QRa8NVx/ruLn36I",
+	"5shzzij3g8dVp90S+py+QyvwQotIRMLVy2BQlWLVja9ERHXkj+p738iiMvBJ+5mh4c+na0DABxp5ELCh",
+	"8K40jOFKK8juqv+BGB1OIUcRQF9QmKp9r9oCTCL0xV75uOpkd7ZFF3bvLmY7cKYtWy2e1EttwPiN8XpW",
+	"sY6ieengaHRdWRzsOVIIjfoPprihTcvRIw8MuHUrfY+53zcGewHlW1oC55jA7CRpGuG6aOlxicHAGatu",
+	"JTcpuVAakzYSSzSTug5LSUXyf//9riS/XFyUxvJ3R85b39eIeoy4lpYOqGfe6ysbV/YiS+K3GNKLPuVe",
+	"rSLN/3VoZJF1+t7+cDP58MvHyY+/fPrwzq9WCIhjXu87cGz3ArIl4hzOfYf9AxYLcPUOwGl4fPLK8kG3",
+	"SQUFfjFyFR9lrCos+NBmXXu3aWcdlS88m9mGaNnXjWcYRUC2AqYVmDG6BGKBAJzLjyyVeg9J4xhOKy6R",
+	"YqK5NAZzezRHLEwSRu9hXK/Lte4DV8Nqbc6Qsg8omTAEzZVAK/QMcRrfN+O2wyDS0t7OIKxmue39c4nU",
+	"jqmUTKTh2rV9VSBJRUVLHU1n7e9SBNDmVcEIRVPPuH1gMB6SbuqHbt5iMqo2W9UQbMwW67Ohd6e1t48l",
+	"Zq0N7xMWV8uEMnGrZXG91Kjb/DfwASwhu4voA8k3v5KBf7/4+T1Q5vISCoGY0U6nMQ3veAdpqCfsADJX",
+	"PlfvIdFdgynGXJlLvariYPyv1YAZdY0B6AyYIw2IBRRANweCAqwGD3wqqP6peVSCHuIVMHTM5vCOZqyW",
+	"psFMkxzUF9JcgDFDMFoB9AVzgaKXQeuZnsNdTJojaJAhv5l4qx+az3F3BT/DcIEJGkpApewCag5gTs06",
+	"28IXK6HsoyVcgSkCaJmIFcAz9WVI0zhSJ7b85YtgMHSRUQxvnf+leLJ0CUkZSLtJN59LNv5AY8OHyPdS",
+	"nNRuWBUI4EqilCP2F/PxKKRLW33UzX3nJuT8gbKSdspRmDJ0/RfOj+1R8sZti8ymyzv4Fli9U/rDXybt",
+	"xHVm3VA9gyup3Xnfdu1EO4TLqtuNXUHjfl6s6g7bgtnt2bZtLgE1vg/Aa8dUL133lO2vY9+JmEdl2i1P",
+	"vN4gFXbgtDs9aT0HdadBFnyaT+ddjbmAqRNmu/cCl++/Gp0fBtpbgRLfNm7eDidb2A7OTtDAt7K0A3XN",
+	"Dd+k+cazdNMp5Pna+8JzEMBU0ImxaBwMzWDMvcK3TPfvvtsO3Zc0QrG93jCGaYSGNEn58HT4Wq5Of8Mp",
+	"IUgMT4dnxXcLiO/S4enwlbv26hgdrkMaEabumicJjXG4amPOG9n2Wjf1SlHnKjYTnxoRJdKUJvYylQk6",
+	"qKofmIUpFpMpQ/AOsQnMDURXK/x1gcQCMeUQMX2A6QMwB7rbACQw5ZjMAYxjkN3WApYSbnuya9lnv/du",
+	"npCO1nu2bQmylsiQ6m3vA8l9IUWfs7OvSi8wHJ2vpd9Rb7CzhfM9w/NhPetuiM6eLqF3JaB7BRLtXe/d",
+	"ZijSQYKPDnrbXBfj1Hv7Wuy+nV1s75/DbuYbNMdcILZzb0Z1o/0NEgTeUdQ/Qm9dz4g17He9/SSD+tDF",
+	"G+Uxb7z7Ke4yyhkT8nsVRWMuPshc6Sp2dmQpkHDcBruZzA9qob1VgFzCLxO58zPS50abk0Bn5c95jTmt",
+	"05WlC6FEnaFkOIM4TplSEeMHuOKuMHEaNC/TBteZ1rvwlPj8ncan0utObp17POWNnFi+y7Vv09xQwgkn",
+	"MOELKnrfo+aRR9WMMsRCRAScI0BnIMeRSrjj4MX4//7nf4/H45cD9VMqf4ECqMw/IJd/FNTmW3r5pef9",
+	"oEpF6In9ppsvlhKi/7I9bLk/PYQkRHHc6zqsc8Ro+XjcyulnxZ3mN1FWmFmfs+8mJZeUixv64JFo3S8q",
+	"XZJ5k3L6a4S+CCKbgptePTYmc43Xy+ayIjHsi8Q8KiNHU6eMr5uUbEEdkYLxwDpISpp8Rl5puabkpkRA",
+	"XFikz0u0x3Q+EUbb8ug8DBFh3/eXEuXfSWEtNQfKsER3rBOkxQJz5egA6oAEdPafgKRxrFUOSgXI3Hv9",
+	"QxXUiZuHJZX9LjhcmDmhkKq4yGF5caxjB1/WgVIzda2SUdap5KRcMCjQfAVSjiI1hZrewFI3c24MkZAp",
+	"m0a5mGdpHEvW3Wb0xsHOsUHwALHUMyd5cE+vSI+ahAzzK2WRvr5qu8XO4iyKEIs8SDgfJk/o6B5UcZOS",
+	"X7FY3GYOdxjHv8yC89+6CMH2rJWWMfwO+465Jp+zegPr532sFWG2h1yRflHJlRi339MsdBtHiAg8wyba",
+	"D5PMB6rT8QdAnubdArqbg4r6KqXfatrKTjTYmgDtPpqrnfNQ2U5ZoLmTwu07ZVRKRkvErR2c1Bzznkno",
+	"lpvTEnqKqPhCwkfamC5CAPzr34J2qAXSYfXDfC2/sFtM5rH/yE8Z4SBvqk72WP4hDVOM+ABQBrjqrlup",
+	"FndoBWJK79JE+SZQh6OiwKw8MDrgLpfrtz2TxdvpXezCT2o7rJdg/8nEpbmxUmvl1JuRVGbYB32cr51R",
+	"v372fIWDNFx/Zso/jziktVLji0V8riWwG+VRS9xtBmN0ziM2EK6bxt+6R4/77tGsjNk62/SpaYHr5e9b",
+	"YElTcT3h0Xxflk2Rl8oyrfaRqt8ZgV9PAvgfNJG7PU+7hnKfeL9rNIIehurrbd2l3S6xKvfWc9MwGjuE",
+	"UnXEpIbNnXTIRgRwxPYUCLCt+8hdhaQ03nP2xr27yAPer2d4ND4aBXc/i0zyyBYMEsVqh7RHpGhCYcqw",
+	"WN3KEbObRHqH0UXqq9D4t18/AkHvEAFcmteQA0iA1OV+IfEK6GtroAfICjfmn7LSjbJ7QSmY4P9CK139",
+	"DpMZzfKEoI6UM53+ShN0JX6l7I6DjwguA085RSWTwcX1lfGQImD3ypwrS0jgXDsH5Mkpmejon+SjcefK",
+	"XsayMuX/6AwIlopFPqicQALIYCiO/ilXEuMQmVxqA+7PVx8lFzmaLk0Q0WMeUTYfmU58JNsWQttZ6cX1",
+	"VTAI7hHjeo3jo+OjsTqvEkRggoPz4NXR+OiVorNYKOqNYCoWI+X3UOxJNZtKJs2q657rrI9Pehuai/m3",
+	"NFptraKhk1Xy5LKmVNbLdTdPxuOtza13VbWYooIJ8FQVlZylUgIsEIxMkelbJIaXmlMrTJ/zt+T+nJ0L",
+	"aCpVRZ8Gwen4uA7QfOWjan1HsxuD898+DwKelUCUsANM5F5TuVWYzEEmROGcK2krt+tnOUbOADQVjRxA",
+	"U5GzgEOL0yoK3tP5HEWApsLCYKyk1ZorddYmx1VRrSljcme2LE4fS6aGhbuun5C41IP417Z7Pru01gCy",
+	"zPAt4Okn5OAoXtm1alDUhjNmoqPqWSKLn9qhXCiHaHUSDcc7J5lKuc8QhCKXxXcsJsbtTGFVJVZdvm/v",
+	"klcTbpIqGTUABAQ9NDDQAot4aPiBj6arIRcoGT3qstRPTXvRCiR7u1Juh4FT3b/GQVk0GVmls58+73A7",
+	"2yFvHhZxKvxvtqtlp9P2TnmpY78YcABSlasAM5XELSJKynmJ+Oi8RdCVhr2pV3074U8iGiJCl4TTFVDF",
+	"zvtSbmQlB/nl+oVu8AclY17tYV1punvSryWzc14x5CvxyzqcoqNymxSAcuzvtvhkF5pEGdY9mxl9eDQv",
+	"Q/JH5VFNjU4sauxwXnvivMdcXGeN+jJg8fxK3Y2m3dh+rqVDe/sZkZ3KPzvNysNbxuuDIn0rTGcgR+o2",
+	"7DE5psodLIiQ0TH/6vPToEaIODWed2RGeOtI79mWyBPYPPQxribjUtzfrnfoqJFkdHsrvbJKSntbjh6x",
+	"1gYjFCOdEufS9536vqBvv/1Zrz2c1r9OpEGJDqKp6eUC2IzBQa3yvH1EjffJwodXkjO/bVk/dkVR6sG+",
+	"c029GQG2L8K8d+h7VmE60D+ryvR8FReHZTRW23ZrRd6NTDb90GTTy4lQo6LMkbjUfd7qLruVhJelbH8F",
+	"3zY8sbLTq/ZOxTNQGxJIYa5SvEC7L3rQLH+V7mkUUmnqhAvzTE6LHL6kXFwuzAMw/TRL5yU9qS2Wiifj",
+	"JQL6TRm1HgkXUGABcxVX89wfplHNo3JvIiuWTn14NfYFGGx8SHS6rXQfnKpGD1VkyDuI45XGg8QASGTH",
+	"wx0lkRccTStFJoZIhJhJFzAcqLirnf1UdY1u3HejC3HslvlYSoqV7pT1Brs0yTbl681SybJ0wYPe0Hcw",
+	"/nJiM/pwuO3FUjKM0T2KNSxKtKtynnXCvePW4sU7cB12V/Zq3F6kO5zPGZpnzzE8X/HeJtUzpPkuM+U6",
+	"MxIcirVCC4j12QklOGz2Ov2gWmzOOt+Ejyovr99JRink64q+OvspzN/w2Iq/So/v8IZntoJbNDO0ebFU",
+	"7f8N+eHzLl1gdpLEnv1f+l2EKu1VvsTePV/r2THrO7wd55pkJhWe4xFLGaM1i6XRo36pvoPnbRs82S5G",
+	"rDf3u1moiuybO+r2aYtmrj2iCOgVDnUax3Mgwng/W/ngHkBNnor/z5Lg9c6/A9FpV+7C3uJ+TzxyEC/h",
+	"jkXFZudD5oislS0dz4NRBOdNpo95MumPJYvs96l8fqWLn7Rup96AApBEQL8Ctb+r8pOT3T/+frkKYyTF",
+	"rwodkPqF1mXz196wXLI3Nqx4EA7MGUwW4MW7i59eavV4Y47MfF01ccUwJeHCvFh1aLY82Spb2k9w1UlC",
+	"FYKXP4EFYN7+AKenJgWAYApFuFCgKQ6I4/zZDhNTLiF/AfmKhC/7MAaxkpCbLetqujLfil21IyFUU9He",
+	"l1Rg7FsbFSA0KzwI0SVAPmhqHScuFdtMYk9d/udsINfnye/ZXPa9Z1Blpw9Vwh3Gll6fAQvL2LOWrjzY",
+	"TeSMHu2Pnazn7bNv+xn1wQGyh03t44ZnEQvjIW2zQKm30J4VQXZlt20ohcbPQAp9rYEg/Vh1TbkzElmi",
+	"vPfk/Ih8GtAzFjwSYBdzHJHDEPIWkQhAIMoQrUPErN5w412i+7rOM1ZSS5D6rmGyxz8036fM3EMfMGsp",
+	"8YJUHwBkmg8zlbot2G/71NtZ6J+3wM++IwDX5KE/pMfPd4Bsh2drJVJj3JA05W5Swt+u1o1h3efV9C5F",
+	"XVYdums4zPbuleVgtZRWM7UZzFtwg+3UQr5JyYFMYlWotkrRm5R8vTYvenCe3GpjnVrBkD3P2yQbbvMn",
+	"fJ91wEo5oGi5hEOOZA971+oSWYgDQYEukwemq6wSrimbODBVJF/WRFsV1edrc+4H9Y/5CqrKZ4I0AS+Y",
+	"qcGZlYKRjepmNZXva6fcpWCslhPtJCIz929RRtS8qq0wcTi/ZQaXJ46HJrrOpGEUwyNusG62adpEsi5m",
+	"+pyFslM5b89i2ZR6rfKR3irfVmiPKdXtj+0p+K1Njo/M2+21LgLnMfpnypreN/73bLD4Hu33sKpuBphq",
+	"oAVIgthQU9OkzeiLY/P8exGM+DxZ2uHQt2l8BzRHFSKT0SVYQqZjrtWK/37x83ugClQuoRBObZcenKtf",
+	"3+vkXN+KXO0Q4qoB6uHPujUX519jdJoWQTWnXJ0X63lQYryvM+nwWaq5/uTEqDkKSb3X6mDU2pVvq7/6",
+	"sjdW+TNUrS5UrUHQdD8kKtFBJetP6VZcalP6ZR5lJJtAfZRwECGG71GkjzPlfNOT/Qcvu+H08U1+T1Eq",
+	"B+QrEgL0BYWpnOoIZK8onI6/B1g/JqX3KIwZgtEKLHTtUv1otgRjAE7HY7ct5nnziBIkW5y6LSirwIU5",
+	"IFSAmaSNrg/qi5DaS3RUi3zeqiuneKmo2aej6ZYRKqPgnxvSE7fl8STZ5noPd1JWJr616o5V8J5/s+5m",
+	"zzPJXavwqKfhcgRuywtdHrgpYX6ZiGEBQYc6PfYDzs/ZJ+J/jmH/VX+cB6+9lTNsWn1j/pISp9Z5Tjx8",
+	"2i67Ro/Zn1cdSxRtkbXb5dPHHLh+JY4cfH2lNmqJ7G0SqSGR+5mRbHxAyfEsai85EHlqMHmOm8ZaTIen",
+	"7w5rOa17Ph2Sy/40iEVDEanuUk2eX1INHz2ylLRUVF7H+LtJyT7EVBdLzggmy24/oIyStpGSSxocLHj+",
+	"ALLHOqp3WLSE4Kzno3MM8D/DbzYJv2kweVNuqvPX0vCTavFtFpPNHyvqRD6Ny4Nca+WFZ1NDrYzU+rNF",
+	"645FSs1DFjusy/dJv/HxVerspeceMiTXa+dbRud4P896bK5F75M6+kxTT8eUle2CQA0a9uY02pV6bD8p",
+	"+ExehFL88a1EMtdu+NILMe77b799llzBEbvPeMlF4cX1Fbg/BlPIEUigerJRv3qmHvO9P1ZMZWas9C2e",
+	"L9I3AZGpEJmH1qknaKoxe4pu1jtunp7ZMVZXUrq5t1VO3Vvnprm3zpv2zG2785uHMEpUm7eodRWukVIX",
+	"/dg8THYN2LAgNzDeB0o5Jr462F/TJSRDTIZigYYxpYl52QPGvgHVgwLVQTyZaw1QuYlDvlhVLoBgMLxT",
+	"ufwkAnQqtwKc4hiLlW9IXYXu6fPT/wcAAP//BhBj69PIAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/frontend/src/composables/__tests__/useNotifications.spec.ts
+++ b/frontend/src/composables/__tests__/useNotifications.spec.ts
@@ -139,7 +139,12 @@ describe('useNotifications', () => {
       expect(configs.value[0]!.enabled).toBe(false)
       expect(mockPut).toHaveBeenCalledWith('/projects/{projectId}/notifications/{notificationId}', {
         params: { path: { projectId: 'p1', notificationId: 'n1' } },
-        body: { enabled: false },
+        body: {
+          channel_type: 'discord',
+          config: { url: 'https://discord.com/api/webhooks/123/abc123' },
+          events_filter: ['run.completed', 'run.failed'],
+          enabled: false,
+        },
       })
     })
 

--- a/frontend/src/composables/__tests__/useNotifications.spec.ts
+++ b/frontend/src/composables/__tests__/useNotifications.spec.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useNotifications } from '../useNotifications'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockPut = vi.fn()
+const mockDelete = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+    POST: (...args: unknown[]) => mockPost(...args),
+    PUT: (...args: unknown[]) => mockPut(...args),
+    DELETE: (...args: unknown[]) => mockDelete(...args),
+  },
+}))
+
+const mockConfig = {
+  id: 'n1',
+  project_id: 'p1',
+  channel_type: 'discord' as const,
+  config: { url: 'https://discord.com/api/webhooks/123/abc123' },
+  events_filter: ['run.completed', 'run.failed'],
+  enabled: true,
+  created_at: '2026-01-15T10:00:00Z',
+  updated_at: '2026-01-15T10:00:00Z',
+}
+
+describe('useNotifications', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockPut.mockReset()
+    mockDelete.mockReset()
+    mockGet.mockResolvedValue({
+      data: { data: [], pagination: { total: 0, page: 1, per_page: 20 } },
+      error: undefined,
+    })
+  })
+
+  it('exposes reactive properties with initial values', () => {
+    const { configs, isLoading, error } = useNotifications('p1')
+    expect(configs.value).toEqual([])
+    expect(isLoading.value).toBe(false)
+    expect(error.value).toBeNull()
+  })
+
+  describe('fetchConfigs', () => {
+    it('populates configs.value from API response', async () => {
+      mockGet.mockResolvedValue({
+        data: { data: [mockConfig], pagination: { total: 1, page: 1, per_page: 20 } },
+        error: undefined,
+      })
+
+      const { configs, isLoading, fetchConfigs } = useNotifications('p1')
+      await fetchConfigs()
+
+      expect(configs.value).toEqual([mockConfig])
+      expect(isLoading.value).toBe(false)
+      expect(mockGet).toHaveBeenCalledWith('/projects/{projectId}/notifications', {
+        params: { path: { projectId: 'p1' } },
+      })
+    })
+
+    it('sets error state on fetch failure', async () => {
+      mockGet.mockResolvedValue({
+        data: undefined,
+        error: { error: { code: 'INTERNAL', message: 'Server error' } },
+      })
+
+      const { error, fetchConfigs } = useNotifications('p1')
+      await fetchConfigs()
+
+      expect(error.value).toBe('Failed to load channels')
+    })
+
+    it('sets isLoading to false after fetch completes', async () => {
+      const { isLoading, fetchConfigs } = useNotifications('p1')
+      await fetchConfigs()
+      expect(isLoading.value).toBe(false)
+    })
+  })
+
+  describe('createConfig', () => {
+    it('pushes to configs.value on success and returns the new config', async () => {
+      mockPost.mockResolvedValue({
+        data: mockConfig,
+        error: undefined,
+      })
+
+      const { configs, createConfig } = useNotifications('p1')
+      const result = await createConfig({
+        channel_type: 'discord',
+        config: { url: 'https://discord.com/api/webhooks/123/abc123' },
+        events_filter: ['run.completed'],
+        enabled: true,
+      })
+
+      expect(result).toEqual(mockConfig)
+      expect(configs.value).toContainEqual(mockConfig)
+    })
+
+    it('returns null on API error', async () => {
+      mockPost.mockResolvedValue({
+        data: undefined,
+        error: { error: { code: 'BAD_REQUEST', message: 'Invalid URL' } },
+      })
+
+      const { configs, createConfig } = useNotifications('p1')
+      const result = await createConfig({
+        channel_type: 'discord',
+        config: { url: 'https://discord.com/api/webhooks/123/abc123' },
+        events_filter: [],
+        enabled: true,
+      })
+
+      expect(result).toBeNull()
+      expect(configs.value).toHaveLength(0)
+    })
+  })
+
+  describe('toggleEnabled', () => {
+    it('optimistically updates config.enabled', async () => {
+      mockGet.mockResolvedValue({
+        data: { data: [mockConfig], pagination: { total: 1, page: 1, per_page: 20 } },
+        error: undefined,
+      })
+      mockPut.mockResolvedValue({ error: undefined })
+
+      const { configs, fetchConfigs, toggleEnabled } = useNotifications('p1')
+      await fetchConfigs()
+
+      expect(configs.value).toHaveLength(1)
+      const first = configs.value[0]!
+      expect(first.enabled).toBe(true)
+
+      await toggleEnabled(first)
+
+      expect(configs.value[0]!.enabled).toBe(false)
+      expect(mockPut).toHaveBeenCalledWith('/projects/{projectId}/notifications/{notificationId}', {
+        params: { path: { projectId: 'p1', notificationId: 'n1' } },
+        body: { enabled: false },
+      })
+    })
+
+    it('reverts optimistic update on API error', async () => {
+      mockGet.mockResolvedValue({
+        data: { data: [mockConfig], pagination: { total: 1, page: 1, per_page: 20 } },
+        error: undefined,
+      })
+      mockPut.mockResolvedValue({
+        error: { error: { code: 'INTERNAL', message: 'Server error' } },
+      })
+
+      const { configs, fetchConfigs, toggleEnabled } = useNotifications('p1')
+      await fetchConfigs()
+
+      expect(configs.value).toHaveLength(1)
+      const first = configs.value[0]!
+      expect(first.enabled).toBe(true)
+
+      await expect(toggleEnabled(first)).rejects.toBeDefined()
+
+      expect(configs.value[0]!.enabled).toBe(true)
+    })
+  })
+
+  describe('deleteConfig', () => {
+    it('removes item from configs.value on success', async () => {
+      mockGet.mockResolvedValue({
+        data: { data: [mockConfig], pagination: { total: 1, page: 1, per_page: 20 } },
+        error: undefined,
+      })
+      mockDelete.mockResolvedValue({ error: undefined })
+
+      const { configs, fetchConfigs, deleteConfig } = useNotifications('p1')
+      await fetchConfigs()
+
+      expect(configs.value).toHaveLength(1)
+
+      await deleteConfig('n1')
+
+      expect(configs.value).toHaveLength(0)
+      expect(mockDelete).toHaveBeenCalledWith(
+        '/projects/{projectId}/notifications/{notificationId}',
+        {
+          params: { path: { projectId: 'p1', notificationId: 'n1' } },
+        },
+      )
+    })
+  })
+
+  describe('testConfig', () => {
+    it('resolves on success', async () => {
+      mockPost.mockResolvedValue({ error: undefined })
+
+      const { testConfig } = useNotifications('p1')
+
+      await expect(testConfig('n1')).resolves.toBeUndefined()
+      expect(mockPost).toHaveBeenCalledWith(
+        '/projects/{projectId}/notifications/{notificationId}/test',
+        {
+          params: { path: { projectId: 'p1', notificationId: 'n1' } },
+        },
+      )
+    })
+
+    it('throws on API error', async () => {
+      const apiErr = { error: { code: 'INTERNAL', message: 'Webhook failed' } }
+      mockPost.mockResolvedValue({ error: apiErr })
+
+      const { testConfig } = useNotifications('p1')
+
+      await expect(testConfig('n1')).rejects.toBeDefined()
+    })
+  })
+})

--- a/frontend/src/composables/useNotifications.ts
+++ b/frontend/src/composables/useNotifications.ts
@@ -1,0 +1,103 @@
+import { onMounted, ref } from 'vue'
+import { apiClient } from '@/api/client'
+import type { components } from '@/api/schema'
+
+export type NotificationConfig = components['schemas']['NotificationConfig']
+export type CreateNotificationConfigRequest =
+  components['schemas']['CreateNotificationConfigRequest']
+export type UpdateNotificationConfigRequest =
+  components['schemas']['UpdateNotificationConfigRequest']
+
+/**
+ * Composable for managing notification configs for a project.
+ * Handles CRUD operations with optimistic updates for toggle.
+ */
+export function useNotifications(projectId: string) {
+  const configs = ref<NotificationConfig[]>([])
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchConfigs() {
+    isLoading.value = true
+    error.value = null
+    try {
+      const { data, error: apiErr } = await apiClient.GET(
+        '/projects/{projectId}/notifications',
+        { params: { path: { projectId } } },
+      )
+      if (apiErr) throw apiErr
+      configs.value = data?.data ?? []
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load channels'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function createConfig(
+    payload: CreateNotificationConfigRequest,
+  ): Promise<NotificationConfig | null> {
+    const { data, error: apiErr } = await apiClient.POST(
+      '/projects/{projectId}/notifications',
+      { params: { path: { projectId } }, body: payload },
+    )
+    if (apiErr || !data) return null
+    configs.value.push(data)
+    return data
+  }
+
+  async function updateConfig(id: string, payload: UpdateNotificationConfigRequest): Promise<void> {
+    await apiClient.PUT('/projects/{projectId}/notifications/{notificationId}', {
+      params: { path: { projectId, notificationId: id } },
+      body: payload,
+    })
+  }
+
+  async function toggleEnabled(config: NotificationConfig) {
+    const original = config.enabled
+    const idx = configs.value.findIndex((c) => c.id === config.id)
+    // optimistic update
+    if (idx >= 0) configs.value[idx] = { ...config, enabled: !original }
+    const { error: apiErr } = await apiClient.PUT(
+      '/projects/{projectId}/notifications/{notificationId}',
+      {
+        params: { path: { projectId, notificationId: config.id } },
+        body: { enabled: !original },
+      },
+    )
+    if (apiErr) {
+      // revert on failure
+      if (idx >= 0) configs.value[idx] = { ...config, enabled: original }
+      throw apiErr
+    }
+  }
+
+  async function deleteConfig(id: string) {
+    await apiClient.DELETE('/projects/{projectId}/notifications/{notificationId}', {
+      params: { path: { projectId, notificationId: id } },
+    })
+    configs.value = configs.value.filter((c) => c.id !== id)
+  }
+
+  async function testConfig(id: string) {
+    const { error: apiErr } = await apiClient.POST(
+      '/projects/{projectId}/notifications/{notificationId}/test',
+      { params: { path: { projectId, notificationId: id } } },
+    )
+    if (apiErr) throw apiErr
+  }
+
+  onMounted(fetchConfigs)
+
+  return {
+    configs,
+    isLoading,
+    error,
+    fetchConfigs,
+    createConfig,
+    updateConfig,
+    toggleEnabled,
+    deleteConfig,
+    testConfig,
+  }
+}

--- a/frontend/src/composables/useNotifications.ts
+++ b/frontend/src/composables/useNotifications.ts
@@ -62,7 +62,12 @@ export function useNotifications(projectId: string) {
       '/projects/{projectId}/notifications/{notificationId}',
       {
         params: { path: { projectId, notificationId: config.id } },
-        body: { enabled: !original },
+        body: {
+          channel_type: config.channel_type,
+          config: config.config,
+          events_filter: config.events_filter,
+          enabled: !original,
+        },
       },
     )
     if (apiErr) {

--- a/frontend/src/features/notifications/AddChannelDialog.vue
+++ b/frontend/src/features/notifications/AddChannelDialog.vue
@@ -13,7 +13,7 @@ import Button from 'primevue/button'
 import Message from 'primevue/message'
 import { useNotifications, type NotificationConfig } from '@/composables/useNotifications'
 
-export const addChannelSchema = toTypedSchema(
+const addChannelSchema = toTypedSchema(
   z.object({
     channel_type: z.enum(['discord', 'webhook']),
     url: z

--- a/frontend/src/features/notifications/AddChannelDialog.vue
+++ b/frontend/src/features/notifications/AddChannelDialog.vue
@@ -1,0 +1,184 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useForm } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/zod'
+import { z } from 'zod'
+import Dialog from 'primevue/dialog'
+import InputText from 'primevue/inputtext'
+import Select from 'primevue/select'
+import MultiSelect from 'primevue/multiselect'
+import ToggleSwitch from 'primevue/toggleswitch'
+import FloatLabel from 'primevue/floatlabel'
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import { useNotifications, type NotificationConfig } from '@/composables/useNotifications'
+
+export const addChannelSchema = toTypedSchema(
+  z.object({
+    channel_type: z.enum(['discord', 'webhook']),
+    url: z
+      .string()
+      .min(1, 'URL is required')
+      .startsWith('https://', 'URL must start with https://'),
+    events_filter: z.array(z.string()).default([]),
+    enabled: z.boolean().default(true),
+  }),
+)
+
+const props = defineProps<{
+  visible: boolean
+  projectId: string
+}>()
+
+const emit = defineEmits<{
+  'update:visible': [value: boolean]
+  created: [config: NotificationConfig]
+}>()
+
+const channelTypeOptions = [
+  { label: 'Discord', value: 'discord' },
+  { label: 'Webhook', value: 'webhook' },
+]
+
+const EVENT_OPTIONS = [
+  { label: 'Run Completed', value: 'run.completed' },
+  { label: 'Run Failed', value: 'run.failed' },
+  { label: 'Approval Pending', value: 'hitl_gate.pending' },
+  { label: 'Circuit Breaker Triggered', value: 'circuit_breaker.triggered' },
+]
+
+const { defineField, handleSubmit, errors, resetForm, validate } = useForm({
+  validationSchema: addChannelSchema,
+  initialValues: {
+    enabled: true,
+    events_filter: [],
+  },
+})
+
+const [channelType, channelTypeAttrs] = defineField('channel_type')
+const [url, urlAttrs] = defineField('url')
+const [eventsFilter, eventsFilterAttrs] = defineField('events_filter')
+const [enabled, enabledAttrs] = defineField('enabled')
+
+const apiError = ref<string | null>(null)
+const isSaving = ref(false)
+
+const notifs = useNotifications(props.projectId)
+
+async function onSubmit() {
+  const { valid } = await validate()
+  if (!valid) return
+
+  await handleSubmit(async (values) => {
+    isSaving.value = true
+    apiError.value = null
+    try {
+      const result = await notifs.createConfig({
+        channel_type: values.channel_type,
+        config: { url: values.url },
+        events_filter: values.events_filter ?? [],
+        enabled: values.enabled ?? true,
+      })
+      if (result) {
+        emit('created', result)
+        close()
+      } else {
+        apiError.value = 'Failed to add channel'
+      }
+    } finally {
+      isSaving.value = false
+    }
+  })()
+}
+
+function close() {
+  resetForm()
+  apiError.value = null
+  emit('update:visible', false)
+}
+</script>
+
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    header="Add Notification Channel"
+    class="w-full max-w-lg"
+    @update:visible="close"
+  >
+    <form class="flex flex-col gap-6" @submit.prevent="onSubmit">
+      <Message v-if="apiError" severity="error" :closable="false">
+        {{ apiError }}
+      </Message>
+
+      <div class="flex flex-col gap-2">
+        <FloatLabel>
+          <Select
+            id="channel-type"
+            v-model="channelType"
+            v-bind="channelTypeAttrs"
+            :options="channelTypeOptions"
+            option-label="label"
+            option-value="value"
+            class="w-full"
+            :invalid="!!errors.channel_type"
+          />
+          <label for="channel-type">Channel Type *</label>
+        </FloatLabel>
+        <small v-if="errors.channel_type" class="text-red-500">{{ errors.channel_type }}</small>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <FloatLabel>
+          <InputText
+            id="webhook-url"
+            v-model="url"
+            v-bind="urlAttrs"
+            class="w-full"
+            :invalid="!!errors.url"
+          />
+          <label for="webhook-url">Webhook URL *</label>
+        </FloatLabel>
+        <small v-if="errors.url" class="text-red-500">{{ errors.url }}</small>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <FloatLabel>
+          <MultiSelect
+            id="events-filter"
+            v-model="eventsFilter"
+            v-bind="eventsFilterAttrs"
+            :options="EVENT_OPTIONS"
+            option-label="label"
+            option-value="value"
+            class="w-full"
+            placeholder="Select events"
+          />
+          <label for="events-filter">Events</label>
+        </FloatLabel>
+      </div>
+
+      <div class="flex items-center gap-3">
+        <ToggleSwitch
+          id="channel-enabled"
+          v-model="enabled"
+          v-bind="enabledAttrs"
+        />
+        <label for="channel-enabled" class="text-sm">Enabled</label>
+      </div>
+    </form>
+
+    <template #footer>
+      <div class="flex justify-end gap-2">
+        <Button label="Cancel" severity="secondary" text @click="close" />
+        <Button
+          label="Add Channel"
+          severity="success"
+          icon="pi pi-plus"
+          :loading="isSaving"
+          @click="onSubmit"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>

--- a/frontend/src/features/notifications/NotificationChannelRow.vue
+++ b/frontend/src/features/notifications/NotificationChannelRow.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import Tag from 'primevue/tag'
+import Chip from 'primevue/chip'
+import ToggleSwitch from 'primevue/toggleswitch'
+import Button from 'primevue/button'
+import type { NotificationConfig } from '@/composables/useNotifications'
+import { maskUrl } from '@/utils/maskUrl'
+
+defineProps<{
+  config: NotificationConfig
+  isAdmin: boolean
+}>()
+
+const emit = defineEmits<{
+  toggle: [config: NotificationConfig]
+  edit: [config: NotificationConfig]
+  delete: [config: NotificationConfig]
+  test: [config: NotificationConfig]
+}>()
+
+const channelTagSeverity: Record<string, 'info' | 'secondary'> = {
+  discord: 'info',
+  webhook: 'secondary',
+}
+</script>
+
+<template>
+  <div
+    class="flex items-center gap-4 rounded-lg border border-surface-200 bg-surface-0 p-4"
+    data-testid="notification-channel-row"
+  >
+    <!-- Channel type badge -->
+    <Tag
+      :value="config.channel_type"
+      :severity="channelTagSeverity[config.channel_type] ?? 'secondary'"
+      class="capitalize"
+      data-testid="channel-type-badge"
+    />
+
+    <!-- Masked URL -->
+    <span
+      class="flex-1 font-mono text-sm text-surface-600"
+      data-testid="masked-url"
+    >
+      {{ maskUrl(config.config.url) }}
+    </span>
+
+    <!-- Events filter chips -->
+    <div class="flex flex-wrap gap-1" data-testid="events-chips">
+      <Chip
+        v-for="event in config.events_filter"
+        :key="event"
+        :label="event"
+        class="text-xs"
+      />
+      <span v-if="config.events_filter.length === 0" class="text-xs text-surface-400">
+        No events
+      </span>
+    </div>
+
+    <!-- Enabled toggle -->
+    <ToggleSwitch
+      :model-value="config.enabled"
+      :disabled="!isAdmin"
+      data-testid="enabled-toggle"
+      @update:model-value="emit('toggle', config)"
+    />
+
+    <!-- Admin action buttons -->
+    <div v-if="isAdmin" class="flex gap-1" data-testid="admin-actions">
+      <Button
+        icon="pi pi-send"
+        text
+        rounded
+        severity="secondary"
+        size="small"
+        aria-label="Test channel"
+        data-testid="test-btn"
+        @click="emit('test', config)"
+      />
+      <Button
+        icon="pi pi-pencil"
+        text
+        rounded
+        severity="secondary"
+        size="small"
+        aria-label="Edit channel"
+        data-testid="edit-btn"
+        @click="emit('edit', config)"
+      />
+      <Button
+        icon="pi pi-trash"
+        text
+        rounded
+        severity="danger"
+        size="small"
+        aria-label="Delete channel"
+        data-testid="delete-btn"
+        @click="emit('delete', config)"
+      />
+    </div>
+  </div>
+</template>

--- a/frontend/src/features/notifications/NotificationChannelRow.vue
+++ b/frontend/src/features/notifications/NotificationChannelRow.vue
@@ -42,7 +42,7 @@ const channelTagSeverity: Record<string, 'info' | 'secondary'> = {
       class="flex-1 font-mono text-sm text-surface-600"
       data-testid="masked-url"
     >
-      {{ maskUrl(config.config.url) }}
+      {{ maskUrl(config.config['url'] ?? '') }}
     </span>
 
     <!-- Events filter chips -->

--- a/frontend/src/features/notifications/__tests__/AddChannelDialog.spec.ts
+++ b/frontend/src/features/notifications/__tests__/AddChannelDialog.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { maskUrl } from '@/utils/maskUrl'
+
+// Extract the raw zod schema for testing validation logic
+const addChannelRawSchema = z.object({
+  channel_type: z.enum(['discord', 'webhook']),
+  url: z
+    .string()
+    .min(1, 'URL is required')
+    .startsWith('https://', 'URL must start with https://'),
+  events_filter: z.array(z.string()).default([]),
+  enabled: z.boolean().default(true),
+})
+
+describe('AddChannelDialog — zod schema validation', () => {
+  it('accepts a valid Discord webhook URL', () => {
+    const result = addChannelRawSchema.safeParse({
+      channel_type: 'discord',
+      url: 'https://discord.com/api/webhooks/123/abc123',
+      events_filter: ['run.completed'],
+      enabled: true,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a valid webhook URL', () => {
+    const result = addChannelRawSchema.safeParse({
+      channel_type: 'webhook',
+      url: 'https://example.com/webhook',
+      events_filter: [],
+      enabled: false,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a URL starting with http://', () => {
+    const result = addChannelRawSchema.safeParse({
+      channel_type: 'discord',
+      url: 'http://discord.com/api/webhooks/123',
+      events_filter: [],
+      enabled: true,
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const urlErrors = result.error.issues.filter((i) => i.path[0] === 'url')
+      expect(urlErrors.length).toBeGreaterThan(0)
+      expect(urlErrors[0]!.message).toBe('URL must start with https://')
+    }
+  })
+
+  it('rejects an empty URL', () => {
+    const result = addChannelRawSchema.safeParse({
+      channel_type: 'discord',
+      url: '',
+      events_filter: [],
+      enabled: true,
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const urlErrors = result.error.issues.filter((i) => i.path[0] === 'url')
+      expect(urlErrors.length).toBeGreaterThan(0)
+      expect(urlErrors[0]!.message).toBe('URL is required')
+    }
+  })
+
+  it('accepts empty events_filter (no events = disabled notifications)', () => {
+    const result = addChannelRawSchema.safeParse({
+      channel_type: 'webhook',
+      url: 'https://example.com/hook',
+      events_filter: [],
+      enabled: true,
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.events_filter).toEqual([])
+    }
+  })
+
+  it('rejects an invalid channel_type', () => {
+    const result = addChannelRawSchema.safeParse({
+      channel_type: 'slack',
+      url: 'https://hooks.slack.com/services/abc',
+      events_filter: [],
+      enabled: true,
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('defaults enabled to true when not provided', () => {
+    const result = addChannelRawSchema.safeParse({
+      channel_type: 'discord',
+      url: 'https://discord.com/api/webhooks/123/abc',
+      events_filter: [],
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.enabled).toBe(true)
+    }
+  })
+})
+
+describe('maskUrl', () => {
+  it('masks all but last 6 chars for long URLs', () => {
+    expect(maskUrl('https://discord.com/api/webhooks/123/abc123')).toBe('****abc123')
+  })
+
+  it('returns the URL as-is when shorter than 6 chars', () => {
+    expect(maskUrl('https')).toBe('https')
+  })
+
+  it('returns a 6-char URL as-is', () => {
+    expect(maskUrl('abc123')).toBe('abc123')
+  })
+
+  it('masks a 7-char URL showing last 6 chars', () => {
+    expect(maskUrl('abc1234')).toBe('****bc1234')
+  })
+})

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -89,6 +89,11 @@ const router = createRouter({
           name: 'hitl-approve',
           component: () => import('@/views/HITLApprovalView.vue'),
         },
+        {
+          path: 'settings/notifications',
+          name: 'project-notifications',
+          component: () => import('@/views/NotificationSettingsView.vue'),
+        },
       ],
     },
     {

--- a/frontend/src/utils/maskUrl.ts
+++ b/frontend/src/utils/maskUrl.ts
@@ -1,0 +1,8 @@
+/**
+ * Masks a URL by showing only the last 6 characters, prefixed with asterisks.
+ * Used to display partially hidden webhook URLs in the UI.
+ */
+export function maskUrl(url: string): string {
+  if (url.length <= 6) return url
+  return `****${url.slice(-6)}`
+}

--- a/frontend/src/views/NotificationSettingsView.vue
+++ b/frontend/src/views/NotificationSettingsView.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { useToast } from 'primevue/usetoast'
+import { useConfirm } from 'primevue/useconfirm'
+import Button from 'primevue/button'
+import Skeleton from 'primevue/skeleton'
+import { useAuthStore } from '@/stores/auth'
+import { useNotifications, type NotificationConfig } from '@/composables/useNotifications'
+import NotificationChannelRow from '@/features/notifications/NotificationChannelRow.vue'
+import AddChannelDialog from '@/features/notifications/AddChannelDialog.vue'
+
+const route = useRoute()
+const toast = useToast()
+const confirm = useConfirm()
+const authStore = useAuthStore()
+
+const projectId = route.params.id as string
+const isAdmin = computed(() => authStore.user?.role === 'admin')
+
+const { configs, isLoading, toggleEnabled, deleteConfig, testConfig } =
+  useNotifications(projectId)
+
+const showAddDialog = ref(false)
+
+async function handleToggle(config: NotificationConfig) {
+  try {
+    await toggleEnabled(config)
+  } catch {
+    toast.add({
+      severity: 'error',
+      summary: 'Failed to update channel',
+      detail: 'Could not update the channel status. Please try again.',
+      life: 4000,
+    })
+  }
+}
+
+function handleDelete(config: NotificationConfig) {
+  confirm.require({
+    message: `Delete ${config.channel_type} channel?`,
+    header: 'Confirm Delete',
+    icon: 'pi pi-trash',
+    accept: async () => {
+      await deleteConfig(config.id)
+      toast.add({
+        severity: 'success',
+        summary: 'Channel deleted',
+        life: 3000,
+      })
+    },
+  })
+}
+
+async function handleTest(config: NotificationConfig) {
+  try {
+    await testConfig(config.id)
+    toast.add({
+      severity: 'success',
+      summary: 'Test sent',
+      life: 3000,
+    })
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : 'Unknown error'
+    toast.add({
+      severity: 'error',
+      summary: `Test failed: ${reason}`,
+      life: 4000,
+    })
+  }
+}
+
+function handleCreated() {
+  toast.add({
+    severity: 'success',
+    summary: 'Channel added',
+    life: 3000,
+  })
+}
+</script>
+
+<template>
+  <div class="p-6">
+    <!-- Page header -->
+    <div class="mb-6 flex items-center justify-between">
+      <div>
+        <h2 class="text-xl font-semibold">Notification Channels</h2>
+        <p class="mt-1 text-sm text-surface-500">
+          Configure Discord or webhook alerts for pipeline events.
+        </p>
+      </div>
+      <Button
+        v-if="isAdmin"
+        label="Add Channel"
+        icon="pi pi-plus"
+        @click="showAddDialog = true"
+        data-testid="add-channel-btn"
+      />
+    </div>
+
+    <!-- Loading skeleton -->
+    <div v-if="isLoading" class="flex flex-col gap-3" data-testid="loading-skeleton">
+      <Skeleton v-for="i in 3" :key="i" height="4rem" class="rounded-lg" />
+    </div>
+
+    <!-- Empty state -->
+    <div
+      v-else-if="!isLoading && configs.length === 0"
+      class="flex flex-col items-center justify-center rounded-lg border border-dashed border-surface-300 py-16 text-center"
+      data-testid="empty-state"
+    >
+      <i class="pi pi-bell mb-4 text-4xl text-surface-300" />
+      <p class="text-surface-500">No notification channels configured</p>
+      <Button
+        v-if="isAdmin"
+        label="Add your first channel"
+        text
+        severity="secondary"
+        class="mt-3"
+        @click="showAddDialog = true"
+      />
+    </div>
+
+    <!-- Channel list -->
+    <div v-else class="flex flex-col gap-3" data-testid="channel-list">
+      <NotificationChannelRow
+        v-for="config in configs"
+        :key="config.id"
+        :config="config"
+        :is-admin="isAdmin"
+        @toggle="handleToggle"
+        @delete="handleDelete"
+        @test="handleTest"
+      />
+    </div>
+
+    <!-- Add channel dialog -->
+    <AddChannelDialog
+      v-model:visible="showAddDialog"
+      :project-id="projectId"
+      @created="handleCreated"
+    />
+  </div>
+</template>

--- a/frontend/src/views/NotificationSettingsView.vue
+++ b/frontend/src/views/NotificationSettingsView.vue
@@ -4,7 +4,9 @@ import { useRoute } from 'vue-router'
 import { useToast } from 'primevue/usetoast'
 import { useConfirm } from 'primevue/useconfirm'
 import Button from 'primevue/button'
+import ConfirmDialog from 'primevue/confirmdialog'
 import Skeleton from 'primevue/skeleton'
+import Toast from 'primevue/toast'
 import { useAuthStore } from '@/stores/auth'
 import { useNotifications, type NotificationConfig } from '@/composables/useNotifications'
 import NotificationChannelRow from '@/features/notifications/NotificationChannelRow.vue'
@@ -140,5 +142,8 @@ function handleCreated() {
       :project-id="projectId"
       @created="handleCreated"
     />
+
+    <Toast />
+    <ConfirmDialog />
   </div>
 </template>

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -26,6 +26,7 @@ const tabs = [
   { label: 'Pipeline', icon: 'pi pi-cog', route: 'project-pipeline' },
   { label: 'Templates', icon: 'pi pi-file', route: 'project-templates' },
   { label: 'Costs', icon: 'pi pi-dollar', route: 'project-costs' },
+  { label: 'Notifications', icon: 'pi pi-bell', route: 'project-notifications' },
 ]
 
 const activeIndex = computed(() => {


### PR DESCRIPTION
## Summary

- Adds notification settings page at /projects/:id/settings/notifications where admins can manage Discord/webhook channels
- Extends api/openapi.yaml with notification CRUD + test endpoints and regenerates TypeScript client types
- Implements useNotifications composable with optimistic toggle, full CRUD, and testConfig support
- Adds NotificationChannelRow.vue (masked URL, events chips, toggle, admin actions) and AddChannelDialog.vue (vee-validate + zod with https:// enforcement)
- Adds Notifications tab to ProjectDetailView and child route in router

## Test plan

- [x] Unit tests for useNotifications: fetch, create, optimistic toggle (with revert on error), delete, test
- [x] Zod schema tests: valid Discord URL, http:// rejection, empty URL rejection, empty events_filter accepted
- [x] maskUrl utility tests
- [x] npm run lint - passes
- [x] npm run type-check - passes
- [x] npm run test:unit - 395 tests pass

Generated with Claude Code