### PR TITLE
feat(ui): add run progress timeline with real-time SSE updates

### DIFF
--- a/frontend/src/composables/useSSE.ts
+++ b/frontend/src/composables/useSSE.ts
@@ -31,6 +31,7 @@ export function useSSE(
   const knownEvents = [
     'run.started',
     'run.completed',
+    'run.step.updated',
     'step.completed',
     'step.failed',
     'log.emitted',

--- a/frontend/src/features/runs/RunProgressTimeline.vue
+++ b/frontend/src/features/runs/RunProgressTimeline.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import Timeline from 'primevue/timeline'
+import Tag from 'primevue/tag'
+import Skeleton from 'primevue/skeleton'
+import Message from 'primevue/message'
+import Button from 'primevue/button'
+import ProgressSpinner from 'primevue/progressspinner'
+import { formatStepDuration } from '@/utils/formatStepDuration'
+import { useStepTimer } from './composables/useStepTimer'
+import type { RunStep } from './composables/useRunDetail'
+
+defineProps<{
+  steps: RunStep[]
+  projectId: string
+  runId: string
+  isLoading: boolean
+  error: Error | null
+}>()
+
+const stepSeverity: Record<string, 'success' | 'info' | 'danger' | 'secondary' | 'warn'> = {
+  completed: 'success',
+  running: 'info',
+  failed: 'danger',
+  pending: 'secondary',
+  waiting_approval: 'warn',
+  cancelled: 'secondary',
+}
+
+const markerIcon: Record<string, string> = {
+  completed: 'pi-check-circle',
+  running: '',
+  failed: 'pi-times-circle',
+  pending: 'pi-circle',
+  waiting_approval: 'pi-hourglass',
+  cancelled: 'pi-ban',
+}
+
+/** Creates a reactive timer for a running step. Called per running step instance. */
+function getStepTimer(step: RunStep) {
+  if (step.status === 'running' && step.started_at) {
+    return useStepTimer(step.started_at)
+  }
+  return null
+}
+</script>
+
+<template>
+  <div data-testid="run-progress-timeline">
+    <!-- Loading state -->
+    <Skeleton v-if="isLoading" height="120px" data-testid="timeline-skeleton" />
+
+    <!-- Error state -->
+    <Message v-else-if="error" severity="error" :closable="false" data-testid="timeline-error">
+      {{ error.message }}
+    </Message>
+
+    <!-- Empty state -->
+    <Message
+      v-else-if="steps.length === 0"
+      severity="info"
+      :closable="false"
+      data-testid="timeline-empty"
+    >
+      No pipeline steps found for this run
+    </Message>
+
+    <!-- Timeline -->
+    <Timeline
+      v-else
+      :value="steps"
+      layout="vertical"
+      align="left"
+      data-testid="timeline"
+    >
+      <template #marker="{ item }">
+        <ProgressSpinner
+          v-if="(item as RunStep).status === 'running'"
+          style="width: 1.5rem; height: 1.5rem"
+          data-testid="step-spinner"
+        />
+        <span
+          v-else
+          class="pi"
+          :class="markerIcon[(item as RunStep).status] ?? 'pi-circle'"
+        />
+      </template>
+      <template #content="{ item }">
+        <div class="flex flex-col gap-1 mb-4" :data-testid="`step-${(item as RunStep).id}`">
+          <div class="flex items-center gap-2 flex-wrap">
+            <span class="font-medium">{{ (item as RunStep).step_name }}</span>
+            <Tag
+              :value="(item as RunStep).status"
+              :severity="stepSeverity[(item as RunStep).status] ?? 'secondary'"
+              class="text-xs"
+              data-testid="step-status-tag"
+            />
+
+            <!-- Waiting approval badge and link -->
+            <template v-if="(item as RunStep).status === 'waiting_approval'">
+              <Tag
+                value="Awaiting Approval"
+                severity="warn"
+                class="text-xs"
+                data-testid="hitl-tag"
+              />
+              <router-link
+                :to="`/projects/${projectId}/runs/${runId}/approve/${(item as RunStep).id}`"
+              >
+                <Button
+                  label="Review"
+                  severity="warn"
+                  size="small"
+                  data-testid="hitl-button"
+                />
+              </router-link>
+            </template>
+          </div>
+
+          <!-- Duration or live timer -->
+          <div class="text-sm text-surface-500">
+            <template
+              v-if="(item as RunStep).status === 'completed' && (item as RunStep).started_at && (item as RunStep).completed_at"
+            >
+              <span data-testid="step-duration">
+                {{ formatStepDuration((item as RunStep).started_at!, (item as RunStep).completed_at!) }}
+              </span>
+            </template>
+            <template v-else-if="(item as RunStep).status === 'running' && (item as RunStep).started_at">
+              <span data-testid="step-elapsed">
+                {{ getStepTimer(item as RunStep)?.elapsed.value }}
+              </span>
+            </template>
+          </div>
+
+          <!-- Error message -->
+          <div
+            v-if="(item as RunStep).error_message"
+            class="text-sm text-red-500 mt-1"
+            data-testid="step-error"
+          >
+            {{ (item as RunStep).error_message }}
+          </div>
+        </div>
+      </template>
+    </Timeline>
+  </div>
+</template>

--- a/frontend/src/features/runs/__tests__/RunProgressTimeline.spec.ts
+++ b/frontend/src/features/runs/__tests__/RunProgressTimeline.spec.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import RunProgressTimeline from '../RunProgressTimeline.vue'
+import type { RunStep } from '../composables/useRunDetail'
+
+vi.mock('../composables/useStepTimer', () => ({
+  useStepTimer: vi.fn(() => ({
+    elapsed: { value: '5s elapsed' },
+  })),
+}))
+
+vi.mock('@/utils/formatStepDuration', () => ({
+  formatStepDuration: vi.fn(() => '2m 34s'),
+}))
+
+function makeStep(overrides: Partial<RunStep> & Pick<RunStep, 'id'>): RunStep {
+  return {
+    run_id: 'run-1',
+    step_name: 'dev-story',
+    step_order: 1,
+    action: 'agent_run',
+    status: 'pending',
+    created_at: '2026-02-17T10:00:00Z',
+    ...overrides,
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+const defaultProps = {
+  steps: [] as RunStep[],
+  projectId: 'proj-1',
+  runId: 'run-1',
+  isLoading: false,
+  error: null as Error | null,
+}
+
+function mountComponent(propsOverride: Partial<typeof defaultProps> = {}) {
+  wrapper = mount(RunProgressTimeline, {
+    props: { ...defaultProps, ...propsOverride },
+    global: {
+      plugins: [PrimeVue],
+      stubs: {
+        'router-link': {
+          template: '<a :href="to"><slot /></a>',
+          props: ['to'],
+        },
+      },
+    },
+  })
+  return wrapper
+}
+
+describe('RunProgressTimeline', () => {
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('renders skeleton when isLoading is true', () => {
+    mountComponent({ isLoading: true })
+    expect(wrapper.find('[data-testid="timeline-skeleton"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="timeline"]').exists()).toBe(false)
+  })
+
+  it('renders error message when error is set', () => {
+    mountComponent({ error: new Error('Something went wrong') })
+    const msg = wrapper.find('[data-testid="timeline-error"]')
+    expect(msg.exists()).toBe(true)
+    expect(msg.text()).toContain('Something went wrong')
+  })
+
+  it('renders empty state message when steps is empty', () => {
+    mountComponent({ steps: [] })
+    const msg = wrapper.find('[data-testid="timeline-empty"]')
+    expect(msg.exists()).toBe(true)
+    expect(msg.text()).toContain('No pipeline steps found for this run')
+  })
+
+  it('renders Timeline with correct number of steps', () => {
+    mountComponent({
+      steps: [
+        makeStep({ id: 'step-1', step_order: 1, step_name: 'dev-story' }),
+        makeStep({ id: 'step-2', step_order: 2, step_name: 'code-review' }),
+        makeStep({ id: 'step-3', step_order: 3, step_name: 'merge-story' }),
+      ],
+    })
+    expect(wrapper.find('[data-testid="timeline"]').exists()).toBe(true)
+    expect(wrapper.findAll('[data-testid="step-status-tag"]')).toHaveLength(3)
+  })
+
+  it('renders formatted duration for completed step', () => {
+    mountComponent({
+      steps: [
+        makeStep({
+          id: 'step-1',
+          status: 'completed',
+          started_at: '2026-02-17T10:00:00Z',
+          completed_at: '2026-02-17T10:02:34Z',
+        }),
+      ],
+    })
+    const duration = wrapper.find('[data-testid="step-duration"]')
+    expect(duration.exists()).toBe(true)
+    expect(duration.text()).toBe('2m 34s')
+  })
+
+  it('renders live elapsed timer for running step', () => {
+    mountComponent({
+      steps: [
+        makeStep({
+          id: 'step-1',
+          status: 'running',
+          started_at: '2026-02-17T10:00:00Z',
+        }),
+      ],
+    })
+    const elapsed = wrapper.find('[data-testid="step-elapsed"]')
+    expect(elapsed.exists()).toBe(true)
+    expect(elapsed.text()).toBe('5s elapsed')
+  })
+
+  it('renders ProgressSpinner for running step marker', () => {
+    mountComponent({
+      steps: [
+        makeStep({
+          id: 'step-1',
+          status: 'running',
+          started_at: '2026-02-17T10:00:00Z',
+        }),
+      ],
+    })
+    expect(wrapper.find('[data-testid="step-spinner"]').exists()).toBe(true)
+  })
+
+  it('renders Awaiting Approval tag and review button for waiting_approval step', () => {
+    mountComponent({
+      steps: [
+        makeStep({
+          id: 'step-1',
+          status: 'waiting_approval' as RunStep['status'],
+        }),
+      ],
+    })
+    const hitlTag = wrapper.find('[data-testid="hitl-tag"]')
+    expect(hitlTag.exists()).toBe(true)
+
+    const hitlButton = wrapper.find('[data-testid="hitl-button"]')
+    expect(hitlButton.exists()).toBe(true)
+
+    const link = wrapper.find('a')
+    expect(link.attributes('href')).toContain('/approve/step-1')
+  })
+
+  it('does not render timeline when loading', () => {
+    mountComponent({ isLoading: true, steps: [makeStep({ id: 'step-1' })] })
+    expect(wrapper.find('[data-testid="timeline"]').exists()).toBe(false)
+  })
+
+  it('displays step error message when present', () => {
+    mountComponent({
+      steps: [
+        makeStep({
+          id: 'step-1',
+          status: 'failed',
+          error_message: 'Container exited with code 1',
+        }),
+      ],
+    })
+    const errorEl = wrapper.find('[data-testid="step-error"]')
+    expect(errorEl.exists()).toBe(true)
+    expect(errorEl.text()).toContain('Container exited with code 1')
+  })
+})

--- a/frontend/src/features/runs/__tests__/useRunProgress.spec.ts
+++ b/frontend/src/features/runs/__tests__/useRunProgress.spec.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+
+const mockGet = vi.fn()
+let capturedOnEvent: (eventName: string, data: unknown) => void
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+  },
+}))
+
+vi.mock('@/composables/useSSE', () => ({
+  useSSE: vi.fn((_projectId: string, onEvent: (eventName: string, data: unknown) => void) => {
+    capturedOnEvent = onEvent
+    return { status: { value: 'open' }, close: vi.fn() }
+  }),
+}))
+
+/** Wraps composable that calls onMounted in a simulated lifecycle */
+function withSetup<T>(composable: () => T): T {
+  let result!: T
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { createApp, defineComponent } = require('vue')
+  const app = createApp(
+    defineComponent({
+      setup() {
+        result = composable()
+        return () => null
+      },
+    }),
+  )
+  app.mount(document.createElement('div'))
+  return result
+}
+
+const step1 = {
+  id: 'step-1',
+  run_id: 'run-1',
+  step_name: 'dev-story',
+  step_order: 2,
+  action: 'agent_run',
+  status: 'running',
+  created_at: '2026-02-17T10:00:00Z',
+}
+
+const step2 = {
+  id: 'step-2',
+  run_id: 'run-1',
+  step_name: 'code-review',
+  step_order: 1,
+  action: 'agent_run',
+  status: 'pending',
+  created_at: '2026-02-17T10:00:00Z',
+}
+
+describe('useRunProgress', () => {
+  let useRunProgress: typeof import('../composables/useRunProgress').useRunProgress
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockGet.mockReset()
+    const mod = await import('../composables/useRunProgress')
+    useRunProgress = mod.useRunProgress
+  })
+
+  it('fetches steps sorted by step_order ascending', async () => {
+    mockGet.mockResolvedValue({
+      data: { steps: [step1, step2] },
+      error: undefined,
+    })
+
+    const { steps, isLoading } = withSetup(() => useRunProgress('proj-1', 'run-1'))
+    await flushPromises()
+
+    expect(steps.value).toHaveLength(2)
+    expect(steps.value[0]!.id).toBe('step-2')
+    expect(steps.value[1]!.id).toBe('step-1')
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('sets error when API call fails', async () => {
+    mockGet.mockResolvedValue({
+      data: undefined,
+      error: { error: { code: 'NOT_FOUND', message: 'Not found' } },
+    })
+
+    const { error, isLoading } = withSetup(() => useRunProgress('proj-1', 'run-1'))
+    await flushPromises()
+
+    expect(error.value).toBeInstanceOf(Error)
+    expect(error.value?.message).toBe('Failed to load run steps')
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('patches step on run.step.updated event with matching run_id', async () => {
+    mockGet.mockResolvedValue({
+      data: { steps: [step2, step1] },
+      error: undefined,
+    })
+
+    const { steps } = withSetup(() => useRunProgress('proj-1', 'run-1'))
+    await flushPromises()
+
+    capturedOnEvent('run.step.updated', {
+      run_id: 'run-1',
+      step: {
+        id: 'step-1',
+        status: 'completed',
+        completed_at: '2026-02-17T10:05:00Z',
+      },
+    })
+
+    expect(steps.value[1]!.status).toBe('completed')
+    expect(steps.value[1]!.completed_at).toBe('2026-02-17T10:05:00Z')
+  })
+
+  it('ignores run.step.updated event with non-matching run_id', async () => {
+    mockGet.mockResolvedValue({
+      data: { steps: [step1] },
+      error: undefined,
+    })
+
+    const { steps } = withSetup(() => useRunProgress('proj-1', 'run-1'))
+    await flushPromises()
+
+    capturedOnEvent('run.step.updated', {
+      run_id: 'run-OTHER',
+      step: { id: 'step-1', status: 'completed' },
+    })
+
+    expect(steps.value[0]!.status).toBe('running')
+  })
+
+  it('ignores run.step.updated event with unknown step id', async () => {
+    mockGet.mockResolvedValue({
+      data: { steps: [step1] },
+      error: undefined,
+    })
+
+    const { steps } = withSetup(() => useRunProgress('proj-1', 'run-1'))
+    await flushPromises()
+
+    capturedOnEvent('run.step.updated', {
+      run_id: 'run-1',
+      step: { id: 'step-unknown', status: 'completed' },
+    })
+
+    expect(steps.value).toHaveLength(1)
+    expect(steps.value[0]!.status).toBe('running')
+  })
+
+  it('ignores non-run.step.updated events', async () => {
+    mockGet.mockResolvedValue({
+      data: { steps: [step1] },
+      error: undefined,
+    })
+
+    const { steps } = withSetup(() => useRunProgress('proj-1', 'run-1'))
+    await flushPromises()
+
+    capturedOnEvent('run.started', { run_id: 'run-1' })
+
+    expect(steps.value[0]!.status).toBe('running')
+  })
+})

--- a/frontend/src/features/runs/__tests__/useStepTimer.spec.ts
+++ b/frontend/src/features/runs/__tests__/useStepTimer.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+/** Wraps composable that uses lifecycle hooks in a simulated Vue component */
+function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
+  let result!: T
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { createApp, defineComponent } = require('vue')
+  const app = createApp(
+    defineComponent({
+      setup() {
+        result = composable()
+        return () => null
+      },
+    }),
+  )
+  const el = document.createElement('div')
+  app.mount(el)
+  return { result, unmount: () => app.unmount() }
+}
+
+describe('useStepTimer', () => {
+  let useStepTimer: typeof import('../composables/useStepTimer').useStepTimer
+
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    const mod = await import('../composables/useStepTimer')
+    useStepTimer = mod.useStepTimer
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns empty string when startedAt is undefined', () => {
+    const { result } = withSetup(() => useStepTimer(undefined))
+    expect(result.elapsed.value).toBe('')
+  })
+
+  it('formats elapsed time under 60 seconds as Xs elapsed', () => {
+    const startTime = new Date('2026-01-01T10:00:00Z').getTime()
+    vi.setSystemTime(startTime + 42000)
+
+    const { result } = withSetup(() => useStepTimer('2026-01-01T10:00:00Z'))
+    expect(result.elapsed.value).toBe('42s elapsed')
+  })
+
+  it('formats elapsed time over 60 seconds as Xm Ys elapsed', () => {
+    const startTime = new Date('2026-01-01T10:00:00Z').getTime()
+    vi.setSystemTime(startTime + 90000)
+
+    const { result } = withSetup(() => useStepTimer('2026-01-01T10:00:00Z'))
+    expect(result.elapsed.value).toBe('1m 30s elapsed')
+  })
+
+  it('formats elapsed time over 3600 seconds correctly', () => {
+    const startTime = new Date('2026-01-01T10:00:00Z').getTime()
+    vi.setSystemTime(startTime + 3600000)
+
+    const { result } = withSetup(() => useStepTimer('2026-01-01T10:00:00Z'))
+    expect(result.elapsed.value).toBe('60m 0s elapsed')
+  })
+
+  it('clears interval on unmount', () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+    const startTime = new Date('2026-01-01T10:00:00Z').getTime()
+    vi.setSystemTime(startTime)
+
+    const { unmount } = withSetup(() => useStepTimer('2026-01-01T10:00:00Z'))
+    unmount()
+
+    expect(clearIntervalSpy).toHaveBeenCalled()
+    clearIntervalSpy.mockRestore()
+  })
+})

--- a/frontend/src/features/runs/composables/useRunDetail.ts
+++ b/frontend/src/features/runs/composables/useRunDetail.ts
@@ -24,7 +24,7 @@ export interface RunStep {
   step_name: string
   step_order: number
   action: string
-  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'waiting_approval'
   started_at?: string
   completed_at?: string
   error_message?: string

--- a/frontend/src/features/runs/composables/useRunProgress.ts
+++ b/frontend/src/features/runs/composables/useRunProgress.ts
@@ -1,0 +1,50 @@
+import { ref, onMounted } from 'vue'
+import { apiClient } from '@/api/client'
+import { useSSE } from '@/composables/useSSE'
+import type { RunStep } from '@/features/runs/composables/useRunDetail'
+
+interface RunStepUpdatedPayload {
+  run_id: string
+  step: RunStep
+}
+
+/**
+ * Composable that fetches run steps and patches them in real time via SSE.
+ * Exposes sorted steps, loading state, and error for the RunProgressTimeline.
+ */
+export function useRunProgress(projectId: string, runId: string) {
+  const steps = ref<RunStep[]>([])
+  const isLoading = ref(false)
+  const error = ref<Error | null>(null)
+
+  async function fetchRun() {
+    isLoading.value = true
+    error.value = null
+    try {
+      const { data, error: apiError } = await apiClient.GET(
+        '/runs/{runId}' as never,
+        { params: { path: { runId } } } as never,
+      )
+      if (apiError) throw new Error('Failed to load run steps')
+      const run = data as unknown as { steps: RunStep[] }
+      steps.value = [...(run.steps ?? [])].sort((a, b) => a.step_order - b.step_order)
+    } catch (e) {
+      error.value = e instanceof Error ? e : new Error(String(e))
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  useSSE(projectId, (eventName, data) => {
+    if (eventName !== 'run.step.updated') return
+    const payload = data as RunStepUpdatedPayload
+    if (payload.run_id !== runId) return
+    const idx = steps.value.findIndex((s) => s.id === payload.step.id)
+    if (idx === -1) return
+    steps.value[idx] = { ...steps.value[idx], ...payload.step }
+  })
+
+  onMounted(fetchRun)
+
+  return { steps, isLoading, error }
+}

--- a/frontend/src/features/runs/composables/useStepTimer.ts
+++ b/frontend/src/features/runs/composables/useStepTimer.ts
@@ -1,0 +1,31 @@
+import { ref, computed, onBeforeUnmount } from 'vue'
+
+/**
+ * Composable that provides a live elapsed timer for a running step.
+ * Updates every second and formats as 'Xs elapsed' or 'Xm Ys elapsed'.
+ * Clears the interval on component unmount.
+ */
+export function useStepTimer(startedAt: string | undefined) {
+  const now = ref(Date.now())
+
+  if (!startedAt) {
+    return { elapsed: computed(() => '') }
+  }
+
+  const intervalId = setInterval(() => {
+    now.value = Date.now()
+  }, 1000)
+
+  onBeforeUnmount(() => clearInterval(intervalId))
+
+  const elapsed = computed(() => {
+    const startMs = new Date(startedAt).getTime()
+    const totalSeconds = Math.floor((now.value - startMs) / 1000)
+    if (totalSeconds < 60) return `${totalSeconds}s elapsed`
+    const m = Math.floor(totalSeconds / 60)
+    const s = totalSeconds % 60
+    return `${m}m ${s}s elapsed`
+  })
+
+  return { elapsed }
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -90,6 +90,11 @@ const router = createRouter({
           component: () => import('@/views/HITLApprovalView.vue'),
         },
         {
+          path: 'runs/:runId/logs',
+          name: 'run-logs',
+          component: () => import('@/views/RunLogView.vue'),
+        },
+        {
           path: 'settings/notifications',
           name: 'project-notifications',
           component: () => import('@/views/NotificationSettingsView.vue'),

--- a/frontend/src/utils/__tests__/formatStepDuration.spec.ts
+++ b/frontend/src/utils/__tests__/formatStepDuration.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { formatStepDuration } from '../formatStepDuration'
+
+describe('formatStepDuration', () => {
+  it('formats duration under 60 seconds as Xs', () => {
+    expect(formatStepDuration('2026-01-01T10:00:00Z', '2026-01-01T10:00:42Z')).toBe('42s')
+  })
+
+  it('formats duration over 60 seconds as Xm Ys', () => {
+    expect(formatStepDuration('2026-01-01T10:00:00Z', '2026-01-01T10:02:34Z')).toBe('2m 34s')
+  })
+
+  it('formats exactly 60 seconds as 1m 0s', () => {
+    expect(formatStepDuration('2026-01-01T10:00:00Z', '2026-01-01T10:01:00Z')).toBe('1m 0s')
+  })
+
+  it('formats zero duration as 0s', () => {
+    expect(formatStepDuration('2026-01-01T10:00:00Z', '2026-01-01T10:00:00Z')).toBe('0s')
+  })
+})

--- a/frontend/src/utils/formatStepDuration.ts
+++ b/frontend/src/utils/formatStepDuration.ts
@@ -1,0 +1,10 @@
+import { differenceInSeconds } from 'date-fns'
+
+/** Formats the duration between two ISO timestamps as 'Xs' or 'Xm Ys'. */
+export function formatStepDuration(startedAt: string, completedAt: string): string {
+  const total = differenceInSeconds(new Date(completedAt), new Date(startedAt))
+  if (total < 60) return `${total}s`
+  const m = Math.floor(total / 60)
+  const s = total % 60
+  return `${m}m ${s}s`
+}

--- a/frontend/src/views/RunLogView.vue
+++ b/frontend/src/views/RunLogView.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { useRoute } from 'vue-router'
+import { useRunProgress } from '@/features/runs/composables/useRunProgress'
+import RunProgressTimeline from '@/features/runs/RunProgressTimeline.vue'
+import RunLogViewer from '@/features/runs/RunLogViewer.vue'
+
+const route = useRoute()
+const projectId = route.params.id as string
+const runId = route.params.runId as string
+
+const { steps, isLoading, error } = useRunProgress(projectId, runId)
+</script>
+
+<template>
+  <div class="flex flex-col gap-6 p-4">
+    <RunProgressTimeline
+      :steps="steps"
+      :project-id="projectId"
+      :run-id="runId"
+      :is-loading="isLoading"
+      :error="error"
+    />
+    <RunLogViewer :project-id="projectId" :run-id="runId" />
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- Add `RunProgressTimeline` component displaying pipeline steps in a PrimeVue Timeline with status-colored tags, formatted durations for completed steps, and live elapsed timers for running steps
- Add `useRunProgress` composable that fetches run steps via API and patches them in real-time via SSE `run.step.updated` events
- Add `useStepTimer` composable providing a live elapsed timer (1s interval) for running steps, with proper cleanup on unmount
- Add `formatStepDuration` utility formatting step durations as `Xs` or `Xm Ys` using `date-fns`
- Create `RunLogView.vue` at `/projects/:id/runs/:runId/logs` integrating the timeline above the existing `RunLogViewer`
- Add `run.step.updated` to SSE known events list
- Add `waiting_approval` to the `RunStep` status type union

## Test plan
- [x] `formatStepDuration.spec.ts` — 4 tests: edge cases (0s, <60s, >60s, exact 60s)
- [x] `useStepTimer.spec.ts` — 5 tests: undefined input, time formatting, interval cleanup on unmount
- [x] `useRunProgress.spec.ts` — 6 tests: fetch+sort, API error, SSE step patching, run_id/step_id filtering
- [x] `RunProgressTimeline.spec.ts` — 10 tests: loading skeleton, error message, empty state, step rendering, duration/timer display, HITL approval tag+button, spinner marker
- [x] All 60 existing + new tests passing
- [x] ESLint passes with no errors
- [x] No new TypeScript errors introduced (pre-existing schema errors unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)