### PR TITLE
fix(ui): add catch-all 404 route with NotFoundView

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -9,6 +9,7 @@ import ApprovalsView from '@/views/ApprovalsView.vue'
 import PipelineConfigView from '@/views/PipelineConfigView.vue'
 import PromptTemplatesView from '@/views/PromptTemplatesView.vue'
 import BoardView from '@/views/BoardView.vue'
+import NotFoundView from '@/views/NotFoundView.vue'
 import ProjectOverview from '@/features/projects/ProjectOverview.vue'
 import { setupAuthGuard, setupAdminGuard } from './guards'
 
@@ -124,6 +125,12 @@ const router = createRouter({
       name: 'admin-users',
       component: () => import('@/views/admin/UserManagementView.vue'),
       meta: { requiresAuth: true, requiresAdmin: true },
+    },
+    {
+      path: '/:pathMatch(.*)*',
+      name: 'not-found',
+      component: NotFoundView,
+      meta: { requiresAuth: false },
     },
   ],
 })

--- a/frontend/src/views/NotFoundView.vue
+++ b/frontend/src/views/NotFoundView.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="flex items-center justify-center min-h-[60vh]">
+    <div class="text-center space-y-6 max-w-md px-6">
+      <div class="space-y-2">
+        <h1 class="text-6xl font-bold text-surface-500">404</h1>
+        <h2 class="text-2xl font-semibold text-surface-900 dark:text-surface-0">
+          Page Not Found
+        </h2>
+        <p class="text-surface-600 dark:text-surface-400">
+          The page you're looking for doesn't exist or has been moved.
+        </p>
+      </div>
+
+      <div class="flex justify-center gap-3">
+        <Button
+          label="Go to Dashboard"
+          icon="pi pi-home"
+          @click="router.push('/')"
+          severity="secondary"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import Button from 'primevue/button'
+
+const router = useRouter()
+</script>


### PR DESCRIPTION
## Summary
- Add catch-all route to handle invalid URLs
- Create NotFoundView component with 404 message and dashboard navigation
- Set requiresAuth: false to allow 404 page without authentication

## Acceptance Criteria
- ✅ Catch-all route `/:pathMatch(.*)*` exists as last route
- ✅ NotFoundView displays "Page not found" message  
- ✅ NotFoundView has button to navigate back to dashboard
- ✅ 404 page renders inside AppShell (inherits layout)

## Test Plan
- Navigate to `/this-does-not-exist` - should show 404 page
- Click "Go to Dashboard" button - should navigate to `/`
- Verify sidebar and header are visible (AppShell layout)

Fixes: fix-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)