### PR TITLE
chore(ci): add fix-6 and fix-7 stories for remaining E2E failures

### DIFF
--- a/_bmad-output/implementation-artifacts/fix-6-e2e-selector-refinements.md
+++ b/_bmad-output/implementation-artifacts/fix-6-e2e-selector-refinements.md
@@ -1,0 +1,60 @@
+# Story fix-6: E2E test selector refinements for real backend tests
+
+Status: ready-for-dev
+
+## Story
+
+As a developer,
+I want all E2E smoke tests to use robust selectors that don't break on real page content,
+so that test failures reflect actual app bugs, not flaky selectors.
+
+## Context
+
+After fixing 5 bugs (waves 16-18), the smoke suite went from 19/28 failures to 7/28. The remaining 6 failures are all test selector issues, not app bugs.
+
+## Acceptance Criteria (BDD)
+
+**AC1: login with dev credentials passes**
+- **Given** the dev user is seeded in the DB
+- **When** `loginViaUI(page, 'dev')` is called
+- **Then** the user lands on the dashboard (not stuck on /login)
+- **Notes** The password field selector was fixed in fix-4 for `loginViaUI` helper, but the `wrong password` test in smoke-login.spec.ts also has an inline password selector that may need the same fix. Verify all inline password field references use the fallback pattern.
+
+**AC2: logout test finds the logout trigger**
+- **Given** the user is logged in
+- **When** the test looks for a logout button
+- **Then** it finds and clicks it using a selector that matches the actual UI
+- **Notes** The logout button may be inside a PrimeVue Menu or user dropdown. Use Playwright MCP or read the AppShell/header component to find the actual DOM structure, then update the selector. If the logout is in a popover/overlay menu, the test must first click the trigger to open it.
+
+**AC3: project tabs navigation works**
+- **Given** the user is on a project detail page
+- **When** the test clicks board/pipeline/templates tabs
+- **Then** the URL changes to the correct sub-route
+- **Notes** Read `frontend/src/views/ProjectDetailView.vue` to see how tabs are rendered. They may be PrimeVue TabMenu items, not standard links or buttons. Update selectors accordingly.
+
+**AC4: browser back/forward test assertions are correct**
+- **Given** the user navigates between pages
+- **When** `page.goBack()` is called
+- **Then** the URL assertion matches the actual route (root `/` is the dashboard, not `/dashboard`)
+- **Notes** The router maps `/` to the dashboard. The test expects `/dashboard` but the actual URL is `/`. Fix the assertion regex.
+
+**AC5: strict mode violations resolved in projects tests**
+- **Given** the project overview page shows "Todo App" in multiple places
+- **When** the test uses `getByText('Todo App')`
+- **Then** it should use a more specific selector (e.g., `getByRole('heading', { name: 'Todo App' })` or `getByTestId('project-name')`)
+- **Notes** The page has `data-testid="project-name"` on the h1. Use `getByTestId` or scope the selector with `.first()` or a parent locator.
+
+**AC6: seed projects list test uses robust selectors**
+- **Given** the projects list page shows multiple projects
+- **When** the test checks for seed projects
+- **Then** it uses specific selectors that don't cause strict mode violations
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Read actual component DOM structure (ProjectDetailView tabs, AppShell logout, project overview)
+- [ ] Task 2: Fix smoke-login.spec.ts — ensure `login with dev credentials` uses the same password fallback
+- [ ] Task 3: Fix smoke-login.spec.ts — update logout test to match actual UI (find the logout trigger)
+- [ ] Task 4: Fix smoke-navigation.spec.ts — update tab selectors based on actual ProjectDetailView DOM
+- [ ] Task 5: Fix smoke-navigation.spec.ts — fix back/forward URL assertion (`/` not `/dashboard`)
+- [ ] Task 6: Fix smoke-projects.spec.ts — use `getByTestId('project-name')` or scoped selectors
+- [ ] Task 7: Run `npm run test:e2e:real` and verify all 6 previously failing tests now pass

--- a/_bmad-output/implementation-artifacts/fix-7-pipeline-config-seed-data.md
+++ b/_bmad-output/implementation-artifacts/fix-7-pipeline-config-seed-data.md
@@ -1,0 +1,39 @@
+# Story fix-7: Fix pipeline config API returning 404 for seeded project
+
+Status: ready-for-dev
+
+## Story
+
+As a developer,
+I want the pipeline config endpoint to return 200 for seeded projects,
+so that E2E tests can verify the pipeline configuration page works.
+
+## Context
+
+The smoke test `pipeline config API returns 200 with config_yaml field` calls `GET /api/v1/projects/00000000-0000-0000-0000-000000000101/pipeline-config` and gets a 404 response. The seed SQL (`backend/testdata/seed.sql`) does INSERT a pipeline_config for that project, but the data may not be present after `e2e-stack.sh reset` if migrations changed the table schema, or the endpoint path may have changed.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Pipeline config exists after seed**
+- **Given** the database has been reset and seeded via `e2e-stack.sh reset`
+- **When** I query `SELECT * FROM pipeline_configs WHERE project_id = '00000000-0000-0000-0000-000000000101'`
+- **Then** exactly 1 row is returned with valid `config_yaml`
+
+**AC2: API endpoint returns 200**
+- **Given** the pipeline config is seeded
+- **When** I call `GET /api/v1/projects/00000000-0000-0000-0000-000000000101/pipeline-config`
+- **Then** the response is 200 with a JSON body containing `config_yaml`
+
+**AC3: If endpoint path changed, update the test**
+- **Given** the OpenAPI spec defines the pipeline config endpoint
+- **When** I check `api/openapi.yaml` for the correct path
+- **Then** the test uses the correct endpoint path
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Check `api/openapi.yaml` for the pipeline config endpoint path
+- [ ] Task 2: Verify the seed SQL inserts pipeline_configs correctly for the Todo App project
+- [ ] Task 3: Check if the DB table schema matches the seed INSERT columns (migrations may have added/removed columns)
+- [ ] Task 4: If the seed data is missing after reset, fix the seed SQL or the reset script
+- [ ] Task 5: If the endpoint path differs from what the test uses, update `smoke-pipeline-config.spec.ts`
+- [ ] Task 6: Verify `GET /api/v1/projects/{id}/pipeline-config` returns 200 after fix

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -158,6 +158,8 @@ development_status:
   fix-3-catch-all-404-route: ready-for-dev
   fix-4-e2e-test-helpers: ready-for-dev
   fix-5-e2e-stack-docker-reset: ready-for-dev
+  fix-6-e2e-selector-refinements: ready-for-dev
+  fix-7-pipeline-config-seed-data: ready-for-dev
 
 # PARALLEL EXECUTION WAVES
 # ========================
@@ -651,3 +653,16 @@ parallel_waves:
     container_count: 2
     depends_on: [wave-17]
     notes: "P2 test infra fixes: test selectors + stack script — parallel, independent"
+
+  wave-19:
+    phase: 5-bugfixes
+    stories:
+      - key: fix-6-e2e-selector-refinements
+        domain: front
+        status: ready-for-dev
+      - key: fix-7-pipeline-config-seed-data
+        domain: shared
+        status: ready-for-dev
+    container_count: 2
+    depends_on: [wave-18]
+    notes: "Final test fixes: selector refinements + pipeline config 404 — parallel"


### PR DESCRIPTION
## Summary
- Add fix-6 story: E2E selector refinements (6 test bugs)
- Add fix-7 story: pipeline config 404 (seed data)
- Update sprint-status.yaml with wave-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)