### PR TITLE
feat(pipeline): add incremental_retry action with retry policy

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -184,6 +184,12 @@ func run() error {
 			)
 			actionReg.Register(agentRunAction)
 			logger.Info("agent_run action registered")
+
+			incrementalRetryAction := actionadapter.NewIncrementalRetryAction(
+				runRepo, templateSvc, agentRunAction, logger,
+			)
+			actionReg.Register(incrementalRetryAction)
+			logger.Info("incremental_retry action registered")
 		}
 	}
 

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -299,6 +299,14 @@ func (m *mockRunRepo) UpdateRunStepStatus(ctx context.Context, id uuid.UUID, sta
 	return &model.RunStep{ID: id, Status: status}, nil
 }
 
+func (m *mockRunRepo) CreateRetryRunStep(_ context.Context, step *model.RunStep) (*model.RunStep, error) {
+	return step, nil
+}
+
+func (m *mockRunRepo) ListRetryStepsByParent(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+	return nil, nil
+}
+
 func (m *mockRunRepo) getContainerInfoCalls() []containerInfoCall {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/backend/internal/adapter/action/hitl_gate_test.go
+++ b/backend/internal/adapter/action/hitl_gate_test.go
@@ -105,6 +105,14 @@ func (m *hitlMockRunRepo) UpdateRunStepContainerInfo(_ context.Context, id uuid.
 	return &model.RunStep{ID: id}, nil
 }
 
+func (m *hitlMockRunRepo) CreateRetryRunStep(_ context.Context, step *model.RunStep) (*model.RunStep, error) {
+	return step, nil
+}
+
+func (m *hitlMockRunRepo) ListRetryStepsByParent(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+	return nil, nil
+}
+
 func (m *hitlMockRunRepo) getStatusCalls() []hitlStepStatusCall {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/backend/internal/adapter/action/incremental_retry.go
+++ b/backend/internal/adapter/action/incremental_retry.go
@@ -1,0 +1,149 @@
+package action
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// AgentRunExecutor is an interface to allow mocking AgentRunAction in tests.
+type AgentRunExecutor interface {
+	Execute(ctx context.Context, runCtx *model.RunContext) error
+}
+
+// IncrementalRetryAction coordinates retry logic for failed agent steps.
+// It creates a new RunStep record and delegates execution to AgentRunAction.
+type IncrementalRetryAction struct {
+	runRepo     port.RunRepository
+	templateSvc *service.TemplateService
+	agentRun    AgentRunExecutor
+	logger      *slog.Logger
+}
+
+// NewIncrementalRetryAction creates a new IncrementalRetryAction.
+func NewIncrementalRetryAction(
+	runRepo port.RunRepository,
+	templateSvc *service.TemplateService,
+	agentRun AgentRunExecutor,
+	logger *slog.Logger,
+) *IncrementalRetryAction {
+	return &IncrementalRetryAction{
+		runRepo:     runRepo,
+		templateSvc: templateSvc,
+		agentRun:    agentRun,
+		logger:      logger,
+	}
+}
+
+// Name returns the action identifier.
+func (a *IncrementalRetryAction) Name() string {
+	return "incremental_retry"
+}
+
+// Execute coordinates retry logic: fetches the parent step, evaluates the retry
+// policy, creates a new retry RunStep, and delegates execution to AgentRunAction.
+func (a *IncrementalRetryAction) Execute(ctx context.Context, runCtx *model.RunContext) error {
+	// 1. Extract parent step ID from metadata
+	parentStepIDStr, _ := runCtx.Metadata["parent_step_id"].(string)
+	if parentStepIDStr == "" {
+		return errors.NewValidation("parent_step_id", "RETRY_MISSING_PARENT: missing required metadata key parent_step_id")
+	}
+	parentStepID, err := uuid.Parse(parentStepIDStr)
+	if err != nil {
+		return errors.NewValidation("parent_step_id", "invalid UUID format for parent_step_id")
+	}
+
+	// 2. Fetch parent step
+	parent, err := a.runRepo.GetRunStep(ctx, parentStepID)
+	if err != nil {
+		return fmt.Errorf("fetch parent step: %w", err)
+	}
+
+	// 3. Resolve retry policy from metadata
+	maxRetries := a.intFromMetadata(runCtx.Metadata, "retry_policy.max_retries", 3)
+	maxIncremental := a.intFromMetadata(runCtx.Metadata, "retry_policy.max_incremental", 2)
+
+	// 4. Check max retries
+	if parent.RetryCount >= maxRetries {
+		return errors.NewValidation("retry_count",
+			fmt.Sprintf("RETRY_MAX_EXCEEDED: max %d retries reached for step %s", maxRetries, parent.ID))
+	}
+
+	// 5. Determine retry type and template
+	retryType := "incremental"
+	templateName := service.TemplateNameImplementRetry
+	if parent.RetryCount >= maxIncremental {
+		retryType = "full"
+		templateName = service.TemplateNameImplement
+	}
+
+	// 6. Create new RunStep
+	newStep := &model.RunStep{
+		ID:           uuid.New(),
+		RunID:        parent.RunID,
+		StepName:     parent.StepName,
+		StepOrder:    parent.StepOrder,
+		Action:       parent.Action,
+		Status:       model.StepStatusPending,
+		RetryCount:   parent.RetryCount + 1,
+		RetryType:    &retryType,
+		ParentStepID: &parent.ID,
+	}
+	created, err := a.runRepo.CreateRetryRunStep(ctx, newStep)
+	if err != nil {
+		return fmt.Errorf("create retry step: %w", err)
+	}
+
+	// 7. Build new RunContext with retry metadata
+	errorContext := ""
+	if parent.ErrorMessage != nil {
+		errorContext = *parent.ErrorMessage
+	}
+	logTail := ""
+	if parent.LogTail != nil {
+		logTail = *parent.LogTail
+	}
+
+	newMetadata := make(map[string]any, len(runCtx.Metadata))
+	for k, v := range runCtx.Metadata {
+		newMetadata[k] = v
+	}
+	newMetadata["template_name"] = templateName
+	newMetadata["error_context"] = errorContext
+	newMetadata["log_tail"] = logTail
+
+	newRunCtx := &model.RunContext{
+		Run:       runCtx.Run,
+		RunStep:   created,
+		StoryID:   runCtx.StoryID,
+		ProjectID: runCtx.ProjectID,
+		Metadata:  newMetadata,
+	}
+
+	// 8. Delegate to AgentRunAction
+	return a.agentRun.Execute(ctx, newRunCtx)
+}
+
+// intFromMetadata reads an integer from metadata with a fallback default.
+func (a *IncrementalRetryAction) intFromMetadata(metadata map[string]any, key string, defaultVal int) int {
+	val, ok := metadata[key]
+	if !ok {
+		return defaultVal
+	}
+	switch v := val.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	default:
+		return defaultVal
+	}
+}

--- a/backend/internal/adapter/action/incremental_retry_test.go
+++ b/backend/internal/adapter/action/incremental_retry_test.go
@@ -1,0 +1,369 @@
+package action_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/adapter/action"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+	apperrors "github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// --- Partial mocks for IncrementalRetryAction ---
+
+// retryMockRunRepo implements port.RunRepository with configurable fns for retry tests.
+type retryMockRunRepo struct {
+	getRunStepFn         func(ctx context.Context, id uuid.UUID) (*model.RunStep, error)
+	createRetryRunStepFn func(ctx context.Context, step *model.RunStep) (*model.RunStep, error)
+	createdStep          *model.RunStep
+}
+
+func (m *retryMockRunRepo) GetRunStep(ctx context.Context, id uuid.UUID) (*model.RunStep, error) {
+	if m.getRunStepFn != nil {
+		return m.getRunStepFn(ctx, id)
+	}
+	return nil, apperrors.NewNotFound("run step", id)
+}
+
+func (m *retryMockRunRepo) CreateRetryRunStep(ctx context.Context, step *model.RunStep) (*model.RunStep, error) {
+	if m.createRetryRunStepFn != nil {
+		return m.createRetryRunStepFn(ctx, step)
+	}
+	m.createdStep = step
+	return step, nil
+}
+
+// Stub implementations for the full port.RunRepository interface.
+func (m *retryMockRunRepo) CreateRun(_ context.Context, run *model.Run) (*model.Run, error) {
+	return run, nil
+}
+func (m *retryMockRunRepo) GetRun(_ context.Context, id uuid.UUID) (*model.Run, error) {
+	return nil, apperrors.NewNotFound("run", id)
+}
+func (m *retryMockRunRepo) GetActiveRunByStory(_ context.Context, _ uuid.UUID) (*model.Run, error) {
+	return nil, nil
+}
+func (m *retryMockRunRepo) ListRunsByProject(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *retryMockRunRepo) ListRunsByStory(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *retryMockRunRepo) UpdateRunStatus(_ context.Context, id uuid.UUID, status model.RunStatus, _, _ *time.Time, _ *string) (*model.Run, error) {
+	return &model.Run{ID: id, Status: status}, nil
+}
+func (m *retryMockRunRepo) CountRunsByProject(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+func (m *retryMockRunRepo) CountRunsByStory(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+func (m *retryMockRunRepo) CreateRunStep(_ context.Context, step *model.RunStep) (*model.RunStep, error) {
+	return step, nil
+}
+func (m *retryMockRunRepo) ListRunStepsByRun(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+	return nil, nil
+}
+func (m *retryMockRunRepo) UpdateRunStepStatus(_ context.Context, id uuid.UUID, status model.StepStatus, _, _ *time.Time, _ *string) (*model.RunStep, error) {
+	return &model.RunStep{ID: id, Status: status}, nil
+}
+func (m *retryMockRunRepo) UpdateRunStepContainerInfo(_ context.Context, id uuid.UUID, _ *string, _ *string) (*model.RunStep, error) {
+	return &model.RunStep{ID: id}, nil
+}
+func (m *retryMockRunRepo) ListRetryStepsByParent(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+	return nil, nil
+}
+
+// retryMockAgentRun is a mock AgentRunExecutor.
+type retryMockAgentRun struct {
+	executeFn  func(ctx context.Context, runCtx *model.RunContext) error
+	lastRunCtx *model.RunContext
+}
+
+func (m *retryMockAgentRun) Execute(ctx context.Context, runCtx *model.RunContext) error {
+	m.lastRunCtx = runCtx
+	if m.executeFn != nil {
+		return m.executeFn(ctx, runCtx)
+	}
+	return nil
+}
+
+// buildRetryRunCtx creates a minimal RunContext for retry tests.
+func buildRetryRunCtx(parentStepID uuid.UUID, extraMeta map[string]any) *model.RunContext {
+	meta := map[string]any{
+		"parent_step_id": parentStepID.String(),
+	}
+	for k, v := range extraMeta {
+		meta[k] = v
+	}
+	return &model.RunContext{
+		Run:       &model.Run{ID: uuid.New()},
+		RunStep:   &model.RunStep{ID: uuid.New()},
+		ProjectID: uuid.New(),
+		StoryID:   uuid.New(),
+		Metadata:  meta,
+	}
+}
+
+// makeParentStep creates a RunStep suitable as a parent for retry tests.
+func makeParentStep(retryCount int, errorMsg, logTail string) *model.RunStep {
+	step := &model.RunStep{
+		ID:         uuid.New(),
+		RunID:      uuid.New(),
+		StepName:   "implement",
+		StepOrder:  1,
+		Action:     "agent_run",
+		Status:     model.StepStatusFailed,
+		RetryCount: retryCount,
+	}
+	if errorMsg != "" {
+		step.ErrorMessage = &errorMsg
+	}
+	if logTail != "" {
+		step.LogTail = &logTail
+	}
+	return step
+}
+
+// buildTemplateService builds a TemplateService backed by a no-op template repo
+// so the default templates are used (no DB required).
+func buildTemplateService() *service.TemplateService {
+	return service.NewTemplateService(&mockPromptTemplateRepo{}, &mockTemplateRenderer{}, testLogger())
+}
+
+// --- Tests ---
+
+// TestIncrementalRetryAction_Name verifies the action identifier.
+func TestIncrementalRetryAction_Name(t *testing.T) {
+	t.Parallel()
+
+	a := action.NewIncrementalRetryAction(
+		&retryMockRunRepo{}, nil, &retryMockAgentRun{}, testLogger(),
+	)
+	if got := a.Name(); got != "incremental_retry" {
+		t.Errorf("Name() = %q; want %q", got, "incremental_retry")
+	}
+}
+
+// TestIncrementalRetryAction_MissingParentStepID verifies RETRY_MISSING_PARENT error.
+func TestIncrementalRetryAction_MissingParentStepID(t *testing.T) {
+	t.Parallel()
+
+	repo := &retryMockRunRepo{}
+	agentRun := &retryMockAgentRun{}
+	a := action.NewIncrementalRetryAction(repo, nil, agentRun, testLogger())
+
+	runCtx := &model.RunContext{
+		Run:      &model.Run{ID: uuid.New()},
+		RunStep:  &model.RunStep{ID: uuid.New()},
+		Metadata: map[string]any{}, // no parent_step_id
+	}
+
+	err := a.Execute(context.Background(), runCtx)
+	if err == nil {
+		t.Fatal("expected error for missing parent_step_id, got nil")
+	}
+	if !strings.Contains(err.Error(), "RETRY_MISSING_PARENT") {
+		t.Errorf("expected RETRY_MISSING_PARENT in error, got: %v", err)
+	}
+	if agentRun.lastRunCtx != nil {
+		t.Error("expected AgentRun not to be called, but it was")
+	}
+}
+
+// TestIncrementalRetryAction_FirstIncrementalRetry verifies the happy path:
+// parent.retry_count=0 → new step with retry_type="incremental", implement-retry template.
+func TestIncrementalRetryAction_FirstIncrementalRetry(t *testing.T) {
+	t.Parallel()
+
+	parent := makeParentStep(0, "test error", "last log line")
+	agentRun := &retryMockAgentRun{}
+	repo := &retryMockRunRepo{
+		getRunStepFn: func(_ context.Context, _ uuid.UUID) (*model.RunStep, error) {
+			return parent, nil
+		},
+	}
+
+	templateSvc := buildTemplateService()
+	a := action.NewIncrementalRetryAction(repo, templateSvc, agentRun, testLogger())
+
+	runCtx := buildRetryRunCtx(parent.ID, nil)
+	if err := a.Execute(context.Background(), runCtx); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	createdStep := repo.createdStep
+	if createdStep == nil {
+		t.Fatal("expected a retry step to be created")
+	}
+	if createdStep.RetryCount != 1 {
+		t.Errorf("RetryCount = %d; want 1", createdStep.RetryCount)
+	}
+	if createdStep.RetryType == nil || *createdStep.RetryType != "incremental" {
+		t.Errorf("RetryType = %v; want %q", createdStep.RetryType, "incremental")
+	}
+	if createdStep.ParentStepID == nil || *createdStep.ParentStepID != parent.ID {
+		t.Errorf("ParentStepID = %v; want %v", createdStep.ParentStepID, parent.ID)
+	}
+
+	if agentRun.lastRunCtx == nil {
+		t.Fatal("expected AgentRun.Execute to be called")
+	}
+	if agentRun.lastRunCtx.RunStep.ID != createdStep.ID {
+		t.Errorf("delegated RunStep.ID = %v; want %v", agentRun.lastRunCtx.RunStep.ID, createdStep.ID)
+	}
+	if agentRun.lastRunCtx.Metadata["template_name"] != service.TemplateNameImplementRetry {
+		t.Errorf("template_name = %v; want %q", agentRun.lastRunCtx.Metadata["template_name"], service.TemplateNameImplementRetry)
+	}
+	if agentRun.lastRunCtx.Metadata["error_context"] != "test error" {
+		t.Errorf("error_context = %v; want %q", agentRun.lastRunCtx.Metadata["error_context"], "test error")
+	}
+	if agentRun.lastRunCtx.Metadata["log_tail"] != "last log line" {
+		t.Errorf("log_tail = %v; want %q", agentRun.lastRunCtx.Metadata["log_tail"], "last log line")
+	}
+}
+
+// TestIncrementalRetryAction_SecondFailureFallsToFullRetry verifies that when
+// parent.retry_count >= max_incremental (default 2), retry_type switches to "full".
+func TestIncrementalRetryAction_SecondFailureFallsToFullRetry(t *testing.T) {
+	t.Parallel()
+
+	parent := makeParentStep(2, "persistent error", "")
+	retryType := "incremental"
+	parent.RetryType = &retryType
+
+	agentRun := &retryMockAgentRun{}
+	repo := &retryMockRunRepo{
+		getRunStepFn: func(_ context.Context, _ uuid.UUID) (*model.RunStep, error) {
+			return parent, nil
+		},
+	}
+
+	templateSvc := buildTemplateService()
+	a := action.NewIncrementalRetryAction(repo, templateSvc, agentRun, testLogger())
+
+	runCtx := buildRetryRunCtx(parent.ID, nil)
+	if err := a.Execute(context.Background(), runCtx); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	createdStep := repo.createdStep
+	if createdStep == nil {
+		t.Fatal("expected a retry step to be created")
+	}
+	if createdStep.RetryCount != 3 {
+		t.Errorf("RetryCount = %d; want 3", createdStep.RetryCount)
+	}
+	if createdStep.RetryType == nil || *createdStep.RetryType != "full" {
+		t.Errorf("RetryType = %v; want %q", createdStep.RetryType, "full")
+	}
+	if agentRun.lastRunCtx == nil {
+		t.Fatal("expected AgentRun.Execute to be called")
+	}
+	if agentRun.lastRunCtx.Metadata["template_name"] != service.TemplateNameImplement {
+		t.Errorf("template_name = %v; want %q", agentRun.lastRunCtx.Metadata["template_name"], service.TemplateNameImplement)
+	}
+}
+
+// TestIncrementalRetryAction_MaxRetriesExceeded verifies RETRY_MAX_EXCEEDED error.
+func TestIncrementalRetryAction_MaxRetriesExceeded(t *testing.T) {
+	t.Parallel()
+
+	parent := makeParentStep(3, "error", "") // retry_count == default max_retries (3)
+	agentRun := &retryMockAgentRun{}
+	repo := &retryMockRunRepo{
+		getRunStepFn: func(_ context.Context, _ uuid.UUID) (*model.RunStep, error) {
+			return parent, nil
+		},
+	}
+
+	a := action.NewIncrementalRetryAction(repo, nil, agentRun, testLogger())
+
+	runCtx := buildRetryRunCtx(parent.ID, nil)
+	err := a.Execute(context.Background(), runCtx)
+	if err == nil {
+		t.Fatal("expected RETRY_MAX_EXCEEDED error, got nil")
+	}
+	if !strings.Contains(err.Error(), "RETRY_MAX_EXCEEDED") {
+		t.Errorf("expected RETRY_MAX_EXCEEDED in error, got: %v", err)
+	}
+	if repo.createdStep != nil {
+		t.Error("expected no retry step to be created on max-retries-exceeded")
+	}
+	if agentRun.lastRunCtx != nil {
+		t.Error("expected AgentRun not to be called on max-retries-exceeded")
+	}
+}
+
+// TestIncrementalRetryAction_CreateRetryStepFailure verifies that when the repo
+// fails to create a retry step, Execute returns an error and AgentRun is not called.
+func TestIncrementalRetryAction_CreateRetryStepFailure(t *testing.T) {
+	t.Parallel()
+
+	parent := makeParentStep(0, "error", "")
+	agentRun := &retryMockAgentRun{}
+	createErr := fmt.Errorf("db write failure")
+	repo := &retryMockRunRepo{
+		getRunStepFn: func(_ context.Context, _ uuid.UUID) (*model.RunStep, error) {
+			return parent, nil
+		},
+		createRetryRunStepFn: func(_ context.Context, _ *model.RunStep) (*model.RunStep, error) {
+			return nil, createErr
+		},
+	}
+
+	templateSvc := buildTemplateService()
+	a := action.NewIncrementalRetryAction(repo, templateSvc, agentRun, testLogger())
+
+	runCtx := buildRetryRunCtx(parent.ID, nil)
+	err := a.Execute(context.Background(), runCtx)
+	if err == nil {
+		t.Fatal("expected error from CreateRetryRunStep, got nil")
+	}
+	if agentRun.lastRunCtx != nil {
+		t.Error("expected AgentRun not to be called when step creation fails")
+	}
+}
+
+// TestIncrementalRetryAction_CustomRetryPolicy verifies that metadata-specified
+// retry policy values override the defaults.
+func TestIncrementalRetryAction_CustomRetryPolicy(t *testing.T) {
+	t.Parallel()
+
+	// max_retries=5, max_incremental=1 → with retry_count=1, should switch to full
+	parent := makeParentStep(1, "error", "")
+	agentRun := &retryMockAgentRun{}
+	repo := &retryMockRunRepo{
+		getRunStepFn: func(_ context.Context, _ uuid.UUID) (*model.RunStep, error) {
+			return parent, nil
+		},
+	}
+
+	templateSvc := buildTemplateService()
+	a := action.NewIncrementalRetryAction(repo, templateSvc, agentRun, testLogger())
+
+	extraMeta := map[string]any{
+		"retry_policy.max_retries":     5,
+		"retry_policy.max_incremental": 1,
+	}
+	runCtx := buildRetryRunCtx(parent.ID, extraMeta)
+	if err := a.Execute(context.Background(), runCtx); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	createdStep := repo.createdStep
+	if createdStep == nil {
+		t.Fatal("expected a retry step to be created")
+	}
+	if createdStep.RetryType == nil || *createdStep.RetryType != "full" {
+		t.Errorf("RetryType = %v; want %q", createdStep.RetryType, "full")
+	}
+	if agentRun.lastRunCtx.Metadata["template_name"] != service.TemplateNameImplement {
+		t.Errorf("template_name = %v; want %q", agentRun.lastRunCtx.Metadata["template_name"], service.TemplateNameImplement)
+	}
+}

--- a/backend/internal/adapter/postgres/models.go
+++ b/backend/internal/adapter/postgres/models.go
@@ -110,6 +110,9 @@ type RunStep struct {
 	ContainerID  pgtype.Text        `json:"container_id"`
 	LogTail      pgtype.Text        `json:"log_tail"`
 	CreatedAt    time.Time          `json:"created_at"`
+	RetryCount   int32              `json:"retry_count"`
+	RetryType    pgtype.Text        `json:"retry_type"`
+	ParentStepID pgtype.UUID        `json:"parent_step_id"`
 }
 
 type Story struct {

--- a/backend/internal/adapter/postgres/run_repo.go
+++ b/backend/internal/adapter/postgres/run_repo.go
@@ -246,16 +246,53 @@ func toDomainRun(r Run) *model.Run {
 	return run
 }
 
+func (r *RunRepo) CreateRetryRunStep(ctx context.Context, step *model.RunStep) (*model.RunStep, error) {
+	params := CreateRetryRunStepParams{
+		ID:         step.ID,
+		RunID:      step.RunID,
+		StepName:   step.StepName,
+		StepOrder:  int32(step.StepOrder),
+		Action:     step.Action,
+		Status:     string(step.Status),
+		RetryCount: int32(step.RetryCount),
+	}
+	if step.RetryType != nil {
+		params.RetryType = pgtype.Text{String: *step.RetryType, Valid: true}
+	}
+	if step.ParentStepID != nil {
+		params.ParentStepID = pgtype.UUID{Bytes: *step.ParentStepID, Valid: true}
+	}
+
+	row, err := r.queries.CreateRetryRunStep(ctx, params)
+	if err != nil {
+		return nil, apperrors.NewInternal("failed to create retry run step", err)
+	}
+	return toDomainRunStep(row), nil
+}
+
+func (r *RunRepo) ListRetryStepsByParent(ctx context.Context, parentStepID uuid.UUID) ([]*model.RunStep, error) {
+	rows, err := r.queries.ListRetryStepsByParent(ctx, pgtype.UUID{Bytes: parentStepID, Valid: true})
+	if err != nil {
+		return nil, apperrors.NewInternal("failed to list retry steps by parent", err)
+	}
+	steps := make([]*model.RunStep, len(rows))
+	for i, row := range rows {
+		steps[i] = toDomainRunStep(row)
+	}
+	return steps, nil
+}
+
 // toDomainRunStep maps a sqlc-generated RunStep to a domain RunStep.
 func toDomainRunStep(s RunStep) *model.RunStep {
 	step := &model.RunStep{
-		ID:        s.ID,
-		RunID:     s.RunID,
-		StepName:  s.StepName,
-		StepOrder: int(s.StepOrder),
-		Action:    s.Action,
-		Status:    model.StepStatus(s.Status),
-		CreatedAt: s.CreatedAt,
+		ID:         s.ID,
+		RunID:      s.RunID,
+		StepName:   s.StepName,
+		StepOrder:  int(s.StepOrder),
+		Action:     s.Action,
+		Status:     model.StepStatus(s.Status),
+		RetryCount: int(s.RetryCount),
+		CreatedAt:  s.CreatedAt,
 	}
 	if s.StartedAt.Valid {
 		step.StartedAt = &s.StartedAt.Time
@@ -271,6 +308,13 @@ func toDomainRunStep(s RunStep) *model.RunStep {
 	}
 	if s.LogTail.Valid {
 		step.LogTail = &s.LogTail.String
+	}
+	if s.RetryType.Valid {
+		step.RetryType = &s.RetryType.String
+	}
+	if s.ParentStepID.Valid {
+		uid := uuid.UUID(s.ParentStepID.Bytes)
+		step.ParentStepID = &uid
 	}
 	return step
 }

--- a/backend/internal/adapter/postgres/run_steps.sql.go
+++ b/backend/internal/adapter/postgres/run_steps.sql.go
@@ -12,10 +12,65 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const createRetryRunStep = `-- name: CreateRetryRunStep :one
+INSERT INTO run_steps (
+    id, run_id, step_name, step_order, action, status,
+    retry_count, retry_type, parent_step_id
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
+)
+RETURNING id, run_id, step_name, step_order, action, status, started_at, completed_at, error_message, container_id, log_tail, created_at, retry_count, retry_type, parent_step_id
+`
+
+type CreateRetryRunStepParams struct {
+	ID           uuid.UUID   `json:"id"`
+	RunID        uuid.UUID   `json:"run_id"`
+	StepName     string      `json:"step_name"`
+	StepOrder    int32       `json:"step_order"`
+	Action       string      `json:"action"`
+	Status       string      `json:"status"`
+	RetryCount   int32       `json:"retry_count"`
+	RetryType    pgtype.Text `json:"retry_type"`
+	ParentStepID pgtype.UUID `json:"parent_step_id"`
+}
+
+func (q *Queries) CreateRetryRunStep(ctx context.Context, arg CreateRetryRunStepParams) (RunStep, error) {
+	row := q.db.QueryRow(ctx, createRetryRunStep,
+		arg.ID,
+		arg.RunID,
+		arg.StepName,
+		arg.StepOrder,
+		arg.Action,
+		arg.Status,
+		arg.RetryCount,
+		arg.RetryType,
+		arg.ParentStepID,
+	)
+	var i RunStep
+	err := row.Scan(
+		&i.ID,
+		&i.RunID,
+		&i.StepName,
+		&i.StepOrder,
+		&i.Action,
+		&i.Status,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.ErrorMessage,
+		&i.ContainerID,
+		&i.LogTail,
+		&i.CreatedAt,
+		&i.RetryCount,
+		&i.RetryType,
+		&i.ParentStepID,
+	)
+	return i, err
+}
+
 const createRunStep = `-- name: CreateRunStep :one
 INSERT INTO run_steps (run_id, step_name, step_order, action, status)
 VALUES ($1, $2, $3, $4, $5)
-RETURNING id, run_id, step_name, step_order, action, status, started_at, completed_at, error_message, container_id, log_tail, created_at
+RETURNING id, run_id, step_name, step_order, action, status, started_at, completed_at, error_message, container_id, log_tail, created_at, retry_count, retry_type, parent_step_id
 `
 
 type CreateRunStepParams struct {
@@ -48,12 +103,15 @@ func (q *Queries) CreateRunStep(ctx context.Context, arg CreateRunStepParams) (R
 		&i.ContainerID,
 		&i.LogTail,
 		&i.CreatedAt,
+		&i.RetryCount,
+		&i.RetryType,
+		&i.ParentStepID,
 	)
 	return i, err
 }
 
 const getRunStep = `-- name: GetRunStep :one
-SELECT id, run_id, step_name, step_order, action, status, started_at, completed_at, error_message, container_id, log_tail, created_at FROM run_steps WHERE id = $1
+SELECT id, run_id, step_name, step_order, action, status, started_at, completed_at, error_message, container_id, log_tail, created_at, retry_count, retry_type, parent_step_id FROM run_steps WHERE id = $1
 `
 
 func (q *Queries) GetRunStep(ctx context.Context, id uuid.UUID) (RunStep, error) {
@@ -72,12 +130,57 @@ func (q *Queries) GetRunStep(ctx context.Context, id uuid.UUID) (RunStep, error)
 		&i.ContainerID,
 		&i.LogTail,
 		&i.CreatedAt,
+		&i.RetryCount,
+		&i.RetryType,
+		&i.ParentStepID,
 	)
 	return i, err
 }
 
+const listRetryStepsByParent = `-- name: ListRetryStepsByParent :many
+SELECT id, run_id, step_name, step_order, action, status, started_at, completed_at, error_message, container_id, log_tail, created_at, retry_count, retry_type, parent_step_id FROM run_steps
+WHERE parent_step_id = $1
+ORDER BY retry_count ASC
+`
+
+func (q *Queries) ListRetryStepsByParent(ctx context.Context, parentStepID pgtype.UUID) ([]RunStep, error) {
+	rows, err := q.db.Query(ctx, listRetryStepsByParent, parentStepID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []RunStep{}
+	for rows.Next() {
+		var i RunStep
+		if err := rows.Scan(
+			&i.ID,
+			&i.RunID,
+			&i.StepName,
+			&i.StepOrder,
+			&i.Action,
+			&i.Status,
+			&i.StartedAt,
+			&i.CompletedAt,
+			&i.ErrorMessage,
+			&i.ContainerID,
+			&i.LogTail,
+			&i.CreatedAt,
+			&i.RetryCount,
+			&i.RetryType,
+			&i.ParentStepID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRunStepsByRun = `-- name: ListRunStepsByRun :many
-SELECT id, run_id, step_name, step_order, action, status, started_at, completed_at, error_message, container_id, log_tail, created_at FROM run_steps
+SELECT id, run_id, step_name, step_order, action, status, started_at, completed_at, error_message, container_id, log_tail, created_at, retry_count, retry_type, parent_step_id FROM run_steps
 WHERE run_id = $1
 ORDER BY step_order ASC
 `
@@ -104,6 +207,9 @@ func (q *Queries) ListRunStepsByRun(ctx context.Context, runID uuid.UUID) ([]Run
 			&i.ContainerID,
 			&i.LogTail,
 			&i.CreatedAt,
+			&i.RetryCount,
+			&i.RetryType,
+			&i.ParentStepID,
 		); err != nil {
 			return nil, err
 		}
@@ -120,7 +226,7 @@ UPDATE run_steps
 SET container_id = COALESCE($2, container_id),
     log_tail = COALESCE($3, log_tail)
 WHERE id = $1
-RETURNING id, run_id, step_name, step_order, action, status, started_at, completed_at, error_message, container_id, log_tail, created_at
+RETURNING id, run_id, step_name, step_order, action, status, started_at, completed_at, error_message, container_id, log_tail, created_at, retry_count, retry_type, parent_step_id
 `
 
 type UpdateRunStepContainerInfoParams struct {
@@ -145,6 +251,9 @@ func (q *Queries) UpdateRunStepContainerInfo(ctx context.Context, arg UpdateRunS
 		&i.ContainerID,
 		&i.LogTail,
 		&i.CreatedAt,
+		&i.RetryCount,
+		&i.RetryType,
+		&i.ParentStepID,
 	)
 	return i, err
 }
@@ -158,7 +267,7 @@ SET status = $2,
     container_id = COALESCE($6, container_id),
     log_tail = COALESCE($7, log_tail)
 WHERE id = $1
-RETURNING id, run_id, step_name, step_order, action, status, started_at, completed_at, error_message, container_id, log_tail, created_at
+RETURNING id, run_id, step_name, step_order, action, status, started_at, completed_at, error_message, container_id, log_tail, created_at, retry_count, retry_type, parent_step_id
 `
 
 type UpdateRunStepStatusParams struct {
@@ -195,6 +304,9 @@ func (q *Queries) UpdateRunStepStatus(ctx context.Context, arg UpdateRunStepStat
 		&i.ContainerID,
 		&i.LogTail,
 		&i.CreatedAt,
+		&i.RetryCount,
+		&i.RetryType,
+		&i.ParentStepID,
 	)
 	return i, err
 }

--- a/backend/internal/api/handler/run_handler_test.go
+++ b/backend/internal/api/handler/run_handler_test.go
@@ -80,6 +80,14 @@ func (m *runHandlerRunRepo) UpdateRunStepContainerInfo(_ context.Context, _ uuid
 	return nil, nil
 }
 
+func (m *runHandlerRunRepo) CreateRetryRunStep(_ context.Context, step *model.RunStep) (*model.RunStep, error) {
+	return step, nil
+}
+
+func (m *runHandlerRunRepo) ListRetryStepsByParent(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+	return nil, nil
+}
+
 // runHandlerStoryRepo is a minimal mock of port.StoryRepository for handler tests.
 type runHandlerStoryRepo struct {
 	getByIDFn func(ctx context.Context, id uuid.UUID) (*model.Story, error)

--- a/backend/internal/domain/model/run.go
+++ b/backend/internal/domain/model/run.go
@@ -76,6 +76,12 @@ type RunStep struct {
 	ErrorMessage *string
 	ContainerID  *string
 	LogTail      *string
+	// RetryCount is the number of retries attempted from this step.
+	RetryCount int
+	// RetryType is "incremental" or "full"; nil for original (non-retry) steps.
+	RetryType *string
+	// ParentStepID is the ID of the step this was retried from; nil for original steps.
+	ParentStepID *uuid.UUID
 	CreatedAt    time.Time
 }
 

--- a/backend/internal/domain/model/template_context.go
+++ b/backend/internal/domain/model/template_context.go
@@ -15,6 +15,8 @@ type TemplateContext struct {
 	AcceptanceCriteria string `json:"acceptance_criteria"`
 	// ErrorContext holds error details (for retry templates).
 	ErrorContext string `json:"error_context"`
+	// LogTail holds the last N log lines from a failed step (for retry templates).
+	LogTail string `json:"log_tail"`
 	// DiffContent holds git diff or changes (for review/merge templates).
 	DiffContent string `json:"diff_content"`
 	// BranchName is the git branch name.

--- a/backend/internal/domain/port/run_repository.go
+++ b/backend/internal/domain/port/run_repository.go
@@ -28,4 +28,10 @@ type RunRepository interface {
 	// UpdateRunStepContainerInfo updates container_id and/or log_tail on a run step
 	// without changing its status. Nil values are ignored (existing values preserved).
 	UpdateRunStepContainerInfo(ctx context.Context, id uuid.UUID, containerID *string, logTail *string) (*model.RunStep, error)
+
+	// CreateRetryRunStep persists a new retry run step with retry metadata.
+	CreateRetryRunStep(ctx context.Context, step *model.RunStep) (*model.RunStep, error)
+
+	// ListRetryStepsByParent returns all retry steps for a given parent step, ordered by retry_count asc.
+	ListRetryStepsByParent(ctx context.Context, parentStepID uuid.UUID) ([]*model.RunStep, error)
 }

--- a/backend/internal/domain/service/run_service_test.go
+++ b/backend/internal/domain/service/run_service_test.go
@@ -105,6 +105,14 @@ func (m *mockRunRepo) UpdateRunStepContainerInfo(_ context.Context, id uuid.UUID
 	return &model.RunStep{ID: id}, nil
 }
 
+func (m *mockRunRepo) CreateRetryRunStep(_ context.Context, step *model.RunStep) (*model.RunStep, error) {
+	return step, nil
+}
+
+func (m *mockRunRepo) ListRetryStepsByParent(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+	return nil, nil
+}
+
 // mockStoryRepoForRun implements port.StoryRepository for testing.
 type mockStoryRepoForRun struct {
 	getByIDFn func(ctx context.Context, id uuid.UUID) (*model.Story, error)

--- a/backend/migrations/000014_add_retry_fields_to_run_steps.down.sql
+++ b/backend/migrations/000014_add_retry_fields_to_run_steps.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_run_steps_parent_step_id;
+ALTER TABLE run_steps
+    DROP COLUMN IF EXISTS parent_step_id,
+    DROP COLUMN IF EXISTS retry_type,
+    DROP COLUMN IF EXISTS retry_count;

--- a/backend/migrations/000014_add_retry_fields_to_run_steps.up.sql
+++ b/backend/migrations/000014_add_retry_fields_to_run_steps.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE run_steps
+    ADD COLUMN retry_count    INT         NOT NULL DEFAULT 0,
+    ADD COLUMN retry_type     VARCHAR(50) NULL
+        CHECK (retry_type IN ('incremental', 'full')),
+    ADD COLUMN parent_step_id UUID        NULL
+        REFERENCES run_steps(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_run_steps_parent_step_id ON run_steps(parent_step_id);

--- a/backend/queries/run_steps.sql
+++ b/backend/queries/run_steps.sql
@@ -28,3 +28,17 @@ SET container_id = COALESCE(sqlc.narg('container_id'), container_id),
     log_tail = COALESCE(sqlc.narg('log_tail'), log_tail)
 WHERE id = $1
 RETURNING *;
+
+-- name: CreateRetryRunStep :one
+INSERT INTO run_steps (
+    id, run_id, step_name, step_order, action, status,
+    retry_count, retry_type, parent_step_id
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
+)
+RETURNING *;
+
+-- name: ListRetryStepsByParent :many
+SELECT * FROM run_steps
+WHERE parent_step_id = $1
+ORDER BY retry_count ASC;


### PR DESCRIPTION
## Summary

- Adds DB migration 000014 with retry_count, retry_type, and parent_step_id columns to run_steps
- Extends RunStep domain model, sqlc queries, RunRepository port, and postgres adapter with retry support methods (CreateRetryRunStep, ListRetryStepsByParent)
- Adds LogTail field to TemplateContext for retry template rendering
- Implements IncrementalRetryAction that evaluates retry policy (max_retries=3, max_incremental=2 defaults), creates a new retry RunStep, and delegates to AgentRunAction with the appropriate template
- Falls back to full retry after max_incremental incremental failures; enforces hard max_retries cap with RETRY_MAX_EXCEEDED error
- Registers incremental_retry action in ActionRegistry on startup

## Test plan

- [x] Unit tests cover: first retry, full-retry fallback, max exceeded, missing parent, step creation failure, custom policy
- [x] go test ./... -short — all packages green
- [x] go vet ./... passes
- [x] gofmt applied

Refs: S-8-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)