### PR TITLE
feat(ui): add retry step grouping and circuit breaker indicator

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -310,6 +310,23 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /projects/{id}/circuit-breaker/reset:
+    post:
+      operationId: resetCircuitBreaker
+      summary: Reset circuit breaker for a project
+      tags: [projects]
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "204":
+          description: Circuit breaker reset successfully
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   # ── Epics ──────────────────────────────────────────────────────────────
   /projects/{projectId}/epics:
     get:
@@ -1239,6 +1256,10 @@ components:
           type: string
           format: uuid
           example: 550e8400-e29b-41d4-a716-446655440000
+        circuit_breaker_active:
+          type: boolean
+          description: Whether the circuit breaker is active, pausing all pipeline runs
+          example: false
         created_at:
           type: string
           format: date-time
@@ -1897,6 +1918,20 @@ components:
           type: string
         log_tail:
           type: string
+        parent_step_id:
+          type: string
+          format: uuid
+          description: ID of the original step this is a retry of; null for root steps
+          nullable: true
+        retry_count:
+          type: integer
+          description: Which retry attempt this is (1-based); null for root steps
+          nullable: true
+        retry_type:
+          type: string
+          enum: [incremental, full]
+          description: Retry strategy used for this attempt; null for root steps
+          nullable: true
         created_at:
           type: string
           format: date-time

--- a/frontend/src/features/projects/CircuitBreakerBanner.vue
+++ b/frontend/src/features/projects/CircuitBreakerBanner.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { watch } from 'vue'
+import { useConfirm } from 'primevue/useconfirm'
+import { useToast } from 'primevue/usetoast'
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import { useAsyncAction } from '@/composables/useAsyncAction'
+import { apiClient } from '@/api/client'
+
+const props = defineProps<{
+  /** The project ID for which the circuit breaker is active */
+  projectId: string
+  /** Whether the current user has admin privileges */
+  isAdmin: boolean
+}>()
+
+const emit = defineEmits<{
+  /** Fired after the circuit breaker is successfully reset */
+  reset: []
+}>()
+
+const confirm = useConfirm()
+const toast = useToast()
+
+const {
+  execute: doReset,
+  isLoading,
+  error: resetError,
+} = useAsyncAction(async () => {
+  const { response } = await apiClient.POST('/projects/{id}/circuit-breaker/reset', {
+    params: { path: { id: props.projectId } },
+  })
+  if (!response.ok) {
+    throw new Error(`Reset failed with status ${response.status}`)
+  }
+  emit('reset')
+  toast.add({
+    severity: 'success',
+    summary: 'Circuit breaker reset',
+    detail: 'Pipeline runs can now proceed.',
+    life: 3000,
+  })
+})
+
+// Show error toast whenever the reset action fails
+watch(resetError, (err) => {
+  if (err) {
+    toast.add({
+      severity: 'error',
+      summary: 'Reset failed',
+      detail: 'Could not reset the circuit breaker. Please try again.',
+      life: 5000,
+    })
+  }
+})
+
+function handleReset() {
+  confirm.require({
+    message: 'This will allow new pipeline runs to start. Continue?',
+    header: 'Reset Circuit Breaker',
+    icon: 'pi pi-exclamation-triangle',
+    rejectLabel: 'Cancel',
+    acceptLabel: 'Reset',
+    acceptClass: 'p-button-danger',
+    accept: () => doReset(),
+  })
+}
+</script>
+
+<template>
+  <Message severity="error" :closable="false" class="mb-4" data-testid="circuit-breaker-banner">
+    <div class="flex items-center justify-between w-full gap-4">
+      <span>Circuit breaker active — all pipeline runs are paused.</span>
+      <Button
+        v-if="isAdmin"
+        label="Reset"
+        severity="danger"
+        size="small"
+        :loading="isLoading"
+        data-testid="reset-button"
+        @click="handleReset"
+      />
+    </div>
+  </Message>
+</template>

--- a/frontend/src/features/projects/__tests__/CircuitBreakerBanner.spec.ts
+++ b/frontend/src/features/projects/__tests__/CircuitBreakerBanner.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import ConfirmationService from 'primevue/confirmationservice'
+import ToastService from 'primevue/toastservice'
+import CircuitBreakerBanner from '../CircuitBreakerBanner.vue'
+
+const mockConfirmRequire = vi.fn()
+const mockToastAdd = vi.fn()
+const mockPost = vi.fn()
+
+vi.mock('primevue/useconfirm', () => ({
+  useConfirm: () => ({ require: mockConfirmRequire }),
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: mockToastAdd }),
+}))
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    POST: (...args: unknown[]) => mockPost(...args),
+  },
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function mountBanner(props: { projectId?: string; isAdmin?: boolean } = {}) {
+  wrapper = mount(CircuitBreakerBanner, {
+    props: {
+      projectId: 'proj-1',
+      isAdmin: false,
+      ...props,
+    },
+    global: {
+      plugins: [PrimeVue, ConfirmationService, ToastService],
+    },
+  })
+  return wrapper
+}
+
+describe('CircuitBreakerBanner', () => {
+  beforeEach(() => {
+    mockConfirmRequire.mockReset()
+    mockToastAdd.mockReset()
+    mockPost.mockReset()
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('renders the banner message', () => {
+    mountBanner()
+    expect(wrapper.find('[data-testid="circuit-breaker-banner"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Circuit breaker active')
+    expect(wrapper.text()).toContain('all pipeline runs are paused')
+  })
+
+  it('does not render Reset button when isAdmin is false', () => {
+    mountBanner({ isAdmin: false })
+    expect(wrapper.find('[data-testid="reset-button"]').exists()).toBe(false)
+  })
+
+  it('renders Reset button when isAdmin is true', () => {
+    mountBanner({ isAdmin: true })
+    expect(wrapper.find('[data-testid="reset-button"]').exists()).toBe(true)
+  })
+
+  it('calls confirm.require when Reset button is clicked', async () => {
+    mountBanner({ isAdmin: true })
+    await wrapper.find('[data-testid="reset-button"]').trigger('click')
+    expect(mockConfirmRequire).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+        message: 'This will allow new pipeline runs to start. Continue?',
+        header: 'Reset Circuit Breaker',
+      }))
+  })
+
+  it('calls apiClient.POST on confirm accept and emits reset event on success', async () => {
+    mockPost.mockResolvedValue({ response: { ok: true, status: 204 } })
+
+    // Capture the accept callback from confirm.require
+    mockConfirmRequire.mockImplementation((options: { accept?: () => void }) => {
+      options.accept?.()
+    })
+
+    mountBanner({ isAdmin: true, projectId: 'proj-abc' })
+    await wrapper.find('[data-testid="reset-button"]').trigger('click')
+    await flushPromises()
+
+    expect(mockPost).toHaveBeenCalledWith('/projects/{id}/circuit-breaker/reset', {
+      params: { path: { id: 'proj-abc' } },
+    })
+    expect(wrapper.emitted('reset')).toBeDefined()
+    expect(wrapper.emitted('reset')).toHaveLength(1)
+    expect(mockToastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'success' }),
+    )
+  })
+
+  it('shows error toast and does not emit reset when API call fails', async () => {
+    mockPost.mockResolvedValue({ response: { ok: false, status: 500 } })
+
+    mockConfirmRequire.mockImplementation((options: { accept?: () => void }) => {
+      options.accept?.()
+    })
+
+    mountBanner({ isAdmin: true })
+    await wrapper.find('[data-testid="reset-button"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.emitted('reset')).toBeUndefined()
+    expect(mockToastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error' }),
+    )
+  })
+
+  it('does not call apiClient.POST when confirm is rejected', async () => {
+    // confirm.require but never calls accept
+    mockConfirmRequire.mockImplementation((_options: unknown) => {
+      // Simulates user clicking Cancel — no accept() invocation
+    })
+
+    mountBanner({ isAdmin: true })
+    await wrapper.find('[data-testid="reset-button"]').trigger('click')
+    await flushPromises()
+
+    expect(mockPost).not.toHaveBeenCalled()
+    expect(wrapper.emitted('reset')).toBeUndefined()
+  })
+})

--- a/frontend/src/features/runs/RetryStepEntry.vue
+++ b/frontend/src/features/runs/RetryStepEntry.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import Button from 'primevue/button'
+import Tag from 'primevue/tag'
+import type { components } from '@/api/schema'
+
+type RunStep = components['schemas']['RunStep']
+
+const props = defineProps<{
+  step: RunStep
+  /** The parent step whose error_message and log_tail may be shown */
+  parentStep?: RunStep
+}>()
+
+const MAX_LOG_LINES = 20
+
+const isExpanded = ref(false)
+
+function toggleExpand() {
+  isExpanded.value = !isExpanded.value
+}
+
+/** Returns "Retry #N (type)" label for display */
+function retryLabel(step: RunStep): string {
+  const num = step.retry_count ?? 1
+  const type = step.retry_type ?? 'incremental'
+  return `Retry #${num} (${type})`
+}
+
+/** Severity map for step status to PrimeVue Tag severity */
+function statusSeverity(status: string): 'success' | 'danger' | 'warn' | 'info' | 'secondary' {
+  switch (status) {
+    case 'completed':
+      return 'success'
+    case 'failed':
+      return 'danger'
+    case 'running':
+      return 'info'
+    case 'waiting_approval':
+      return 'warn'
+    default:
+      return 'secondary'
+  }
+}
+
+const errorContext = computed(() => props.step.error_message ?? props.parentStep?.error_message ?? '')
+
+const truncatedLog = computed(() => {
+  const source = props.step.log_tail ?? props.parentStep?.log_tail ?? ''
+  const lines = source ? source.split('\n') : []
+  const isTruncated = lines.length > MAX_LOG_LINES
+  return {
+    lines: isTruncated ? lines.slice(-MAX_LOG_LINES) : lines,
+    isTruncated,
+    totalLines: lines.length,
+  }
+})
+
+const hasExpandableContent = computed(
+  () => !!errorContext.value || truncatedLog.value.lines.length > 0,
+)
+</script>
+
+<template>
+  <div class="ml-8 flex flex-col gap-1 border-l-2 border-surface-200 pl-4 py-2">
+    <div class="flex items-center gap-2">
+      <span class="text-sm text-surface-600 font-medium">{{ retryLabel(step) }}</span>
+      <Tag :severity="statusSeverity(step.status)" :value="step.status" class="text-xs" />
+      <Button
+        v-if="hasExpandableContent"
+        :icon="isExpanded ? 'pi pi-chevron-up' : 'pi pi-chevron-down'"
+        text
+        rounded
+        size="small"
+        severity="secondary"
+        :aria-label="isExpanded ? 'Collapse error context' : 'Expand error context'"
+        data-testid="expand-toggle"
+        @click="toggleExpand"
+      />
+    </div>
+
+    <div v-if="isExpanded" class="mt-2 rounded border border-surface-200 bg-surface-50 p-3">
+      <div v-if="errorContext" class="mb-2">
+        <p class="text-xs font-semibold text-surface-500 uppercase mb-1">Error</p>
+        <pre class="text-xs text-red-700 whitespace-pre-wrap break-words">{{ errorContext }}</pre>
+      </div>
+      <div v-if="truncatedLog.lines.length > 0">
+        <p class="text-xs font-semibold text-surface-500 uppercase mb-1">Log tail</p>
+        <pre class="text-xs text-surface-800 whitespace-pre-wrap break-words">{{
+          truncatedLog.lines.join('\n')
+        }}</pre>
+        <p v-if="truncatedLog.isTruncated" class="mt-1 text-xs text-surface-500">
+          Showing last {{ MAX_LOG_LINES }} of {{ truncatedLog.totalLines }} lines.
+          <a href="#" class="text-primary underline" @click.prevent="isExpanded = true"
+            >Show more</a
+          >
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/features/runs/RunTimeline.vue
+++ b/frontend/src/features/runs/RunTimeline.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import Tag from 'primevue/tag'
+import RetryStepEntry from './RetryStepEntry.vue'
+import { useRunTimeline } from './composables/useRunTimeline'
+import type { components } from '@/api/schema'
+
+type RunStep = components['schemas']['RunStep']
+
+const props = defineProps<{
+  steps: RunStep[]
+}>()
+
+const stepsRef = computed(() => props.steps)
+const { groupedSteps } = useRunTimeline(stepsRef)
+
+/** Severity map for step status to PrimeVue Tag severity */
+function statusSeverity(status: string): 'success' | 'danger' | 'warn' | 'info' | 'secondary' {
+  switch (status) {
+    case 'completed':
+      return 'success'
+    case 'failed':
+      return 'danger'
+    case 'running':
+      return 'info'
+    case 'waiting_approval':
+      return 'warn'
+    default:
+      return 'secondary'
+  }
+}
+
+function formatDate(iso?: string | null): string {
+  if (!iso) return ''
+  return new Date(iso).toLocaleString()
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-4">
+    <div
+      v-for="group in groupedSteps"
+      :key="group.root.id"
+      class="rounded border border-surface-200 p-4"
+      data-testid="step-group"
+    >
+      <!-- Root step header -->
+      <div class="flex items-center gap-3" data-testid="root-step">
+        <span class="font-semibold text-surface-800">{{ group.root.step_name }}</span>
+        <Tag
+          :severity="statusSeverity(group.root.status)"
+          :value="group.root.status"
+          class="text-xs"
+        />
+        <span v-if="group.root.started_at" class="text-xs text-surface-400">
+          {{ formatDate(group.root.started_at) }}
+        </span>
+        <span
+          v-if="group.root.completed_at"
+          class="text-xs text-surface-400"
+          data-testid="completed-at"
+        >
+          → {{ formatDate(group.root.completed_at) }}
+        </span>
+      </div>
+
+      <!-- Error message on root step -->
+      <div v-if="group.root.error_message" class="mt-2 text-sm text-red-600">
+        {{ group.root.error_message }}
+      </div>
+
+      <!-- Retry entries -->
+      <RetryStepEntry
+        v-for="retry in group.retries"
+        :key="retry.id"
+        :step="retry"
+        :parent-step="group.root"
+        data-testid="retry-entry"
+      />
+    </div>
+
+    <div v-if="groupedSteps.length === 0" class="text-surface-400 text-sm" data-testid="empty-state">
+      No steps to display.
+    </div>
+  </div>
+</template>

--- a/frontend/src/features/runs/__tests__/RunTimeline.spec.ts
+++ b/frontend/src/features/runs/__tests__/RunTimeline.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import RunTimeline from '../RunTimeline.vue'
+import type { components } from '@/api/schema'
+
+type RunStep = components['schemas']['RunStep']
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function makeStep(overrides: Partial<RunStep> & Pick<RunStep, 'id' | 'step_order'>): RunStep {
+  return {
+    run_id: 'run-1',
+    step_name: 'dev-story',
+    action: 'agent_run',
+    status: 'completed',
+    created_at: '2026-02-17T10:00:00Z',
+    parent_step_id: null,
+    retry_count: null,
+    retry_type: null,
+    ...overrides,
+  }
+}
+
+function mountTimeline(steps: RunStep[]) {
+  wrapper = mount(RunTimeline, {
+    props: { steps },
+    global: {
+      plugins: [PrimeVue],
+    },
+  })
+  return wrapper
+}
+
+describe('RunTimeline', () => {
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('renders empty state when no steps provided', () => {
+    mountTimeline([])
+    expect(wrapper.find('[data-testid="empty-state"]').exists()).toBe(true)
+  })
+
+  it('renders root steps', () => {
+    mountTimeline([
+      makeStep({ id: 'step-1', step_order: 1, step_name: 'dev-story' }),
+      makeStep({ id: 'step-2', step_order: 2, step_name: 'code-review' }),
+    ])
+    const groups = wrapper.findAll('[data-testid="step-group"]')
+    expect(groups).toHaveLength(2)
+  })
+
+  it('renders retry entries with correct label', () => {
+    mountTimeline([
+      makeStep({ id: 'root', step_order: 1, step_name: 'dev-story', status: 'failed' }),
+      makeStep({
+        id: 'retry-1',
+        step_order: 1,
+        step_name: 'dev-story',
+        parent_step_id: 'root',
+        retry_count: 1,
+        retry_type: 'incremental',
+      }),
+    ])
+
+    const retryEntries = wrapper.findAll('[data-testid="retry-entry"]')
+    expect(retryEntries).toHaveLength(1)
+    expect(retryEntries[0]!.text()).toContain('Retry #1 (incremental)')
+  })
+
+  it('renders "Retry #2 (full)" for a full retry', () => {
+    mountTimeline([
+      makeStep({ id: 'root', step_order: 1, step_name: 'dev-story', status: 'failed' }),
+      makeStep({
+        id: 'retry-2',
+        step_order: 1,
+        step_name: 'dev-story',
+        parent_step_id: 'root',
+        retry_count: 2,
+        retry_type: 'full',
+      }),
+    ])
+
+    expect(wrapper.text()).toContain('Retry #2 (full)')
+  })
+
+  it('displays root step name and status', () => {
+    mountTimeline([
+      makeStep({ id: 'step-1', step_order: 1, step_name: 'dev-story', status: 'running' }),
+    ])
+    expect(wrapper.text()).toContain('dev-story')
+    expect(wrapper.text()).toContain('running')
+  })
+})

--- a/frontend/src/features/runs/__tests__/useRunTimeline.spec.ts
+++ b/frontend/src/features/runs/__tests__/useRunTimeline.spec.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useRunTimeline } from '../composables/useRunTimeline'
+import type { components } from '@/api/schema'
+
+type RunStep = components['schemas']['RunStep']
+
+function makeStep(overrides: Partial<RunStep> & Pick<RunStep, 'id' | 'step_order'>): RunStep {
+  return {
+    run_id: 'run-1',
+    step_name: 'dev-story',
+    action: 'agent_run',
+    status: 'completed',
+    created_at: '2026-02-17T10:00:00Z',
+    parent_step_id: null,
+    retry_count: null,
+    retry_type: null,
+    ...overrides,
+  }
+}
+
+describe('useRunTimeline', () => {
+  it('returns an empty array for empty steps input', () => {
+    const steps = ref<RunStep[]>([])
+    const { groupedSteps } = useRunTimeline(steps)
+    expect(groupedSteps.value).toEqual([])
+  })
+
+  it('makes each root step (no parent_step_id) its own group with empty retries', () => {
+    const steps = ref<RunStep[]>([
+      makeStep({ id: 'step-1', step_order: 1 }),
+      makeStep({ id: 'step-2', step_order: 2 }),
+    ])
+
+    const { groupedSteps } = useRunTimeline(steps)
+    const groups = groupedSteps.value
+    expect(groups).toHaveLength(2)
+    expect(groups[0]!.root.id).toBe('step-1')
+    expect(groups[0]!.retries).toEqual([])
+    expect(groups[1]!.root.id).toBe('step-2')
+    expect(groups[1]!.retries).toEqual([])
+  })
+
+  it('groups retry steps under their parent step', () => {
+    const retry1 = makeStep({
+      id: 'step-1-retry-1',
+      step_order: 1,
+      parent_step_id: 'step-1',
+      retry_count: 1,
+      retry_type: 'incremental',
+    })
+    const retry2 = makeStep({
+      id: 'step-1-retry-2',
+      step_order: 1,
+      parent_step_id: 'step-1',
+      retry_count: 2,
+      retry_type: 'full',
+    })
+
+    const steps = ref<RunStep[]>([
+      makeStep({ id: 'step-1', step_order: 1, status: 'failed' }),
+      retry1,
+      retry2,
+    ])
+
+    const { groupedSteps } = useRunTimeline(steps)
+    const groups = groupedSteps.value
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.root.id).toBe('step-1')
+    expect(groups[0]!.retries).toHaveLength(2)
+    expect(groups[0]!.retries[0]!.id).toBe('step-1-retry-1')
+    expect(groups[0]!.retries[1]!.id).toBe('step-1-retry-2')
+  })
+
+  it('sorts root steps by step_order', () => {
+    const steps = ref<RunStep[]>([
+      makeStep({ id: 'step-3', step_order: 3 }),
+      makeStep({ id: 'step-1', step_order: 1 }),
+      makeStep({ id: 'step-2', step_order: 2 }),
+    ])
+
+    const { groupedSteps } = useRunTimeline(steps)
+    expect(groupedSteps.value.map((g) => g.root.id)).toEqual(['step-1', 'step-2', 'step-3'])
+  })
+
+  it('sorts retry steps by retry_count within their group', () => {
+    const steps = ref<RunStep[]>([
+      makeStep({ id: 'step-1', step_order: 1, status: 'failed' }),
+      makeStep({
+        id: 'retry-2',
+        step_order: 1,
+        parent_step_id: 'step-1',
+        retry_count: 2,
+        retry_type: 'full',
+      }),
+      makeStep({
+        id: 'retry-1',
+        step_order: 1,
+        parent_step_id: 'step-1',
+        retry_count: 1,
+        retry_type: 'incremental',
+      }),
+    ])
+
+    const { groupedSteps } = useRunTimeline(steps)
+    const group = groupedSteps.value[0]!
+    expect(group.retries[0]!.id).toBe('retry-1')
+    expect(group.retries[1]!.id).toBe('retry-2')
+  })
+
+  it('handles a mixed scenario: 2 root steps, one with 2 retries', () => {
+    const steps = ref<RunStep[]>([
+      makeStep({ id: 'root-a', step_order: 1, status: 'failed' }),
+      makeStep({ id: 'root-b', step_order: 2, status: 'completed' }),
+      makeStep({
+        id: 'retry-a-1',
+        step_order: 1,
+        parent_step_id: 'root-a',
+        retry_count: 1,
+        retry_type: 'incremental',
+      }),
+      makeStep({
+        id: 'retry-a-2',
+        step_order: 1,
+        parent_step_id: 'root-a',
+        retry_count: 2,
+        retry_type: 'full',
+      }),
+    ])
+
+    const { groupedSteps } = useRunTimeline(steps)
+    const groups = groupedSteps.value
+    expect(groups).toHaveLength(2)
+    expect(groups[0]!.root.id).toBe('root-a')
+    expect(groups[0]!.retries).toHaveLength(2)
+    expect(groups[1]!.root.id).toBe('root-b')
+    expect(groups[1]!.retries).toHaveLength(0)
+  })
+
+  it('is reactive: updates groupedSteps when steps change', () => {
+    const steps = ref<RunStep[]>([makeStep({ id: 'step-1', step_order: 1 })])
+    const { groupedSteps } = useRunTimeline(steps)
+    expect(groupedSteps.value).toHaveLength(1)
+
+    steps.value = [
+      makeStep({ id: 'step-1', step_order: 1 }),
+      makeStep({ id: 'step-2', step_order: 2 }),
+    ]
+    expect(groupedSteps.value).toHaveLength(2)
+  })
+})

--- a/frontend/src/features/runs/composables/useRunTimeline.ts
+++ b/frontend/src/features/runs/composables/useRunTimeline.ts
@@ -1,0 +1,31 @@
+import { computed, type Ref } from 'vue'
+import type { components } from '@/api/schema'
+
+type RunStep = components['schemas']['RunStep']
+
+/** A root step grouped with its retry attempts. */
+export interface StepGroup {
+  root: RunStep
+  retries: RunStep[]
+}
+
+/**
+ * Groups a flat list of run steps into root steps and their associated retries.
+ * Root steps have no `parent_step_id`; retry steps reference a root via `parent_step_id`.
+ */
+export function useRunTimeline(steps: Ref<RunStep[]>) {
+  const groupedSteps = computed<StepGroup[]>(() => {
+    const rootSteps = steps.value
+      .filter((s) => !s.parent_step_id)
+      .sort((a, b) => a.step_order - b.step_order)
+
+    return rootSteps.map((root) => ({
+      root,
+      retries: steps.value
+        .filter((s) => s.parent_step_id === root.id)
+        .sort((a, b) => (a.retry_count ?? 0) - (b.retry_count ?? 0)),
+    }))
+  })
+
+  return { groupedSteps }
+}

--- a/frontend/src/stores/projects.ts
+++ b/frontend/src/stores/projects.ts
@@ -8,6 +8,7 @@ export interface Project {
   name: string
   description?: string
   owner_id: string
+  circuit_breaker_active?: boolean
   created_at: string
   updated_at: string
 }

--- a/frontend/src/stores/runs.ts
+++ b/frontend/src/stores/runs.ts
@@ -7,6 +7,12 @@ export const useRunsStore = defineStore('runs', () => {
   const current = ref<{ id: string; status: string; steps: Array<unknown> } | null>(null)
   const isLoading = ref(false)
 
+  /**
+   * Whether the circuit breaker is currently active for the viewed project.
+   * Updated reactively via SSE events.
+   */
+  const circuitBreakerActive = ref(false)
+
   /** Handle SSE events dispatched from the useSSE composable */
   function handleSSEEvent(event: { type: string; payload: Record<string, unknown> }) {
     if (event.type === 'hitl_gate.pending') {
@@ -21,7 +27,15 @@ export const useRunsStore = defineStore('runs', () => {
         },
       )
     }
+
+    if (event.type === 'circuit_breaker.triggered') {
+      circuitBreakerActive.value = true
+    }
+
+    if (event.type === 'circuit_breaker.reset') {
+      circuitBreakerActive.value = false
+    }
   }
 
-  return { items, current, isLoading, handleSSEEvent }
+  return { items, current, isLoading, circuitBreakerActive, handleSSEEvent }
 })

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -6,9 +6,14 @@ import TabMenu from 'primevue/tabmenu'
 import Skeleton from 'primevue/skeleton'
 import Message from 'primevue/message'
 import { useProject } from '@/composables/useProject'
+import { useAuthStore } from '@/stores/auth'
+import { useRunsStore } from '@/stores/runs'
+import CircuitBreakerBanner from '@/features/projects/CircuitBreakerBanner.vue'
 
 const route = useRoute()
 const router = useRouter()
+const authStore = useAuthStore()
+const runsStore = useRunsStore()
 
 const projectId = route.params.id as string
 const { project, isLoading, error, retry } = useProject(projectId)
@@ -30,12 +35,31 @@ const activeIndex = computed(() => {
   return idx >= 0 ? idx : 0
 })
 
+/** Whether the circuit breaker banner should be shown */
+const showCircuitBreaker = computed(
+  () => project.value?.circuit_breaker_active || runsStore.circuitBreakerActive,
+)
+
+/** Whether the current user is an admin */
+const isAdmin = computed(() => authStore.user?.role === 'admin')
+
 function onTabChange(event: { index: number }) {
   const tab = tabs[event.index]
   if (tab) {
     router.push({ name: tab.route, params: { id: projectId } })
   }
 }
+
+/** Sync circuit breaker state from project data into the store */
+watch(
+  () => project.value?.circuit_breaker_active,
+  (active) => {
+    if (typeof active === 'boolean') {
+      runsStore.circuitBreakerActive = active
+    }
+  },
+  { immediate: true },
+)
 
 watch(
   () => route.params.id,
@@ -67,6 +91,16 @@ watch(
         {{ project.name }}
       </h1>
       <h1 v-else class="text-2xl font-bold text-surface-400">Project</h1>
+    </div>
+
+    <!-- Circuit breaker banner -->
+    <div v-if="showCircuitBreaker" class="px-6 pt-4">
+      <CircuitBreakerBanner
+        :project-id="projectId"
+        :is-admin="isAdmin"
+        data-testid="circuit-breaker-banner-wrapper"
+        @reset="runsStore.circuitBreakerActive = false"
+      />
     </div>
 
     <!-- Error state -->


### PR DESCRIPTION
## Summary

- AC1/AC2: useRunTimeline composable groups RunStep[] into root+retry groups. RunTimeline.vue and RetryStepEntry.vue render grouped steps with "Retry #N (type)" labels and expandable error context (log tail truncated to last 20 lines).
- AC3/AC4: CircuitBreakerBanner.vue shows PrimeVue error Message with admin-only Reset button backed by useConfirm and POST /projects/{id}/circuit-breaker/reset API call.
- AC5: OpenAPI spec updated — RunStep gains retry_count, retry_type (incremental|full), parent_step_id; Project gains circuit_breaker_active; new reset endpoint defined (204/403/404).
- AC6: runs store handles circuit_breaker.triggered and circuit_breaker.reset SSE events reactively; ProjectDetailView syncs project data into store so banner appears without page reload.
- AC7: TypeScript types regenerated (schema.d.ts gitignored, regenerated on generate:api).

## Test plan

- [x] useRunTimeline.spec.ts — 7 unit tests (empty, root grouping, retry grouping, sort orders, reactivity)
- [x] RunTimeline.spec.ts — 5 unit tests (empty state, step rendering, retry labels)
- [x] CircuitBreakerBanner.spec.ts — 7 unit tests (banner render, admin gate, confirm accept/reject, API correctness, success/error toasts)
- [x] All 392 tests pass across 48 test files
- [x] ESLint and vue-tsc type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)