### PR TITLE
chore(ci): add pre-push hook and validation gate for agent pipeline

### DIFF
--- a/agent/claude-md/backend.md
+++ b/agent/claude-md/backend.md
@@ -381,6 +381,17 @@ go test ./... -v
 golangci-lint run ./...
 ```
 
+### Integration Tests (Docker Available)
+
+The Docker socket is mounted in this container. Testcontainers work.
+Run the full test suite including integration tests before creating the PR:
+
+```bash
+cd backend && go test ./... -race -count=1
+```
+
+This catches type mismatches between sqlc-generated code and actual Postgres behavior (e.g., COALESCE return types, NULL handling).
+
 ## go-wire Dependency Injection
 
 ### Provider Sets

--- a/agent/claude-md/base.md
+++ b/agent/claude-md/base.md
@@ -80,6 +80,21 @@ chore(deploy): update docker-compose health checks
 - Backend: `golangci-lint run ./...`
 - Frontend: `npm run lint`
 
+### Pre-push Validation (ENFORCED)
+
+A git pre-push hook automatically runs lint + unit tests before every push.
+If they fail, the push is BLOCKED. Run these commands proactively to avoid wasting time:
+
+**Backend** (if you modified files in `backend/`):
+```bash
+cd backend && golangci-lint run ./... && go test ./... -short
+```
+
+**Frontend** (if you modified files in `frontend/`):
+```bash
+cd frontend && npm run lint && npm run type-check
+```
+
 ## Testing Principles
 
 - Every new feature has tests

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -58,6 +58,110 @@ else
     cd /workspace
 fi
 
+# Install pre-push git hook to enforce lint + unit tests before every push
+install_pre_push_hook() {
+    local hooks_dir="/workspace/.git/hooks"
+    mkdir -p "$hooks_dir"
+
+    cat > "$hooks_dir/pre-push" <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pre-push hook: detect changed directories and run lint + unit tests.
+# Receives stdin lines: <local ref> <local sha> <remote ref> <remote sha>
+
+ERRORS=0
+
+# Determine the commit range being pushed
+read -r LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA || true
+
+if [[ -z "${LOCAL_SHA:-}" ]]; then
+    echo "[pre-push] No commits to push, skipping validation."
+    exit 0
+fi
+
+# If remote sha is all zeros this is a first push — compare against empty tree
+EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+if [[ "${REMOTE_SHA:-}" == "0000000000000000000000000000000000000000" ]] || [[ -z "${REMOTE_SHA:-}" ]]; then
+    RANGE="${EMPTY_TREE}..${LOCAL_SHA}"
+else
+    RANGE="${REMOTE_SHA}..${LOCAL_SHA}"
+fi
+
+echo "[pre-push] Validating range: $RANGE"
+
+# Detect which top-level directories have changed
+CHANGED_DIRS=$(git diff --name-only "$RANGE" 2>/dev/null | cut -d/ -f1 | sort -u || true)
+
+BACKEND_CHANGED=false
+FRONTEND_CHANGED=false
+
+if echo "$CHANGED_DIRS" | grep -q "^backend$"; then
+    BACKEND_CHANGED=true
+fi
+if echo "$CHANGED_DIRS" | grep -q "^frontend$"; then
+    FRONTEND_CHANGED=true
+fi
+
+if [[ "$BACKEND_CHANGED" == "false" && "$FRONTEND_CHANGED" == "false" ]]; then
+    echo "[pre-push] No backend or frontend changes detected — skipping checks."
+    exit 0
+fi
+
+# Backend checks
+if [[ "$BACKEND_CHANGED" == "true" ]] && [[ -d "/workspace/backend" ]]; then
+    echo "[pre-push] Backend changed — running lint..."
+    if (cd /workspace/backend && golangci-lint run ./... 2>&1); then
+        echo "[pre-push] Backend lint: PASSED"
+    else
+        echo "[pre-push] Backend lint: FAILED"
+        ERRORS=$((ERRORS + 1))
+    fi
+
+    echo "[pre-push] Backend changed — running unit tests..."
+    if (cd /workspace/backend && go test ./... -short 2>&1); then
+        echo "[pre-push] Backend unit tests: PASSED"
+    else
+        echo "[pre-push] Backend unit tests: FAILED"
+        ERRORS=$((ERRORS + 1))
+    fi
+fi
+
+# Frontend checks
+if [[ "$FRONTEND_CHANGED" == "true" ]] && [[ -d "/workspace/frontend" ]]; then
+    echo "[pre-push] Frontend changed — running lint..."
+    if (cd /workspace/frontend && npm run lint 2>&1); then
+        echo "[pre-push] Frontend lint: PASSED"
+    else
+        echo "[pre-push] Frontend lint: FAILED"
+        ERRORS=$((ERRORS + 1))
+    fi
+
+    echo "[pre-push] Frontend changed — running type-check..."
+    if (cd /workspace/frontend && npm run type-check 2>&1); then
+        echo "[pre-push] Frontend type-check: PASSED"
+    else
+        echo "[pre-push] Frontend type-check: FAILED"
+        ERRORS=$((ERRORS + 1))
+    fi
+fi
+
+if [[ "$ERRORS" -gt 0 ]]; then
+    echo ""
+    echo "[pre-push] PUSH BLOCKED: $ERRORS check(s) failed. Fix the issues above before pushing."
+    exit 1
+fi
+
+echo "[pre-push] All checks passed."
+exit 0
+HOOK
+
+    chmod +x "$hooks_dir/pre-push"
+    echo "=== Pre-push hook installed ==="
+}
+
+install_pre_push_hook
+
 # Pipeline or single-phase mode
 if [[ "${PIPELINE:-false}" == "true" ]]; then
     echo "=== Pipeline mode ==="

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -54,9 +54,90 @@ fi
 
 log ""
 
+# Validation gate: lint + tests after dev-story, before code-review
+log "=== Validation gate (post-dev-story) ==="
+VALIDATION_ERRORS=""
+
+if [[ -d "/workspace/backend" ]]; then
+    log "Running backend lint..."
+    BACKEND_LINT_OUT=$(cd /workspace/backend && golangci-lint run ./... 2>&1) && BACKEND_LINT_EXIT=0 || BACKEND_LINT_EXIT=$?
+    if [[ "$BACKEND_LINT_EXIT" -ne 0 ]]; then
+        log "⚠️  Backend lint FAILED"
+        VALIDATION_ERRORS="${VALIDATION_ERRORS}
+### Backend lint failures
+\`\`\`
+${BACKEND_LINT_OUT}
+\`\`\`"
+    else
+        log "✅ Backend lint passed"
+    fi
+
+    log "Running backend tests (including integration, with race detector)..."
+    BACKEND_TEST_OUT=$(cd /workspace/backend && go test ./... -race -count=1 2>&1) && BACKEND_TEST_EXIT=0 || BACKEND_TEST_EXIT=$?
+    if [[ "$BACKEND_TEST_EXIT" -ne 0 ]]; then
+        log "⚠️  Backend tests FAILED"
+        VALIDATION_ERRORS="${VALIDATION_ERRORS}
+### Backend test failures
+\`\`\`
+${BACKEND_TEST_OUT}
+\`\`\`"
+    else
+        log "✅ Backend tests passed"
+    fi
+fi
+
+if [[ -d "/workspace/frontend" ]]; then
+    log "Running frontend lint..."
+    FRONTEND_LINT_OUT=$(cd /workspace/frontend && npm run lint 2>&1) && FRONTEND_LINT_EXIT=0 || FRONTEND_LINT_EXIT=$?
+    if [[ "$FRONTEND_LINT_EXIT" -ne 0 ]]; then
+        log "⚠️  Frontend lint FAILED"
+        VALIDATION_ERRORS="${VALIDATION_ERRORS}
+### Frontend lint failures
+\`\`\`
+${FRONTEND_LINT_OUT}
+\`\`\`"
+    else
+        log "✅ Frontend lint passed"
+    fi
+
+    log "Running frontend type-check..."
+    FRONTEND_TC_OUT=$(cd /workspace/frontend && npm run type-check 2>&1) && FRONTEND_TC_EXIT=0 || FRONTEND_TC_EXIT=$?
+    if [[ "$FRONTEND_TC_EXIT" -ne 0 ]]; then
+        log "⚠️  Frontend type-check FAILED"
+        VALIDATION_ERRORS="${VALIDATION_ERRORS}
+### Frontend type-check failures
+\`\`\`
+${FRONTEND_TC_OUT}
+\`\`\`"
+    else
+        log "✅ Frontend type-check passed"
+    fi
+fi
+
+if [[ -n "$VALIDATION_ERRORS" ]]; then
+    log "⚠️  Validation gate detected issues — passing to code-review agent as priority context"
+else
+    log "✅ Validation gate passed — no issues found"
+fi
+
+log ""
+
 # Phase 2: Code Review
 log "=== Phase 2/3: code-review ($MODEL_REVIEW) ==="
-REVIEW_PROMPT="${STORY_CONTEXT}
+
+VALIDATION_PREAMBLE=""
+if [[ -n "$VALIDATION_ERRORS" ]]; then
+    VALIDATION_PREAMBLE="## PRIORITY: Validation gate failures detected
+
+The following checks failed after dev-story completed. Address these FIRST before reviewing other aspects of the code:
+${VALIDATION_ERRORS}
+
+---
+
+"
+fi
+
+REVIEW_PROMPT="${VALIDATION_PREAMBLE}${STORY_CONTEXT}
 Execute /bmad-bmm-code-review for story ${STORY_KEY}.
 The story file is at _bmad-output/implementation-artifacts/${STORY_KEY}.md
 Review ALL code changes on branch feat/${STORY_KEY} vs ${BASE_BRANCH}. Fix any issues found. Push fixes and ensure CI is green."


### PR DESCRIPTION
## Summary
- Pre-push git hook injecté dans les containers agents (lint + unit tests, bloque le push si fail)
- Validation gate dans pipeline.sh entre dev-story et code-review (lint + integ tests, soft fail → contexte au review agent)
- CLAUDE.md hardened : checklist pre-push + instructions tests d'intégration avec Docker socket

## Motivation
Les agents dev pushaient du code sans lint (gofmt), et les tests d'intégration (::BIGINT cast) n'étaient pas exécutés malgré le Docker socket disponible.

## Test plan
- [ ] `bash -n scripts/entrypoint.sh` — syntax OK
- [ ] `bash -n scripts/pipeline.sh` — syntax OK
- [ ] Build image : `docker build -t bmad-dev-agent -f scripts/Dockerfile.dev-agent scripts/`
- [ ] Vérifier hook installé dans container : `cat /workspace/.git/hooks/pre-push`
- [ ] Tester push avec lint error → bloqué

🤖 Generated with [Claude Code](https://claude.com/claude-code)