### PR TITLE
fix(ui): correct E2E test selectors and API request fixtures

### DIFF
--- a/frontend/e2e/real-tests/helpers/auth.ts
+++ b/frontend/e2e/real-tests/helpers/auth.ts
@@ -33,12 +33,24 @@ export type SeedUserKey = keyof typeof SEED_USERS
 /**
  * Login via the UI form. Fills email/password and submits.
  * Waits for navigation away from /login.
+ *
+ * The password field uses PrimeVue Password which wraps the native input,
+ * so getByLabel may not resolve correctly. We fall back to a CSS selector.
  */
 export async function loginViaUI(page: Page, userKey: SeedUserKey): Promise<void> {
   const user = SEED_USERS[userKey]
   await page.goto('/login')
   await page.getByLabel(/email/i).fill(user.email)
-  await page.getByLabel(/password/i).fill(user.password)
+
+  // PrimeVue Password component wraps the <input> — getByLabel may not find it.
+  // Try label association first, fall back to the raw input[type="password"] selector.
+  const passwordByLabel = page.getByLabel(/password/i)
+  const passwordBySelector = page.locator('input[type="password"]')
+  const passwordField = (await passwordByLabel.isVisible().catch(() => false))
+    ? passwordByLabel
+    : passwordBySelector
+  await passwordField.fill(user.password)
+
   await page.getByRole('button', { name: /sign in|log in|login/i }).click()
   await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 10000 })
 }

--- a/frontend/e2e/real-tests/helpers/auth.ts
+++ b/frontend/e2e/real-tests/helpers/auth.ts
@@ -46,7 +46,7 @@ export async function loginViaUI(page: Page, userKey: SeedUserKey): Promise<void
   // Try label association first, fall back to the raw input[type="password"] selector.
   const passwordByLabel = page.getByLabel(/password/i)
   const passwordBySelector = page.locator('input[type="password"]')
-  const passwordField = (await passwordByLabel.isVisible().catch(() => false))
+  const passwordField = (await passwordByLabel.count()) > 0
     ? passwordByLabel
     : passwordBySelector
   await passwordField.fill(user.password)

--- a/frontend/e2e/real-tests/smoke-login.spec.ts
+++ b/frontend/e2e/real-tests/smoke-login.spec.ts
@@ -67,7 +67,13 @@ test.describe('Auth smoke tests (real backend)', () => {
     await page.goto('/login')
 
     await page.getByLabel(/email/i).fill(SEED_USERS.admin.email)
-    await page.getByLabel(/password/i).fill('this-is-the-wrong-password')
+
+    // PrimeVue Password wraps the input — fall back to CSS selector if getByLabel fails
+    const pwByLabel = page.getByLabel(/password/i)
+    const pwBySelector = page.locator('input[type="password"]')
+    const pwField = (await pwByLabel.isVisible().catch(() => false)) ? pwByLabel : pwBySelector
+    await pwField.fill('this-is-the-wrong-password')
+
     await page.getByRole('button', { name: /sign in|log in|login/i }).click()
 
     // The form should remain on /login and show an error
@@ -132,7 +138,6 @@ test.describe('Auth smoke tests (real backend)', () => {
    */
   test('AUDIT: /auth/me does not return role field (known bug)', async ({
     context,
-    request,
   }) => {
     test.info().annotations.push({
       type: 'known-bug',
@@ -146,8 +151,9 @@ test.describe('Auth smoke tests (real backend)', () => {
     // Login via API to get the session cookie set on the browser context
     await loginViaAPI(context, 'admin')
 
-    // Call /auth/me with the authenticated session
-    const response = await request.get('/api/v1/auth/me')
+    // Use context.request so the session cookie set by loginViaAPI is applied.
+    // The standalone `request` fixture has a separate cookie jar and won't be authenticated.
+    const response = await context.request.get('/api/v1/auth/me')
     expect(response.status(), '/auth/me should return 200 for authenticated user').toBe(200)
 
     const body = await response.json()

--- a/frontend/e2e/real-tests/smoke-login.spec.ts
+++ b/frontend/e2e/real-tests/smoke-login.spec.ts
@@ -71,7 +71,7 @@ test.describe('Auth smoke tests (real backend)', () => {
     // PrimeVue Password wraps the input — fall back to CSS selector if getByLabel fails
     const pwByLabel = page.getByLabel(/password/i)
     const pwBySelector = page.locator('input[type="password"]')
-    const pwField = (await pwByLabel.isVisible().catch(() => false)) ? pwByLabel : pwBySelector
+    const pwField = (await pwByLabel.count()) > 0 ? pwByLabel : pwBySelector
     await pwField.fill('this-is-the-wrong-password')
 
     await page.getByRole('button', { name: /sign in|log in|login/i }).click()

--- a/frontend/e2e/real-tests/smoke-navigation.spec.ts
+++ b/frontend/e2e/real-tests/smoke-navigation.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { loginViaAPI, loginViaUI, SEED_USERS } from './helpers/auth'
+import { loginViaAPI } from './helpers/auth'
 import { LogCollector } from './helpers/log-collector'
 
 const TODO_APP_ID = '00000000-0000-0000-0000-000000000101'
@@ -24,8 +24,8 @@ test.describe('smoke: navigation', () => {
     await loginViaAPI(context, 'admin')
     await page.goto('/')
 
-    // Click the sidebar link to projects
-    await page.getByRole('link', { name: /projects/i }).first().click()
+    // Sidebar uses PrimeVue Button components, not <a> links
+    await page.getByRole('button', { name: /projects/i }).first().click()
 
     await expect(page).toHaveURL(/\/projects/)
   })
@@ -34,7 +34,8 @@ test.describe('smoke: navigation', () => {
     await loginViaAPI(context, 'admin')
     await page.goto('/')
 
-    await page.getByRole('link', { name: /approvals/i }).first().click()
+    // Sidebar uses PrimeVue Button components, not <a> links
+    await page.getByRole('button', { name: /approvals/i }).first().click()
 
     await expect(page).toHaveURL(/\/approvals/)
   })
@@ -46,18 +47,19 @@ test.describe('smoke: navigation', () => {
     // Verify we land on the project detail page
     await expect(page).toHaveURL(new RegExp(TODO_APP_ID))
 
+    // PrimeVue TabMenu renders items as <a> with role="tab", not role="link"
     // Navigate to board tab
-    const boardTab = page.getByRole('link', { name: /board/i })
+    const boardTab = page.getByRole('tab', { name: /board/i })
     await boardTab.first().click()
     await expect(page).toHaveURL(new RegExp(`${TODO_APP_ID}/board`))
 
     // Navigate to pipeline tab
-    const pipelineTab = page.getByRole('link', { name: /pipeline/i })
+    const pipelineTab = page.getByRole('tab', { name: /pipeline/i })
     await pipelineTab.first().click()
     await expect(page).toHaveURL(new RegExp(`${TODO_APP_ID}/pipeline`))
 
     // Navigate to templates tab
-    const templatesTab = page.getByRole('link', { name: /templates/i })
+    const templatesTab = page.getByRole('tab', { name: /templates/i })
     await templatesTab.first().click()
     await expect(page).toHaveURL(new RegExp(`${TODO_APP_ID}/templates`))
   })


### PR DESCRIPTION
## Summary
- **loginViaUI password fallback**: PrimeVue Password wraps the native `<input>`, so `getByLabel(/password/i)` may not resolve. Added fallback to `input[type="password"]` CSS selector.
- **AUDIT test context.request**: The `/auth/me` AUDIT test in `smoke-login.spec.ts` was using the standalone `request` fixture instead of `context.request`, which meant the session cookie from `loginViaAPI` was not applied.
- **Sidebar selectors**: Navigation tests used `getByRole('link')` for sidebar items, but the sidebar uses PrimeVue `Button` components (`<button>` elements). Changed to `getByRole('button')`.
- **Tab selectors**: Project tabs used `getByRole('link')`, but PrimeVue `TabMenu` renders items with `role="tab"`. Changed to `getByRole('tab')`.
- Cleaned up unused imports in navigation spec.

## Files Changed
- `frontend/e2e/real-tests/helpers/auth.ts` — password selector fallback
- `frontend/e2e/real-tests/smoke-login.spec.ts` — context.request fix + password fallback
- `frontend/e2e/real-tests/smoke-navigation.spec.ts` — button/tab role selectors

## Test plan
- [ ] Run `npx playwright test real-tests/` against a live backend to verify all selectors resolve
- [ ] Verify `loginViaUI` successfully fills the PrimeVue Password field
- [ ] Verify AUDIT test gets 200 from `/auth/me` (not 401)
- [ ] Verify sidebar navigation tests click the correct `<button>` elements
- [ ] Verify tab navigation tests click the correct `role="tab"` elements

Refs: fix-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)