### PR TITLE
feat(pipeline): add ci_poll action for CI status polling via GitProvider

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -197,6 +197,15 @@ func run() error {
 	actionReg.Register(hitlGateAction)
 	logger.Info("hitl_gate action registered")
 
+	// CI poll action (always available — polls CI status via GitProvider)
+	ciPollCfg := actionadapter.CIPollConfig{
+		DefaultPollInterval: 30 * time.Second,
+		DefaultTimeout:      15 * time.Minute,
+	}
+	ciPollAction := actionadapter.NewCIPollAction(gitProvider, eventRepo, ciPollCfg, logger)
+	actionReg.Register(ciPollAction)
+	logger.Info("ci_poll action registered")
+
 	// Orphan cleanup and timeout enforcement (requires Docker)
 	if containerMgr != nil {
 		orphanCleaner := service.NewOrphanCleaner(containerMgr, runRepo, logger)

--- a/backend/internal/adapter/action/ci_poll.go
+++ b/backend/internal/adapter/action/ci_poll.go
@@ -1,0 +1,128 @@
+package action
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+)
+
+// CIPollConfig holds tuneable parameters for CI polling.
+type CIPollConfig struct {
+	// DefaultPollInterval is how often to check CI status (default: 30s).
+	DefaultPollInterval time.Duration
+	// DefaultTimeout is the maximum time to wait for CI to pass (default: 15min).
+	DefaultTimeout time.Duration
+}
+
+// CIPollAction implements model.Action for polling CI status via GitProvider.
+type CIPollAction struct {
+	gitProvider port.GitProvider
+	eventPub    port.EventPublisher
+	config      CIPollConfig
+	logger      *slog.Logger
+}
+
+// NewCIPollAction creates a new CIPollAction.
+func NewCIPollAction(
+	gitProvider port.GitProvider,
+	eventPub port.EventPublisher,
+	config CIPollConfig,
+	logger *slog.Logger,
+) *CIPollAction {
+	return &CIPollAction{
+		gitProvider: gitProvider,
+		eventPub:    eventPub,
+		config:      config,
+		logger:      logger,
+	}
+}
+
+// Name returns the action identifier.
+func (a *CIPollAction) Name() string { return "ci_poll" }
+
+// Execute polls CI status for a merged PR until it passes, fails, or times out.
+// It reads pr_url from runCtx.Metadata and optionally poll_interval_seconds and timeout_seconds.
+func (a *CIPollAction) Execute(ctx context.Context, runCtx *model.RunContext) error {
+	prURL, _ := runCtx.Metadata["pr_url"].(string)
+	if prURL == "" {
+		return fmt.Errorf("CI_POLL_MISSING_PR_URL: missing required metadata key pr_url")
+	}
+
+	workDir, _ := runCtx.Metadata["work_dir"].(string)
+
+	pollInterval := a.config.DefaultPollInterval
+	if secs, ok := runCtx.Metadata["poll_interval_seconds"].(float64); ok && secs > 0 {
+		pollInterval = time.Duration(secs) * time.Second
+	}
+	timeout := a.config.DefaultTimeout
+	if secs, ok := runCtx.Metadata["timeout_seconds"].(float64); ok && secs > 0 {
+		timeout = time.Duration(secs) * time.Second
+	}
+
+	pollCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-pollCtx.Done():
+			if ctx.Err() != nil {
+				// Parent context was cancelled — propagate it.
+				return ctx.Err()
+			}
+			return fmt.Errorf("CI_POLL_TIMEOUT: timed out after %v waiting for CI on %s", timeout, prURL)
+		case <-ticker.C:
+			status, err := a.gitProvider.GetCIStatus(pollCtx, workDir)
+			if err != nil {
+				a.logger.Warn("ci_poll: GetCIStatus error", "error", err, "pr_url", prURL)
+				a.publishPollingEvent(ctx, runCtx, prURL, "error")
+				continue
+			}
+			switch status {
+			case "pass":
+				a.publishPollingEvent(ctx, runCtx, prURL, status)
+				return nil
+			case "fail":
+				a.publishPollingEvent(ctx, runCtx, prURL, status)
+				return fmt.Errorf("CI_POLL_FAILED: CI checks failed for PR %s", prURL)
+			default:
+				// "pending", "no_checks" — keep polling.
+				a.publishPollingEvent(ctx, runCtx, prURL, status)
+			}
+		}
+	}
+}
+
+// publishPollingEvent publishes a ci_poll.checking event to the event system.
+// Errors are logged as warnings and do not interrupt polling.
+func (a *CIPollAction) publishPollingEvent(ctx context.Context, runCtx *model.RunContext, prURL, status string) {
+	payload, err := json.Marshal(map[string]string{
+		"pr_url": prURL,
+		"status": status,
+	})
+	if err != nil {
+		a.logger.Warn("ci_poll: failed to marshal polling event payload", "error", err)
+		return
+	}
+
+	event := model.Event{
+		ID:         uuid.New(),
+		ProjectID:  runCtx.ProjectID,
+		EntityType: "ci_poll",
+		EntityID:   runCtx.RunStep.ID,
+		Action:     "checking",
+		Payload:    payload,
+	}
+
+	if err := a.eventPub.Publish(ctx, event); err != nil {
+		a.logger.Warn("ci_poll: failed to publish polling event", "error", err)
+	}
+}

--- a/backend/internal/adapter/action/ci_poll_test.go
+++ b/backend/internal/adapter/action/ci_poll_test.go
@@ -12,12 +12,19 @@ import (
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
 )
 
+const (
+	ciPollActionName = "ci_poll"
+	ciStatusPass     = "pass"
+	ciStatusPending  = "pending"
+	ciStatusFail     = "fail"
+)
+
 // --- Mocks for CIPollAction ---
 
 type ciMockGitProvider struct {
-	mu              sync.Mutex
-	getCIStatusFn   func(ctx context.Context, workDir string) (string, error)
-	calls           int
+	mu            sync.Mutex
+	getCIStatusFn func(ctx context.Context, workDir string) (string, error)
+	calls         int
 }
 
 func (m *ciMockGitProvider) GetCIStatus(ctx context.Context, workDir string) (string, error) {
@@ -33,8 +40,8 @@ func (m *ciMockGitProvider) Push(_ context.Context, _ string, _ string) error   
 func (m *ciMockGitProvider) CreatePR(_ context.Context, _ string, _ string, _ string, _ string) (string, error) {
 	return "", nil
 }
-func (m *ciMockGitProvider) MergePR(_ context.Context, _ string, _ string) error       { return nil }
-func (m *ciMockGitProvider) GetPRDiff(_ context.Context, _ string) (string, error)     { return "", nil }
+func (m *ciMockGitProvider) MergePR(_ context.Context, _ string, _ string) error   { return nil }
+func (m *ciMockGitProvider) GetPRDiff(_ context.Context, _ string) (string, error) { return "", nil }
 
 func (m *ciMockGitProvider) getCalls() int {
 	m.mu.Lock()
@@ -88,7 +95,7 @@ func buildCIRunCtx(metadata map[string]any) *model.RunContext {
 		RunStep: &model.RunStep{
 			ID:     stepID,
 			RunID:  runID,
-			Action: "ci_poll",
+			Action: ciPollActionName,
 			Status: model.StepStatusRunning,
 		},
 		ProjectID: projectID,
@@ -101,8 +108,8 @@ func buildCIRunCtx(metadata map[string]any) *model.RunContext {
 
 func TestCIPollAction_Name(t *testing.T) {
 	a := action.NewCIPollAction(nil, nil, fastCIPollConfig(), testLogger())
-	if a.Name() != "ci_poll" {
-		t.Fatalf("expected Name() = %q, got %q", "ci_poll", a.Name())
+	if a.Name() != ciPollActionName {
+		t.Fatalf("expected Name() = %q, got %q", ciPollActionName, a.Name())
 	}
 }
 
@@ -130,7 +137,7 @@ func TestCIPollAction_Execute_MissingPRURL(t *testing.T) {
 func TestCIPollAction_Execute_HappyPath_PassOnFirstTick(t *testing.T) {
 	gitProvider := &ciMockGitProvider{
 		getCIStatusFn: func(_ context.Context, _ string) (string, error) {
-			return "pass", nil
+			return ciStatusPass, nil
 		},
 	}
 	eventPub := &ciMockEventPublisher{}
@@ -155,8 +162,8 @@ func TestCIPollAction_Execute_HappyPath_PassOnFirstTick(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event published, got %d", len(events))
 	}
-	if events[0].EntityType != "ci_poll" {
-		t.Fatalf("expected entity_type %q, got %q", "ci_poll", events[0].EntityType)
+	if events[0].EntityType != ciPollActionName {
+		t.Fatalf("expected entity_type %q, got %q", ciPollActionName, events[0].EntityType)
 	}
 	if events[0].Action != "checking" {
 		t.Fatalf("expected action %q, got %q", "checking", events[0].Action)
@@ -169,9 +176,9 @@ func TestCIPollAction_Execute_PendingThenPass(t *testing.T) {
 		getCIStatusFn: func(_ context.Context, _ string) (string, error) {
 			callCount++
 			if callCount < 3 {
-				return "pending", nil
+				return ciStatusPending, nil
 			}
-			return "pass", nil
+			return ciStatusPass, nil
 		},
 	}
 	eventPub := &ciMockEventPublisher{}
@@ -197,7 +204,7 @@ func TestCIPollAction_Execute_PendingThenPass(t *testing.T) {
 		t.Fatalf("expected 3 events published, got %d", len(events))
 	}
 	for _, e := range events {
-		if e.EntityType != "ci_poll" || e.Action != "checking" {
+		if e.EntityType != ciPollActionName || e.Action != "checking" {
 			t.Fatalf("unexpected event: entity_type=%q action=%q", e.EntityType, e.Action)
 		}
 	}
@@ -207,7 +214,7 @@ func TestCIPollAction_Execute_CIFailure(t *testing.T) {
 	prURL := "https://github.com/owner/repo/pull/3"
 	gitProvider := &ciMockGitProvider{
 		getCIStatusFn: func(_ context.Context, _ string) (string, error) {
-			return "fail", nil
+			return ciStatusFail, nil
 		},
 	}
 	eventPub := &ciMockEventPublisher{}
@@ -230,7 +237,7 @@ func TestCIPollAction_Execute_CIFailure(t *testing.T) {
 func TestCIPollAction_Execute_Timeout(t *testing.T) {
 	gitProvider := &ciMockGitProvider{
 		getCIStatusFn: func(_ context.Context, _ string) (string, error) {
-			return "pending", nil
+			return ciStatusPending, nil
 		},
 	}
 	eventPub := &ciMockEventPublisher{}

--- a/backend/internal/adapter/action/ci_poll_test.go
+++ b/backend/internal/adapter/action/ci_poll_test.go
@@ -1,0 +1,308 @@
+package action_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/adapter/action"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+)
+
+// --- Mocks for CIPollAction ---
+
+type ciMockGitProvider struct {
+	mu              sync.Mutex
+	getCIStatusFn   func(ctx context.Context, workDir string) (string, error)
+	calls           int
+}
+
+func (m *ciMockGitProvider) GetCIStatus(ctx context.Context, workDir string) (string, error) {
+	m.mu.Lock()
+	m.calls++
+	m.mu.Unlock()
+	return m.getCIStatusFn(ctx, workDir)
+}
+
+func (m *ciMockGitProvider) CloneRepo(_ context.Context, _ string, _ string) error    { return nil }
+func (m *ciMockGitProvider) CreateBranch(_ context.Context, _ string, _ string) error { return nil }
+func (m *ciMockGitProvider) Push(_ context.Context, _ string, _ string) error         { return nil }
+func (m *ciMockGitProvider) CreatePR(_ context.Context, _ string, _ string, _ string, _ string) (string, error) {
+	return "", nil
+}
+func (m *ciMockGitProvider) MergePR(_ context.Context, _ string, _ string) error       { return nil }
+func (m *ciMockGitProvider) GetPRDiff(_ context.Context, _ string) (string, error)     { return "", nil }
+
+func (m *ciMockGitProvider) getCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+type ciMockEventPublisher struct {
+	mu        sync.Mutex
+	Published []model.Event
+}
+
+func (m *ciMockEventPublisher) Publish(_ context.Context, e model.Event) error {
+	m.mu.Lock()
+	m.Published = append(m.Published, e)
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *ciMockEventPublisher) getPublished() []model.Event {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]model.Event, len(m.Published))
+	copy(result, m.Published)
+	return result
+}
+
+// --- Helpers ---
+
+// fastCIPollConfig returns a config with very short intervals for tests.
+func fastCIPollConfig() action.CIPollConfig {
+	return action.CIPollConfig{
+		DefaultPollInterval: 1 * time.Millisecond,
+		DefaultTimeout:      5 * time.Second,
+	}
+}
+
+func buildCIRunCtx(metadata map[string]any) *model.RunContext {
+	runID := uuid.New()
+	stepID := uuid.New()
+	projectID := uuid.New()
+	storyID := uuid.New()
+
+	return &model.RunContext{
+		Run: &model.Run{
+			ID:        runID,
+			ProjectID: projectID,
+			StoryID:   storyID,
+			Status:    model.RunStatusRunning,
+		},
+		RunStep: &model.RunStep{
+			ID:     stepID,
+			RunID:  runID,
+			Action: "ci_poll",
+			Status: model.StepStatusRunning,
+		},
+		ProjectID: projectID,
+		StoryID:   storyID,
+		Metadata:  metadata,
+	}
+}
+
+// --- Tests ---
+
+func TestCIPollAction_Name(t *testing.T) {
+	a := action.NewCIPollAction(nil, nil, fastCIPollConfig(), testLogger())
+	if a.Name() != "ci_poll" {
+		t.Fatalf("expected Name() = %q, got %q", "ci_poll", a.Name())
+	}
+}
+
+func TestCIPollAction_Execute_MissingPRURL(t *testing.T) {
+	gitProvider := &ciMockGitProvider{}
+	eventPub := &ciMockEventPublisher{}
+
+	a := action.NewCIPollAction(gitProvider, eventPub, fastCIPollConfig(), testLogger())
+	runCtx := buildCIRunCtx(map[string]any{})
+
+	err := a.Execute(context.Background(), runCtx)
+	if err == nil {
+		t.Fatal("expected error when pr_url is missing")
+	}
+	if !strings.Contains(err.Error(), "CI_POLL_MISSING_PR_URL") {
+		t.Fatalf("expected error to contain %q, got %q", "CI_POLL_MISSING_PR_URL", err.Error())
+	}
+
+	// GetCIStatus should never be called
+	if gitProvider.getCalls() != 0 {
+		t.Fatalf("expected 0 GetCIStatus calls, got %d", gitProvider.getCalls())
+	}
+}
+
+func TestCIPollAction_Execute_HappyPath_PassOnFirstTick(t *testing.T) {
+	gitProvider := &ciMockGitProvider{
+		getCIStatusFn: func(_ context.Context, _ string) (string, error) {
+			return "pass", nil
+		},
+	}
+	eventPub := &ciMockEventPublisher{}
+
+	a := action.NewCIPollAction(gitProvider, eventPub, fastCIPollConfig(), testLogger())
+	runCtx := buildCIRunCtx(map[string]any{
+		"pr_url": "https://github.com/owner/repo/pull/1",
+	})
+
+	err := a.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	// One GetCIStatus call for the "pass"
+	if gitProvider.getCalls() != 1 {
+		t.Fatalf("expected 1 GetCIStatus call, got %d", gitProvider.getCalls())
+	}
+
+	// One event published (for the "pass" status)
+	events := eventPub.getPublished()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event published, got %d", len(events))
+	}
+	if events[0].EntityType != "ci_poll" {
+		t.Fatalf("expected entity_type %q, got %q", "ci_poll", events[0].EntityType)
+	}
+	if events[0].Action != "checking" {
+		t.Fatalf("expected action %q, got %q", "checking", events[0].Action)
+	}
+}
+
+func TestCIPollAction_Execute_PendingThenPass(t *testing.T) {
+	callCount := 0
+	gitProvider := &ciMockGitProvider{
+		getCIStatusFn: func(_ context.Context, _ string) (string, error) {
+			callCount++
+			if callCount < 3 {
+				return "pending", nil
+			}
+			return "pass", nil
+		},
+	}
+	eventPub := &ciMockEventPublisher{}
+
+	a := action.NewCIPollAction(gitProvider, eventPub, fastCIPollConfig(), testLogger())
+	runCtx := buildCIRunCtx(map[string]any{
+		"pr_url": "https://github.com/owner/repo/pull/2",
+	})
+
+	err := a.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	// 3 calls: pending, pending, pass
+	if gitProvider.getCalls() != 3 {
+		t.Fatalf("expected 3 GetCIStatus calls, got %d", gitProvider.getCalls())
+	}
+
+	// 3 events published (2 pending + 1 pass)
+	events := eventPub.getPublished()
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events published, got %d", len(events))
+	}
+	for _, e := range events {
+		if e.EntityType != "ci_poll" || e.Action != "checking" {
+			t.Fatalf("unexpected event: entity_type=%q action=%q", e.EntityType, e.Action)
+		}
+	}
+}
+
+func TestCIPollAction_Execute_CIFailure(t *testing.T) {
+	prURL := "https://github.com/owner/repo/pull/3"
+	gitProvider := &ciMockGitProvider{
+		getCIStatusFn: func(_ context.Context, _ string) (string, error) {
+			return "fail", nil
+		},
+	}
+	eventPub := &ciMockEventPublisher{}
+
+	a := action.NewCIPollAction(gitProvider, eventPub, fastCIPollConfig(), testLogger())
+	runCtx := buildCIRunCtx(map[string]any{"pr_url": prURL})
+
+	err := a.Execute(context.Background(), runCtx)
+	if err == nil {
+		t.Fatal("expected error when CI fails")
+	}
+	if !strings.Contains(err.Error(), "CI_POLL_FAILED") {
+		t.Fatalf("expected error to contain %q, got %q", "CI_POLL_FAILED", err.Error())
+	}
+	if !strings.Contains(err.Error(), prURL) {
+		t.Fatalf("expected error to contain PR URL %q, got %q", prURL, err.Error())
+	}
+}
+
+func TestCIPollAction_Execute_Timeout(t *testing.T) {
+	gitProvider := &ciMockGitProvider{
+		getCIStatusFn: func(_ context.Context, _ string) (string, error) {
+			return "pending", nil
+		},
+	}
+	eventPub := &ciMockEventPublisher{}
+
+	// 1ms timeout — expires almost immediately
+	cfg := action.CIPollConfig{
+		DefaultPollInterval: 1 * time.Millisecond,
+		DefaultTimeout:      1 * time.Millisecond,
+	}
+	a := action.NewCIPollAction(gitProvider, eventPub, cfg, testLogger())
+	runCtx := buildCIRunCtx(map[string]any{
+		"pr_url": "https://github.com/owner/repo/pull/4",
+	})
+
+	err := a.Execute(context.Background(), runCtx)
+	if err == nil {
+		t.Fatal("expected error on timeout")
+	}
+	if !strings.Contains(err.Error(), "CI_POLL_TIMEOUT") {
+		t.Fatalf("expected error to contain %q, got %q", "CI_POLL_TIMEOUT", err.Error())
+	}
+}
+
+func TestCIPollAction_Execute_ContextCancellation(t *testing.T) {
+	ready := make(chan struct{})
+	gitProvider := &ciMockGitProvider{
+		getCIStatusFn: func(ctx context.Context, _ string) (string, error) {
+			// Signal that we're inside the poll loop, then block.
+			select {
+			case ready <- struct{}{}:
+			default:
+			}
+			// Block until context is cancelled.
+			<-ctx.Done()
+			return "", ctx.Err()
+		},
+	}
+	eventPub := &ciMockEventPublisher{}
+
+	cfg := action.CIPollConfig{
+		DefaultPollInterval: 1 * time.Millisecond,
+		DefaultTimeout:      30 * time.Second,
+	}
+	a := action.NewCIPollAction(gitProvider, eventPub, cfg, testLogger())
+	runCtx := buildCIRunCtx(map[string]any{
+		"pr_url": "https://github.com/owner/repo/pull/5",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- a.Execute(ctx, runCtx)
+	}()
+
+	// Wait for the first poll attempt then cancel.
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first poll")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected error on context cancellation")
+		}
+		if !strings.Contains(err.Error(), "context canceled") {
+			t.Fatalf("expected context.Canceled error, got %q", err.Error())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Execute to return after cancel")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `CIPollAction` in `backend/internal/adapter/action/ci_poll.go` that polls CI status for a merged PR via `GitProvider.GetCIStatus`
- Registers `ci_poll` action in `backend/cmd/api/main.go` with default config (30s poll interval, 15min timeout)
- Unit tests cover happy path, pending→pass, CI failure, timeout, missing PR URL, and context cancellation

## Test plan

- [x] `TestCIPollAction_Name`
- [x] `TestCIPollAction_Execute_MissingPRURL`
- [x] `TestCIPollAction_Execute_HappyPath_PassOnFirstTick`
- [x] `TestCIPollAction_Execute_PendingThenPass`
- [x] `TestCIPollAction_Execute_CIFailure`
- [x] `TestCIPollAction_Execute_Timeout`
- [x] `TestCIPollAction_Execute_ContextCancellation`
- [x] All existing action adapter tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)