### PR TITLE
fix(config): align seed data and smoke test with pipeline config API

### DIFF
--- a/backend/testdata/seed.sql
+++ b/backend/testdata/seed.sql
@@ -305,31 +305,31 @@ INSERT INTO pipeline_configs (id, project_id, config_yaml, version)
 VALUES (
     '00000000-0000-0000-0000-000000000401',
     '00000000-0000-0000-0000-000000000101',
-    'version: 1
-steps:
-  - name: git-branch
-    action: git_branch
-  - name: dev-agent
-    action: agent_run
-    config:
-      model: claude-sonnet-4-20250514
-      prompt_template: implement
-      max_tokens: 8192
-  - name: ci-wait
-    action: ci_poll
-    config:
-      timeout_minutes: 30
-  - name: review-agent
-    action: agent_run
-    config:
-      model: claude-sonnet-4-20250514
-      prompt_template: review
-  - name: hitl-gate
-    action: hitl_gate
-    config:
-      gate_type: approval
-  - name: merge
-    action: git_merge
+    'steps:
+  - id: 10000000-0000-0000-0000-000000000001
+    name: implement
+    action_type: implement
+    model: claude-sonnet-4-5
+    auto_approve: false
+    retry_policy:
+      max_retries: 2
+      retry_type: on-failure
+  - id: 10000000-0000-0000-0000-000000000002
+    name: review
+    action_type: review
+    model: claude-sonnet-4-5
+    auto_approve: true
+    retry_policy:
+      max_retries: 1
+      retry_type: on-failure
+  - id: 10000000-0000-0000-0000-000000000003
+    name: merge
+    action_type: merge
+    model: claude-sonnet-4-5
+    auto_approve: false
+    retry_policy:
+      max_retries: 0
+      retry_type: none
 ',
     1
 ) ON CONFLICT (project_id) DO UPDATE SET

--- a/frontend/e2e/real-tests/smoke-pipeline-config.spec.ts
+++ b/frontend/e2e/real-tests/smoke-pipeline-config.spec.ts
@@ -47,35 +47,24 @@ test.describe('Pipeline config smoke tests (real backend)', () => {
     await expect(pipelineContent).toBeVisible({ timeout: 10000 })
   })
 
-  test('pipeline config API returns 200 with config_yaml field', async ({ context }) => {
+  test('pipeline config API returns 200 with steps array', async ({ context }) => {
     await loginViaAPI(context, 'admin')
 
     const response = await context.request.get(
-      `/api/v1/projects/${TODO_APP_ID}/pipeline-config`,
+      `/api/v1/projects/${TODO_APP_ID}/pipeline`,
     )
 
     expect(
       response.status(),
-      `GET /api/v1/projects/${TODO_APP_ID}/pipeline-config should return 200`,
+      `GET /api/v1/projects/${TODO_APP_ID}/pipeline should return 200`,
     ).toBe(200)
 
     const body = await response.json()
 
-    // The response must include a config_yaml field (may be empty string if not yet set)
-    expect(
-      body,
-      'Response body should be an object',
-    ).toEqual(expect.objectContaining({}))
-
-    expect(
-      'config_yaml' in body,
-      'Response should contain a config_yaml field',
-    ).toBe(true)
-
-    // config_yaml should be a string (even if empty)
-    expect(
-      typeof body.config_yaml,
-      'config_yaml field should be a string',
-    ).toBe('string')
+    // The response must include project_id and steps fields per the OpenAPI spec
+    expect(body, 'Response should contain project_id').toHaveProperty('project_id')
+    expect(body, 'Response should contain steps').toHaveProperty('steps')
+    expect(Array.isArray(body.steps), 'steps field should be an array').toBe(true)
+    expect(body.steps.length, 'steps array should have at least one entry').toBeGreaterThan(0)
   })
 })

--- a/frontend/e2e/tests/project-detail.spec.ts
+++ b/frontend/e2e/tests/project-detail.spec.ts
@@ -59,11 +59,11 @@ test.describe('Project Detail — Tabbed Navigation', () => {
       })
     })
 
-    await page.route('**/api/v1/projects/p1/pipeline-configs*', async (route) => {
+    await page.route('**/api/v1/projects/p1/pipeline', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ data: [], pagination: { total: 0, page: 1, per_page: 20 } }),
+        body: JSON.stringify({ project_id: 'p1', steps: [], updated_at: '2026-01-01T00:00:00Z' }),
       })
     })
 


### PR DESCRIPTION
## Summary
- **Seed data YAML schema mismatch**: The `pipeline_configs` seed in `backend/testdata/seed.sql` used an old YAML structure (`version`, `action`, `config` fields) that didn't match the handler's `pipelineConfigYAML` struct (`id`, `name`, `action_type`, `model`, `auto_approve`, `retry_policy`). Updated seed YAML to use the correct schema with valid enum values.
- **Wrong smoke test endpoint path**: `smoke-pipeline-config.spec.ts` called `/pipeline-config` instead of `/pipeline`. Fixed to match the OpenAPI spec path `/projects/{projectId}/pipeline`.
- **Wrong smoke test response assertions**: The test asserted on a `config_yaml` string field that doesn't exist in the API response. The actual response returns `{ project_id, steps, updated_at }`. Updated assertions to validate `project_id` and `steps` array.
- **Stale mock route in project-detail E2E**: Fixed `project-detail.spec.ts` mock route from `/pipeline-configs*` to `/pipeline` with correct response shape.

## Test plan
- [x] ESLint passes on modified files
- [x] All 23 pipeline config unit tests pass (pipelineConfig store + usePipelineConfig composable)
- [ ] `e2e-stack.sh reset` seeds pipeline config with new YAML (manual verification against live stack)
- [ ] `smoke-pipeline-config.spec.ts` passes against live backend
- [ ] `project-detail.spec.ts` E2E tests pass

Refs: fix-7-pipeline-config-seed-data

🤖 Generated with [Claude Code](https://claude.com/claude-code)