### PR TITLE
fix(ui): add user menu logout and refine E2E test selectors

### DIFF
--- a/_bmad-output/implementation-artifacts/fix-6-e2e-selector-refinements.md
+++ b/_bmad-output/implementation-artifacts/fix-6-e2e-selector-refinements.md
@@ -1,6 +1,6 @@
 # Story fix-6: E2E test selector refinements for real backend tests
 
-Status: ready-for-dev
+Status: in-progress
 
 ## Story
 
@@ -51,10 +51,10 @@ After fixing 5 bugs (waves 16-18), the smoke suite went from 19/28 failures to 7
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Read actual component DOM structure (ProjectDetailView tabs, AppShell logout, project overview)
-- [ ] Task 2: Fix smoke-login.spec.ts — ensure `login with dev credentials` uses the same password fallback
-- [ ] Task 3: Fix smoke-login.spec.ts — update logout test to match actual UI (find the logout trigger)
-- [ ] Task 4: Fix smoke-navigation.spec.ts — update tab selectors based on actual ProjectDetailView DOM
-- [ ] Task 5: Fix smoke-navigation.spec.ts — fix back/forward URL assertion (`/` not `/dashboard`)
-- [ ] Task 6: Fix smoke-projects.spec.ts — use `getByTestId('project-name')` or scoped selectors
-- [ ] Task 7: Run `npm run test:e2e:real` and verify all 6 previously failing tests now pass
+- [x] Task 1: Read actual component DOM structure (ProjectDetailView tabs, AppShell logout, project overview)
+- [x] Task 2: Fix smoke-login.spec.ts — ensure `login with dev credentials` uses the same password fallback (verified: already correct in helper and inline code)
+- [x] Task 3: Fix smoke-login.spec.ts — update logout test to match actual UI (added PrimeVue popup Menu to AppHeader with logout item, updated test to click user-menu-button then menuitem)
+- [x] Task 4: Fix smoke-navigation.spec.ts — update tab selectors based on actual ProjectDetailView DOM (verified: `getByRole('tab')` already correct for PrimeVue TabMenu)
+- [x] Task 5: Fix smoke-navigation.spec.ts — fix back/forward URL assertion (verified: regex `/^\/?$|\/dashboard/` already handles both `/` and `/dashboard`)
+- [x] Task 6: Fix smoke-projects.spec.ts — use `getByTestId('project-name')` and row-scoped selectors to avoid strict mode violations
+- [ ] Task 7: Run `npm run test:e2e:real` and verify all 6 previously failing tests now pass (requires running test stack)

--- a/frontend/e2e/real-tests/smoke-login.spec.ts
+++ b/frontend/e2e/real-tests/smoke-login.spec.ts
@@ -103,25 +103,12 @@ test.describe('Auth smoke tests (real backend)', () => {
     // Wait until we are past the login page
     await expect(page).not.toHaveURL(/\/login/)
 
-    // Locate the logout trigger — could be a button, a user menu item, etc.
-    // Try common patterns: a "Logout" or "Sign out" button, or a user avatar menu.
-    const logoutButton = page
-      .getByRole('button', { name: /logout|sign out/i })
-      .or(page.getByText(/logout|sign out/i))
-      .first()
+    // The logout is inside a PrimeVue popup Menu triggered by the "User menu" button.
+    // Click the user menu button to open the popup.
+    await page.getByTestId('user-menu-button').click()
 
-    // Some UIs hide logout behind a user menu click — try to open it first.
-    const userMenu = page
-      .getByRole('button', { name: /user|account|profile|menu/i })
-      .or(page.getByText(SEED_USERS.dev.name))
-      .first()
-
-    // If logout button is not immediately visible, click the user menu first.
-    if (!(await logoutButton.isVisible())) {
-      await userMenu.click()
-    }
-
-    await logoutButton.click()
+    // PrimeVue Menu renders items as <a role="menuitem"> — click the Logout item
+    await page.getByRole('menuitem', { name: /logout/i }).click()
 
     await expect(page).toHaveURL(/\/login/, { timeout: 8000 })
   })

--- a/frontend/e2e/real-tests/smoke-projects.spec.ts
+++ b/frontend/e2e/real-tests/smoke-projects.spec.ts
@@ -34,9 +34,9 @@ test.describe('Projects smoke tests (real backend)', () => {
     await loginViaUI(page, 'admin')
     await page.goto('/projects')
 
-    // Wait for the project list to render
-    await expect(page.getByText('Todo App')).toBeVisible({ timeout: 10000 })
-    await expect(page.getByText('E-commerce API')).toBeVisible({ timeout: 5000 })
+    // Wait for the project list to render — use row-scoped selectors to avoid strict mode violations
+    await expect(page.getByRole('row', { name: /Todo App/i }).first()).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('row', { name: /E-commerce API/i }).first()).toBeVisible({ timeout: 5000 })
   })
 
   test('click project navigates to project detail', async ({ page }) => {
@@ -54,8 +54,9 @@ test.describe('Projects smoke tests (real backend)', () => {
     await loginViaUI(page, 'admin')
     await page.goto(`/projects/${TODO_APP_ID}`)
 
-    // The project name must be visible
-    await expect(page.getByText('Todo App')).toBeVisible({ timeout: 10000 })
+    // The project name appears in h1[data-testid="project-name"] — use testid to avoid strict mode
+    await expect(page.getByTestId('project-name')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByTestId('project-name')).toHaveText('Todo App')
 
     // Some description text should also be present (could be a subheading or paragraph)
     // We look for a non-empty block of text beneath the title rather than a fixed string,

--- a/frontend/src/ui/layout/AppHeader.vue
+++ b/frontend/src/ui/layout/AppHeader.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
 import Button from 'primevue/button'
+import Menu from 'primevue/menu'
+import type { MenuItem } from 'primevue/menuitem'
+import { useAuthStore } from '@/stores/auth'
 
 defineProps<{
   showHamburger: boolean
@@ -8,6 +13,25 @@ defineProps<{
 const emit = defineEmits<{
   'toggle-sidebar': []
 }>()
+
+const router = useRouter()
+const authStore = useAuthStore()
+const userMenu = ref<InstanceType<typeof Menu> | null>(null)
+
+const menuItems: MenuItem[] = [
+  {
+    label: 'Logout',
+    icon: 'pi pi-sign-out',
+    command: async () => {
+      await authStore.logout()
+      router.push('/login')
+    },
+  },
+]
+
+function toggleUserMenu(event: Event) {
+  userMenu.value?.toggle(event)
+}
 </script>
 
 <template>
@@ -26,7 +50,20 @@ const emit = defineEmits<{
       <span class="text-lg font-semibold text-surface-700">Hope</span>
     </div>
     <div class="flex items-center gap-2">
-      <Button icon="pi pi-user" text rounded aria-label="User menu" />
+      <Button
+        icon="pi pi-user"
+        text
+        rounded
+        aria-label="User menu"
+        data-testid="user-menu-button"
+        @click="toggleUserMenu"
+      />
+      <Menu
+        ref="userMenu"
+        :model="menuItems"
+        :popup="true"
+        data-testid="user-menu"
+      />
     </div>
   </header>
 </template>


### PR DESCRIPTION
## Summary

- **AppHeader**: Added functional user menu dropdown (PrimeVue `Menu` component) with a **Logout** action. Previously the "User menu" button was decorative with no click handler or attached menu. Now it calls `authStore.logout()` and redirects to `/login`.
- **smoke-login.spec.ts**: Updated logout test to click the `data-testid="user-menu-button"` then the `role="menuitem"` Logout item, matching the new PrimeVue popup Menu DOM structure.
- **smoke-projects.spec.ts**: Fixed strict mode violations by using `getByRole('row', { name: /Todo App/i }).first()` for project list assertions and `getByTestId('project-name')` for project detail page assertions.

### Acceptance Criteria addressed:
- **AC1**: Verified `loginViaUI` helper and inline password selectors already use the PrimeVue Password fallback pattern — no changes needed.
- **AC2**: Added logout functionality to AppHeader and updated test selector.
- **AC3**: Verified `getByRole('tab')` selectors already match PrimeVue TabMenu rendering — no changes needed.
- **AC4**: Verified back/forward URL regex already handles both `/` and `/dashboard` — no changes needed.
- **AC5**: Used `getByTestId('project-name')` to avoid strict mode violations on project detail page.
- **AC6**: Used row-scoped selectors for the project list to avoid strict mode violations.

## Test plan

- [x] `vue-tsc --noEmit` passes (0 type errors)
- [x] `npm run lint` passes
- [x] `npx vitest run` passes (57 test files, 480 tests)
- [ ] `npm run test:e2e:real` — requires live E2E stack (`./scripts/e2e-stack.sh up`)

Refs: fix-6-e2e-selector-refinements

🤖 Generated with [Claude Code](https://claude.com/claude-code)