### PR TITLE
feat(api): add HITL approval and rejection API endpoints

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1074,24 +1074,55 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
-  /hitl-requests/{hitlRequestId}/approve:
+  /projects/{projectId}/runs/{runId}/hitl/approve:
     post:
-      operationId: approveHITLRequest
-      summary: Approve a HITL request
+      operationId: approveHITLGate
+      summary: Approve a pending HITL gate, resuming pipeline execution
       tags: [hitl]
       parameters:
-        - $ref: "#/components/parameters/HITLRequestIdPath"
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/RunIdPath"
       responses:
-        "200":
-          description: HITL request approved
+        "202":
+          description: HITL gate approved, pipeline resuming
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HITLRequest"
-        "400":
-          $ref: "#/components/responses/BadRequest"
+                $ref: "#/components/schemas/HITLActionResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /projects/{projectId}/runs/{runId}/hitl/reject:
+    post:
+      operationId: rejectHITLGate
+      summary: Reject a pending HITL gate, failing the pipeline run
+      tags: [hitl]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/RunIdPath"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RejectHITLRequest"
+      responses:
+        "202":
+          description: HITL gate rejected, run marked as failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HITLActionResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
@@ -1190,35 +1221,6 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
-
-  /hitl-requests/{hitlRequestId}/reject:
-    post:
-      operationId: rejectHITLRequest
-      summary: Reject a HITL request
-      tags: [hitl]
-      parameters:
-        - $ref: "#/components/parameters/HITLRequestIdPath"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/RejectHITLRequest"
-      responses:
-        "200":
-          description: HITL request rejected
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/HITLRequest"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "409":
-          $ref: "#/components/responses/Conflict"
 
 # ── Components ──────────────────────────────────────────────────────────
 components:
@@ -2362,14 +2364,27 @@ components:
 
     RejectHITLRequest:
       type: object
-      required:
-        - reason
       properties:
         reason:
           type: string
-          minLength: 10
-          description: Reason for rejecting the HITL request
+          description: Optional reason for rejecting the HITL request
 
+    HITLActionResponse:
+      type: object
+      required: [run_id, hitl_request_id, status]
+      properties:
+        run_id:
+          type: string
+          format: uuid
+          description: ID of the pipeline run
+        hitl_request_id:
+          type: string
+          format: uuid
+          description: ID of the resolved HITL request
+        status:
+          type: string
+          description: Current run status after the action
+          example: running
 
     # ── Costs ──────────────────────────────────────────────────────────
     CostSummary:

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -145,6 +145,7 @@ func run() error {
 	// River job queue for async pipeline execution
 	workers := river.NewWorkers()
 	river.AddWorker(workers, riveradapter.NewExecuteRunWorker(pipelineExecutor))
+	river.AddWorker(workers, riveradapter.NewResumeRunWorker(pipelineExecutor))
 
 	jobQueue, err := riveradapter.NewJobQueue(pool, workers)
 	if err != nil {
@@ -256,7 +257,11 @@ func run() error {
 	// SSE handler for real-time event streaming
 	sseHandler := handler.NewSSEHandler(eventBus, eventRepo, projectUserRepo, logger)
 
-	server := handler.NewServer(authHandler, projectHandler, userHandler, epicHandler, storyHandler, promptTemplateHandler, runHandler, pipelineConfigHandler, notificationHandler)
+	// HITL service and handler
+	hitlService := service.NewHITLService(hitlRepo, runRepo, eventRepo, jobQueue, logger)
+	hitlHandler := handler.NewHITLHandler(hitlService, projectUserService)
+
+	server := handler.NewServer(authHandler, projectHandler, userHandler, epicHandler, storyHandler, promptTemplateHandler, runHandler, pipelineConfigHandler, notificationHandler, hitlHandler)
 
 	// Project user handler
 	projectUserHandler := handler.NewProjectUserHandler(projectUserService)

--- a/backend/internal/adapter/action/hitl_gate_test.go
+++ b/backend/internal/adapter/action/hitl_gate_test.go
@@ -36,6 +36,10 @@ func (m *hitlMockHITLRepo) GetByRunStepID(_ context.Context, _ uuid.UUID) (*mode
 	return nil, apperrors.NewNotFound("hitl_request", uuid.Nil)
 }
 
+func (m *hitlMockHITLRepo) GetPendingByRunID(_ context.Context, _ uuid.UUID) (*model.HITLRequest, error) {
+	return nil, apperrors.NewNotFound("hitl_request", uuid.Nil)
+}
+
 func (m *hitlMockHITLRepo) UpdateStatus(_ context.Context, _ uuid.UUID, _ model.HITLStatus, _ *uuid.UUID, _ *string, _ time.Time) (*model.HITLRequest, error) {
 	return nil, nil
 }

--- a/backend/internal/adapter/postgres/hitl_repo.go
+++ b/backend/internal/adapter/postgres/hitl_repo.go
@@ -61,6 +61,18 @@ func (r *HITLRepo) GetByRunStepID(ctx context.Context, runStepID uuid.UUID) (*mo
 	return toDomainHITLRequest(row), nil
 }
 
+// GetPendingByRunID returns the pending HITL request for a given run.
+func (r *HITLRepo) GetPendingByRunID(ctx context.Context, runID uuid.UUID) (*model.HITLRequest, error) {
+	row, err := r.queries.GetPendingHITLRequestByRunID(ctx, runID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperrors.NewNotFound("hitl_request", runID)
+		}
+		return nil, apperrors.NewInternal("failed to get pending HITL request by run", err)
+	}
+	return toDomainHITLRequest(row), nil
+}
+
 // UpdateStatus transitions a HITL request to approved or rejected.
 func (r *HITLRepo) UpdateStatus(ctx context.Context, id uuid.UUID, status model.HITLStatus, resolvedBy *uuid.UUID, rejectionReason *string, resolvedAt time.Time) (*model.HITLRequest, error) {
 	params := UpdateHITLRequestStatusParams{

--- a/backend/internal/adapter/postgres/hitl_requests.sql.go
+++ b/backend/internal/adapter/postgres/hitl_requests.sql.go
@@ -73,6 +73,32 @@ func (q *Queries) GetHITLRequestByRunStepID(ctx context.Context, runStepID uuid.
 	return i, err
 }
 
+const getPendingHITLRequestByRunID = `-- name: GetPendingHITLRequestByRunID :one
+SELECT hr.id, hr.run_step_id, hr.gate_type, hr.diff_content, hr.status, hr.resolved_at, hr.resolved_by, hr.rejection_reason, hr.created_at
+FROM hitl_requests hr
+JOIN run_steps rs ON rs.id = hr.run_step_id
+WHERE rs.run_id = $1
+  AND hr.status = 'pending'
+LIMIT 1
+`
+
+func (q *Queries) GetPendingHITLRequestByRunID(ctx context.Context, runID uuid.UUID) (HitlRequest, error) {
+	row := q.db.QueryRow(ctx, getPendingHITLRequestByRunID, runID)
+	var i HitlRequest
+	err := row.Scan(
+		&i.ID,
+		&i.RunStepID,
+		&i.GateType,
+		&i.DiffContent,
+		&i.Status,
+		&i.ResolvedAt,
+		&i.ResolvedBy,
+		&i.RejectionReason,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const updateHITLRequestStatus = `-- name: UpdateHITLRequestStatus :one
 UPDATE hitl_requests
 SET status = $2, resolved_at = $3, resolved_by = $4, rejection_reason = $5

--- a/backend/internal/adapter/river/job_queue.go
+++ b/backend/internal/adapter/river/job_queue.go
@@ -46,3 +46,12 @@ func (q *JobQueue) EnqueueExecuteRun(ctx context.Context, runID uuid.UUID) error
 	}
 	return nil
 }
+
+// EnqueueResumeRun enqueues a job to resume a suspended pipeline run from a specific step.
+func (q *JobQueue) EnqueueResumeRun(ctx context.Context, runID, stepID uuid.UUID) error {
+	_, err := q.client.Insert(ctx, ResumeRunArgs{RunID: runID, StepID: stepID}, nil)
+	if err != nil {
+		return fmt.Errorf("enqueue resume_run job: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/adapter/river/resume_run_job.go
+++ b/backend/internal/adapter/river/resume_run_job.go
@@ -1,0 +1,35 @@
+package river
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+)
+
+// ResumeRunArgs is the River job payload for resuming a suspended pipeline run.
+type ResumeRunArgs struct {
+	RunID  uuid.UUID `json:"run_id"`
+	StepID uuid.UUID `json:"step_id"`
+}
+
+// Kind returns the unique job kind identifier used by River.
+func (ResumeRunArgs) Kind() string { return "resume_run" }
+
+// ResumeRunWorker processes resume_run jobs by calling PipelineExecutor.
+type ResumeRunWorker struct {
+	river.WorkerDefaults[ResumeRunArgs]
+	executor *service.PipelineExecutor
+}
+
+// NewResumeRunWorker creates a new ResumeRunWorker.
+func NewResumeRunWorker(executor *service.PipelineExecutor) *ResumeRunWorker {
+	return &ResumeRunWorker{executor: executor}
+}
+
+// Work resumes the pipeline run from the specified step.
+func (w *ResumeRunWorker) Work(ctx context.Context, job *river.Job[ResumeRunArgs]) error {
+	return w.executor.ResumeRun(ctx, job.Args.RunID, job.Args.StepID)
+}

--- a/backend/internal/api/handler/gen_server.go
+++ b/backend/internal/api/handler/gen_server.go
@@ -367,6 +367,18 @@ type Error struct {
 	} `json:"error"`
 }
 
+// HITLActionResponse defines model for HITLActionResponse.
+type HITLActionResponse struct {
+	// HitlRequestId ID of the resolved HITL request
+	HitlRequestId openapi_types.UUID `json:"hitl_request_id"`
+
+	// RunId ID of the pipeline run
+	RunId openapi_types.UUID `json:"run_id"`
+
+	// Status Current run status after the action
+	Status string `json:"status"`
+}
+
 // HITLRequest defines model for HITLRequest.
 type HITLRequest struct {
 	CreatedAt time.Time `json:"created_at"`
@@ -527,8 +539,8 @@ type RegisterRequest struct {
 
 // RejectHITLRequest defines model for RejectHITLRequest.
 type RejectHITLRequest struct {
-	// Reason Reason for rejecting the HITL request
-	Reason string `json:"reason"`
+	// Reason Optional reason for rejecting the HITL request
+	Reason *string `json:"reason,omitempty"`
 }
 
 // RetryPolicy defines model for RetryPolicy.
@@ -925,9 +937,6 @@ type LoginUserJSONRequestBody = LoginRequest
 // RegisterUserJSONRequestBody defines body for RegisterUser for application/json ContentType.
 type RegisterUserJSONRequestBody = RegisterRequest
 
-// RejectHITLRequestJSONRequestBody defines body for RejectHITLRequest for application/json ContentType.
-type RejectHITLRequestJSONRequestBody = RejectHITLRequest
-
 // CreateProjectJSONRequestBody defines body for CreateProject for application/json ContentType.
 type CreateProjectJSONRequestBody = CreateProjectRequest
 
@@ -951,6 +960,9 @@ type UpdatePipelineConfigJSONRequestBody = UpdatePipelineConfigRequest
 
 // CreateRunJSONRequestBody defines body for CreateRun for application/json ContentType.
 type CreateRunJSONRequestBody = CreateRunRequest
+
+// RejectHITLGateJSONRequestBody defines body for RejectHITLGate for application/json ContentType.
+type RejectHITLGateJSONRequestBody = RejectHITLRequest
 
 // CreateStoryJSONRequestBody defines body for CreateStory for application/json ContentType.
 type CreateStoryJSONRequestBody = CreateStoryRequest
@@ -1052,12 +1064,6 @@ type ServerInterface interface {
 	// Get a HITL request by ID
 	// (GET /hitl-requests/{hitlRequestId})
 	GetHITLRequest(w http.ResponseWriter, r *http.Request, hitlRequestId HITLRequestIdPath)
-	// Approve a HITL request
-	// (POST /hitl-requests/{hitlRequestId}/approve)
-	ApproveHITLRequest(w http.ResponseWriter, r *http.Request, hitlRequestId HITLRequestIdPath)
-	// Reject a HITL request
-	// (POST /hitl-requests/{hitlRequestId}/reject)
-	RejectHITLRequest(w http.ResponseWriter, r *http.Request, hitlRequestId HITLRequestIdPath)
 	// List all projects
 	// (GET /projects)
 	ListProjects(w http.ResponseWriter, r *http.Request, params ListProjectsParams)
@@ -1133,6 +1139,12 @@ type ServerInterface interface {
 	// Create a new pipeline run for a project
 	// (POST /projects/{projectId}/runs)
 	CreateRun(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath)
+	// Approve a pending HITL gate, resuming pipeline execution
+	// (POST /projects/{projectId}/runs/{runId}/hitl/approve)
+	ApproveHITLGate(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, runId RunIdPath)
+	// Reject a pending HITL gate, failing the pipeline run
+	// (POST /projects/{projectId}/runs/{runId}/hitl/reject)
+	RejectHITLGate(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, runId RunIdPath)
 	// List stories for a project with optional status filtering
 	// (GET /projects/{projectId}/stories)
 	ListStories(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, params ListStoriesParams)
@@ -1226,18 +1238,6 @@ func (_ Unimplemented) GetHITLRequestByStep(w http.ResponseWriter, r *http.Reque
 // Get a HITL request by ID
 // (GET /hitl-requests/{hitlRequestId})
 func (_ Unimplemented) GetHITLRequest(w http.ResponseWriter, r *http.Request, hitlRequestId HITLRequestIdPath) {
-	w.WriteHeader(http.StatusNotImplemented)
-}
-
-// Approve a HITL request
-// (POST /hitl-requests/{hitlRequestId}/approve)
-func (_ Unimplemented) ApproveHITLRequest(w http.ResponseWriter, r *http.Request, hitlRequestId HITLRequestIdPath) {
-	w.WriteHeader(http.StatusNotImplemented)
-}
-
-// Reject a HITL request
-// (POST /hitl-requests/{hitlRequestId}/reject)
-func (_ Unimplemented) RejectHITLRequest(w http.ResponseWriter, r *http.Request, hitlRequestId HITLRequestIdPath) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1388,6 +1388,18 @@ func (_ Unimplemented) ListRunsByProject(w http.ResponseWriter, r *http.Request,
 // Create a new pipeline run for a project
 // (POST /projects/{projectId}/runs)
 func (_ Unimplemented) CreateRun(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Approve a pending HITL gate, resuming pipeline execution
+// (POST /projects/{projectId}/runs/{runId}/hitl/approve)
+func (_ Unimplemented) ApproveHITLGate(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, runId RunIdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Reject a pending HITL gate, failing the pipeline run
+// (POST /projects/{projectId}/runs/{runId}/hitl/reject)
+func (_ Unimplemented) RejectHITLGate(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, runId RunIdPath) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1629,68 +1641,6 @@ func (siw *ServerInterfaceWrapper) GetHITLRequest(w http.ResponseWriter, r *http
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetHITLRequest(w, r, hitlRequestId)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// ApproveHITLRequest operation middleware
-func (siw *ServerInterfaceWrapper) ApproveHITLRequest(w http.ResponseWriter, r *http.Request) {
-
-	var err error
-
-	// ------------- Path parameter "hitlRequestId" -------------
-	var hitlRequestId HITLRequestIdPath
-
-	err = runtime.BindStyledParameterWithOptions("simple", "hitlRequestId", chi.URLParam(r, "hitlRequestId"), &hitlRequestId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "hitlRequestId", Err: err})
-		return
-	}
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.ApproveHITLRequest(w, r, hitlRequestId)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// RejectHITLRequest operation middleware
-func (siw *ServerInterfaceWrapper) RejectHITLRequest(w http.ResponseWriter, r *http.Request) {
-
-	var err error
-
-	// ------------- Path parameter "hitlRequestId" -------------
-	var hitlRequestId HITLRequestIdPath
-
-	err = runtime.BindStyledParameterWithOptions("simple", "hitlRequestId", chi.URLParam(r, "hitlRequestId"), &hitlRequestId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "hitlRequestId", Err: err})
-		return
-	}
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.RejectHITLRequest(w, r, hitlRequestId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2649,6 +2599,86 @@ func (siw *ServerInterfaceWrapper) CreateRun(w http.ResponseWriter, r *http.Requ
 	handler.ServeHTTP(w, r)
 }
 
+// ApproveHITLGate operation middleware
+func (siw *ServerInterfaceWrapper) ApproveHITLGate(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "runId" -------------
+	var runId RunIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "runId", chi.URLParam(r, "runId"), &runId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "runId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ApproveHITLGate(w, r, projectId, runId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// RejectHITLGate operation middleware
+func (siw *ServerInterfaceWrapper) RejectHITLGate(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "runId" -------------
+	var runId RunIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "runId", chi.URLParam(r, "runId"), &runId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "runId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.RejectHITLGate(w, r, projectId, runId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListStories operation middleware
 func (siw *ServerInterfaceWrapper) ListStories(w http.ResponseWriter, r *http.Request) {
 
@@ -3493,12 +3523,6 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/hitl-requests/{hitlRequestId}", wrapper.GetHITLRequest)
 	})
 	r.Group(func(r chi.Router) {
-		r.Post(options.BaseURL+"/hitl-requests/{hitlRequestId}/approve", wrapper.ApproveHITLRequest)
-	})
-	r.Group(func(r chi.Router) {
-		r.Post(options.BaseURL+"/hitl-requests/{hitlRequestId}/reject", wrapper.RejectHITLRequest)
-	})
-	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/projects", wrapper.ListProjects)
 	})
 	r.Group(func(r chi.Router) {
@@ -3574,6 +3598,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Post(options.BaseURL+"/projects/{projectId}/runs", wrapper.CreateRun)
 	})
 	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/projects/{projectId}/runs/{runId}/hitl/approve", wrapper.ApproveHITLGate)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/projects/{projectId}/runs/{runId}/hitl/reject", wrapper.RejectHITLGate)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/projects/{projectId}/stories", wrapper.ListStories)
 	})
 	r.Group(func(r chi.Router) {
@@ -3634,114 +3664,116 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+w97W4bOZKvQvQdcAkgWbJjJzO+P+s4M7Pey2QMO8FgdzYQqG5K4rpF9pBsOzrDwL3D",
-	"veE9yYEf3U12s7/06UwGCBBL4kexqlisKlYVH4OQLhNKEBE8OH8MEsjgEgnE1KcfEhxeRddQLOSnCPGQ",
-	"4URgSoJz9Rv49OnqXTAIsPwikc0GAYFLFJwHSHUNBgFDv6eYoSg4FyxFg4CHC7SEcrwZZUsogvMgTbFs",
-	"KVaJ7MkFw2QePD0Ngr9efXx/g35PERd1YMgmgOk2DeAssIjzkTaEqg6UG8RpykLUAAbedO4PVOAZDqGc",
-	"sg4Ouw0IKZnheQNIxBlxQ/Cu4RxdSxaqQiV/AiRdThHLAPk9RWxVQJLAOQrs+SI0g2ksgvPjQbDEBC/T",
-	"pfrbzIuJQHPE9MSINcx9JdCSgwQxYObwTo/YpB6Ek/EgWMIvBobxuB0iRv+Fwlq+NT83ECbJBtiQJjdp",
-	"LafcpKQBAJZuzhC3lIm3qxqy/IhRHAFBAadMgOmqhjDy14n61UOXIGQIChRNoPADIFDStHwuUNKAA666",
-	"b4oEQdmqDgj1YyMEqvOGIHxEyySGAjWw4zIRQJhmDfCIfKSNQHqSnXlCCUfqqHkLIyOf5aeQEoGI+hMm",
-	"SWzE0+hfXAL7aE3z7wzNgvPg30bFMTbSv/LRD4xRpqdyF/sWRtmRETwNgktKZjEO9zBxfkKEZkrwAh3N",
-	"j0CU6qkQQEuI45cSqh8pm+IoQmT3YOVTgSGA0RITAMMQcQ5y8uqT50eakmiPWCJUgJma82kQfCIwFQvK",
-	"8H+jPcDgzCZ/Nj3kgJeUi3dQwGuK9fwJowliAmtOjqBA8n/0BS6TWDL9yfjk9XB8MjweB4NiY6h2lY0x",
-	"CAQVMJ6ElItJyiNnpPHR8cmrU3sMmk5jaxRzvurdlW3N3/Kp3JE/593oVJ40ei9wcZsul5CtqiuD93Pd",
-	"Wx6VSi6tD+EgmKbRHIlJjJe4utLjcacxEsQwjSaIRDUYf/NxPD5X//5Rxv1Q4KWXAGZQLiATdYRcY1gL",
-	"+0tKxKKy5ldHp2ev33RadwOPHB+dvDo96zvKA0J3HmKevX7zXX92K0FXwqhDtUEdU3mZUx310vCwjorS",
-	"5rN3sU06Za7MKANyXyMiMv14hqBIGeKBUu/eIzKXx+PJWGp4FRLqI9Ae9hNHDFw4Q5ZGOjtTqmL2+dgz",
-	"LBdQpNxVa6YwvIvpPBgEiEgl8zfrG0wmCaNzhrgEO6IEWeiyDn2bJgr0eqTaNsOlMhlqURwuICEonuiR",
-	"HnP4IsxDyiRJH9B0QemdnK7AVPFzZf3aRlESJoqwBAHG186clS75uI9BymJp4AmR8PPRyExzFNLlCCZ4",
-	"ZGDho6OjI8Xz5fUjAqexPlJy7GtlJp9DfzQ9p5TGCBLV9V4eJpMZjgViDl/8JpVnCUMSI4GUppSSoxnE",
-	"cqbPgwBLg8S7MPMFZAyuKkR0UJ/jrQxIPZWN0dF/91wArv4Exihxefy46275eQWufQO0b5J+3Ky12Uzn",
-	"rV1uFcB3mgPAlfy8REQAPVT/PZ2pyRNLTynm+TtNAWQI4GweTOZACT/w+KiF4B1aPT1Jpm2fqrQR80GV",
-	"gi6UKcXQPUYPcizElIkbplzQpbtF7Y4d8O9ZpOlXT5mblNSSI8EJijFRoxl54DaQxpj6I98+Jf0kzDi3",
-	"lhc7LcuM41tF4/bU8Pm6aZLiqJux5o5peg4q+KnHsrIpa/EslftEQBKiSciwQAxDL84ilCAS8YlGaVeR",
-	"NVCuv25rHQR3aOXujNvh+NjdbWc+2aJXjO+RFyIeUndLyLNTqxszplhV/skXkKHIc3TaJ3KT9aDQfKub",
-	"SjxAJhXaGY4R74cxgUVckkSFBIrpHJPMcVWWQs3MI7Gbje7jFqkUeQ74wqPi0X6Ph8dnH4/H56/6ab+b",
-	"KGaVwXBJ3X/zZoy+Ox2Ph+jk++nw9Dg6HcI3x6+Hp6evX5+dnZ6Ox2PH9Krjxq76XdVk0KfapAzY69fb",
-	"Aazgx67aYAFD0dIzrBQuIU2N97+V2S9106dBkCbRtpmkxLxa5hWIHWTi2SCjBP7A9QRa8NVx/ruLn36I",
-	"5shzzij3g8dVp90S+py+QyvwQotIRMLVy2BQlWLVja9ERHXkj+p738iiMvBJ+5mh4c+na0DABxp5ELCh",
-	"8K40jOFKK8juqv+BGB1OIUcRQF9QmKp9r9oCTCL0xV75uOpkd7ZFF3bvLmY7cKYtWy2e1EttwPiN8XpW",
-	"sY6ieengaHRdWRzsOVIIjfoPprihTcvRIw8MuHUrfY+53zcGewHlW1oC55jA7CRpGuG6aOlxicHAGatu",
-	"JTcpuVAakzYSSzSTug5LSUXyf//9riS/XFyUxvJ3R85b39eIeoy4lpYOqGfe6ysbV/YiS+K3GNKLPuVe",
-	"rSLN/3VoZJF1+t7+cDP58MvHyY+/fPrwzq9WCIhjXu87cGz3ArIl4hzOfYf9AxYLcPUOwGl4fPLK8kG3",
-	"SQUFfjFyFR9lrCos+NBmXXu3aWcdlS88m9mGaNnXjWcYRUC2AqYVmDG6BGKBAJzLjyyVeg9J4xhOKy6R",
-	"YqK5NAZzezRHLEwSRu9hXK/Lte4DV8Nqbc6Qsg8omTAEzZVAK/QMcRrfN+O2wyDS0t7OIKxmue39c4nU",
-	"jqmUTKTh2rV9VSBJRUVLHU1n7e9SBNDmVcEIRVPPuH1gMB6SbuqHbt5iMqo2W9UQbMwW67Ohd6e1t48l",
-	"Zq0N7xMWV8uEMnGrZXG91Kjb/DfwASwhu4voA8k3v5KBf7/4+T1Q5vISCoGY0U6nMQ3veAdpqCfsADJX",
-	"PlfvIdFdgynGXJlLvariYPyv1YAZdY0B6AyYIw2IBRRANweCAqwGD3wqqP6peVSCHuIVMHTM5vCOZqyW",
-	"psFMkxzUF9JcgDFDMFoB9AVzgaKXQeuZnsNdTJojaJAhv5l4qx+az3F3BT/DcIEJGkpApewCag5gTs06",
-	"28IXK6HsoyVcgSkCaJmIFcAz9WVI0zhSJ7b85YtgMHSRUQxvnf+leLJ0CUkZSLtJN59LNv5AY8OHyPdS",
-	"nNRuWBUI4EqilCP2F/PxKKRLW33UzX3nJuT8gbKSdspRmDJ0/RfOj+1R8sZti8ymyzv4Fli9U/rDXybt",
-	"xHVm3VA9gyup3Xnfdu1EO4TLqtuNXUHjfl6s6g7bgtnt2bZtLgE1vg/Aa8dUL133lO2vY9+JmEdl2i1P",
-	"vN4gFXbgtDs9aT0HdadBFnyaT+ddjbmAqRNmu/cCl++/Gp0fBtpbgRLfNm7eDidb2A7OTtDAt7K0A3XN",
-	"Dd+k+cazdNMp5Pna+8JzEMBU0ImxaBwMzWDMvcK3TPfvvtsO3Zc0QrG93jCGaYSGNEn58HT4Wq5Of8Mp",
-	"IUgMT4dnxXcLiO/S4enwlbv26hgdrkMaEabumicJjXG4amPOG9n2Wjf1SlHnKjYTnxoRJdKUJvYylQk6",
-	"qKofmIUpFpMpQ/AOsQnMDURXK/x1gcQCMeUQMX2A6QMwB7rbACQw5ZjMAYxjkN3WApYSbnuya9lnv/du",
-	"npCO1nu2bQmylsiQ6m3vA8l9IUWfs7OvSi8wHJ2vpd9Rb7CzhfM9w/NhPetuiM6eLqF3JaB7BRLtXe/d",
-	"ZijSQYKPDnrbXBfj1Hv7Wuy+nV1s75/DbuYbNMdcILZzb0Z1o/0NEgTeUdQ/Qm9dz4g17He9/SSD+tDF",
-	"G+Uxb7z7Ke4yyhkT8nsVRWMuPshc6Sp2dmQpkHDcBruZzA9qob1VgFzCLxO58zPS50abk0Bn5c95jTmt",
-	"05WlC6FEnaFkOIM4TplSEeMHuOKuMHEaNC/TBteZ1rvwlPj8ncan0utObp17POWNnFi+y7Vv09xQwgkn",
-	"MOELKnrfo+aRR9WMMsRCRAScI0BnIMeRSrjj4MX4//7nf4/H45cD9VMqf4ECqMw/IJd/FNTmW3r5pef9",
-	"oEpF6In9ppsvlhKi/7I9bLk/PYQkRHHc6zqsc8Ro+XjcyulnxZ3mN1FWmFmfs+8mJZeUixv64JFo3S8q",
-	"XZJ5k3L6a4S+CCKbgptePTYmc43Xy+ayIjHsi8Q8KiNHU6eMr5uUbEEdkYLxwDpISpp8Rl5puabkpkRA",
-	"XFikz0u0x3Q+EUbb8ug8DBFh3/eXEuXfSWEtNQfKsER3rBOkxQJz5egA6oAEdPafgKRxrFUOSgXI3Hv9",
-	"QxXUiZuHJZX9LjhcmDmhkKq4yGF5caxjB1/WgVIzda2SUdap5KRcMCjQfAVSjiI1hZrewFI3c24MkZAp",
-	"m0a5mGdpHEvW3Wb0xsHOsUHwALHUMyd5cE+vSI+ahAzzK2WRvr5qu8XO4iyKEIs8SDgfJk/o6B5UcZOS",
-	"X7FY3GYOdxjHv8yC89+6CMH2rJWWMfwO+465Jp+zegPr532sFWG2h1yRflHJlRi339MsdBtHiAg8wyba",
-	"D5PMB6rT8QdAnubdArqbg4r6KqXfatrKTjTYmgDtPpqrnfNQ2U5ZoLmTwu07ZVRKRkvErR2c1Bzznkno",
-	"lpvTEnqKqPhCwkfamC5CAPzr34J2qAXSYfXDfC2/sFtM5rH/yE8Z4SBvqk72WP4hDVOM+ABQBrjqrlup",
-	"FndoBWJK79JE+SZQh6OiwKw8MDrgLpfrtz2TxdvpXezCT2o7rJdg/8nEpbmxUmvl1JuRVGbYB32cr51R",
-	"v372fIWDNFx/Zso/jziktVLji0V8riWwG+VRS9xtBmN0ziM2EK6bxt+6R4/77tGsjNk62/SpaYHr5e9b",
-	"YElTcT3h0Xxflk2Rl8oyrfaRqt8ZgV9PAvgfNJG7PU+7hnKfeL9rNIIehurrbd2l3S6xKvfWc9MwGjuE",
-	"UnXEpIbNnXTIRgRwxPYUCLCt+8hdhaQ03nP2xr27yAPer2d4ND4aBXc/i0zyyBYMEsVqh7RHpGhCYcqw",
-	"WN3KEbObRHqH0UXqq9D4t18/AkHvEAFcmteQA0iA1OV+IfEK6GtroAfICjfmn7LSjbJ7QSmY4P9CK139",
-	"DpMZzfKEoI6UM53+ShN0JX6l7I6DjwguA085RSWTwcX1lfGQImD3ypwrS0jgXDsH5Mkpmejon+SjcefK",
-	"XsayMuX/6AwIlopFPqicQALIYCiO/ilXEuMQmVxqA+7PVx8lFzmaLk0Q0WMeUTYfmU58JNsWQttZ6cX1",
-	"VTAI7hHjeo3jo+OjsTqvEkRggoPz4NXR+OiVorNYKOqNYCoWI+X3UOxJNZtKJs2q657rrI9Pehuai/m3",
-	"NFptraKhk1Xy5LKmVNbLdTdPxuOtza13VbWYooIJ8FQVlZylUgIsEIxMkelbJIaXmlMrTJ/zt+T+nJ0L",
-	"aCpVRZ8Gwen4uA7QfOWjan1HsxuD898+DwKelUCUsANM5F5TuVWYzEEmROGcK2krt+tnOUbOADQVjRxA",
-	"U5GzgEOL0yoK3tP5HEWApsLCYKyk1ZorddYmx1VRrSljcme2LE4fS6aGhbuun5C41IP417Z7Pru01gCy",
-	"zPAt4Okn5OAoXtm1alDUhjNmoqPqWSKLn9qhXCiHaHUSDcc7J5lKuc8QhCKXxXcsJsbtTGFVJVZdvm/v",
-	"klcTbpIqGTUABAQ9NDDQAot4aPiBj6arIRcoGT3qstRPTXvRCiR7u1Juh4FT3b/GQVk0GVmls58+73A7",
-	"2yFvHhZxKvxvtqtlp9P2TnmpY78YcABSlasAM5XELSJKynmJ+Oi8RdCVhr2pV3074U8iGiJCl4TTFVDF",
-	"zvtSbmQlB/nl+oVu8AclY17tYV1punvSryWzc14x5CvxyzqcoqNymxSAcuzvtvhkF5pEGdY9mxl9eDQv",
-	"Q/JH5VFNjU4sauxwXnvivMdcXGeN+jJg8fxK3Y2m3dh+rqVDe/sZkZ3KPzvNysNbxuuDIn0rTGcgR+o2",
-	"7DE5psodLIiQ0TH/6vPToEaIODWed2RGeOtI79mWyBPYPPQxribjUtzfrnfoqJFkdHsrvbJKSntbjh6x",
-	"1gYjFCOdEufS9536vqBvv/1Zrz2c1r9OpEGJDqKp6eUC2IzBQa3yvH1EjffJwodXkjO/bVk/dkVR6sG+",
-	"c029GQG2L8K8d+h7VmE60D+ryvR8FReHZTRW23ZrRd6NTDb90GTTy4lQo6LMkbjUfd7qLruVhJelbH8F",
-	"3zY8sbLTq/ZOxTNQGxJIYa5SvEC7L3rQLH+V7mkUUmnqhAvzTE6LHL6kXFwuzAMw/TRL5yU9qS2Wiifj",
-	"JQL6TRm1HgkXUGABcxVX89wfplHNo3JvIiuWTn14NfYFGGx8SHS6rXQfnKpGD1VkyDuI45XGg8QASGTH",
-	"wx0lkRccTStFJoZIhJhJFzAcqLirnf1UdY1u3HejC3HslvlYSoqV7pT1Brs0yTbl681SybJ0wYPe0Hcw",
-	"/nJiM/pwuO3FUjKM0T2KNSxKtKtynnXCvePW4sU7cB12V/Zq3F6kO5zPGZpnzzE8X/HeJtUzpPkuM+U6",
-	"MxIcirVCC4j12QklOGz2Ov2gWmzOOt+Ejyovr99JRink64q+OvspzN/w2Iq/So/v8IZntoJbNDO0ebFU",
-	"7f8N+eHzLl1gdpLEnv1f+l2EKu1VvsTePV/r2THrO7wd55pkJhWe4xFLGaM1i6XRo36pvoPnbRs82S5G",
-	"rDf3u1moiuybO+r2aYtmrj2iCOgVDnUax3Mgwng/W/ngHkBNnor/z5Lg9c6/A9FpV+7C3uJ+TzxyEC/h",
-	"jkXFZudD5oislS0dz4NRBOdNpo95MumPJYvs96l8fqWLn7Rup96AApBEQL8Ctb+r8pOT3T/+frkKYyTF",
-	"rwodkPqF1mXz196wXLI3Nqx4EA7MGUwW4MW7i59eavV4Y47MfF01ccUwJeHCvFh1aLY82Spb2k9w1UlC",
-	"FYKXP4EFYN7+AKenJgWAYApFuFCgKQ6I4/zZDhNTLiF/AfmKhC/7MAaxkpCbLetqujLfil21IyFUU9He",
-	"l1Rg7FsbFSA0KzwI0SVAPmhqHScuFdtMYk9d/udsINfnye/ZXPa9Z1Blpw9Vwh3Gll6fAQvL2LOWrjzY",
-	"TeSMHu2Pnazn7bNv+xn1wQGyh03t44ZnEQvjIW2zQKm30J4VQXZlt20ohcbPQAp9rYEg/Vh1TbkzElmi",
-	"vPfk/Ih8GtAzFjwSYBdzHJHDEPIWkQhAIMoQrUPErN5w412i+7rOM1ZSS5D6rmGyxz8036fM3EMfMGsp",
-	"8YJUHwBkmg8zlbot2G/71NtZ6J+3wM++IwDX5KE/pMfPd4Bsh2drJVJj3JA05W5Swt+u1o1h3efV9C5F",
-	"XVYdums4zPbuleVgtZRWM7UZzFtwg+3UQr5JyYFMYlWotkrRm5R8vTYvenCe3GpjnVrBkD3P2yQbbvMn",
-	"fJ91wEo5oGi5hEOOZA971+oSWYgDQYEukwemq6wSrimbODBVJF/WRFsV1edrc+4H9Y/5CqrKZ4I0AS+Y",
-	"qcGZlYKRjepmNZXva6fcpWCslhPtJCIz929RRtS8qq0wcTi/ZQaXJ46HJrrOpGEUwyNusG62adpEsi5m",
-	"+pyFslM5b89i2ZR6rfKR3irfVmiPKdXtj+0p+K1Njo/M2+21LgLnMfpnypreN/73bLD4Hu33sKpuBphq",
-	"oAVIgthQU9OkzeiLY/P8exGM+DxZ2uHQt2l8BzRHFSKT0SVYQqZjrtWK/37x83ugClQuoRBObZcenKtf",
-	"3+vkXN+KXO0Q4qoB6uHPujUX519jdJoWQTWnXJ0X63lQYryvM+nwWaq5/uTEqDkKSb3X6mDU2pVvq7/6",
-	"sjdW+TNUrS5UrUHQdD8kKtFBJetP6VZcalP6ZR5lJJtAfZRwECGG71GkjzPlfNOT/Qcvu+H08U1+T1Eq",
-	"B+QrEgL0BYWpnOoIZK8onI6/B1g/JqX3KIwZgtEKLHTtUv1otgRjAE7HY7ct5nnziBIkW5y6LSirwIU5",
-	"IFSAmaSNrg/qi5DaS3RUi3zeqiuneKmo2aej6ZYRKqPgnxvSE7fl8STZ5noPd1JWJr616o5V8J5/s+5m",
-	"zzPJXavwqKfhcgRuywtdHrgpYX6ZiGEBQYc6PfYDzs/ZJ+J/jmH/VX+cB6+9lTNsWn1j/pISp9Z5Tjx8",
-	"2i67Ro/Zn1cdSxRtkbXb5dPHHLh+JY4cfH2lNmqJ7G0SqSGR+5mRbHxAyfEsai85EHlqMHmOm8ZaTIen",
-	"7w5rOa17Ph2Sy/40iEVDEanuUk2eX1INHz2ylLRUVF7H+LtJyT7EVBdLzggmy24/oIyStpGSSxocLHj+",
-	"ALLHOqp3WLSE4Kzno3MM8D/DbzYJv2kweVNuqvPX0vCTavFtFpPNHyvqRD6Ny4Nca+WFZ1NDrYzU+rNF",
-	"645FSs1DFjusy/dJv/HxVerspeceMiTXa+dbRud4P896bK5F75M6+kxTT8eUle2CQA0a9uY02pV6bD8p",
-	"+ExehFL88a1EMtdu+NILMe77b799llzBEbvPeMlF4cX1Fbg/BlPIEUigerJRv3qmHvO9P1ZMZWas9C2e",
-	"L9I3AZGpEJmH1qknaKoxe4pu1jtunp7ZMVZXUrq5t1VO3Vvnprm3zpv2zG2785uHMEpUm7eodRWukVIX",
-	"/dg8THYN2LAgNzDeB0o5Jr462F/TJSRDTIZigYYxpYl52QPGvgHVgwLVQTyZaw1QuYlDvlhVLoBgMLxT",
-	"ufwkAnQqtwKc4hiLlW9IXYXu6fPT/wcAAP//BhBj69PIAAA=",
+	"H4sIAAAAAAAC/+w9aW8buZJ/hehdYBNAsmTHTma8X57jzOG3mYxhOxjMmxcIdDcl8blF9pBsO1rDwP6H",
+	"/Yf7SxY8upvsZl86nUmAALEkHsWqYrEuFh+DkC4SShARPDh9DBLI4AIJxNSnHxIcXkSXUMzlpwjxkOFE",
+	"YEqCU/Ub+Pjx4l0wCLD8IpHNBgGBCxScBkh1DQYBQ3+mmKEoOBUsRYOAh3O0gHK8KWULKILTIE2xbCmW",
+	"iezJBcNkFjw9DYKfL27eX6E/U8RFHRiyCWC6TQM4cyzifKQ1oaoD5QpxmrIQNYCB1537AxV4ikMop6yD",
+	"w24DQkqmeNYAEnFGXBO8SzhDl5KFqlDJnwBJF7eIZYD8mSK2LCBJ4AwF9nwRmsI0FsHp4SBYYIIX6UL9",
+	"bebFRKAZYnpixBrmvhBowUGCGDBzeKdHbFIPwtF4ECzgZwPDeNwOEaP/QmEt35qfGwiTZAOsSZOrtJZT",
+	"rlLSAABL12eIa8rE22UNWX7EKI6AoIBTJsDtsoYw8teJ+tVDlyBkCAoUTaDwAyBQ0rR8LlDSgAOuuq+L",
+	"BEHZsg4I9WMjBKrzmiDcoEUSQ4Ea2HGRCCBMswZ4RD7SWiA9yc48oYQjddS8hZGRz/JTSIlARP0JkyQ2",
+	"4mn0Ly6BfbSm+XeGpsFp8G+j4hgb6V/56AfGKNNTuYt9C6PsyAieBsE5JdMYhzuYOD8hQjMleIEOZgcg",
+	"SvVUCKAFxPFLCdWPlN3iKEJk+2DlU4EhgNECEwDDEHEOcvLqk+dHmpJoh1giVICpmvNpEHwkMBVzyvB/",
+	"ox3A4MwmfzY95IDnlIt3UMBLivX8CaMJYgJrTo6gQPJ/9Bkuklgy/dH46PVwfDQ8HAeDYmOodpWNMQgE",
+	"FTCehJSLScojZ6TxweHRq2N7DJrextYo5nzVuyvbmn/kU7kjf8q70Vt50ui9wMV1ulhAtqyuDN7PdG95",
+	"VCq5tDqEg+A2jWZITGK8wNWVHo47jZEghmk0QSSqwfibm/H4VP37Rxn3Q4EXXgKYQbmATNQRcoVhLewv",
+	"KBHzyppfHRyfvH7Tad0NPHJ4cPTq+KTvKA8I3XmIefL6zXf92a0EXQmjDtUGdUzlZU511EvDwzoqSpvP",
+	"3sU26ZS5MqUMyH2NiMj04ymCImWIB0q9e4/ITB6PR2Op4VVIqI9Ae9iPHDFw5gxZGunkRKmK2edDz7Bc",
+	"QJFyV625heFdTGfBIEBEKpl/WN9gMkkYnTHEJdgRJchCl3Xo2zRRoNcj1bYZzpXJUIvicA4JQfFEj/SY",
+	"wxdhHlImSfqAbueU3snpCkwVP1fWr20UJWGiCEsQYHzpzFnpko/7GKQslgaeEAk/HY3MNAchXYxggkcG",
+	"Fj46ODhQPF9ePyLwNtZHSo59rczkc+iPpuctpTGCRHW9l4fJZIpjgZjDF39I5VnCkMRIIKUppeRgCrGc",
+	"6dMgwNIg8S7MfAEZg8sKER3U53grA1JPZWN09N89Z4CrP4ExSlweP+y6W35ZgkvfAO2bpB83a20203lr",
+	"l1sF8J3mAHAhPy8QEUAP1X9PZ2ryxNJTinl+pymADAGczYPJDCjhBx4ftRC8Q8unJ8m07VOVNmI+qFLQ",
+	"hTKlGLrH6EGOhZgyccOUC7pwt6jdsQP+PYs0/eopc5WSWnIkOEExJmo0Iw/cBtIYU3/k26ekn4QZ59by",
+	"YqdlmXF8q2jcnho+XzdNUhx1M9bcMU3PQQU/9VhWNmUtnqVynwhIQjQJGRaIYejFWYQSRCI+0SjtKrIG",
+	"yvXXba2D4A4t3Z1xPRwfurvtxCdb9IrxPfJCxEPqbgl5dmp1Y8oUq8o/+RwyFHmOTvtEbrIeFJqvdVOJ",
+	"B8ikQjvFMeL9MCawiEuSqJBAMZ1hkjmuylKomXkkdrPRfdwilSLPAV94VDza7+Hw8OTmcHz6qp/2u45i",
+	"VhkMl9T9N2/G6Lvj8XiIjr6/HR4fRsdD+Obw9fD4+PXrk5Pj4/F47JheddzYVb+rmgz6VJuUAXv9ejOA",
+	"FfzYVRssYChaeoaVwiWkqfH+tzL7uW76NAjSJNo0k5SYV8u8ArGDTDwbZJTAH7ieQAu+Os5/d/bTD9EM",
+	"ec4Z5X7wuOq0W0Kf03doCV5oEYlIuHwZDKpSrLrxlYiojnyjvveNLCoDH7WfGRr+fLoGBHygkQcBawrv",
+	"SsMYLrWC7K76H4jR4S3kKALoMwpTte9VW4BJhD7bKx9XnezOtujC7t3FbAfOtGWrxZN6qQ0YvzJezyrW",
+	"UTQrHRyNriuLgz1HCqFR/8EUN7RpOXrkgQG3bqXvMff7xmAvoHxLS+AME5idJE0jXBYtPS4xGDhj1a3k",
+	"KiVnSmPSRmKJZlLXYSmpSP7vv9+W5JeLi9JY/u7Ieev7GlGPEdfS0gH1xBu+snFlL7IkfoshvehT7tUq",
+	"0vxfh0YWWafv9Q9Xkw+/3kx+/PXjh3d+tUJAHPN634FjuxeQLRDncOY77B+wmIOLdwDehodHrywfdJtU",
+	"UOAXI1fxUcaqwoIPbT9f3Lw/UzZIvbCYYxFPTBDDMF8p5vkO0CkQcwQY4jS+RxGwY+VdeK/g67qhM5ME",
+	"sJT042Z3xPOUMSmEmYrIyTYATgViahJjjtm8zlJCvIxewnHOtGV05aDU4b/e/eVoxx2VXzyd2o6AcqwB",
+	"TzGKgGwFTCswZXShVz8ziJEKUBrH8LbikiommkljPPcH5OiCScLoPYzrdelWyrkabjvrIGWfUTJhCJqQ",
+	"TCv0GaM24bbDIPcYPWxmEFaz3Pb++c7ptMm4QEnX9tUDQSqKejNoOmt/oyKANm8LRiiaesbtA4PxUHVT",
+	"/3TzFpNdtdmohmZjtlifDb07rb19rGPO2vA+YXGxSCgT1/osrJcadZv/Cj6ABWR3EX0g+eZXZ9DvZ7+8",
+	"B8pdsYBCykJtHdzGNLzjHU4jPWEHkLnyeXsP6e4aZDHm0gRVq4qb8X9XE5ZUGEmeKUalAGIOBdDNgaAA",
+	"q8EDnwmgf2oelaCHeAkMHbM5vKMZq7FpMNMkB/WFNNdgzBCMlgB9xlyg6GXQqlPlcBeT5ggaZMhvJt7y",
+	"h2Y9yl3BLzCcY4KGElApu4CaAxitpc628+WqKPt0AZfgFgG0SMQS4Kn6MqRpHCmNSf7yWTAYusgohrf0",
+	"r1I+X7qApAyk3aSbzysbf6Cx4UPkeylOajesSsRwJVHKEfub+XgQ0oWt8OjmvnMTcv5AWck64ChMGbr8",
+	"G+eH9ih547ZFZtPlHXwLrMb0/vLBvK24Lq0I4TMICW7P+7ltJ+Y+XIbdIqYFjft5Eas7bANuD8+2bXPJ",
+	"qPF9AF46rpJSuK1s/x76TsQ8K9ZueeT1xqm0D6fd8VHrOag7DbLk33w672qMtVknzLbvhS/HHxudTwba",
+	"a4ES3zZu3g5HG9gOzk7QwLeytAN1TYR10hxxLkWahfY29Aw4DwKYCjoxFo2DoSmMuVf4lun+3XebofuC",
+	"Rii21xvGMI3QkCYpHx4PX8vV6W84JQSJ4fHwpPhuDvFdOjwevnLXXh2jQziqEWEq1j9JaIzDZRtzXsm2",
+	"l7qpV4o6ofBMfGpElEhTmtjLVCbpo6p+YBamWExuGYJ3iE1gbiC6WuFvcyTmxh1k+gDTB2AOdLcBSGDK",
+	"MZkBGMeOa4rbzqNa9tlt3NOTUtMa59yUIGvJzKlG2x9I7gsp+pycfFF6geHofC39jnqDnQ2c7xme9xvZ",
+	"cFOkdpQEsC0B3SuRa+d67yZTwfaS/LXXaH9djlnv7Wux+2Z2sb1/9ruZr9AMc4HY1r0Z1Y32d0gQeEdR",
+	"/wzJVT0j1rDf9faTDOpTR6+Ux7wx9lPEMlz15NdE+zmAbqDSmUwEhMyU0lIKvVWh9oBTaGgVQBbw80Tu",
+	"7oy8uWHmXFK07ih6DTatt5UlCKFEnZNkOIU4TplSA+MHuOSuwHAaNJPBBteZ1kuHlPh8msZv0ivutkqs",
+	"TnkcJ5Z/cuWImZuuOeEEJnxORe9YdZ7dVb21h1iIiIAzBOgU5DhSlxo5eDH+v//538Px+OVA/ZTKX6AA",
+	"6nYlkMs/CGrvtHr5pWcMUF336In9puhWEfS1vWi5zzyEJERx3Cvk1Tkrt3wEbuSEs3J782iTlcrX53y7",
+	"Ssk55eKKPnikVvdgpEsy78Wn/lqfL0vLpuC64cXGC3Pj1W7MWdkudrAwz3zJ0dTpVt1VSjagckjBuGc9",
+	"IyVNfiGvtFxRclMiIC6szucl2mM6mwijUXn0GoaIsGP6ddkzlGGJ7lhfQhdzzJUzA6gDEtDpfwKSxrHW",
+	"JigVIHPh9U9HUCdunvpV9q3gcG7mhEKq2yKH5cWhzs98WQdKzdS1Skb5pq+clAsGBZotQcpRpKZQ0xtY",
+	"6mbODR4SMmW3KDfyNI1jybqbzNDY2zk2CB4glirkJE/g6ZXNUXPpxfxKWaRDVG2R6iyXokijyBOx82Hy",
+	"SzPdEyeuUvIbFvPrzKkO4/jXaXD6Rxch2H4zqGUMv1O+432eT1lNh9Xv1qyURbaD+zj9Mr8reWx/pll6",
+	"PI4QEXiKTUYlJpmfU5c8GAB5mndLmm9OHOqrlH6tV4O2osHWJMH30VzteyWV7ZQl8zvX5H2njLr20pLV",
+	"bCcgNd8ryCR0S3S0hJ7i5kEh4SNtTBdhfv/6N6AdaoG0X/0wX8uv7BqTWew/8lNGOMibqpM9ln9IwxQj",
+	"PgCUAa6661aqxR1agpjSuzRRvgnU4agoMCsPjA64y+X6dc8L+e30LnbhR7UdViti8NHknrn5UCvVLTAj",
+	"qdt3H/RxvnLVgtUrFFQ4SMP1rRrB88g1Wqn8QLGIT7UEdjM5aom7yYSLzne1DYSrlkpo3aOHffdoVipu",
+	"lW361LTA1WokWGBJU3E14dEcE8umyMuRmVa7KIfQGYFfziX7v+hl+fa78DWU+8j7hcoIehiqrzcVL7te",
+	"YFVSr+emYTR2CKVqtUkNmztXThsRwBHbUbB/UzHHbaWdNMYye+PeXeQeY+gZHo2PRsHdzyKTPLIBg0Sx",
+	"2j7tESmaUJgyLJbXcsQskkjvMDpLfVUw//7bDRD0DhHApXkNOYAESF3uVxIvgQ5NAz1AVhwz/5SVx5Td",
+	"C0rBBP8XWuoKg5hMaXYXCOpsONPpZ5qgC/EbZXcc3CC4CDwlK5VMBmeXF8ZDioDdK3OuLCCBM+0ckCen",
+	"ZKKDf5Ib486VvYxlZUos0ikQLBXzfFA5gQSQwVAc/FOuJMYhMldQDbi/XNxILnI0XZogosc8oGw2Mp34",
+	"SLYthLaz0rPLi2AQ3CPG9RrHB4cHY3VeJYjABAenwauD8cErRWcxV9QbwVTMR8rvodiTajaVTJpVMD7V",
+	"Nzs+6m1oYu5vabTcWNVI5+bIk8uaUlkv1zY9Go83NrfeVdWClQomwFNVuHOaSgkwRzAyhbyvkRiea06t",
+	"MH3O35L7c3YuoKlUbn0aBMfjwzpA85WPqjU0zW4MTv/4NAh4VmZSwg4wkXtN3Z/CZAYyIQpnXElbuV0/",
+	"yTFyBqCpaOQAmoqcBRxaHFdR8J7OZigCNBUWBmMlrVZcqbM2Oa7KXDW3nFsWp48lUyfEXddPSJir0v61",
+	"bZ/Pzq01gOz2/Qbw9BNycBQv7XpAKGrDGTMZUPUskeVIbVEulNOwOomGw62TTJU1yBCEIpfFtywmxu1M",
+	"YVV+Vl2+b++SV2xukioZNQAEBD00MNAci3ho+IGPbpdDLlAyetSlv5+a9qKVLPZ2qdwOA+cFhRoHZdFk",
+	"ZJUnf/q0xe1sp7V5WMR5RWG9XS07Hbd3ystJ+8WAA5CqDmZqQygcZ0SUlPMS8dF576ErDXtTr/o+xTci",
+	"GiJCl4S3S6AKynsoZ1RXXkskaYtcZo36kqh4FaIuCGA3tl+R6NDeft1gq5S3bx94KG8MJRTpQAqdghyp",
+	"m1Bh5JjqSk1BhIyO+VefpGXnPXid0rNbOnm95W13fPzm9zo89DHWmbHCg1WPxvXoqJFkjkPr1lGVlPa2",
+	"HD1iLUAjFCN9U8Sl7zv1fUHffvuzXm4e1z+aokGJ9iLc9HIBbMbgoPa82Tyixrtk4f2fK5mro3ykuKIo",
+	"9WDfieysR4DNizBv2GnHzoUO9M+KlexMhK3HMhqrbbu1Iu9G5pLp0FwylRMh0WRcciTOdZ+3ust2JeF5",
+	"6RKsgm8TzgvZ6VV7p+J1mjUJpDBXudOrNf4eNMsfy3oahVRaAOHcvN7RIofPKRfnc/MuRT/N0nngS2qL",
+	"pZqueIGAfupCrUfCBRRYwHiva14hwzSqeevqTWSln6gPr8a+mNzah0QnB7/7Dk414F6RIe8gjpcaDxID",
+	"IJEd93eURF5wNK0UmRgiEWImw9ZwoOKudvZTl867cd+Vvp++XeaTxnO+0q2y3mCbJtm6fL3e7Yvshs1e",
+	"g1odjL+c2Iw+7G97sZQMY3SPYg2LEu2qyl2dcO+4tXjxPFWH3ZU9ZrUT6Q5nM4ZmWZX45yve26R6hjSf",
+	"/1+uMyPBvlgrtIBYnZ1QgsNmr9MPqsX6rPNV+Kjyqt+dZJRCvi50qS8MhPnTAhvxV+nxHd7wzFZwi2aG",
+	"Ni+WKkm+Jj982qYLzM4r3rH/S5drr9JepRjv3PO1mh3TO/bkd65JZlIRbY9YyhitWSyNHvUD2h08b5vg",
+	"yXYxYj0F3s1CVWRf31G3S1s0c+0RRUCvcKjTOJ4DEca72cp79wBq8lT8f5YEr3f+7YlO23IX9hb3O+KR",
+	"vXgJtywq1jsfMkdkrWzpeB6MIjhrMn3MSy5/LVlkP5vj8yud/aR1O/U0DYAkAvpxmh2JqEFwfHS0/Tep",
+	"z5dhjKT4VYX9pX6hddn8ESosl+xNpyjeqQIzBpM5ePHu7KeXWj1emyMzX1dNKh5MSTg3D+nsmy2PNsqW",
+	"9stAdZJQZa3kL/MAmLffw+mpSQEguIUinCvQFAfEcV7N3qRhSshfQL4k4cs+jEGse3vNlnX1hh/fiF21",
+	"JSFUU+jZl4dr7FsbFSA0K9wL0SVAPmhqHScuFdtMYk+56udsINdfLd2xuewr811lpw9Vwu3Hll6dAQvL",
+	"2LOWrjzYTeSMHu2PnaznzbNv+xn1wQGyh03t44ZnkQvjIW2zQKm30J4VQbZlt60phcbPQAp9qYkg/Vh1",
+	"RbkzEtndUu/JeYN8GtAzFjwSYBdzHJH9EPIakQhAIMoQrULErERnYyzRfXTiGSupJUh9YZisJr7m+5SZ",
+	"OPQeE/0TL0j1CUCm+TBTqduS/TZPva2l/nlrYuw6A3BFHvpLevx8B8hmeLZWIjXmDUlT7iol/O1y1RzW",
+	"XYamtynqsoKqXdNhNhdXloPVUlrN1GYwb8ANtlUL+SolezKJVW3HKkWvUvLl2rzowXmJpo11GgXD6JGl",
+	"SrucYxGPrKeR/Ox2phv8fHHz/ico0PaFxVVKduF69TyPXXcbbqaoYF7FHViUQDxdmLocf8VokyG95DRd",
+	"Ixbk6Bjkiy/QgT6jMC0p0Z4bei0MqV88aEqSzx5Y2A87buPCd/nJiCcjMp8J62evQA+U7FlAdociALl5",
+	"Wvevyv2aLH7mlyvPHuUovV7flfOzB4Sb1LTr/JHhZ507WM7tXCzgkCPZw1agdIEvxIGgQBf5A7fLrI6v",
+	"Kfo4MDUwX9Ykvha182srBgzqnxsWVBX/BGkCXjBTQTQrZCMb1c1q6vbXTrlNHbVaDLWTtppF4ooiqObd",
+	"b4WJ/YWQMrg8KZU0e/5GE9nwiHtvIts0bdqxLsX6nPVjp+7fjjVkU6i2ykd6q3xdWZam0Lg/zbLgtzY5",
+	"PjKvy9fqLc5z+c+UNUtP+u/Fd1SCgaex10DXzZQWGhsBkiA21NQ0Nxh1Do95oL7IC3+eLO1w6Ns0vgOa",
+	"owqRyehCKV/q+ota8e9nv7wHqrzmAgrhVKbpwbn6fcBOcc6NyNUOtw00QD1CC9cmh+lLTBTWIqjmlKsL",
+	"KDwPSox3dSbtv2BArj856cKOQlIfQNgbtbYVZuivvuyMVb5lDddlDTcImu6HRCVRs2T9Kd2KW2YzS0l2",
+	"ZwolHESI4XsU6eNM2c96sv/g5YiIPr7JnylK5YB8ScLCx3QAsjcgjsffA6yfwtJ7FMYMwWgJ5rryqn7W",
+	"W4IxAMfjsdsW87x5RAmSLY7dFpRV4MIcECrAVNJGVzf1JavuJFG1RT5v1KtevLPU7F7XdMsIlVHw24b0",
+	"pNB6nPq2ud7Ds58VuW8tgGaV6+dfbeTP85Bz14Jo6mG7HIGbCgiWB26qXbJIxLCAoEPJNPuJ6efsE/E/",
+	"JrH7AmzOk9zeIkY2rb4yf0mJU+s8Jx4+bZddo8fsz4uO1eI2yNrt8ukmB65ftTkHX1+ojVoie5tEaqip",
+	"8cxINt6j5HgWZfAciDzl8DzHTWNZvP3Td4tl9VY9n/bJZd8MYtFQz6+7VJPnl52v0JTvu4rx15j4Mt6p",
+	"JWcEk2W371FGSdtIySUNDhY8f77ZYx3VOyxasiFX89E5Bvi3TMh1MiEbTN6Um7cFamn4UbX4Out6508t",
+	"dSKfxuVewlp5DfDUUCsjtf5s0bpjvWjzDMcWS6R+1C+UfJE6e+mxigzJ9dr5htE53s2jJOtr0bukjj7T",
+	"1MM3ZWW7IFCDhr0+jbalHtsPIj6T96wUf3wtl0pqN3zpfRv39bo/Pkmu4IjdZ7zkovDs8gLcH4JbyBFI",
+	"oHpwUr/Zpp4ivj9UTGVmrPQtHl/SkYDIFOvNU+vUAzrVnD1FN+sVOk/P7Birq+7f3Nt62cJbcqy5ty5h",
+	"4Znbduc3D2GUqDZvUesqXCOlLvuxeZgsDNiwIPeOkg+U8vWk6mA/pwtIhpgMxRwNY0oTk1MPY9+AKn+2",
+	"OojnEnEDVO4dTl+uKhdAMBjeqbIqJAL0Vm4FeItjLJa+IXVB0KdPT/8fAAD//9CasUj1ygAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/backend/internal/api/handler/hitl_handler.go
+++ b/backend/internal/api/handler/hitl_handler.go
@@ -1,0 +1,93 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+	"github.com/zakari/hopeitworks/backend/internal/api/middleware"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// HITLHandler implements HITL approval/rejection HTTP handlers.
+type HITLHandler struct {
+	service     *service.HITLService
+	userService *service.ProjectUserService
+}
+
+// NewHITLHandler creates a new HITLHandler.
+func NewHITLHandler(svc *service.HITLService, userSvc *service.ProjectUserService) *HITLHandler {
+	return &HITLHandler{service: svc, userService: userSvc}
+}
+
+// checkProjectAccess verifies the current user has access to the given project.
+func (h *HITLHandler) checkProjectAccess(r *http.Request, projectID uuid.UUID) error {
+	if middleware.IsAdmin(r.Context()) {
+		return nil
+	}
+	userID, _ := middleware.UserIDFromContext(r.Context())
+	isMember, err := h.userService.IsUserInProject(r.Context(), projectID, userID)
+	if err != nil {
+		return err
+	}
+	if !isMember {
+		return errors.NewForbidden("You are not a member of this project")
+	}
+	return nil
+}
+
+// ApproveHITLGate handles POST /projects/{projectId}/runs/{runId}/hitl/approve.
+func (h *HITLHandler) ApproveHITLGate(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, runID RunIdPath) {
+	if err := h.checkProjectAccess(r, projectID); err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+
+	reviewerID, _ := middleware.UserIDFromContext(r.Context())
+	result, err := h.service.Approve(r.Context(), projectID, runID, reviewerID)
+	if err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+
+	resp := HITLActionResponse{
+		RunId:         openapi_types.UUID(result.RunID),
+		HitlRequestId: openapi_types.UUID(result.HITLRequestID),
+		Status:        result.Status,
+	}
+	writeJSON(w, http.StatusAccepted, resp)
+}
+
+// RejectHITLGate handles POST /projects/{projectId}/runs/{runId}/hitl/reject.
+func (h *HITLHandler) RejectHITLGate(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, runID RunIdPath) {
+	if err := h.checkProjectAccess(r, projectID); err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+
+	var body struct {
+		Reason string `json:"reason"`
+	}
+	if r.ContentLength > 0 {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeErrorResponse(w, errors.NewValidation("body", "invalid JSON"))
+			return
+		}
+	}
+
+	reviewerID, _ := middleware.UserIDFromContext(r.Context())
+	result, err := h.service.Reject(r.Context(), projectID, runID, reviewerID, body.Reason)
+	if err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+
+	resp := HITLActionResponse{
+		RunId:         openapi_types.UUID(result.RunID),
+		HitlRequestId: openapi_types.UUID(result.HITLRequestID),
+		Status:        result.Status,
+	}
+	writeJSON(w, http.StatusAccepted, resp)
+}

--- a/backend/internal/api/handler/run_handler_test.go
+++ b/backend/internal/api/handler/run_handler_test.go
@@ -180,6 +180,10 @@ func (m *runHandlerJobQueue) EnqueueExecuteRun(ctx context.Context, runID uuid.U
 	return nil
 }
 
+func (m *runHandlerJobQueue) EnqueueResumeRun(_ context.Context, _, _ uuid.UUID) error {
+	return nil
+}
+
 // handlerTestPipelineYAML is a minimal valid pipeline config for handler tests.
 const handlerTestPipelineYAML = `steps:
   - id: "step-1"

--- a/backend/internal/api/handler/server.go
+++ b/backend/internal/api/handler/server.go
@@ -15,11 +15,12 @@ type Server struct {
 	runs            *RunHandler
 	pipelineConfig  *PipelineConfigHandler
 	notifications   *NotificationHandler
+	hitl            *HITLHandler
 }
 
 // NewServer creates a new Server with the given handlers.
-func NewServer(auth *AuthHandler, projects *ProjectHandler, users *UserHandler, epics *EpicHandler, stories *StoryHandler, promptTemplates *PromptTemplateHandler, runs *RunHandler, pipelineConfig *PipelineConfigHandler, notifications *NotificationHandler) *Server {
-	return &Server{auth: auth, projects: projects, users: users, epics: epics, stories: stories, promptTemplates: promptTemplates, runs: runs, pipelineConfig: pipelineConfig, notifications: notifications}
+func NewServer(auth *AuthHandler, projects *ProjectHandler, users *UserHandler, epics *EpicHandler, stories *StoryHandler, promptTemplates *PromptTemplateHandler, runs *RunHandler, pipelineConfig *PipelineConfigHandler, notifications *NotificationHandler, hitl *HITLHandler) *Server {
+	return &Server{auth: auth, projects: projects, users: users, epics: epics, stories: stories, promptTemplates: promptTemplates, runs: runs, pipelineConfig: pipelineConfig, notifications: notifications, hitl: hitl}
 }
 
 // RegisterUser delegates to AuthHandler.
@@ -230,4 +231,14 @@ func (s *Server) UpdateNotificationConfig(w http.ResponseWriter, r *http.Request
 // DeleteNotificationConfig delegates to NotificationHandler.
 func (s *Server) DeleteNotificationConfig(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, notificationID NotificationIdPath) {
 	s.notifications.DeleteNotificationConfig(w, r, projectID, notificationID)
+}
+
+// ApproveHITLGate delegates to HITLHandler.
+func (s *Server) ApproveHITLGate(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, runID RunIdPath) {
+	s.hitl.ApproveHITLGate(w, r, projectID, runID)
+}
+
+// RejectHITLGate delegates to HITLHandler.
+func (s *Server) RejectHITLGate(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, runID RunIdPath) {
+	s.hitl.RejectHITLGate(w, r, projectID, runID)
 }

--- a/backend/internal/domain/port/hitl_repository.go
+++ b/backend/internal/domain/port/hitl_repository.go
@@ -14,6 +14,8 @@ type HITLRepository interface {
 	Create(ctx context.Context, req *model.HITLRequest) (*model.HITLRequest, error)
 	// GetByRunStepID returns the HITL request for the given run step.
 	GetByRunStepID(ctx context.Context, runStepID uuid.UUID) (*model.HITLRequest, error)
+	// GetPendingByRunID returns the pending HITL request for the given run by joining on run_steps.
+	GetPendingByRunID(ctx context.Context, runID uuid.UUID) (*model.HITLRequest, error)
 	// UpdateStatus transitions the HITL request to approved or rejected.
 	UpdateStatus(ctx context.Context, id uuid.UUID, status model.HITLStatus, resolvedBy *uuid.UUID, rejectionReason *string, resolvedAt time.Time) (*model.HITLRequest, error)
 }

--- a/backend/internal/domain/port/job_queue.go
+++ b/backend/internal/domain/port/job_queue.go
@@ -10,4 +10,6 @@ import (
 type JobQueue interface {
 	// EnqueueExecuteRun enqueues a job to execute a pipeline run asynchronously.
 	EnqueueExecuteRun(ctx context.Context, runID uuid.UUID) error
+	// EnqueueResumeRun enqueues a job to resume a suspended pipeline run from a specific step.
+	EnqueueResumeRun(ctx context.Context, runID, stepID uuid.UUID) error
 }

--- a/backend/internal/domain/service/hitl_service.go
+++ b/backend/internal/domain/service/hitl_service.go
@@ -1,0 +1,226 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// HITLService provides business logic for approving and rejecting HITL gates.
+type HITLService struct {
+	hitlRepo port.HITLRepository
+	runRepo  port.RunRepository
+	eventPub port.EventPublisher
+	jobQueue port.JobQueue
+	logger   *slog.Logger
+}
+
+// NewHITLService creates a new HITLService.
+func NewHITLService(
+	hitlRepo port.HITLRepository,
+	runRepo port.RunRepository,
+	eventPub port.EventPublisher,
+	jobQueue port.JobQueue,
+	logger *slog.Logger,
+) *HITLService {
+	return &HITLService{
+		hitlRepo: hitlRepo,
+		runRepo:  runRepo,
+		eventPub: eventPub,
+		jobQueue: jobQueue,
+		logger:   logger,
+	}
+}
+
+// ApproveResult holds the data returned by a successful approval.
+type ApproveResult struct {
+	RunID         uuid.UUID
+	HITLRequestID uuid.UUID
+	Status        string
+}
+
+// RejectResult holds the data returned by a successful rejection.
+type RejectResult struct {
+	RunID         uuid.UUID
+	HITLRequestID uuid.UUID
+	Status        string
+}
+
+// Approve approves a pending HITL gate for the given run, resuming pipeline execution.
+func (s *HITLService) Approve(ctx context.Context, projectID, runID, reviewerID uuid.UUID) (*ApproveResult, error) {
+	// Fetch run and verify project ownership
+	run, err := s.runRepo.GetRun(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	if run.ProjectID != projectID {
+		return nil, errors.NewNotFound("run", runID)
+	}
+
+	// Fetch pending HITL request
+	hitlReq, err := s.hitlRepo.GetPendingByRunID(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Guard idempotency
+	if hitlReq.Status != model.HITLStatusPending {
+		return nil, &errors.DomainError{
+			Category: errors.CategoryConflict,
+			Code:     "HITL_ALREADY_RESOLVED",
+			Message:  fmt.Sprintf("HITL request %s is already %s", hitlReq.ID, hitlReq.Status),
+		}
+	}
+
+	// Update HITL status to approved
+	now := time.Now()
+	if _, err := s.hitlRepo.UpdateStatus(ctx, hitlReq.ID, model.HITLStatusApproved, &reviewerID, nil, now); err != nil {
+		return nil, err
+	}
+
+	// Transition step from waiting_approval to running
+	if _, err := s.runRepo.UpdateRunStepStatus(ctx, hitlReq.RunStepID, model.StepStatusRunning, nil, nil, nil); err != nil {
+		return nil, err
+	}
+
+	// Publish hitl_gate.approved event (non-fatal)
+	s.publishApprovedEvent(ctx, projectID, runID, hitlReq.RunStepID, hitlReq.ID)
+
+	// Enqueue resume job (non-fatal)
+	if err := s.jobQueue.EnqueueResumeRun(ctx, runID, hitlReq.RunStepID); err != nil {
+		s.logger.Error("failed to enqueue resume_run job",
+			"run_id", runID, "step_id", hitlReq.RunStepID, "error", err)
+	}
+
+	return &ApproveResult{
+		RunID:         runID,
+		HITLRequestID: hitlReq.ID,
+		Status:        string(run.Status),
+	}, nil
+}
+
+// Reject rejects a pending HITL gate for the given run, failing the pipeline.
+func (s *HITLService) Reject(ctx context.Context, projectID, runID, reviewerID uuid.UUID, reason string) (*RejectResult, error) {
+	// Fetch run and verify project ownership
+	run, err := s.runRepo.GetRun(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	if run.ProjectID != projectID {
+		return nil, errors.NewNotFound("run", runID)
+	}
+
+	// Fetch pending HITL request
+	hitlReq, err := s.hitlRepo.GetPendingByRunID(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Guard idempotency
+	if hitlReq.Status != model.HITLStatusPending {
+		return nil, &errors.DomainError{
+			Category: errors.CategoryConflict,
+			Code:     "HITL_ALREADY_RESOLVED",
+			Message:  fmt.Sprintf("HITL request %s is already %s", hitlReq.ID, hitlReq.Status),
+		}
+	}
+
+	// Build error message
+	errorMsg := "HITL_REJECTED"
+	if reason != "" {
+		errorMsg = fmt.Sprintf("HITL_REJECTED: %s", reason)
+	}
+
+	// Update HITL status to rejected
+	now := time.Now()
+	var reasonPtr *string
+	if reason != "" {
+		reasonPtr = &reason
+	}
+	if _, err := s.hitlRepo.UpdateStatus(ctx, hitlReq.ID, model.HITLStatusRejected, &reviewerID, reasonPtr, now); err != nil {
+		return nil, err
+	}
+
+	// Transition step to failed
+	if _, err := s.runRepo.UpdateRunStepStatus(ctx, hitlReq.RunStepID, model.StepStatusFailed, nil, &now, &errorMsg); err != nil {
+		return nil, err
+	}
+
+	// Transition run to failed
+	if _, err := s.runRepo.UpdateRunStatus(ctx, runID, model.RunStatusFailed, nil, &now, &errorMsg); err != nil {
+		return nil, err
+	}
+
+	// Publish hitl_gate.rejected event (non-fatal)
+	s.publishRejectedEvent(ctx, projectID, runID, hitlReq.RunStepID, hitlReq.ID, reason)
+
+	return &RejectResult{
+		RunID:         runID,
+		HITLRequestID: hitlReq.ID,
+		Status:        "failed",
+	}, nil
+}
+
+// publishApprovedEvent publishes a hitl_gate.approved event.
+func (s *HITLService) publishApprovedEvent(ctx context.Context, projectID, runID, stepID, hitlRequestID uuid.UUID) {
+	payload := map[string]string{
+		"run_id":          runID.String(),
+		"step_id":         stepID.String(),
+		"hitl_request_id": hitlRequestID.String(),
+		"project_id":      projectID.String(),
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		s.logger.Error("failed to marshal hitl_gate.approved payload", "error", err)
+		return
+	}
+
+	event := model.Event{
+		ID:         uuid.New(),
+		ProjectID:  projectID,
+		EntityType: "hitl_gate",
+		EntityID:   stepID,
+		Action:     "approved",
+		Payload:    payloadJSON,
+	}
+
+	if err := s.eventPub.Publish(ctx, event); err != nil {
+		s.logger.Error("failed to publish hitl_gate.approved event", "error", err)
+	}
+}
+
+// publishRejectedEvent publishes a hitl_gate.rejected event.
+func (s *HITLService) publishRejectedEvent(ctx context.Context, projectID, runID, stepID, hitlRequestID uuid.UUID, reason string) {
+	payload := map[string]string{
+		"run_id":          runID.String(),
+		"step_id":         stepID.String(),
+		"hitl_request_id": hitlRequestID.String(),
+		"project_id":      projectID.String(),
+		"reason":          reason,
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		s.logger.Error("failed to marshal hitl_gate.rejected payload", "error", err)
+		return
+	}
+
+	event := model.Event{
+		ID:         uuid.New(),
+		ProjectID:  projectID,
+		EntityType: "hitl_gate",
+		EntityID:   stepID,
+		Action:     "rejected",
+		Payload:    payloadJSON,
+	}
+
+	if err := s.eventPub.Publish(ctx, event); err != nil {
+		s.logger.Error("failed to publish hitl_gate.rejected event", "error", err)
+	}
+}

--- a/backend/internal/domain/service/hitl_service_test.go
+++ b/backend/internal/domain/service/hitl_service_test.go
@@ -1,0 +1,418 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+const codeRunNotFound = "RUN_NOT_FOUND"
+
+// mockHITLRepo implements port.HITLRepository for testing.
+type mockHITLRepo struct {
+	createFn            func(ctx context.Context, req *model.HITLRequest) (*model.HITLRequest, error)
+	getByRunStepIDFn    func(ctx context.Context, runStepID uuid.UUID) (*model.HITLRequest, error)
+	getPendingByRunIDFn func(ctx context.Context, runID uuid.UUID) (*model.HITLRequest, error)
+	updateStatusFn      func(ctx context.Context, id uuid.UUID, status model.HITLStatus, resolvedBy *uuid.UUID, rejectionReason *string, resolvedAt time.Time) (*model.HITLRequest, error)
+}
+
+func (m *mockHITLRepo) Create(ctx context.Context, req *model.HITLRequest) (*model.HITLRequest, error) {
+	if m.createFn != nil {
+		return m.createFn(ctx, req)
+	}
+	return req, nil
+}
+
+func (m *mockHITLRepo) GetByRunStepID(ctx context.Context, runStepID uuid.UUID) (*model.HITLRequest, error) {
+	if m.getByRunStepIDFn != nil {
+		return m.getByRunStepIDFn(ctx, runStepID)
+	}
+	return nil, errors.NewNotFound("hitl_request", runStepID)
+}
+
+func (m *mockHITLRepo) GetPendingByRunID(ctx context.Context, runID uuid.UUID) (*model.HITLRequest, error) {
+	if m.getPendingByRunIDFn != nil {
+		return m.getPendingByRunIDFn(ctx, runID)
+	}
+	return nil, errors.NewNotFound("hitl_request", runID)
+}
+
+func (m *mockHITLRepo) UpdateStatus(ctx context.Context, id uuid.UUID, status model.HITLStatus, resolvedBy *uuid.UUID, rejectionReason *string, resolvedAt time.Time) (*model.HITLRequest, error) {
+	if m.updateStatusFn != nil {
+		return m.updateStatusFn(ctx, id, status, resolvedBy, rejectionReason, resolvedAt)
+	}
+	return &model.HITLRequest{ID: id, Status: status}, nil
+}
+
+// hitlTestFixture provides shared test setup for HITLService tests.
+type hitlTestFixture struct {
+	projectID   uuid.UUID
+	runID       uuid.UUID
+	reviewerID  uuid.UUID
+	stepID      uuid.UUID
+	hitlReqID   uuid.UUID
+	run         *model.Run
+	hitlRequest *model.HITLRequest
+
+	hitlRepo *mockHITLRepo
+	runRepo  *mockRunRepo
+	eventPub *mockEventPublisher
+	jobQueue *mockJobQueue
+	service  *HITLService
+}
+
+func newHITLTestFixture() *hitlTestFixture {
+	f := &hitlTestFixture{
+		projectID:  uuid.New(),
+		runID:      uuid.New(),
+		reviewerID: uuid.New(),
+		stepID:     uuid.New(),
+		hitlReqID:  uuid.New(),
+	}
+
+	f.run = &model.Run{
+		ID:        f.runID,
+		ProjectID: f.projectID,
+		StoryID:   uuid.New(),
+		Status:    model.RunStatusRunning,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	f.hitlRequest = &model.HITLRequest{
+		ID:        f.hitlReqID,
+		RunStepID: f.stepID,
+		GateType:  "approval",
+		Status:    model.HITLStatusPending,
+		CreatedAt: time.Now(),
+	}
+
+	f.hitlRepo = &mockHITLRepo{
+		getPendingByRunIDFn: func(_ context.Context, runID uuid.UUID) (*model.HITLRequest, error) {
+			if runID == f.runID {
+				cp := *f.hitlRequest
+				return &cp, nil
+			}
+			return nil, errors.NewNotFound("hitl_request", runID)
+		},
+		updateStatusFn: func(_ context.Context, _ uuid.UUID, status model.HITLStatus, _ *uuid.UUID, _ *string, _ time.Time) (*model.HITLRequest, error) {
+			cp := *f.hitlRequest
+			cp.Status = status
+			return &cp, nil
+		},
+	}
+
+	f.runRepo = &mockRunRepo{
+		getRunFn: func(_ context.Context, id uuid.UUID) (*model.Run, error) {
+			if id == f.runID {
+				cp := *f.run
+				return &cp, nil
+			}
+			return nil, errors.NewNotFound("run", id)
+		},
+		updateRunStepStatusFn: func(_ context.Context, id uuid.UUID, status model.StepStatus, _ *time.Time, _ *time.Time, _ *string) (*model.RunStep, error) {
+			return &model.RunStep{ID: id, Status: status}, nil
+		},
+		updateRunStatusFn: func(_ context.Context, _ uuid.UUID, status model.RunStatus, _ *time.Time, _ *time.Time, _ *string) (*model.Run, error) {
+			cp := *f.run
+			cp.Status = status
+			return &cp, nil
+		},
+	}
+
+	f.eventPub = newMockEventPublisher()
+	f.jobQueue = &mockJobQueue{}
+	f.service = NewHITLService(f.hitlRepo, f.runRepo, f.eventPub, f.jobQueue, testLogger())
+
+	return f
+}
+
+func TestHITLService_Approve_HappyPath(t *testing.T) {
+	f := newHITLTestFixture()
+
+	var updatedStatus model.HITLStatus
+	var updatedReviewer *uuid.UUID
+	f.hitlRepo.updateStatusFn = func(_ context.Context, _ uuid.UUID, status model.HITLStatus, resolvedBy *uuid.UUID, _ *string, _ time.Time) (*model.HITLRequest, error) {
+		updatedStatus = status
+		updatedReviewer = resolvedBy
+		cp := *f.hitlRequest
+		cp.Status = status
+		return &cp, nil
+	}
+
+	var stepStatusUpdated model.StepStatus
+	f.runRepo.updateRunStepStatusFn = func(_ context.Context, _ uuid.UUID, status model.StepStatus, _ *time.Time, _ *time.Time, _ *string) (*model.RunStep, error) {
+		stepStatusUpdated = status
+		return &model.RunStep{ID: f.stepID, Status: status}, nil
+	}
+
+	result, err := f.service.Approve(context.Background(), f.projectID, f.runID, f.reviewerID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if result.RunID != f.runID {
+		t.Errorf("expected run_id %s, got %s", f.runID, result.RunID)
+	}
+	if result.HITLRequestID != f.hitlReqID {
+		t.Errorf("expected hitl_request_id %s, got %s", f.hitlReqID, result.HITLRequestID)
+	}
+	if result.Status != string(model.RunStatusRunning) {
+		t.Errorf("expected status 'running', got %s", result.Status)
+	}
+	if updatedStatus != model.HITLStatusApproved {
+		t.Errorf("expected HITL status approved, got %s", updatedStatus)
+	}
+	if updatedReviewer == nil || *updatedReviewer != f.reviewerID {
+		t.Errorf("expected reviewer %s, got %v", f.reviewerID, updatedReviewer)
+	}
+	if stepStatusUpdated != model.StepStatusRunning {
+		t.Errorf("expected step status running, got %s", stepStatusUpdated)
+	}
+
+	// Verify event published
+	events := f.eventPub.getEvents()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Event.Action != "approved" {
+		t.Errorf("expected event action 'approved', got %s", events[0].Event.Action)
+	}
+	if events[0].Event.EntityType != "hitl_gate" {
+		t.Errorf("expected entity_type 'hitl_gate', got %s", events[0].Event.EntityType)
+	}
+
+	// Verify job enqueued
+	if len(f.jobQueue.enqueuedResumes) != 1 {
+		t.Fatalf("expected 1 resume job enqueued, got %d", len(f.jobQueue.enqueuedResumes))
+	}
+	if f.jobQueue.enqueuedResumes[0].RunID != f.runID {
+		t.Errorf("expected enqueued run_id %s, got %s", f.runID, f.jobQueue.enqueuedResumes[0].RunID)
+	}
+	if f.jobQueue.enqueuedResumes[0].StepID != f.stepID {
+		t.Errorf("expected enqueued step_id %s, got %s", f.stepID, f.jobQueue.enqueuedResumes[0].StepID)
+	}
+}
+
+func TestHITLService_Approve_RunNotFound(t *testing.T) {
+	f := newHITLTestFixture()
+
+	unknownRunID := uuid.New()
+	_, err := f.service.Approve(context.Background(), f.projectID, unknownRunID, f.reviewerID)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected DomainError, got %T", err)
+	}
+	if domainErr.Code != codeRunNotFound {
+		t.Errorf("expected code %s, got %s", codeRunNotFound, domainErr.Code)
+	}
+}
+
+func TestHITLService_Approve_ProjectMismatch(t *testing.T) {
+	f := newHITLTestFixture()
+
+	otherProjectID := uuid.New()
+	_, err := f.service.Approve(context.Background(), otherProjectID, f.runID, f.reviewerID)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected DomainError, got %T", err)
+	}
+	if domainErr.Code != codeRunNotFound {
+		t.Errorf("expected code %s, got %s", codeRunNotFound, domainErr.Code)
+	}
+}
+
+func TestHITLService_Approve_NoHITLRequest(t *testing.T) {
+	f := newHITLTestFixture()
+	f.hitlRepo.getPendingByRunIDFn = func(_ context.Context, _ uuid.UUID) (*model.HITLRequest, error) {
+		return nil, errors.NewNotFound("hitl_request", f.runID)
+	}
+
+	_, err := f.service.Approve(context.Background(), f.projectID, f.runID, f.reviewerID)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected DomainError, got %T", err)
+	}
+	if domainErr.Code != "HITL_REQUEST_NOT_FOUND" {
+		t.Errorf("expected code HITL_REQUEST_NOT_FOUND, got %s", domainErr.Code)
+	}
+}
+
+func TestHITLService_Approve_AlreadyResolved(t *testing.T) {
+	f := newHITLTestFixture()
+	f.hitlRequest.Status = model.HITLStatusApproved
+
+	_, err := f.service.Approve(context.Background(), f.projectID, f.runID, f.reviewerID)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected DomainError, got %T", err)
+	}
+	if domainErr.Code != "HITL_ALREADY_RESOLVED" {
+		t.Errorf("expected code HITL_ALREADY_RESOLVED, got %s", domainErr.Code)
+	}
+	if domainErr.Category != errors.CategoryConflict {
+		t.Errorf("expected category conflict, got %s", domainErr.Category)
+	}
+
+	// Verify no mutations occurred
+	if len(f.eventPub.getEvents()) != 0 {
+		t.Error("expected no events published for already-resolved request")
+	}
+	if len(f.jobQueue.enqueuedResumes) != 0 {
+		t.Error("expected no jobs enqueued for already-resolved request")
+	}
+}
+
+func TestHITLService_Reject_HappyPathWithReason(t *testing.T) {
+	f := newHITLTestFixture()
+
+	var updatedStatus model.HITLStatus
+	var capturedReason *string
+	f.hitlRepo.updateStatusFn = func(_ context.Context, _ uuid.UUID, status model.HITLStatus, _ *uuid.UUID, rejectionReason *string, _ time.Time) (*model.HITLRequest, error) {
+		updatedStatus = status
+		capturedReason = rejectionReason
+		cp := *f.hitlRequest
+		cp.Status = status
+		return &cp, nil
+	}
+
+	var stepErrorMsg *string
+	f.runRepo.updateRunStepStatusFn = func(_ context.Context, _ uuid.UUID, _ model.StepStatus, _ *time.Time, _ *time.Time, errorMsg *string) (*model.RunStep, error) {
+		stepErrorMsg = errorMsg
+		return &model.RunStep{ID: f.stepID, Status: model.StepStatusFailed}, nil
+	}
+
+	var runErrorMsg *string
+	f.runRepo.updateRunStatusFn = func(_ context.Context, _ uuid.UUID, _ model.RunStatus, _ *time.Time, _ *time.Time, errorMsg *string) (*model.Run, error) {
+		runErrorMsg = errorMsg
+		cp := *f.run
+		cp.Status = model.RunStatusFailed
+		return &cp, nil
+	}
+
+	reason := "code review required"
+	result, err := f.service.Reject(context.Background(), f.projectID, f.runID, f.reviewerID, reason)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if result.Status != "failed" {
+		t.Errorf("expected status 'failed', got %s", result.Status)
+	}
+	if updatedStatus != model.HITLStatusRejected {
+		t.Errorf("expected HITL status rejected, got %s", updatedStatus)
+	}
+	if capturedReason == nil || *capturedReason != reason {
+		t.Errorf("expected reason '%s', got %v", reason, capturedReason)
+	}
+
+	expectedErrorMsg := "HITL_REJECTED: code review required"
+	if stepErrorMsg == nil || *stepErrorMsg != expectedErrorMsg {
+		t.Errorf("expected step error '%s', got %v", expectedErrorMsg, stepErrorMsg)
+	}
+	if runErrorMsg == nil || *runErrorMsg != expectedErrorMsg {
+		t.Errorf("expected run error '%s', got %v", expectedErrorMsg, runErrorMsg)
+	}
+
+	// Verify event published
+	events := f.eventPub.getEvents()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Event.Action != "rejected" {
+		t.Errorf("expected event action 'rejected', got %s", events[0].Event.Action)
+	}
+
+	// Verify no resume job enqueued for rejection
+	if len(f.jobQueue.enqueuedResumes) != 0 {
+		t.Error("expected no resume jobs enqueued for rejection")
+	}
+}
+
+func TestHITLService_Reject_HappyPathWithoutReason(t *testing.T) {
+	f := newHITLTestFixture()
+
+	var stepErrorMsg *string
+	f.runRepo.updateRunStepStatusFn = func(_ context.Context, _ uuid.UUID, _ model.StepStatus, _ *time.Time, _ *time.Time, errorMsg *string) (*model.RunStep, error) {
+		stepErrorMsg = errorMsg
+		return &model.RunStep{ID: f.stepID, Status: model.StepStatusFailed}, nil
+	}
+
+	var runErrorMsg *string
+	f.runRepo.updateRunStatusFn = func(_ context.Context, _ uuid.UUID, _ model.RunStatus, _ *time.Time, _ *time.Time, errorMsg *string) (*model.Run, error) {
+		runErrorMsg = errorMsg
+		cp := *f.run
+		cp.Status = model.RunStatusFailed
+		return &cp, nil
+	}
+
+	result, err := f.service.Reject(context.Background(), f.projectID, f.runID, f.reviewerID, "")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if result.Status != "failed" {
+		t.Errorf("expected status 'failed', got %s", result.Status)
+	}
+
+	expectedErrorMsg := "HITL_REJECTED"
+	if stepErrorMsg == nil || *stepErrorMsg != expectedErrorMsg {
+		t.Errorf("expected step error '%s', got %v", expectedErrorMsg, stepErrorMsg)
+	}
+	if runErrorMsg == nil || *runErrorMsg != expectedErrorMsg {
+		t.Errorf("expected run error '%s', got %v", expectedErrorMsg, runErrorMsg)
+	}
+}
+
+func TestHITLService_Reject_AlreadyResolved(t *testing.T) {
+	f := newHITLTestFixture()
+	f.hitlRequest.Status = model.HITLStatusRejected
+
+	_, err := f.service.Reject(context.Background(), f.projectID, f.runID, f.reviewerID, "reason")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected DomainError, got %T", err)
+	}
+	if domainErr.Code != "HITL_ALREADY_RESOLVED" {
+		t.Errorf("expected code HITL_ALREADY_RESOLVED, got %s", domainErr.Code)
+	}
+	if domainErr.Category != errors.CategoryConflict {
+		t.Errorf("expected category conflict, got %s", domainErr.Category)
+	}
+}
+
+func TestHITLService_Reject_ProjectMismatch(t *testing.T) {
+	f := newHITLTestFixture()
+
+	otherProjectID := uuid.New()
+	_, err := f.service.Reject(context.Background(), otherProjectID, f.runID, f.reviewerID, "reason")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected DomainError, got %T", err)
+	}
+	if domainErr.Code != codeRunNotFound {
+		t.Errorf("expected code %s, got %s", codeRunNotFound, domainErr.Code)
+	}
+}

--- a/backend/internal/domain/service/pipeline_executor.go
+++ b/backend/internal/domain/service/pipeline_executor.go
@@ -114,6 +114,72 @@ func (e *PipelineExecutor) ExecuteRun(ctx context.Context, runID uuid.UUID) erro
 	return nil
 }
 
+// ResumeRun resumes a suspended pipeline run from the given step.
+// It continues executing steps sequentially from the resumed step's order.
+func (e *PipelineExecutor) ResumeRun(ctx context.Context, runID, stepID uuid.UUID) error {
+	run, err := e.runRepo.GetRun(ctx, runID)
+	if err != nil {
+		return err
+	}
+
+	steps, err := e.runRepo.ListRunStepsByRun(ctx, runID)
+	if err != nil {
+		return err
+	}
+
+	slices.SortFunc(steps, func(a, b *model.RunStep) int {
+		return cmp.Compare(a.StepOrder, b.StepOrder)
+	})
+
+	// Find the resumed step's order and start executing from the next step
+	var resumeOrder int
+	for _, s := range steps {
+		if s.ID == stepID {
+			resumeOrder = s.StepOrder
+			break
+		}
+	}
+
+	metadata := make(map[string]any)
+	for i := range steps {
+		step := steps[i]
+		if step.StepOrder <= resumeOrder {
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			e.handleCancellation(run, step)
+			return ctx.Err()
+		default:
+		}
+
+		if err := e.executeStep(ctx, run, step, metadata); err != nil {
+			if errors.Is(err, errStepSuspended) {
+				e.logger.Info("pipeline step suspended for approval",
+					"run_id", run.ID, "step_id", step.ID)
+				return nil
+			}
+			e.handleStepFailure(ctx, run, step, err)
+			return err
+		}
+	}
+
+	// All remaining steps completed
+	completedAt := time.Now()
+	if _, err := e.runRepo.UpdateRunStatus(ctx, runID, model.RunStatusCompleted, nil, &completedAt, nil); err != nil {
+		return err
+	}
+
+	e.publishEvent(ctx, run.ProjectID, "run", run.ID, "completed", map[string]any{
+		"run_id":       runID.String(),
+		"status":       string(model.RunStatusCompleted),
+		"completed_at": completedAt.Format(time.RFC3339),
+	})
+
+	return nil
+}
+
 // executeStep executes a single pipeline step.
 func (e *PipelineExecutor) executeStep(ctx context.Context, run *model.Run, step *model.RunStep, metadata map[string]any) error {
 	// Transition step to "running"

--- a/backend/internal/domain/service/run_service_test.go
+++ b/backend/internal/domain/service/run_service_test.go
@@ -167,14 +167,30 @@ func (m *mockPipelineConfigRepoForRun) Upsert(_ context.Context, _ *model.Pipeli
 	return nil, nil
 }
 
+// resumeRunCall records a call to EnqueueResumeRun.
+type resumeRunCall struct {
+	RunID  uuid.UUID
+	StepID uuid.UUID
+}
+
 // mockJobQueue implements port.JobQueue for testing.
 type mockJobQueue struct {
 	enqueueExecuteRunFn func(ctx context.Context, runID uuid.UUID) error
+	enqueueResumeRunFn  func(ctx context.Context, runID, stepID uuid.UUID) error
+	enqueuedResumes     []resumeRunCall
 }
 
 func (m *mockJobQueue) EnqueueExecuteRun(ctx context.Context, runID uuid.UUID) error {
 	if m.enqueueExecuteRunFn != nil {
 		return m.enqueueExecuteRunFn(ctx, runID)
+	}
+	return nil
+}
+
+func (m *mockJobQueue) EnqueueResumeRun(ctx context.Context, runID, stepID uuid.UUID) error {
+	m.enqueuedResumes = append(m.enqueuedResumes, resumeRunCall{RunID: runID, StepID: stepID})
+	if m.enqueueResumeRunFn != nil {
+		return m.enqueueResumeRunFn(ctx, runID, stepID)
 	}
 	return nil
 }

--- a/backend/queries/hitl_requests.sql
+++ b/backend/queries/hitl_requests.sql
@@ -6,6 +6,14 @@ RETURNING *;
 -- name: GetHITLRequestByRunStepID :one
 SELECT * FROM hitl_requests WHERE run_step_id = $1 LIMIT 1;
 
+-- name: GetPendingHITLRequestByRunID :one
+SELECT hr.*
+FROM hitl_requests hr
+JOIN run_steps rs ON rs.id = hr.run_step_id
+WHERE rs.run_id = $1
+  AND hr.status = 'pending'
+LIMIT 1;
+
 -- name: UpdateHITLRequestStatus :one
 UPDATE hitl_requests
 SET status = $2, resolved_at = $3, resolved_by = $4, rejection_reason = $5

--- a/frontend/src/features/approvals/__tests__/useApprovalActions.spec.ts
+++ b/frontend/src/features/approvals/__tests__/useApprovalActions.spec.ts
@@ -14,29 +14,29 @@ describe('useApprovalActions', () => {
     mockPOST.mockReset()
   })
 
-  it('approve calls correct endpoint with hitlRequestId', async () => {
-    const responseData = { id: 'hitl-1', status: 'approved' }
+  it('approve calls correct endpoint with projectId and runId', async () => {
+    const responseData = { run_id: 'run-1', hitl_request_id: 'hitl-1', status: 'running' }
     mockPOST.mockResolvedValue({ data: responseData })
 
     const { approveAction } = useApprovalActions()
-    await approveAction.execute('hitl-1')
+    await approveAction.execute('proj-1', 'run-1')
 
-    expect(mockPOST).toHaveBeenCalledWith('/hitl-requests/{hitlRequestId}/approve', {
-      params: { path: { hitlRequestId: 'hitl-1' } },
+    expect(mockPOST).toHaveBeenCalledWith('/projects/{projectId}/runs/{runId}/hitl/approve', {
+      params: { path: { projectId: 'proj-1', runId: 'run-1' } },
     })
     expect(approveAction.data.value).toEqual(responseData)
     expect(approveAction.error.value).toBeNull()
   })
 
-  it('reject calls correct endpoint with hitlRequestId and reason', async () => {
-    const responseData = { id: 'hitl-1', status: 'rejected' }
+  it('reject calls correct endpoint with projectId, runId and reason', async () => {
+    const responseData = { run_id: 'run-1', hitl_request_id: 'hitl-1', status: 'failed' }
     mockPOST.mockResolvedValue({ data: responseData })
 
     const { rejectAction } = useApprovalActions()
-    await rejectAction.execute('hitl-1', 'this is my rejection reason')
+    await rejectAction.execute('proj-1', 'run-1', 'this is my rejection reason')
 
-    expect(mockPOST).toHaveBeenCalledWith('/hitl-requests/{hitlRequestId}/reject', {
-      params: { path: { hitlRequestId: 'hitl-1' } },
+    expect(mockPOST).toHaveBeenCalledWith('/projects/{projectId}/runs/{runId}/hitl/reject', {
+      params: { path: { projectId: 'proj-1', runId: 'run-1' } },
       body: { reason: 'this is my rejection reason' },
     })
     expect(rejectAction.data.value).toEqual(responseData)
@@ -49,7 +49,7 @@ describe('useApprovalActions', () => {
     })
 
     const { approveAction } = useApprovalActions()
-    await approveAction.execute('hitl-1')
+    await approveAction.execute('proj-1', 'run-1')
 
     expect(approveAction.error.value).toBeInstanceOf(Error)
     expect(approveAction.error.value?.message).toBe('Not found')
@@ -61,7 +61,7 @@ describe('useApprovalActions', () => {
     })
 
     const { rejectAction } = useApprovalActions()
-    await rejectAction.execute('hitl-1', 'some reason here')
+    await rejectAction.execute('proj-1', 'run-1', 'some reason here')
 
     expect(rejectAction.error.value).toBeInstanceOf(Error)
     expect(rejectAction.error.value?.message).toBe('Already processed')
@@ -71,7 +71,7 @@ describe('useApprovalActions', () => {
     mockPOST.mockResolvedValue({ error: {} })
 
     const { approveAction } = useApprovalActions()
-    await approveAction.execute('hitl-1')
+    await approveAction.execute('proj-1', 'run-1')
 
     expect(approveAction.error.value?.message).toBe('Approve failed')
   })
@@ -88,11 +88,11 @@ describe('useApprovalActions', () => {
 
     const { approveAction, rejectAction } = useApprovalActions()
 
-    const approvePromise = approveAction.execute('hitl-1')
+    const approvePromise = approveAction.execute('proj-1', 'run-1')
     expect(approveAction.isLoading.value).toBe(true)
     expect(rejectAction.isLoading.value).toBe(false)
 
-    resolveApprove!({ data: { id: 'hitl-1' } })
+    resolveApprove!({ data: { run_id: 'run-1', hitl_request_id: 'hitl-1', status: 'running' } })
     await approvePromise
 
     expect(approveAction.isLoading.value).toBe(false)
@@ -103,11 +103,11 @@ describe('useApprovalActions', () => {
       }),
     )
 
-    const rejectPromise = rejectAction.execute('hitl-2', 'reason text here')
+    const rejectPromise = rejectAction.execute('proj-1', 'run-2', 'reason text here')
     expect(rejectAction.isLoading.value).toBe(true)
     expect(approveAction.isLoading.value).toBe(false)
 
-    resolveReject!({ data: { id: 'hitl-2' } })
+    resolveReject!({ data: { run_id: 'run-2', hitl_request_id: 'hitl-2', status: 'failed' } })
     await rejectPromise
 
     expect(rejectAction.isLoading.value).toBe(false)

--- a/frontend/src/features/approvals/composables/useApprovalActions.ts
+++ b/frontend/src/features/approvals/composables/useApprovalActions.ts
@@ -2,17 +2,17 @@ import { useAsyncAction } from '@/composables/useAsyncAction'
 import { apiClient } from '@/api/client'
 
 export function useApprovalActions() {
-  const approveAction = useAsyncAction(async (hitlRequestId: string) => {
-    const { data, error } = await apiClient.POST('/hitl-requests/{hitlRequestId}/approve', {
-      params: { path: { hitlRequestId } },
+  const approveAction = useAsyncAction(async (projectId: string, runId: string) => {
+    const { data, error } = await apiClient.POST('/projects/{projectId}/runs/{runId}/hitl/approve', {
+      params: { path: { projectId, runId } },
     })
     if (error) throw new Error((error as { error?: { message?: string } }).error?.message ?? 'Approve failed')
     return data
   })
 
-  const rejectAction = useAsyncAction(async (hitlRequestId: string, reason: string) => {
-    const { data, error } = await apiClient.POST('/hitl-requests/{hitlRequestId}/reject', {
-      params: { path: { hitlRequestId } },
+  const rejectAction = useAsyncAction(async (projectId: string, runId: string, reason: string) => {
+    const { data, error } = await apiClient.POST('/projects/{projectId}/runs/{runId}/hitl/reject', {
+      params: { path: { projectId, runId } },
       body: { reason },
     })
     if (error) throw new Error((error as { error?: { message?: string } }).error?.message ?? 'Reject failed')

--- a/frontend/src/views/HITLApprovalView.vue
+++ b/frontend/src/views/HITLApprovalView.vue
@@ -46,7 +46,13 @@ const { approveAction, rejectAction } = useApprovalActions()
 
 async function handleApprove() {
   if (!fetchAction.data.value) return
-  await approveAction.execute(fetchAction.data.value.id)
+  const projectId = fetchAction.data.value.project_id
+  const runIdValue = fetchAction.data.value.run_id
+  if (!projectId || !runIdValue) {
+    toast.add({ severity: 'error', summary: 'Missing project or run ID', life: 3000 })
+    return
+  }
+  await approveAction.execute(projectId, runIdValue)
   if (!approveAction.error.value) {
     toast.add({ severity: 'success', summary: 'Approval submitted', life: 3000 })
     router.push({ name: 'run-detail', params: { id: runId.value } })
@@ -68,7 +74,13 @@ async function handleReject() {
   rejectValidationError.value = null
 
   if (!fetchAction.data.value) return
-  await rejectAction.execute(fetchAction.data.value.id, rejectReason.value)
+  const projectId = fetchAction.data.value.project_id
+  const runIdValue = fetchAction.data.value.run_id
+  if (!projectId || !runIdValue) {
+    toast.add({ severity: 'error', summary: 'Missing project or run ID', life: 3000 })
+    return
+  }
+  await rejectAction.execute(projectId, runIdValue, rejectReason.value)
   if (!rejectAction.error.value) {
     showRejectDialog.value = false
     toast.add({ severity: 'success', summary: 'Rejection submitted', life: 3000 })


### PR DESCRIPTION
## Summary
- Replace stub HITL endpoints with project-scoped routes: `POST /projects/{projectId}/runs/{runId}/hitl/approve` (202) and `POST /projects/{projectId}/runs/{runId}/hitl/reject` (202)
- Implement `HITLService` with `Approve` and `Reject` methods that handle status transitions, event publishing, and job enqueueing
- Add `HITLHandler` with project access checks, `GetPendingByRunID` sqlc query, `ResumeRun` River job, and `PipelineExecutor.ResumeRun` for post-approval pipeline continuation
- 9 unit tests covering happy paths (approve, reject with/without reason) and error cases (not found, project mismatch, already resolved)

## Test plan
- [x] All 9 new HITL service unit tests pass
- [x] All existing tests pass (`go test ./... -short`)
- [x] golangci-lint passes with no errors
- [x] Backend builds cleanly (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)