### PR TITLE
fix(ci): use docker exec for database reset in e2e-stack.sh

### DIFF
--- a/scripts/e2e-stack.sh
+++ b/scripts/e2e-stack.sh
@@ -106,9 +106,48 @@ cmd_status() {
 }
 
 cmd_reset() {
-  log_info "Resetting database..."
-  (cd "${PROJECT_ROOT}/backend" && make reset-db)
+  local container="hopeitworks-postgres"
+  local db_user="${POSTGRES_USER:-hopeitworks}"
+  local db_name="${POSTGRES_DB:-hopeitworks_dev}"
+
+  log_info "Resetting database via docker exec (no local psql tools required)..."
+
+  # Verify the postgres container is running
+  if ! docker exec "${container}" pg_isready -U "${db_user}" > /dev/null 2>&1; then
+    log_error "Postgres container '${container}' is not running or not ready."
+    return 1
+  fi
+
+  # Terminate active connections and drop/recreate database
+  log_info "Dropping database ${db_name}..."
+  docker exec "${container}" psql -U "${db_user}" -d postgres \
+    -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${db_name}' AND pid <> pg_backend_pid();" \
+    > /dev/null 2>&1 || true
+  docker exec "${container}" psql -U "${db_user}" -d postgres \
+    -c "DROP DATABASE IF EXISTS ${db_name};"
+
+  log_info "Creating database ${db_name}..."
+  docker exec "${container}" psql -U "${db_user}" -d postgres \
+    -c "CREATE DATABASE ${db_name} OWNER ${db_user};"
+
+  # Run migrations (sorted order)
+  log_info "Running migrations..."
+  local migration_dir="${PROJECT_ROOT}/backend/migrations"
+  local migration_count=0
+  for f in "${migration_dir}"/*.up.sql; do
+    [ -f "$f" ] || continue
+    docker exec -i "${container}" psql -U "${db_user}" -d "${db_name}" --set ON_ERROR_STOP=1 < "$f"
+    migration_count=$((migration_count + 1))
+  done
+  log_info "Applied ${migration_count} migrations."
+
+  # Seed dev data
+  log_info "Seeding dev data..."
+  docker exec -i "${container}" psql -U "${db_user}" -d "${db_name}" --set ON_ERROR_STOP=1 \
+    < "${PROJECT_ROOT}/backend/testdata/seed.sql"
+
   log_success "Database reset complete."
+  log_info "Credentials: admin@hopeitworks.dev/admin123, dev@hopeitworks.dev/dev123, alice@hopeitworks.dev/alice123"
 }
 
 cmd_up() {


### PR DESCRIPTION
## Summary
- Replaced `make reset-db` in `scripts/e2e-stack.sh` with `docker exec` commands that run inside the `hopeitworks-postgres` container
- Eliminates the need for local PostgreSQL tools (`dropdb`, `createdb`, `psql`, `migrate`) on the developer's machine
- The reset command now: verifies Postgres container health, terminates active connections, drops/recreates the database, applies all migrations (piped via stdin), and seeds dev data

## Changes
- `scripts/e2e-stack.sh`: Rewrote `cmd_reset()` function to use `docker exec` instead of `make reset-db`

## Test plan
- [ ] Run `./scripts/e2e-stack.sh up` on a machine without local PostgreSQL tools — stack should start and DB reset should succeed
- [ ] Run `./scripts/e2e-stack.sh reset` standalone — should drop, recreate, migrate, and seed without error
- [ ] Run `./scripts/e2e-stack.sh status` after reset — all services should report UP
- [ ] Verify seed data is present: 3 users, 3 projects, epics, stories queryable via the API

Refs: fix-5-e2e-stack-docker-reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)