### PR TITLE
chore(stories): add wave 20-21 auth enhancement stories

### DIFF
--- a/_bmad-output/implementation-artifacts/feat-1-logout-api.md
+++ b/_bmad-output/implementation-artifacts/feat-1-logout-api.md
@@ -1,0 +1,479 @@
+# Story feat-1: [BACK] Logout API with token blacklisting
+
+Status: ready-for-dev
+
+## Story
+
+As an authenticated user,
+I want a server-side logout endpoint that invalidates my JWT token,
+so that logging out prevents the token from being reused even if it was intercepted or copied before expiry.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Token blacklisted on logout**
+- **Given** a user is authenticated with a valid JWT in the `token` httpOnly cookie
+- **When** they call `POST /api/v1/auth/logout`
+- **Then** the server adds the token's JTI (JWT ID) and its expiry to `revoked_tokens`, clears the cookie, and returns `204 No Content`
+
+**AC2: Blacklisted token rejected by auth middleware**
+- **Given** a user has logged out (their token's JTI is in `revoked_tokens`)
+- **When** they make any authenticated request with that same token cookie
+- **Then** the auth middleware returns `401 Unauthorized` with code `TOKEN_REVOKED`
+
+**AC3: No cookie still returns 401**
+- **Given** a request with no `token` cookie is sent to `POST /api/v1/auth/logout`
+- **Then** the server returns `401 Unauthorized` with code `UNAUTHORIZED` (the route is protected by the existing auth middleware)
+
+**AC4: JWT claims must include a JTI**
+- **Given** a user logs in or registers
+- **When** a JWT is generated
+- **Then** the token's `Claims` struct includes a unique `jti` (JWT ID) field in `RegisteredClaims`, enabling per-token revocation
+
+**AC5: Expired blacklist entries are cleaned up periodically**
+- **Given** revoked tokens exist in the `revoked_tokens` table
+- **When** their `expires_at` timestamp has passed
+- **Then** a periodic background cleanup (running on startup via goroutine) removes them, preventing unbounded table growth
+
+**AC6: Double logout is idempotent**
+- **Given** a user has already logged out
+- **When** they call `POST /api/v1/auth/logout` again (with the same now-blacklisted token)
+- **Then** the middleware rejects the request with `401 TOKEN_REVOKED` (AC2 applies, logout itself is never reached a second time)
+
+## Tasks / Subtasks
+
+- [ ] [BACK] Task 1: Add JTI to JWT generation (AC: #4)
+  - [ ] Import `github.com/google/uuid` in `auth_service.go` (already in go.mod)
+  - [ ] In `generateToken()`, set `RegisteredClaims.ID` to `uuid.New().String()` before signing
+  - [ ] Verify `ValidateToken()` returns claims with a non-empty `ID` field (no change needed, `RegisteredClaims` already carries it)
+
+- [ ] [BACK] Task 2: Create migration `000023_create_revoked_tokens_table` (AC: #1, #2, #5)
+  - [ ] Write `000023_create_revoked_tokens_table.up.sql` with the table and index (see Migration SQL Content below)
+  - [ ] Write `000023_create_revoked_tokens_table.down.sql`
+
+- [ ] [BACK] Task 3: Add sqlc queries for revoked tokens (AC: #1, #2, #5)
+  - [ ] Create `backend/queries/revoked_tokens.sql` with `InsertRevokedToken`, `IsTokenRevoked`, `DeleteExpiredRevokedTokens` (see sqlc Query Signatures below)
+  - [ ] Run `cd backend && sqlc generate` to produce the generated Go code
+
+- [ ] [BACK] Task 4: Implement `TokenBlacklistRepository` port and postgres adapter (AC: #1, #2, #5)
+  - [ ] Create `backend/internal/domain/port/token_blacklist_repository.go` with the `TokenBlacklistRepository` interface
+  - [ ] Create `backend/internal/adapter/postgres/token_blacklist_repo.go` implementing the port using sqlc-generated queries
+
+- [ ] [BACK] Task 5: Extend `AuthService` with `Logout` and `PurgeExpiredTokens` methods (AC: #1, #5)
+  - [ ] Add `blacklistRepo port.TokenBlacklistRepository` field to `AuthService`
+  - [ ] Add `Logout(ctx context.Context, tokenString string) error` — parses claims, extracts JTI + expiry, calls `blacklistRepo.Revoke`
+  - [ ] Add `PurgeExpiredTokens(ctx context.Context) error` — delegates to `blacklistRepo.DeleteExpired`
+  - [ ] Add sentinel error `ErrTokenRevoked` for use by middleware
+
+- [ ] [BACK] Task 6: Update auth middleware to check the blacklist (AC: #2, #3)
+  - [ ] Add `blacklistRepo port.TokenBlacklistRepository` parameter to `Auth()` function signature
+  - [ ] After `authService.ValidateToken(cookie.Value)` succeeds, call `blacklistRepo.IsRevoked(ctx, claims.ID)`
+  - [ ] If revoked, call `writeUnauthorized(w)` with body `{"error":{"code":"TOKEN_REVOKED","message":"Token has been revoked"}}` and return
+
+- [ ] [BACK] Task 7: Update `AuthHandler.Logout` to call `authService.Logout` (AC: #1)
+  - [ ] Extract token string from the cookie before clearing it
+  - [ ] Call `h.authService.Logout(r.Context(), cookie.Value)`
+  - [ ] On error, log with slog (warn level) but still clear the cookie and return 204 — logout must always succeed from the client's perspective
+  - [ ] Clear the cookie as today (MaxAge: -1)
+
+- [ ] [BACK] Task 8: Start background cleanup goroutine (AC: #5)
+  - [ ] In `internal/api/router.go` or `cmd/api/main.go`, after wiring, launch a goroutine that calls `authService.PurgeExpiredTokens` every hour via a `time.Ticker`
+  - [ ] Goroutine must respect context cancellation for clean shutdown
+  - [ ] Log purge results at debug/info level with `slog`
+
+- [ ] [BACK] Task 9: Wire `TokenBlacklistRepository` into the DI graph (AC: all)
+  - [ ] Add `postgres.NewTokenBlacklistRepo` to `wire.go` provider set (or directly pass to `NewAuthService` and `Auth` middleware)
+  - [ ] Update `NewAuthService` signature to accept `port.TokenBlacklistRepository`
+  - [ ] Update `Auth()` call in router to pass the blacklist repo
+  - [ ] Regenerate wire: `cd backend && wire ./cmd/api/`
+
+- [ ] [BACK] Task 10: Tests (AC: #1, #2, #4, #5, #6)
+  - [ ] Unit test `AuthService.Logout` with mock `TokenBlacklistRepository`
+  - [ ] Unit test auth middleware: token in blacklist → 401 TOKEN_REVOKED
+  - [ ] Integration test `TokenBlacklistRepository` against a real Postgres container (testcontainers)
+  - [ ] Integration test full flow: login → logout → re-use token → 401
+
+## Dev Notes
+
+### Dependencies
+
+No new Go modules required. All dependencies already in `backend/go.mod`:
+- `github.com/golang-jwt/jwt/v5` — JWT parsing (JTI extraction)
+- `github.com/google/uuid` — JTI generation
+- `github.com/jackc/pgx/v5` — Postgres driver
+- sqlc for query generation
+
+### File Paths (exact)
+
+| File | Action |
+|------|--------|
+| `backend/migrations/000023_create_revoked_tokens_table.up.sql` | Create |
+| `backend/migrations/000023_create_revoked_tokens_table.down.sql` | Create |
+| `backend/queries/revoked_tokens.sql` | Create |
+| `backend/internal/domain/port/token_blacklist_repository.go` | Create |
+| `backend/internal/adapter/postgres/token_blacklist_repo.go` | Create |
+| `backend/internal/domain/service/auth_service.go` | Modify |
+| `backend/internal/api/middleware/auth.go` | Modify |
+| `backend/internal/api/handler/auth_handler.go` | Modify |
+| `backend/internal/api/router.go` | Modify |
+| `backend/cmd/api/wire.go` | Modify |
+| `backend/cmd/api/wire_gen.go` | Regenerate (never edit manually) |
+| `backend/internal/adapter/postgres/revoked_tokens.sql.go` | Regenerate via sqlc |
+
+### Migration SQL Content
+
+**`000023_create_revoked_tokens_table.up.sql`:**
+
+```sql
+-- Stores revoked JWT IDs (JTI) to prevent reuse after logout.
+-- Entries are cleaned up once expires_at has passed.
+CREATE TABLE revoked_tokens (
+    jti        TEXT        NOT NULL PRIMARY KEY,  -- JWT ID claim (uuid string)
+    expires_at TIMESTAMPTZ NOT NULL               -- copied from JWT exp claim
+);
+
+-- Index for fast lookup in auth middleware hot path
+CREATE INDEX idx_revoked_tokens_expires_at ON revoked_tokens (expires_at);
+```
+
+**`000023_create_revoked_tokens_table.down.sql`:**
+
+```sql
+DROP TABLE IF EXISTS revoked_tokens;
+```
+
+### sqlc Query Signatures
+
+**`backend/queries/revoked_tokens.sql`:**
+
+```sql
+-- name: InsertRevokedToken :exec
+INSERT INTO revoked_tokens (jti, expires_at)
+VALUES ($1, $2)
+ON CONFLICT (jti) DO NOTHING;
+
+-- name: IsTokenRevoked :one
+SELECT EXISTS (
+    SELECT 1 FROM revoked_tokens WHERE jti = $1
+) AS revoked;
+
+-- name: DeleteExpiredRevokedTokens :exec
+DELETE FROM revoked_tokens WHERE expires_at < now();
+```
+
+After writing this file, run: `cd backend && sqlc generate`
+
+This produces `backend/internal/adapter/postgres/revoked_tokens.sql.go` with:
+- `InsertRevokedToken(ctx, InsertRevokedTokenParams{Jti string, ExpiresAt pgtype.Timestamptz})`
+- `IsTokenRevoked(ctx, jti string) (bool, error)`
+- `DeleteExpiredRevokedTokens(ctx) error`
+
+### Domain Model / Port changes
+
+**`backend/internal/domain/port/token_blacklist_repository.go`:**
+
+```go
+package port
+
+import (
+    "context"
+    "time"
+)
+
+// TokenBlacklistRepository manages revoked JWT IDs.
+type TokenBlacklistRepository interface {
+    // Revoke adds a token's JTI to the blacklist until expiresAt.
+    Revoke(ctx context.Context, jti string, expiresAt time.Time) error
+    // IsRevoked returns true if the JTI is in the blacklist.
+    IsRevoked(ctx context.Context, jti string) (bool, error)
+    // DeleteExpired removes all entries whose expiresAt has passed.
+    DeleteExpired(ctx context.Context) error
+}
+```
+
+**`backend/internal/adapter/postgres/token_blacklist_repo.go`** (skeleton — implement from sqlc output):
+
+```go
+package postgres
+
+import (
+    "context"
+    "time"
+
+    "github.com/jackc/pgx/v5/pgtype"
+    "github.com/zakari/hopeitworks/backend/internal/domain/port"
+    apperrors "github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+var _ port.TokenBlacklistRepository = (*TokenBlacklistRepo)(nil)
+
+// TokenBlacklistRepo implements port.TokenBlacklistRepository using sqlc.
+type TokenBlacklistRepo struct {
+    q *Queries
+}
+
+// NewTokenBlacklistRepo creates a new TokenBlacklistRepo.
+func NewTokenBlacklistRepo(db DBTX) *TokenBlacklistRepo {
+    return &TokenBlacklistRepo{q: New(db)}
+}
+
+func (r *TokenBlacklistRepo) Revoke(ctx context.Context, jti string, expiresAt time.Time) error {
+    err := r.q.InsertRevokedToken(ctx, InsertRevokedTokenParams{
+        Jti:       jti,
+        ExpiresAt: pgtype.Timestamptz{Time: expiresAt, Valid: true},
+    })
+    if err != nil {
+        return apperrors.NewInternal("failed to revoke token", err)
+    }
+    return nil
+}
+
+func (r *TokenBlacklistRepo) IsRevoked(ctx context.Context, jti string) (bool, error) {
+    revoked, err := r.q.IsTokenRevoked(ctx, jti)
+    if err != nil {
+        return false, apperrors.NewInternal("failed to check token revocation", err)
+    }
+    return revoked, nil
+}
+
+func (r *TokenBlacklistRepo) DeleteExpired(ctx context.Context) error {
+    if err := r.q.DeleteExpiredRevokedTokens(ctx); err != nil {
+        return apperrors.NewInternal("failed to delete expired revoked tokens", err)
+    }
+    return nil
+}
+```
+
+### AuthService changes
+
+**Add to `service/auth_service.go`:**
+
+New sentinel error:
+```go
+var ErrTokenRevoked = errors.New("token has been revoked")
+```
+
+Updated struct (add blacklistRepo field):
+```go
+type AuthService struct {
+    repo          port.UserRepository
+    blacklistRepo port.TokenBlacklistRepository
+    jwtSecret     []byte
+    jwtExpiration time.Duration
+}
+
+func NewAuthService(
+    repo port.UserRepository,
+    blacklistRepo port.TokenBlacklistRepository,
+    jwtSecret string,
+    jwtExpiration time.Duration,
+) *AuthService {
+    return &AuthService{
+        repo:          repo,
+        blacklistRepo: blacklistRepo,
+        jwtSecret:     []byte(jwtSecret),
+        jwtExpiration: jwtExpiration,
+    }
+}
+```
+
+Updated `generateToken` — add JTI:
+```go
+func (s *AuthService) generateToken(userID uuid.UUID, role model.Role) (string, error) {
+    now := time.Now()
+    claims := &Claims{
+        UserID: userID,
+        Role:   role,
+        RegisteredClaims: jwt.RegisteredClaims{
+            ID:        uuid.New().String(), // JTI — unique per token
+            ExpiresAt: jwt.NewNumericDate(now.Add(s.jwtExpiration)),
+            IssuedAt:  jwt.NewNumericDate(now),
+        },
+    }
+    token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+    return token.SignedString(s.jwtSecret)
+}
+```
+
+New `Logout` method:
+```go
+// Logout invalidates the given JWT token string by adding its JTI to the blacklist.
+func (s *AuthService) Logout(ctx context.Context, tokenString string) error {
+    claims, err := s.ValidateToken(tokenString)
+    if err != nil {
+        // Token already expired or invalid — nothing to revoke.
+        return nil
+    }
+    jti := claims.ID
+    if jti == "" {
+        return nil // legacy token without JTI — skip
+    }
+    expiresAt := claims.ExpiresAt.Time
+    return s.blacklistRepo.Revoke(ctx, jti, expiresAt)
+}
+
+// PurgeExpiredTokens removes expired entries from the token blacklist.
+func (s *AuthService) PurgeExpiredTokens(ctx context.Context) error {
+    return s.blacklistRepo.DeleteExpired(ctx)
+}
+```
+
+### Auth Middleware changes
+
+Updated `Auth()` signature in `backend/internal/api/middleware/auth.go`:
+
+```go
+// Auth returns middleware that validates JWT tokens, checks the blacklist, and injects user context.
+func Auth(authService *service.AuthService, blacklistRepo port.TokenBlacklistRepository) func(http.Handler) http.Handler {
+    return func(next http.Handler) http.Handler {
+        return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            if isPublicPath(r.URL.Path) {
+                next.ServeHTTP(w, r)
+                return
+            }
+
+            cookie, err := r.Cookie("token")
+            if err != nil {
+                writeUnauthorized(w)
+                return
+            }
+
+            claims, err := authService.ValidateToken(cookie.Value)
+            if err != nil {
+                writeUnauthorized(w)
+                return
+            }
+
+            // Check blacklist (token revoked via logout)
+            if claims.ID != "" {
+                revoked, err := blacklistRepo.IsRevoked(r.Context(), claims.ID)
+                if err != nil {
+                    writeUnauthorized(w)
+                    return
+                }
+                if revoked {
+                    writeRevokedToken(w)
+                    return
+                }
+            }
+
+            ctx := context.WithValue(r.Context(), ContextKeyUserID, claims.UserID)
+            ctx = context.WithValue(ctx, ContextKeyRole, claims.Role)
+            next.ServeHTTP(w, r.WithContext(ctx))
+        })
+    }
+}
+
+func writeRevokedToken(w http.ResponseWriter) {
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusUnauthorized)
+    _, _ = w.Write([]byte(`{"error":{"code":"TOKEN_REVOKED","message":"Token has been revoked"}}`))
+}
+```
+
+Import to add: `"github.com/zakari/hopeitworks/backend/internal/domain/port"`
+
+### AuthHandler.Logout changes
+
+Updated `Logout` in `backend/internal/api/handler/auth_handler.go`:
+
+```go
+// Logout handles POST /auth/logout.
+func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
+    cookie, err := r.Cookie("token")
+    if err == nil && cookie.Value != "" {
+        // Best-effort blacklist — always clear cookie regardless of outcome
+        if logoutErr := h.authService.Logout(r.Context(), cookie.Value); logoutErr != nil {
+            // Log but do not fail the request
+            slog.WarnContext(r.Context(), "failed to blacklist token on logout",
+                "error", logoutErr,
+            )
+        }
+    }
+    http.SetCookie(w, &http.Cookie{
+        Name:     "token",
+        Value:    "",
+        Path:     "/api",
+        HttpOnly: true,
+        Secure:   h.cookieSecure,
+        SameSite: http.SameSiteLaxMode,
+        MaxAge:   -1,
+    })
+    w.WriteHeader(http.StatusNoContent)
+}
+```
+
+Import to add: `"log/slog"`
+
+### Background cleanup goroutine
+
+In `backend/internal/api/router.go` or wherever the app lifecycle is managed (add after wiring, before `ListenAndServe`). Preferred location is a new `StartBackgroundJobs(ctx context.Context, authService *service.AuthService, logger *slog.Logger)` function called from `main.go`:
+
+```go
+// StartBackgroundJobs launches recurring maintenance tasks.
+// Call this once from main after the server starts. The goroutine stops when ctx is cancelled.
+func StartBackgroundJobs(ctx context.Context, authService *service.AuthService, logger *slog.Logger) {
+    go func() {
+        ticker := time.NewTicker(1 * time.Hour)
+        defer ticker.Stop()
+        for {
+            select {
+            case <-ctx.Done():
+                return
+            case <-ticker.C:
+                if err := authService.PurgeExpiredTokens(ctx); err != nil {
+                    logger.Warn("failed to purge expired revoked tokens", "error", err)
+                } else {
+                    logger.Info("purged expired revoked tokens")
+                }
+            }
+        }
+    }()
+}
+```
+
+### OpenAPI spec changes
+
+The `POST /auth/logout` endpoint already exists in `api/openapi.yaml` (lines 103-112). No schema changes are needed — the endpoint has no request body and returns 204 / 401. The blacklisting is a server-side implementation detail invisible to the spec.
+
+No regeneration of backend types (`make generate`) is needed for this story.
+
+### Error Responses
+
+| Situation | HTTP | Code | Message |
+|-----------|------|------|---------|
+| No cookie on any protected route | 401 | `UNAUTHORIZED` | `Authentication required` |
+| Token signature invalid / expired | 401 | `UNAUTHORIZED` | `Authentication required` |
+| Token JTI present in `revoked_tokens` | 401 | `TOKEN_REVOKED` | `Token has been revoked` |
+| Blacklist DB error during middleware check | 401 | `UNAUTHORIZED` | `Authentication required` |
+| Blacklist DB error during logout | 204 | — | Cookie cleared, error logged only |
+
+### Testing Requirements
+
+**Unit tests** (`-short` compatible, no containers):
+
+1. `TestAuthService_Logout_RevokesToken` — mock `TokenBlacklistRepository.Revoke` called with correct JTI and expiry
+2. `TestAuthService_Logout_InvalidToken_Noop` — expired/invalid token string causes no call to `Revoke`
+3. `TestAuthService_Logout_EmptyJTI_Noop` — legacy token with empty JTI causes no call to `Revoke`
+4. `TestAuthMiddleware_RevokedToken_Returns401` — middleware with mock blacklist returning `true` → 401 `TOKEN_REVOKED`
+5. `TestAuthMiddleware_ValidToken_NotRevoked_Passes` — mock returns `false` → handler called
+6. `TestAuthService_GenerateToken_HasJTI` — generated token always has non-empty `claims.ID`
+
+**Integration tests** (`run Integration`, testcontainers):
+
+7. `TestTokenBlacklistRepo_Integration` — `Revoke` then `IsRevoked` returns true; `DeleteExpired` removes it after advancing time
+8. `TestLogoutFlow_Integration` — full HTTP cycle: login → get cookie → logout → replay cookie → assert 401 `TOKEN_REVOKED`
+
+Test file locations:
+- `backend/internal/domain/service/auth_service_test.go` (extend existing or create)
+- `backend/internal/api/middleware/auth_test.go` (extend existing or create)
+- `backend/internal/adapter/postgres/token_blacklist_repo_integration_test.go` (new)
+
+## Dev Agent Record
+
+_To be filled by the implementing agent._
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-21 | zakari | Initial story draft |

--- a/_bmad-output/implementation-artifacts/feat-2-user-profile-api.md
+++ b/_bmad-output/implementation-artifacts/feat-2-user-profile-api.md
@@ -1,0 +1,346 @@
+# Story feat-2: [BACK] User profile API (GET/PUT /users/me)
+
+Status: ready-for-dev
+
+## Story
+
+As an authenticated user,
+I want to view and update my own profile (name, email) and change my password via dedicated self-service endpoints,
+so that I can manage my account without requiring admin access.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Get own profile**
+- **Given** I am authenticated (valid JWT cookie)
+- **When** I send `GET /api/v1/users/me`
+- **Then** I receive HTTP 200 with my user object (`id`, `email`, `name`, `role`, `created_at`, `updated_at`)
+
+**AC2: Update own profile (name and/or email)**
+- **Given** I am authenticated
+- **When** I send `PUT /api/v1/users/me` with a JSON body containing `name` and/or `email`
+- **Then** I receive HTTP 200 with the updated user object
+- **And** the changes are persisted to the database
+
+**AC3: Change own password**
+- **Given** I am authenticated
+- **When** I send `PUT /api/v1/users/me/password` with `current_password` and `new_password`
+- **Then** I receive HTTP 204 No Content on success
+
+**AC4: Password change fails on wrong current password**
+- **Given** I am authenticated
+- **When** I send `PUT /api/v1/users/me/password` with an incorrect `current_password`
+- **Then** I receive HTTP 401 with error code `INVALID_CREDENTIALS`
+
+**AC5: Update profile fails on empty name or malformed email**
+- **Given** I am authenticated
+- **When** I send `PUT /api/v1/users/me` with an empty `name` or a non-email string for `email`
+- **Then** I receive HTTP 400 with error code `VALIDATION_ERROR`
+
+**AC6: Unauthenticated requests are rejected**
+- **Given** I have no valid JWT cookie
+- **When** I send `GET /api/v1/users/me` or `PUT /api/v1/users/me` or `PUT /api/v1/users/me/password`
+- **Then** I receive HTTP 401 with error code `UNAUTHORIZED`
+
+## Tasks / Subtasks
+
+- [ ] [BACK] Task 1: Update `api/openapi.yaml` with new endpoints and schemas (AC: #1, #2, #3, #5, #6)
+  - [ ] Add `GET /users/me` endpoint (operationId: `getMyProfile`, tag: `users`)
+  - [ ] Add `PUT /users/me` endpoint (operationId: `updateMyProfile`, tag: `users`) with `UpdateMyProfileRequest` schema
+  - [ ] Add `PUT /users/me/password` endpoint (operationId: `changeMyPassword`, tag: `users`) with `ChangePasswordRequest` schema
+  - [ ] Reference the existing `User` response schema for both GET and PUT responses
+  - [ ] Regenerate backend types: `cd backend && make generate`
+
+- [ ] [BACK] Task 2: Add `UpdateProfile` and `ChangePassword` methods to `UserService` (AC: #1, #2, #3, #4, #5)
+  - [ ] Add `UpdateProfileParams` struct (fields: `ID uuid.UUID`, `Name *string`, `Email *string`)
+  - [ ] Add `UpdateProfile(ctx, params UpdateProfileParams) (*model.User, error)` — validates name non-empty (max 255), delegates to `repo.Update`; no role field (users cannot self-promote)
+  - [ ] Add `ChangePassword(ctx, userID uuid.UUID, currentPassword, newPassword string) error` — fetches user, verifies current password with `bcrypt.CompareHashAndPassword`, hashes new password, calls `repo.UpdatePasswordHash`
+  - [ ] Add `ErrInvalidCurrentPassword` sentinel to `UserService` (or reuse `AuthService.ErrInvalidCredentials`; prefer a new sentinel in service package to avoid cross-service import)
+  - [ ] Add sqlc query `UpdateUserPasswordHash` in `backend/queries/users.sql`
+  - [ ] Run `cd backend && sqlc generate` to regenerate DB layer
+  - [ ] Add `UpdatePasswordHash(ctx, id uuid.UUID, hash string) error` to `port.UserRepository` interface
+  - [ ] Implement `UpdatePasswordHash` on `postgres.UserRepository`
+
+- [ ] [BACK] Task 3: Implement `ProfileHandler` in `backend/internal/api/handler/profile_handler.go` (AC: #1, #2, #3, #4, #5, #6)
+  - [ ] `GetMyProfile(w, r)` — extract `userID` from `middleware.UserIDFromContext`, call `userService.GetByID`, respond 200 with `toAPIUser`
+  - [ ] `UpdateMyProfile(w, r)` — decode body, validate, call `userService.UpdateProfile`, respond 200 with `toAPIUser`
+  - [ ] `ChangeMyPassword(w, r)` — decode body, validate non-empty fields, call `userService.ChangePassword`, respond 204; map `ErrInvalidCurrentPassword` → 401 `INVALID_CREDENTIALS`
+  - [ ] Use `writeErrorResponse` / `writeJSON` helpers from `handler` package
+
+- [ ] [BACK] Task 4: Wire `ProfileHandler` into `Server` and register routes (AC: #1, #2, #3, #6)
+  - [ ] Add `profile *ProfileHandler` field to `Server` struct in `server.go`
+  - [ ] Update `NewServer(...)` to accept `*ProfileHandler`
+  - [ ] Add delegate methods: `GetMyProfile`, `UpdateMyProfile`, `ChangeMyPassword` on `Server`
+  - [ ] Instantiate `ProfileHandler` in `cmd/api/main.go` and pass to `NewServer`
+  - [ ] Verify routes are registered via `HandlerFromMuxWithBaseURL` (generated from the updated OpenAPI spec)
+
+- [ ] [BACK] Task 5: Tests (AC: #1, #2, #3, #4, #5, #6)
+  - [ ] Unit tests for `UserService.UpdateProfile` — table-driven: valid update, empty name, email conflict (duplicate)
+  - [ ] Unit tests for `UserService.ChangePassword` — correct current password, wrong current password, new password too short
+  - [ ] Handler tests for `ProfileHandler` using `httptest` with mock `UserService` — cover all 3 endpoints and error paths
+
+## Dev Notes
+
+### Dependencies
+
+- No new Go modules required — `bcrypt` already used in `auth_service.go` (via `golang.org/x/crypto`)
+- `UserRepository.Update` already exists; only `UpdatePasswordHash` is new
+
+### File Paths (exact)
+
+| File | Action |
+|------|--------|
+| `api/openapi.yaml` | Add 3 new paths and 2 new schemas |
+| `backend/queries/users.sql` | Add `UpdateUserPasswordHash` query |
+| `backend/internal/adapter/postgres/db/` | Regenerated by sqlc — do not edit manually |
+| `backend/internal/domain/port/user_repository.go` | Add `UpdatePasswordHash` method |
+| `backend/internal/adapter/postgres/user_repository.go` | Implement `UpdatePasswordHash` |
+| `backend/internal/domain/service/user_service.go` | Add `UpdateProfile`, `ChangePassword`, params structs, sentinel error |
+| `backend/internal/api/handler/profile_handler.go` | New file — `ProfileHandler` |
+| `backend/internal/api/handler/server.go` | Add `profile` field + delegate methods |
+| `backend/cmd/api/main.go` | Instantiate `ProfileHandler`, pass to `NewServer` |
+
+### New/Modified sqlc Queries
+
+Add to `backend/queries/users.sql`:
+
+```sql
+-- name: UpdateUserPasswordHash :exec
+UPDATE users
+SET password_hash = $2,
+    updated_at    = now()
+WHERE id = $1 AND deleted_at IS NULL;
+```
+
+Regenerate: `cd backend && sqlc generate`
+
+This generates `db.UpdateUserPasswordHash(ctx, db.UpdateUserPasswordHashParams{ID: id, PasswordHash: hash})`.
+
+### OpenAPI spec additions (new endpoints + schemas)
+
+Add to `api/openapi.yaml` under `paths:`, after the existing `/users/{id}` block:
+
+```yaml
+  /users/me:
+    get:
+      operationId: getMyProfile
+      summary: Get the current user's profile
+      tags: [users]
+      responses:
+        "200":
+          description: Current user profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+    put:
+      operationId: updateMyProfile
+      summary: Update the current user's profile (name and/or email)
+      tags: [users]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateMyProfileRequest"
+      responses:
+        "200":
+          description: Updated user profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /users/me/password:
+    put:
+      operationId: changeMyPassword
+      summary: Change the current user's password
+      tags: [users]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangePasswordRequest"
+      responses:
+        "204":
+          description: Password changed successfully
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+```
+
+Add to `components/schemas:`:
+
+```yaml
+    UpdateMyProfileRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        email:
+          type: string
+          format: email
+      minProperties: 1
+
+    ChangePasswordRequest:
+      type: object
+      required: [current_password, new_password]
+      properties:
+        current_password:
+          type: string
+          minLength: 1
+        new_password:
+          type: string
+          minLength: 8
+```
+
+After updating the spec, regenerate: `cd backend && make generate`
+
+### Handler Signatures
+
+```go
+// backend/internal/api/handler/profile_handler.go
+
+package handler
+
+import (
+    "encoding/json"
+    "net/http"
+
+    "golang.org/x/crypto/bcrypt"
+
+    "github.com/zakari/hopeitworks/backend/internal/api/middleware"
+    "github.com/zakari/hopeitworks/backend/internal/domain/service"
+    "github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// ProfileHandler handles self-service profile endpoints for the authenticated user.
+type ProfileHandler struct {
+    userService *service.UserService
+}
+
+// NewProfileHandler creates a new ProfileHandler.
+func NewProfileHandler(svc *service.UserService) *ProfileHandler {
+    return &ProfileHandler{userService: svc}
+}
+
+// GetMyProfile handles GET /users/me.
+func (h *ProfileHandler) GetMyProfile(w http.ResponseWriter, r *http.Request)
+
+// UpdateMyProfile handles PUT /users/me.
+func (h *ProfileHandler) UpdateMyProfile(w http.ResponseWriter, r *http.Request)
+
+// ChangeMyPassword handles PUT /users/me/password.
+func (h *ProfileHandler) ChangeMyPassword(w http.ResponseWriter, r *http.Request)
+```
+
+Service method signatures to add to `backend/internal/domain/service/user_service.go`:
+
+```go
+// ErrInvalidCurrentPassword is returned when the current password does not match.
+var ErrInvalidCurrentPassword = errors.NewUnauthorized("current password is incorrect")
+
+// UpdateProfileParams holds parameters for self-service profile updates.
+// Role is intentionally excluded — users cannot change their own role.
+type UpdateProfileParams struct {
+    ID    uuid.UUID
+    Name  *string
+    Email *string
+}
+
+// UpdateProfile validates and applies a self-service profile update.
+func (s *UserService) UpdateProfile(ctx context.Context, params UpdateProfileParams) (*model.User, error)
+
+// ChangePassword verifies the current password and sets a new bcrypt hash.
+func (s *UserService) ChangePassword(ctx context.Context, userID uuid.UUID, currentPassword, newPassword string) error
+```
+
+Port addition in `backend/internal/domain/port/user_repository.go`:
+
+```go
+// UpdatePasswordHash replaces the bcrypt password hash for a user.
+UpdatePasswordHash(ctx context.Context, id uuid.UUID, hash string) error
+```
+
+Postgres adapter addition in `backend/internal/adapter/postgres/user_repository.go`:
+
+```go
+// UpdatePasswordHash implements port.UserRepository.
+func (r *UserRepository) UpdatePasswordHash(ctx context.Context, id uuid.UUID, hash string) error {
+    return r.queries.UpdateUserPasswordHash(ctx, db.UpdateUserPasswordHashParams{
+        ID:           id,
+        PasswordHash: hash,
+    })
+}
+```
+
+Server delegates to add in `backend/internal/api/handler/server.go`:
+
+```go
+// GetMyProfile delegates to ProfileHandler.
+func (s *Server) GetMyProfile(w http.ResponseWriter, r *http.Request) {
+    s.profile.GetMyProfile(w, r)
+}
+
+// UpdateMyProfile delegates to ProfileHandler.
+func (s *Server) UpdateMyProfile(w http.ResponseWriter, r *http.Request) {
+    s.profile.UpdateMyProfile(w, r)
+}
+
+// ChangeMyPassword delegates to ProfileHandler.
+func (s *Server) ChangeMyPassword(w http.ResponseWriter, r *http.Request) {
+    s.profile.ChangeMyPassword(w, r)
+}
+```
+
+### Error Responses
+
+| Scenario | HTTP | Code |
+|----------|------|------|
+| No valid JWT cookie | 401 | `UNAUTHORIZED` |
+| Empty name in profile update | 400 | `VALIDATION_ERROR` |
+| Name > 255 chars | 400 | `VALIDATION_ERROR` |
+| Malformed email | 400 | `VALIDATION_ERROR` |
+| Email already taken by another user | 409 | `CONFLICT` |
+| Wrong current password | 401 | `INVALID_CREDENTIALS` |
+| New password < 8 chars | 400 | `VALIDATION_ERROR` |
+| User not found (deleted between auth and handler) | 401 | `UNAUTHORIZED` (treat as auth failure, not 404) |
+
+Note: The email conflict on `PUT /users/me` flows through `repo.Update`, which will return a Postgres unique constraint error (code 23505). Use the existing `isDuplicateKeyError` pattern (already in `auth_service.go`) or surface it via the postgres adapter wrapping it as `errors.NewConflict("email", email)`.
+
+### Testing Requirements
+
+- Use `httptest.NewRecorder()` and `httptest.NewRequest()` for handler tests
+- Inject `middleware.SetUserContext(ctx, userID, role)` to simulate authenticated requests in handler tests
+- Mock `UserService` with a hand-written mock implementing the methods under test
+- Service unit tests use a mock `UserRepository` (hand-written)
+- All tests must pass `go test ./... -short`
+- Lint must pass: `cd backend && golangci-lint run ./...`
+
+Key test cases:
+1. `GET /users/me` — 200 returns correct user fields; 401 when no user in context
+2. `PUT /users/me` — 200 with name-only update; 200 with email-only update; 400 on empty name; 400 on no fields provided; 409 on duplicate email
+3. `PUT /users/me/password` — 204 on success; 401 on wrong current password; 400 on new password < 8 chars
+4. `UserService.ChangePassword` — verifies bcrypt check is applied; verifies new hash is stored
+
+## Dev Agent Record
+
+_To be filled in by the implementing agent._
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-21 | Claude | Initial draft |

--- a/_bmad-output/implementation-artifacts/feat-3-reset-password-api.md
+++ b/_bmad-output/implementation-artifacts/feat-3-reset-password-api.md
@@ -1,0 +1,897 @@
+# Story feat-3: [BACK] Reset password API with MailHog SMTP
+
+Status: ready-for-dev
+
+## Story
+
+As a platform user who has forgotten their password,
+I want to request a password reset link via email and use it to set a new password,
+so that I can regain access to my account without contacting an administrator.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Forgot password — valid email**
+- **Given** a registered user with email `user@example.com`
+- **When** a POST request is made to `/api/v1/auth/forgot-password` with `{"email": "user@example.com"}`
+- **Then** the API responds with HTTP 202 and body `{"message": "If this email is registered, a reset link has been sent"}`
+- **And** a password reset token is created in the `password_reset_tokens` table with `expires_at = now() + 1h`
+- **And** an email is sent via SMTP containing a link of the form `{FRONTEND_URL}/reset-password?token={token}`
+
+**AC2: Forgot password — unknown email (no enumeration)**
+- **Given** an email address that does not correspond to any registered user
+- **When** a POST request is made to `/api/v1/auth/forgot-password` with that email
+- **Then** the API responds with HTTP 202 and the **same body** as AC1 (no enumeration leak)
+- **And** no token is created and no email is sent
+
+**AC3: Reset password — valid token**
+- **Given** a valid, unexpired, unused reset token in `password_reset_tokens`
+- **When** a POST request is made to `/api/v1/auth/reset-password` with `{"token": "...", "password": "newPass123"}`
+- **Then** the API responds with HTTP 200 and body `{"message": "Password updated successfully"}`
+- **And** the user's `password_hash` is updated in the `users` table
+- **And** the token's `used_at` is set to `now()` in `password_reset_tokens`
+
+**AC4: Reset password — expired token**
+- **Given** a reset token whose `expires_at` is in the past
+- **When** a POST request is made to `/api/v1/auth/reset-password` with that token
+- **Then** the API responds with HTTP 400 and error code `RESET_TOKEN_EXPIRED`
+
+**AC5: Reset password — already-used token**
+- **Given** a reset token whose `used_at` is not null
+- **When** a POST request is made to `/api/v1/auth/reset-password` with that token
+- **Then** the API responds with HTTP 400 and error code `RESET_TOKEN_INVALID`
+
+**AC6: Reset password — token not found**
+- **Given** a token string that does not exist in `password_reset_tokens`
+- **When** a POST request is made to `/api/v1/auth/reset-password` with that token
+- **Then** the API responds with HTTP 400 and error code `RESET_TOKEN_INVALID`
+
+**AC7: Reset password — weak new password**
+- **Given** a valid reset token
+- **When** a POST request is made to `/api/v1/auth/reset-password` with a password shorter than 8 characters
+- **Then** the API responds with HTTP 400 and error code `VALIDATION_ERROR`
+
+## Tasks / Subtasks
+
+- [ ] [BACK] Task 1: Add migration `000023_create_password_reset_tokens_table` (AC: #1, #3, #4, #5, #6)
+  - [ ] Create `backend/migrations/000023_create_password_reset_tokens_table.up.sql` with the table DDL
+  - [ ] Create `backend/migrations/000023_create_password_reset_tokens_table.down.sql` with `DROP TABLE`
+
+- [ ] [BACK] Task 2: Add sqlc queries for `password_reset_tokens` (AC: #1, #3, #4, #5, #6)
+  - [ ] Create `backend/queries/password_reset_tokens.sql` with the four queries listed in Dev Notes
+  - [ ] Run `cd backend && sqlc generate` to produce `internal/adapter/postgres/password_reset_tokens.sql.go`
+
+- [ ] [BACK] Task 3: Add domain model and port interfaces (AC: #1, #3)
+  - [ ] Create `backend/internal/domain/model/password_reset_token.go` — `PasswordResetToken` struct
+  - [ ] Create `backend/internal/domain/port/password_reset_token_repository.go` — `PasswordResetTokenRepository` interface
+  - [ ] Create `backend/internal/domain/port/email_sender.go` — `EmailSender` interface
+
+- [ ] [BACK] Task 4: Implement `PasswordResetTokenRepository` postgres adapter (AC: #1, #3, #4, #5, #6)
+  - [ ] Create `backend/internal/adapter/postgres/password_reset_token_repository.go`
+  - [ ] Map sqlc rows to domain model via `toDomainPasswordResetToken()` helper
+  - [ ] Add compile-time interface guard `var _ port.PasswordResetTokenRepository = (*PasswordResetTokenRepository)(nil)`
+
+- [ ] [BACK] Task 5: Implement SMTP `EmailSender` adapter with MailHog support (AC: #1)
+  - [ ] Create `backend/internal/adapter/smtp/email_sender.go`
+  - [ ] Use `net/smtp` stdlib — no third-party email library
+  - [ ] Add `SMTPConfig` to `backend/pkg/config/config.go` and env var overrides to `backend/internal/config/loader.go`
+  - [ ] Add compile-time interface guard `var _ port.EmailSender = (*EmailSender)(nil)`
+  - [ ] Add unit test `backend/internal/adapter/smtp/email_sender_test.go` using a mock SMTP server or recorded dial
+
+- [ ] [BACK] Task 6: Add `ForgotPassword` and `ResetPassword` methods to `AuthService` (AC: #1–#7)
+  - [ ] Extend `backend/internal/domain/service/auth_service.go` — inject `PasswordResetTokenRepository` and `EmailSender`
+  - [ ] Add sentinel errors: `ErrResetTokenExpired`, `ErrResetTokenInvalid`
+  - [ ] Write table-driven unit tests in `backend/internal/domain/service/auth_service_test.go`
+
+- [ ] [BACK] Task 7: Add HTTP handlers and register routes (AC: #1–#7)
+  - [ ] Extend `backend/internal/api/handler/auth_handler.go` with `ForgotPassword` and `ResetPassword` handlers
+  - [ ] Update `api/openapi.yaml` with the two new paths and schemas
+  - [ ] Run `cd backend && make generate` to regenerate `gen_server.go`
+  - [ ] Register routes in `backend/internal/api/handler/server.go`
+  - [ ] Add MailHog service to `deploy/docker-compose.yml`
+  - [ ] Add SMTP config and env var documentation
+
+- [ ] [BACK] Task 8: Wire dependencies (AC: all)
+  - [ ] Update `backend/cmd/api/wire.go` provider sets to include `SmtpEmailSender`, `PasswordResetTokenRepository`
+  - [ ] Run `cd backend && wire ./cmd/api/` to regenerate `wire_gen.go`
+  - [ ] Run `golangci-lint run ./...` — must pass with zero warnings
+
+## Dev Notes
+
+### Dependencies
+
+- No new Go modules needed — use `net/smtp` from stdlib
+- MailHog Docker image: `mailhog/mailhog:v1.0.1`
+
+### File Paths (exact)
+
+| File | Purpose |
+|------|---------|
+| `backend/migrations/000023_create_password_reset_tokens_table.up.sql` | Schema migration |
+| `backend/migrations/000023_create_password_reset_tokens_table.down.sql` | Rollback migration |
+| `backend/queries/password_reset_tokens.sql` | sqlc query source |
+| `backend/internal/adapter/postgres/password_reset_tokens.sql.go` | Generated by sqlc — DO NOT EDIT |
+| `backend/internal/adapter/postgres/password_reset_token_repository.go` | Repo adapter |
+| `backend/internal/domain/model/password_reset_token.go` | Domain model |
+| `backend/internal/domain/port/password_reset_token_repository.go` | Repository port |
+| `backend/internal/domain/port/email_sender.go` | EmailSender port |
+| `backend/internal/adapter/smtp/email_sender.go` | SMTP adapter |
+| `backend/internal/adapter/smtp/email_sender_test.go` | Adapter unit test |
+| `backend/internal/domain/service/auth_service.go` | Extended service |
+| `backend/internal/api/handler/auth_handler.go` | Extended handler |
+| `backend/cmd/api/wire.go` | DI wiring update |
+| `backend/pkg/config/config.go` | SMTPConfig struct added |
+| `backend/internal/config/loader.go` | SMTP env var overrides |
+| `deploy/docker-compose.yml` | MailHog service added |
+| `api/openapi.yaml` | New paths + schemas |
+
+### Migration SQL Content (password_reset_tokens table)
+
+**`000023_create_password_reset_tokens_table.up.sql`:**
+
+```sql
+CREATE TABLE password_reset_tokens (
+    id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id    UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token      TEXT        NOT NULL UNIQUE,
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at    TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_password_reset_tokens_token   ON password_reset_tokens (token);
+CREATE INDEX idx_password_reset_tokens_user_id ON password_reset_tokens (user_id);
+```
+
+**`000023_create_password_reset_tokens_table.down.sql`:**
+
+```sql
+DROP TABLE IF EXISTS password_reset_tokens;
+```
+
+### sqlc Query Signatures
+
+**`backend/queries/password_reset_tokens.sql`:**
+
+```sql
+-- name: CreatePasswordResetToken :one
+INSERT INTO password_reset_tokens (user_id, token, expires_at)
+VALUES ($1, $2, $3)
+RETURNING *;
+
+-- name: GetPasswordResetToken :one
+SELECT * FROM password_reset_tokens WHERE token = $1 LIMIT 1;
+
+-- name: MarkPasswordResetTokenUsed :exec
+UPDATE password_reset_tokens SET used_at = now() WHERE id = $1;
+
+-- name: DeleteExpiredPasswordResetTokens :exec
+DELETE FROM password_reset_tokens WHERE expires_at < now() AND used_at IS NULL;
+```
+
+After adding the file, run `cd backend && sqlc generate` to produce `internal/adapter/postgres/password_reset_tokens.sql.go`.
+
+The generated `PasswordResetToken` row struct will look like (do not write this manually — shown for reference):
+
+```go
+type PasswordResetToken struct {
+    ID        uuid.UUID
+    UserID    uuid.UUID
+    Token     string
+    ExpiresAt time.Time
+    UsedAt    pgtype.Timestamptz
+    CreatedAt time.Time
+}
+```
+
+### Domain Model (PasswordResetToken)
+
+**`backend/internal/domain/model/password_reset_token.go`:**
+
+```go
+package model
+
+import (
+    "time"
+
+    "github.com/google/uuid"
+)
+
+// PasswordResetToken represents a one-time token for resetting a user's password.
+type PasswordResetToken struct {
+    ID        uuid.UUID
+    UserID    uuid.UUID
+    Token     string
+    ExpiresAt time.Time
+    UsedAt    *time.Time
+    CreatedAt time.Time
+}
+
+// IsExpired returns true if the token is past its expiry time.
+func (t *PasswordResetToken) IsExpired() bool {
+    return time.Now().After(t.ExpiresAt)
+}
+
+// IsUsed returns true if the token has already been consumed.
+func (t *PasswordResetToken) IsUsed() bool {
+    return t.UsedAt != nil
+}
+```
+
+### New Port: PasswordResetTokenRepository
+
+**`backend/internal/domain/port/password_reset_token_repository.go`:**
+
+```go
+package port
+
+import (
+    "context"
+
+    "github.com/google/uuid"
+    "github.com/zakari/hopeitworks/backend/internal/domain/model"
+)
+
+// PasswordResetTokenRepository defines persistence operations for password reset tokens.
+type PasswordResetTokenRepository interface {
+    Create(ctx context.Context, userID uuid.UUID, token string, expiresAt time.Time) (*model.PasswordResetToken, error)
+    GetByToken(ctx context.Context, token string) (*model.PasswordResetToken, error)
+    MarkUsed(ctx context.Context, id uuid.UUID) error
+}
+```
+
+Note: add `"time"` import to the file above.
+
+### New Port: EmailSender
+
+**`backend/internal/domain/port/email_sender.go`:**
+
+```go
+package port
+
+import "context"
+
+// EmailMessage represents a single outbound email.
+type EmailMessage struct {
+    To      string
+    Subject string
+    // HTMLBody is the HTML email body. Plain-text is auto-derived by the adapter.
+    HTMLBody string
+}
+
+// EmailSender delivers transactional emails.
+type EmailSender interface {
+    Send(ctx context.Context, msg EmailMessage) error
+}
+```
+
+### SMTP Adapter implementation
+
+**`backend/internal/adapter/smtp/email_sender.go`:**
+
+```go
+package smtp
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "html/template"
+    "net/smtp"
+
+    "github.com/zakari/hopeitworks/backend/internal/domain/port"
+    apperrors "github.com/zakari/hopeitworks/backend/pkg/errors"
+    pkgconfig "github.com/zakari/hopeitworks/backend/pkg/config"
+)
+
+// EmailSender implements port.EmailSender via stdlib net/smtp.
+type EmailSender struct {
+    cfg pkgconfig.SMTPConfig
+}
+
+var _ port.EmailSender = (*EmailSender)(nil)
+
+// NewEmailSender creates a new SMTP-backed EmailSender.
+func NewEmailSender(cfg pkgconfig.SMTPConfig) *EmailSender {
+    return &EmailSender{cfg: cfg}
+}
+
+// Send delivers msg via the configured SMTP relay.
+// MailHog accepts unauthenticated connections — no SMTP auth is used when
+// cfg.Username is empty.
+func (s *EmailSender) Send(_ context.Context, msg port.EmailMessage) error {
+    addr := fmt.Sprintf("%s:%d", s.cfg.Host, s.cfg.Port)
+
+    headers := fmt.Sprintf(
+        "From: %s\r\nTo: %s\r\nSubject: %s\r\nMIME-Version: 1.0\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n",
+        s.cfg.From, msg.To, msg.Subject,
+    )
+    body := headers + msg.HTMLBody
+
+    var auth smtp.Auth
+    if s.cfg.Username != "" {
+        auth = smtp.PlainAuth("", s.cfg.Username, s.cfg.Password, s.cfg.Host)
+    }
+
+    if err := smtp.SendMail(addr, auth, s.cfg.From, []string{msg.To}, []byte(body)); err != nil {
+        return apperrors.NewInternal("smtp: failed to send email", err)
+    }
+    return nil
+}
+```
+
+### Docker Compose changes (MailHog service)
+
+Add the following service to `deploy/docker-compose.yml` inside the `services:` block, before `volumes:`:
+
+```yaml
+  mailhog:
+    image: mailhog/mailhog:v1.0.1
+    container_name: hopeitworks-mailhog
+    ports:
+      - "${MAILHOG_SMTP_PORT:-1025}:1025"   # SMTP
+      - "${MAILHOG_UI_PORT:-8025}:8025"     # Web UI
+    networks:
+      - hopeitworks
+    restart: on-failure
+```
+
+Also add the `api` service dependencies on `mailhog`:
+```yaml
+  api:
+    # ... existing config ...
+    environment:
+      # ... existing env vars ...
+      SMTP_HOST: mailhog
+      SMTP_PORT: 1025
+      SMTP_FROM: noreply@hopeitworks.local
+      FRONTEND_URL: ${FRONTEND_URL:-http://localhost:5173}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      socket-proxy:
+        condition: service_started
+      mailhog:
+        condition: service_started
+```
+
+### Config additions (SMTP settings)
+
+**Addition to `backend/pkg/config/config.go`:**
+
+Add `SMTP SMTPConfig` field to `Config` struct, and add the following type:
+
+```go
+// SMTPConfig holds outbound email relay settings.
+type SMTPConfig struct {
+    Host        string `yaml:"host"`
+    Port        int    `yaml:"port"`
+    From        string `yaml:"from"`
+    Username    string `yaml:"username"`
+    Password    string `yaml:"password"`
+    FrontendURL string `yaml:"frontend_url"`
+}
+```
+
+Updated `Config` struct:
+```go
+type Config struct {
+    Server   ServerConfig   `yaml:"server"`
+    Database DatabaseConfig `yaml:"database"`
+    Docker   DockerConfig   `yaml:"docker"`
+    Log      LogConfig      `yaml:"logging"`
+    SMTP     SMTPConfig     `yaml:"smtp"`
+}
+```
+
+**Additions to `backend/internal/config/loader.go` inside `applyEnvOverrides`:**
+
+```go
+if v := os.Getenv("SMTP_HOST"); v != "" {
+    cfg.SMTP.Host = v
+}
+if v := os.Getenv("SMTP_PORT"); v != "" {
+    if port, err := strconv.Atoi(v); err == nil {
+        cfg.SMTP.Port = port
+    }
+}
+if v := os.Getenv("SMTP_FROM"); v != "" {
+    cfg.SMTP.From = v
+}
+if v := os.Getenv("SMTP_USERNAME"); v != "" {
+    cfg.SMTP.Username = v
+}
+if v := os.Getenv("SMTP_PASSWORD"); v != "" {
+    cfg.SMTP.Password = v
+}
+if v := os.Getenv("FRONTEND_URL"); v != "" {
+    cfg.SMTP.FrontendURL = v
+}
+```
+
+Default SMTP config in `backend/config.yaml` (add under existing keys):
+```yaml
+smtp:
+  host: localhost
+  port: 1025
+  from: noreply@hopeitworks.local
+  username: ""
+  password: ""
+  frontend_url: http://localhost:5173
+```
+
+### AuthService extension
+
+**Extend `backend/internal/domain/service/auth_service.go`:**
+
+Add the following sentinel errors at the top alongside existing ones:
+```go
+var (
+    ErrInvalidCredentials  = errors.New("invalid credentials")
+    ErrEmailAlreadyExists  = errors.New("email already exists")
+    ErrValidation          = errors.New("validation error")
+    ErrResetTokenExpired   = errors.New("reset token expired")
+    ErrResetTokenInvalid   = errors.New("reset token invalid or already used")
+)
+```
+
+Extend `AuthService` struct:
+```go
+type AuthService struct {
+    repo           port.UserRepository
+    tokenRepo      port.PasswordResetTokenRepository
+    emailSender    port.EmailSender
+    frontendURL    string
+    jwtSecret      []byte
+    jwtExpiration  time.Duration
+}
+
+func NewAuthService(
+    repo port.UserRepository,
+    tokenRepo port.PasswordResetTokenRepository,
+    emailSender port.EmailSender,
+    frontendURL string,
+    jwtSecret string,
+    jwtExpiration time.Duration,
+) *AuthService {
+    return &AuthService{
+        repo:          repo,
+        tokenRepo:     tokenRepo,
+        emailSender:   emailSender,
+        frontendURL:   frontendURL,
+        jwtSecret:     []byte(jwtSecret),
+        jwtExpiration: jwtExpiration,
+    }
+}
+```
+
+New methods to add to `AuthService`:
+```go
+// ForgotPassword generates a reset token and sends an email if the address is registered.
+// Always returns nil error to prevent email enumeration.
+func (s *AuthService) ForgotPassword(ctx context.Context, email string) error {
+    if email == "" {
+        return ErrValidation
+    }
+
+    user, err := s.repo.GetByEmail(ctx, email)
+    if err != nil {
+        // Unknown email — return nil to prevent enumeration.
+        return nil
+    }
+
+    rawToken, err := generateSecureToken()
+    if err != nil {
+        return err
+    }
+
+    expiresAt := time.Now().Add(1 * time.Hour)
+    if _, err := s.tokenRepo.Create(ctx, user.ID, rawToken, expiresAt); err != nil {
+        return err
+    }
+
+    resetLink := fmt.Sprintf("%s/reset-password?token=%s", s.frontendURL, rawToken)
+    return s.emailSender.Send(ctx, port.EmailMessage{
+        To:      user.Email,
+        Subject: "Reset your HopeItWorks password",
+        HTMLBody: buildResetEmailHTML(user.Name, resetLink),
+    })
+}
+
+// ResetPassword validates the token and updates the user's password.
+func (s *AuthService) ResetPassword(ctx context.Context, rawToken, newPassword string) error {
+    if rawToken == "" || newPassword == "" {
+        return ErrValidation
+    }
+    if len(newPassword) < 8 {
+        return ErrValidation
+    }
+
+    prt, err := s.tokenRepo.GetByToken(ctx, rawToken)
+    if err != nil {
+        return ErrResetTokenInvalid
+    }
+    if prt.IsUsed() {
+        return ErrResetTokenInvalid
+    }
+    if prt.IsExpired() {
+        return ErrResetTokenExpired
+    }
+
+    hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+    if err != nil {
+        return err
+    }
+
+    user, err := s.repo.GetByID(ctx, prt.UserID)
+    if err != nil {
+        return err
+    }
+    user.PasswordHash = string(hash)
+    if _, err := s.repo.Update(ctx, user); err != nil {
+        return err
+    }
+
+    return s.tokenRepo.MarkUsed(ctx, prt.ID)
+}
+
+// generateSecureToken returns a 32-byte URL-safe base64-encoded random token.
+func generateSecureToken() (string, error) {
+    b := make([]byte, 32)
+    if _, err := rand.Read(b); err != nil {
+        return "", err
+    }
+    return base64.URLEncoding.EncodeToString(b), nil
+}
+```
+
+Required additional imports for `auth_service.go`:
+```go
+import (
+    "crypto/rand"
+    "encoding/base64"
+    "fmt"
+    // ... existing imports ...
+)
+```
+
+### Email template (HTML reset link)
+
+Add helper function in `auth_service.go` (or a separate `email_templates.go` in the service package):
+
+```go
+// buildResetEmailHTML returns a minimal HTML email body with the reset link.
+func buildResetEmailHTML(name, resetLink string) string {
+    return fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<body style="font-family: sans-serif; padding: 24px;">
+  <h2>Password Reset Request</h2>
+  <p>Hi %s,</p>
+  <p>We received a request to reset your HopeItWorks password.
+     Click the button below to set a new password. This link expires in <strong>1 hour</strong>.</p>
+  <p><a href="%s" style="background:#4F46E5;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;">
+    Reset my password
+  </a></p>
+  <p>If you did not request a password reset, you can ignore this email.</p>
+</body>
+</html>`, name, resetLink)
+}
+```
+
+### OpenAPI spec additions
+
+Add after the existing `/auth/me` path block in `api/openapi.yaml`:
+
+```yaml
+  /auth/forgot-password:
+    post:
+      operationId: forgotPassword
+      summary: Request a password reset link via email
+      tags: [auth]
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ForgotPasswordRequest"
+      responses:
+        "202":
+          description: Reset email dispatched (always returned — prevents email enumeration)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MessageResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /auth/reset-password:
+    post:
+      operationId: resetPassword
+      summary: Set a new password using a reset token
+      tags: [auth]
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResetPasswordRequest"
+      responses:
+        "200":
+          description: Password updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MessageResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+```
+
+Add the following schemas under `components/schemas` in `api/openapi.yaml`:
+
+```yaml
+    ForgotPasswordRequest:
+      type: object
+      required: [email]
+      properties:
+        email:
+          type: string
+          format: email
+          example: user@example.com
+
+    ResetPasswordRequest:
+      type: object
+      required: [token, password]
+      properties:
+        token:
+          type: string
+          description: The reset token received by email
+          example: "dGVzdC10b2tlbi1mb3ItcmVzZXQ="
+        password:
+          type: string
+          minLength: 8
+          description: The new password (minimum 8 characters)
+          example: "newSecurePass123"
+
+    MessageResponse:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+          example: "If this email is registered, a reset link has been sent"
+```
+
+After modifying the spec, run `cd backend && make generate` to regenerate `internal/api/handler/gen_server.go`.
+
+### HTTP Handler additions
+
+Extend `backend/internal/api/handler/auth_handler.go`:
+
+```go
+type forgotPasswordRequest struct {
+    Email string `json:"email"`
+}
+
+type resetPasswordRequest struct {
+    Token    string `json:"token"`
+    Password string `json:"password"`
+}
+
+type messageResponse struct {
+    Message string `json:"message"`
+}
+
+// ForgotPassword handles POST /auth/forgot-password.
+func (h *AuthHandler) ForgotPassword(w http.ResponseWriter, r *http.Request) {
+    var req forgotPasswordRequest
+    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+        writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Invalid request body")
+        return
+    }
+    if req.Email == "" {
+        writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "email is required")
+        return
+    }
+
+    // Ignore error — always return 202 to prevent enumeration.
+    _ = h.authService.ForgotPassword(r.Context(), req.Email)
+
+    writeJSON(w, http.StatusAccepted, messageResponse{
+        Message: "If this email is registered, a reset link has been sent",
+    })
+}
+
+// ResetPassword handles POST /auth/reset-password.
+func (h *AuthHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
+    var req resetPasswordRequest
+    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+        writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Invalid request body")
+        return
+    }
+    if req.Token == "" || req.Password == "" {
+        writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "token and password are required")
+        return
+    }
+
+    if err := h.authService.ResetPassword(r.Context(), req.Token, req.Password); err != nil {
+        switch {
+        case errors.Is(err, service.ErrResetTokenExpired):
+            writeError(w, http.StatusBadRequest, "RESET_TOKEN_EXPIRED", "The reset link has expired. Please request a new one.")
+        case errors.Is(err, service.ErrResetTokenInvalid):
+            writeError(w, http.StatusBadRequest, "RESET_TOKEN_INVALID", "The reset token is invalid or has already been used.")
+        case errors.Is(err, service.ErrValidation):
+            writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Password must be at least 8 characters.")
+        default:
+            writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred.")
+        }
+        return
+    }
+
+    writeJSON(w, http.StatusOK, messageResponse{Message: "Password updated successfully"})
+}
+```
+
+Register in `backend/internal/api/handler/server.go` under the auth routes block:
+```go
+r.Post("/auth/forgot-password", h.auth.ForgotPassword)
+r.Post("/auth/reset-password",  h.auth.ResetPassword)
+```
+
+### Postgres Adapter implementation
+
+**`backend/internal/adapter/postgres/password_reset_token_repository.go`:**
+
+```go
+package postgres
+
+import (
+    "context"
+    "time"
+
+    "github.com/google/uuid"
+    "github.com/jackc/pgx/v5"
+    "github.com/zakari/hopeitworks/backend/internal/domain/model"
+    "github.com/zakari/hopeitworks/backend/internal/domain/port"
+    apperrors "github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// PasswordResetTokenRepository implements port.PasswordResetTokenRepository using sqlc.
+type PasswordResetTokenRepository struct {
+    q *Queries
+}
+
+var _ port.PasswordResetTokenRepository = (*PasswordResetTokenRepository)(nil)
+
+// NewPasswordResetTokenRepository creates a new PasswordResetTokenRepository.
+func NewPasswordResetTokenRepository(db DBTX) *PasswordResetTokenRepository {
+    return &PasswordResetTokenRepository{q: New(db)}
+}
+
+func (r *PasswordResetTokenRepository) Create(ctx context.Context, userID uuid.UUID, token string, expiresAt time.Time) (*model.PasswordResetToken, error) {
+    row, err := r.q.CreatePasswordResetToken(ctx, CreatePasswordResetTokenParams{
+        UserID:    userID,
+        Token:     token,
+        ExpiresAt: expiresAt,
+    })
+    if err != nil {
+        return nil, apperrors.NewInternal("create password reset token", err)
+    }
+    return toDomainPasswordResetToken(row), nil
+}
+
+func (r *PasswordResetTokenRepository) GetByToken(ctx context.Context, token string) (*model.PasswordResetToken, error) {
+    row, err := r.q.GetPasswordResetToken(ctx, token)
+    if err != nil {
+        if err == pgx.ErrNoRows {
+            return nil, apperrors.NewNotFound("password_reset_token", token)
+        }
+        return nil, apperrors.NewInternal("get password reset token", err)
+    }
+    return toDomainPasswordResetToken(row), nil
+}
+
+func (r *PasswordResetTokenRepository) MarkUsed(ctx context.Context, id uuid.UUID) error {
+    if err := r.q.MarkPasswordResetTokenUsed(ctx, id); err != nil {
+        return apperrors.NewInternal("mark password reset token used", err)
+    }
+    return nil
+}
+
+func toDomainPasswordResetToken(row PasswordResetToken) *model.PasswordResetToken {
+    var usedAt *time.Time
+    if row.UsedAt.Valid {
+        usedAt = &row.UsedAt.Time
+    }
+    return &model.PasswordResetToken{
+        ID:        row.ID,
+        UserID:    row.UserID,
+        Token:     row.Token,
+        ExpiresAt: row.ExpiresAt.Time,
+        UsedAt:    usedAt,
+        CreatedAt: row.CreatedAt.Time,
+    }
+}
+```
+
+Note: the sqlc-generated `PasswordResetToken` struct uses `pgtype.Timestamptz` for `ExpiresAt` and `UsedAt`. Adjust `.Time` field access accordingly once `sqlc generate` has run — inspect the generated struct in `internal/adapter/postgres/password_reset_tokens.sql.go` and correct the field types as needed.
+
+### Error Responses
+
+| Scenario | HTTP | Code |
+|----------|------|------|
+| Invalid/missing body fields | 400 | `VALIDATION_ERROR` |
+| Token not found | 400 | `RESET_TOKEN_INVALID` |
+| Token already used | 400 | `RESET_TOKEN_INVALID` |
+| Token expired | 400 | `RESET_TOKEN_EXPIRED` |
+| Password < 8 chars | 400 | `VALIDATION_ERROR` |
+| Internal/SMTP error | 500 | `INTERNAL_ERROR` |
+
+### Security Considerations
+
+- **No email enumeration**: `ForgotPassword` always returns HTTP 202 regardless of whether the email exists. Do not log or surface any difference.
+- **Token entropy**: 32 random bytes encoded as URL-safe base64 = 256-bit entropy. Sufficient against brute-force.
+- **Token expiry**: 1 hour. Non-configurable for MVP; add to `SMTPConfig` in a future story if needed.
+- **Single-use enforcement**: `used_at` is set atomically on successful password change. Re-use of a consumed token returns `RESET_TOKEN_INVALID`.
+- **Token storage**: raw token stored in plain text in Postgres (acceptable for MVP). If hardened security is required later, store a SHA-256 hash and compare hash on lookup.
+- **Rate limiting**: not enforced at MVP — document the absence explicitly. A future story should add per-IP or per-email rate limiting at the middleware layer before the `ForgotPassword` handler.
+- **SMTP credentials**: never log `cfg.SMTP.Password`. The `ScrubHandler` in `pkg/log` already redacts fields containing `password`, but SMTP config must only be passed to the adapter, not exposed in handler context.
+- **Token cleanup**: `DeleteExpiredPasswordResetTokens` query is defined but not called automatically at MVP. Wire it to a periodic River job or run it as a manual cron in a future story.
+
+### Testing Requirements
+
+**Unit tests — `backend/internal/domain/service/auth_service_test.go`:**
+
+Table-driven tests covering:
+- `ForgotPassword`: email found → token created + email sent
+- `ForgotPassword`: email not found → returns nil (no error)
+- `ForgotPassword`: empty email → returns `ErrValidation`
+- `ResetPassword`: valid token → password updated + token marked used
+- `ResetPassword`: expired token → returns `ErrResetTokenExpired`
+- `ResetPassword`: used token → returns `ErrResetTokenInvalid`
+- `ResetPassword`: token not found → returns `ErrResetTokenInvalid`
+- `ResetPassword`: password < 8 chars → returns `ErrValidation`
+
+Use hand-written mocks for `port.PasswordResetTokenRepository` and `port.EmailSender`. Pattern:
+```go
+type mockPasswordResetTokenRepo struct {
+    createFn     func(ctx context.Context, userID uuid.UUID, token string, expiresAt time.Time) (*model.PasswordResetToken, error)
+    getByTokenFn func(ctx context.Context, token string) (*model.PasswordResetToken, error)
+    markUsedFn   func(ctx context.Context, id uuid.UUID) error
+}
+
+type mockEmailSender struct {
+    sendFn func(ctx context.Context, msg port.EmailMessage) error
+}
+```
+
+**Unit tests — `backend/internal/adapter/smtp/email_sender_test.go`:**
+
+- Test that `Send` constructs correct MIME headers (From, To, Subject, Content-Type)
+- Can use `net/smtp/smtptest` if available, otherwise skip integration and mock `smtp.SendMail` via dependency injection of a `sendMailFn` field
+
+**Handler tests — `backend/internal/api/handler/auth_handler_test.go`:**
+
+Add cases for:
+- `POST /auth/forgot-password`: valid email → 202
+- `POST /auth/forgot-password`: missing email → 400 `VALIDATION_ERROR`
+- `POST /auth/reset-password`: valid token → 200
+- `POST /auth/reset-password`: expired token → 400 `RESET_TOKEN_EXPIRED`
+- `POST /auth/reset-password`: invalid token → 400 `RESET_TOKEN_INVALID`
+- `POST /auth/reset-password`: weak password → 400 `VALIDATION_ERROR`
+
+**Integration test (optional, tagged):**
+
+`backend/internal/adapter/postgres/password_reset_token_repository_integration_test.go`:
+- Create token, retrieve by token string, mark used, verify `used_at` is set
+- Use `testutil.NewTestDB(t)` for ephemeral Postgres container
+
+## Dev Agent Record
+
+_To be filled by the implementing agent._
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-02-21 | Initial story created | architect |

--- a/_bmad-output/implementation-artifacts/feat-4-logout-ui.md
+++ b/_bmad-output/implementation-artifacts/feat-4-logout-ui.md
@@ -1,0 +1,265 @@
+# Story feat-4: [FRONT] Logout button and UI flow
+
+Status: ready-for-dev
+
+## Story
+
+As an authenticated user,
+I want a logout option accessible from the user menu in the header,
+so that I can securely end my session and be redirected to the login page.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Logout menu item triggers session termination**
+- **Given** I am authenticated and viewing any page inside AppShell
+- **When** I click the user menu button (`data-testid="user-menu-button"`) and select "Logout"
+- **Then** the frontend calls `POST /api/v1/auth/logout` with `credentials: 'include'`
+- **And** the auth store clears `user` and `error` state (`authStore.user = null`)
+- **And** I am redirected to `/login`
+
+**AC2: Logout button is accessible from the header user menu**
+- **Given** I am on any authenticated route
+- **When** I look at the AppHeader
+- **Then** I see a user icon button (`data-testid="user-menu-button"`) in the top-right area
+- **And** clicking it opens a PrimeVue `Menu` popup containing a "Logout" item with icon `pi pi-sign-out`
+
+**AC3: Backend errors do not block logout**
+- **Given** the `POST /api/v1/auth/logout` call returns a network error or non-2xx response
+- **When** I click Logout
+- **Then** the error is silently swallowed (best-effort logout)
+- **And** the auth store state is still cleared
+- **And** I am still redirected to `/login`
+
+**AC4: After logout, protected routes redirect to /login**
+- **Given** I have just logged out
+- **When** I navigate to any route with `meta: { requiresAuth: true }` (e.g. `/`, `/projects`)
+- **Then** the Vue Router auth guard redirects me to `/login?redirect=<original-path>`
+
+**AC5: Display user identity in the user menu**
+- **Given** I am authenticated and the auth store contains `user.name` and `user.email`
+- **When** I open the user menu from the header
+- **Then** the menu shows the user's name and email as a non-clickable header item above the Logout entry
+
+## Tasks / Subtasks
+
+- [ ] [FRONT] Task 1: Enhance `AppHeader.vue` to display user identity in the user menu (AC: #2, #5)
+  - [ ] Add a non-clickable `MenuItem` at the top of `menuItems` with the user's `name` and `email` (use `label` with a template or a separator)
+  - [ ] Import `useAuthStore` (already imported) and bind `authStore.user.name` / `authStore.user.email` reactively — change `menuItems` from a static `const` to a `computed<MenuItem[]>` using `computed()` from Vue
+  - [ ] Keep `data-testid="user-menu-button"` on the trigger button and `data-testid="user-menu"` on the `<Menu>` component (already present — do not remove)
+
+- [ ] [FRONT] Task 2: Verify `authStore.logout()` implementation is correct and robust (AC: #1, #3)
+  - [ ] Confirm `stores/auth.ts` `logout()` action: calls `POST /api/v1/auth/logout` with `credentials: 'include'`, swallows errors via `.catch(() => {})`, and sets `this.user = null` and `this.error = null` — this is already implemented; no change needed if correct
+  - [ ] Confirm the `AppHeader.vue` `command` handler calls `await authStore.logout()` then `router.push('/login')` — this is already implemented; verify it matches AC3 (error-swallowing happens inside `logout()`, so the `command` handler is safe)
+
+- [ ] [FRONT] Task 3: Verify auth guard behavior post-logout (AC: #4)
+  - [ ] In `router/guards.ts`, confirm `setupAuthGuard` redirects unauthenticated users to `/login?redirect=<path>` — already implemented; no change needed
+  - [ ] Confirm `authChecked` flag does not prevent re-checking after logout: the guard re-evaluates `auth.isAuthenticated` (a computed from `auth.user`) on every navigation — since `user` is set to `null` in `logout()`, the guard correctly redirects after logout without needing to re-call `checkAuth`
+
+- [ ] [FRONT] Task 4: Add E2E tests for the logout flow (AC: #1, #3, #4)
+  - [ ] Create or extend `frontend/e2e/tests/app-shell.spec.ts` with a new `describe('Logout flow')` block
+  - [ ] Test: open user menu, click Logout, mock `POST /api/v1/auth/logout` returning 204 — assert redirect to `/login`
+  - [ ] Test: mock `POST /api/v1/auth/logout` returning 500 — assert logout still redirects to `/login` (error-swallowing)
+  - [ ] Test: after logout, navigate to `/` — mock `GET /api/v1/auth/me` returning 401 — assert redirect to `/login?redirect=/`
+  - [ ] Test: open user menu — assert user name and email are visible in the menu header
+
+- [ ] [FRONT] Task 5: Add unit test for `authStore.logout()` (AC: #1, #3)
+  - [ ] Create `frontend/src/stores/__tests__/auth.spec.ts` (or add to existing if present)
+  - [ ] Test: `logout()` clears `user` and `error` even when fetch throws
+  - [ ] Test: `logout()` calls `POST /api/v1/auth/logout` with `credentials: 'include'`
+
+## Dev Notes
+
+### Dependencies (feat-1-logout-api)
+
+This story depends on `feat-1-logout-api` which provides the backend `POST /auth/logout` endpoint. The OpenAPI contract is already defined in `api/openapi.yaml`:
+
+```yaml
+/auth/logout:
+  post:
+    operationId: logoutUser
+    summary: Log out the current user
+    tags: [auth]
+    responses:
+      "204":
+        description: Logged out successfully
+```
+
+The backend invalidates the httpOnly session cookie. The frontend call must use `credentials: 'include'` to send the cookie. **Do NOT start this story until `feat-1-logout-api` is merged to develop.**
+
+### File Paths
+
+| File | Action |
+|------|--------|
+| `frontend/src/ui/layout/AppHeader.vue` | Modify — make `menuItems` reactive, add user identity header item |
+| `frontend/src/stores/auth.ts` | Verify only — `logout()` already implemented |
+| `frontend/src/composables/useAuth.ts` | No change needed |
+| `frontend/src/router/guards.ts` | Verify only — guard already redirects unauthenticated users |
+| `frontend/e2e/tests/app-shell.spec.ts` | Extend — add logout flow E2E tests |
+| `frontend/src/stores/__tests__/auth.spec.ts` | Create or extend — unit tests for `logout()` |
+
+### Component Structure
+
+The logout UI is fully contained in `AppHeader.vue`. The component already has:
+- PrimeVue `Menu` component with `:popup="true"` bound to `ref userMenu`
+- A trigger `Button` with `@click="toggleUserMenu"` and `data-testid="user-menu-button"`
+- A `menuItems` array with the Logout item wired to `authStore.logout()` + `router.push('/login')`
+
+The only required change to `AppHeader.vue` is converting `menuItems` from a static `const` to a `computed<MenuItem[]>` so that user identity can be shown reactively:
+
+```typescript
+// Before (static)
+const menuItems: MenuItem[] = [
+  {
+    label: 'Logout',
+    icon: 'pi pi-sign-out',
+    command: async () => {
+      await authStore.logout()
+      router.push('/login')
+    },
+  },
+]
+
+// After (reactive)
+const menuItems = computed<MenuItem[]>(() => [
+  {
+    label: authStore.user?.name ?? 'User',
+    items: [
+      { separator: true },
+    ],
+    // Use a separator + sub-label pattern or a disabled item for identity display
+  },
+  {
+    label: authStore.user?.email ?? '',
+    disabled: true,
+    class: 'text-surface-500 text-sm',
+  },
+  { separator: true },
+  {
+    label: 'Logout',
+    icon: 'pi pi-sign-out',
+    command: async () => {
+      await authStore.logout()
+      router.push('/login')
+    },
+  },
+])
+```
+
+Note: PrimeVue `Menu` supports `disabled: true` items and `separator: true` items natively. Use these for the identity display — no custom template needed.
+
+### PrimeVue Components Used
+
+| Component | Import | Usage |
+|-----------|--------|-------|
+| `Button` | `primevue/button` | User menu trigger (`pi pi-user` icon, text+rounded) |
+| `Menu` | `primevue/menu` | Popup menu with `MenuItem[]` model |
+| `MenuItem` | `primevue/menuitem` | Type for menu items (disabled, separator, command) |
+
+PrimeVue `Menu` `MenuItem` interface supports:
+- `label: string` — display text
+- `icon: string` — PrimeIcons class
+- `command: (event) => void` — click handler
+- `disabled: boolean` — non-interactive item
+- `separator: boolean` — renders a `<hr>` divider
+
+### Testing Requirements
+
+**E2E (Playwright) — extend `frontend/e2e/tests/app-shell.spec.ts`:**
+
+```typescript
+test.describe('Logout flow', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock authenticated user
+    await page.route('**/api/v1/auth/me', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: '1', email: 'test@test.com', name: 'Test User', role: 'member' }),
+      })
+    })
+    await page.goto('/')
+  })
+
+  test('should logout and redirect to /login on success', async ({ page }) => {
+    await page.route('**/api/v1/auth/logout', async (route) => {
+      await route.fulfill({ status: 204 })
+    })
+    // Re-mock /me as 401 after logout for guard check
+    await page.route('**/api/v1/auth/me', async (route) => {
+      await route.fulfill({ status: 401 })
+    })
+    await page.getByTestId('user-menu-button').click()
+    await page.getByRole('menuitem', { name: 'Logout' }).click()
+    await expect(page).toHaveURL('/login')
+  })
+
+  test('should logout even when backend returns 500', async ({ page }) => {
+    await page.route('**/api/v1/auth/logout', async (route) => {
+      await route.fulfill({ status: 500 })
+    })
+    await page.getByTestId('user-menu-button').click()
+    await page.getByRole('menuitem', { name: 'Logout' }).click()
+    await expect(page).toHaveURL('/login')
+  })
+
+  test('should display user name and email in user menu', async ({ page }) => {
+    await page.getByTestId('user-menu-button').click()
+    await expect(page.getByTestId('user-menu')).toContainText('Test User')
+    await expect(page.getByTestId('user-menu')).toContainText('test@test.com')
+  })
+})
+```
+
+**Unit tests — `frontend/src/stores/__tests__/auth.spec.ts`:**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '../auth'
+
+describe('useAuthStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  describe('logout()', () => {
+    it('clears user and error state on success', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: true })
+      const store = useAuthStore()
+      store.user = { id: '1', email: 'a@b.com', name: 'A', role: 'member' }
+      await store.logout()
+      expect(store.user).toBeNull()
+      expect(store.error).toBeNull()
+    })
+
+    it('clears user state even when fetch throws', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network error'))
+      const store = useAuthStore()
+      store.user = { id: '1', email: 'a@b.com', name: 'A', role: 'member' }
+      await store.logout()
+      expect(store.user).toBeNull()
+    })
+
+    it('calls POST /api/v1/auth/logout with credentials include', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+      global.fetch = fetchMock
+      const store = useAuthStore()
+      await store.logout()
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/auth/logout', {
+        method: 'POST',
+        credentials: 'include',
+      })
+    })
+  })
+})
+```
+
+## Dev Agent Record
+
+_To be filled by the implementing agent._
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-21 | Story SM | Initial story creation |

--- a/_bmad-output/implementation-artifacts/feat-5-user-profile-page.md
+++ b/_bmad-output/implementation-artifacts/feat-5-user-profile-page.md
@@ -1,0 +1,547 @@
+# Story feat-5: [FRONT] User profile page
+
+Status: ready-for-dev
+
+## Story
+
+As an authenticated user,
+I want to view and edit my profile (name, email) and change my password,
+so that I can keep my account information up to date without requiring admin intervention.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Profile page loads with current user data**
+- **Given** an authenticated user navigates to `/profile`
+- **When** the page mounts
+- **Then** GET `/api/v1/users/me` is called and the profile form is pre-filled with the user's current `name` and `email`
+- **And** the user's `role` and `member_since` (formatted `created_at`) are displayed as read-only metadata
+
+**AC2: Profile info update succeeds**
+- **Given** the user edits their name or email and clicks "Save Changes"
+- **When** PUT `/api/v1/users/me` returns 200
+- **Then** a success Toast is shown with message "Profile updated"
+- **And** the auth store's `user` is updated to reflect the new values
+
+**AC3: Profile info validation errors**
+- **Given** the user clears the name field or enters an invalid email
+- **When** they blur the field or click "Save Changes"
+- **Then** inline validation errors appear beneath the relevant field
+- **And** the Save button remains disabled while the form is invalid
+
+**AC4: Password change succeeds**
+- **Given** the user fills in a valid current password and a new password (min 8 chars, confirmed)
+- **When** they click "Update Password" and PUT `/api/v1/users/me/password` returns 204
+- **Then** a success Toast is shown with message "Password updated"
+- **And** the password fields are reset to empty
+
+**AC5: Password change validation errors**
+- **Given** the user submits the password form with an empty current password, a new password shorter than 8 characters, or mismatched confirmation
+- **When** they blur the field or click "Update Password"
+- **Then** inline validation errors appear beneath the relevant field
+- **And** the Update Password button remains disabled while the form is invalid
+
+**AC6: Profile page accessible from user menu**
+- **Given** any authenticated user is on any page
+- **When** they open the user menu in the header and click "My Profile"
+- **Then** they are navigated to `/profile`
+
+## Tasks / Subtasks
+
+- [ ] [FRONT] Task 1: Add `GET /users/me` and `PUT /users/me` to the OpenAPI spec (AC: #1, #2)
+  - [ ] Edit `api/openapi.yaml` — add paths `/users/me` (GET) and `/users/me` (PUT) and `/users/me/password` (PUT) under the `users` tag
+  - [ ] GET `/users/me`: no params, response 200 `User` schema (reuse existing `$ref`)
+  - [ ] PUT `/users/me`: request body `UpdateMeRequest` (name?: string, email?: string), response 200 `User`
+  - [ ] PUT `/users/me/password`: request body `ChangePasswordRequest` (current_password: string, new_password: string), response 204 no content
+  - [ ] Add `UpdateMeRequest` and `ChangePasswordRequest` schemas to `components/schemas`
+  - [ ] Regenerate frontend types: `cd frontend && npm run generate-api`
+
+- [ ] [FRONT] Task 2: Extend auth store with `fetchMe` and `updateMe` actions (AC: #1, #2)
+  - [ ] Edit `frontend/src/stores/auth.ts`
+  - [ ] Convert store to setup syntax (Composition API style) to align with other stores — or add actions to existing Options API store, whichever keeps the diff minimal
+  - [ ] Add action `fetchMe(): Promise<void>` — calls `apiClient.GET('/users/me')`, sets `user` on success
+  - [ ] Add action `updateMe(payload: { name?: string; email?: string }): Promise<User>` — calls `apiClient.PUT('/users/me', { body: payload })`, updates `user` in store on success, throws on API error
+  - [ ] Export `User` type from the store file (it is already defined there)
+
+- [ ] [FRONT] Task 3: Create `useProfile` composable (AC: #1, #2, #4)
+  - [ ] Create `frontend/src/composables/useProfile.ts`
+  - [ ] Import `useAuthStore` and `useAsyncAction`
+  - [ ] Expose `fetchMe` wrapped in `useAsyncAction` (loading + error state)
+  - [ ] Expose `updateMe` wrapped in `useAsyncAction`
+  - [ ] Expose `changePassword` wrapped in `useAsyncAction` — calls `apiClient.PUT('/users/me/password', { body: payload })`, throws on API error
+  - [ ] Expose `user` as `computed(() => store.user)`
+  - [ ] Return signature: `{ user, fetchMe, updateMe, changePassword }`
+
+- [ ] [FRONT] Task 4: Create `ProfileInfoForm.vue` feature component (AC: #1, #2, #3)
+  - [ ] Create `frontend/src/features/profile/ProfileInfoForm.vue`
+  - [ ] Props: `user: User`, `isSaving: boolean`
+  - [ ] Emits: `save: [payload: { name: string; email: string }]`
+  - [ ] Zod schema:
+    ```typescript
+    z.object({
+      name: z.string().min(1, 'Name is required').max(255, 'Name must be 255 characters or less'),
+      email: z.string().min(1, 'Email is required').email('Invalid email format'),
+    })
+    ```
+  - [ ] Use `useForm` + `useField` from vee-validate with `toTypedSchema(zod schema)`
+  - [ ] Watch `user` prop and call `resetForm({ values: { name: user.name, email: user.email } })` on change
+  - [ ] PrimeVue `InputText` for name (id="profile-name"), `InputText` type="email" for email (id="profile-email")
+  - [ ] Standard label + input + error pattern (no FloatLabel, match LoginView style for consistency)
+  - [ ] Save button: `Button` label="Save Changes" severity="primary" `:loading="isSaving"` `:disabled="!meta.dirty || !meta.valid"`
+  - [ ] Display read-only metadata: role (PrimeVue `Tag` with severity mapping) and member since (`formatDate(user.created_at)`)
+
+- [ ] [FRONT] Task 5: Create `ChangePasswordForm.vue` feature component (AC: #4, #5)
+  - [ ] Create `frontend/src/features/profile/ChangePasswordForm.vue`
+  - [ ] Props: `isSaving: boolean`
+  - [ ] Emits: `save: [payload: { current_password: string; new_password: string }]`
+  - [ ] Zod schema:
+    ```typescript
+    z.object({
+      current_password: z.string().min(1, 'Current password is required'),
+      new_password: z.string().min(8, 'Password must be at least 8 characters'),
+      confirm_password: z.string().min(1, 'Please confirm your new password'),
+    }).refine((data) => data.new_password === data.confirm_password, {
+      message: 'Passwords do not match',
+      path: ['confirm_password'],
+    })
+    ```
+  - [ ] Use `useForm` + `useField` pattern, all three fields
+  - [ ] PrimeVue `Password` component for all three fields (toggle-mask, :feedback="false"), use `inputId` prop for label association
+  - [ ] Standard label + input + error pattern
+  - [ ] Update Password button: `Button` label="Update Password" severity="secondary" `:loading="isSaving"` `:disabled="!meta.dirty || !meta.valid"`
+  - [ ] On successful emit, the parent resets the form — expose `resetForm` via defineExpose OR accept a `resetKey` prop
+
+- [ ] [FRONT] Task 6: Create `ProfileView.vue` view (AC: #1, #2, #3, #4, #5)
+  - [ ] Create `frontend/src/views/ProfileView.vue`
+  - [ ] On mount: call `fetchMe.execute()` to load fresh data from the API
+  - [ ] Page header: `<h1>My Profile</h1>`
+  - [ ] Loading state: PrimeVue `Skeleton` (3 lines at heights 2rem, 2.5rem, 2rem) while `fetchMe.isLoading && !user`
+  - [ ] Error state: `Message` severity="error" + retry `Button` when `fetchMe.error && !user`
+  - [ ] Two `Card` sections side by side (responsive: single column on mobile, two columns on md+):
+    - Card 1 header "Profile Information" — contains `ProfileInfoForm`
+    - Card 2 header "Change Password" — contains `ChangePasswordForm`
+  - [ ] On `ProfileInfoForm@save`: call `updateMe.execute(payload)`, on success show Toast (severity="success", summary="Saved", detail="Profile updated"), update handled by store, on error show Toast (severity="error", summary="Error", detail=error.message)
+  - [ ] On `ChangePasswordForm@save`: call `changePassword.execute(payload)`, on success show Toast (severity="success", summary="Done", detail="Password updated") and reset password form, on error show Toast (severity="error", detail=error.message)
+  - [ ] Use PrimeVue `useToast()` and include `<Toast />` in template
+  - [ ] Layout: `<div class="flex flex-col gap-6 p-6">`
+
+- [ ] [FRONT] Task 7: Add `/profile` route (AC: #6)
+  - [ ] Edit `frontend/src/router/index.ts`
+  - [ ] Add route before the catch-all:
+    ```typescript
+    {
+      path: '/profile',
+      name: 'profile',
+      component: () => import('@/views/ProfileView.vue'),
+      meta: { requiresAuth: true },
+    }
+    ```
+
+- [ ] [FRONT] Task 8: Add "My Profile" item to user menu in AppHeader (AC: #6)
+  - [ ] Edit `frontend/src/ui/layout/AppHeader.vue`
+  - [ ] Add `{ label: 'My Profile', icon: 'pi pi-user-edit', command: () => router.push({ name: 'profile' }) }` as the first item in `menuItems` (before Logout)
+
+- [ ] [FRONT] Task 9: Unit tests for `useProfile` composable (AC: #1, #2, #4)
+  - [ ] Create `frontend/src/composables/__tests__/useProfile.spec.ts`
+  - [ ] Mock `apiClient` with `vi.mock('@/api/client')`
+  - [ ] Test `fetchMe` success: `user` ref populated
+  - [ ] Test `fetchMe` error: `fetchMe.error` set, `user` stays null
+  - [ ] Test `updateMe` success: store `user` updated, returns updated User
+  - [ ] Test `updateMe` error: throws, `updateMe.error` set
+  - [ ] Test `changePassword` success: resolves without error
+  - [ ] Test `changePassword` error: `changePassword.error` set
+
+- [ ] [FRONT] Task 10: Unit tests for Zod schemas (AC: #3, #5)
+  - [ ] Create `frontend/src/features/profile/__tests__/profileSchemas.spec.ts`
+  - [ ] Test profile info schema: valid, empty name, invalid email
+  - [ ] Test password schema: valid, short new_password, mismatched confirm_password, empty current_password
+
+- [ ] [FRONT] Task 11: E2E test with Playwright (AC: #1, #2, #4, #6)
+  - [ ] Create `frontend/e2e/tests/profile.spec.ts`
+  - [ ] Mock `GET /api/v1/users/me` returning a user fixture
+  - [ ] Test: page loads at `/profile` with name and email pre-filled
+  - [ ] Test: edit name, click "Save Changes" with mocked PUT 200 — success Toast visible
+  - [ ] Test: click "Save Changes" with mocked PUT 400 — error Toast visible
+  - [ ] Test: open user menu in header — "My Profile" item is visible and navigates to `/profile`
+
+## Dev Notes
+
+### Dependencies (feat-2-user-profile-api)
+
+This story depends on `feat-2-user-profile-api` which adds the following backend endpoints:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/users/me` | Returns the current authenticated user's profile |
+| PUT | `/api/v1/users/me` | Updates the current user's name and/or email |
+| PUT | `/api/v1/users/me/password` | Changes the current user's password |
+
+These endpoints do NOT exist in the current `api/openapi.yaml` as of this writing. **Task 1 of this story adds them to the spec.** If feat-2 has already merged and added these endpoints, skip the spec edits in Task 1 and only run `npm run generate-api`.
+
+The current spec has `/users/{id}` (GET/PUT/DELETE) which is admin-only. The `/users/me` endpoints are scoped to the authenticated user and require no admin role. The backend implementation is responsible for:
+- Returning only the authenticated user's data (from JWT claims)
+- Preventing password change if `current_password` is incorrect (return 400)
+- Preventing email change to an already-taken email (return 409)
+
+### File Paths
+
+| File | Action |
+|------|--------|
+| `api/openapi.yaml` | Update — add `/users/me` GET, PUT and `/users/me/password` PUT paths + schemas |
+| `frontend/src/stores/auth.ts` | Update — add `fetchMe`, `updateMe` actions |
+| `frontend/src/composables/useProfile.ts` | Create |
+| `frontend/src/features/profile/ProfileInfoForm.vue` | Create |
+| `frontend/src/features/profile/ChangePasswordForm.vue` | Create |
+| `frontend/src/views/ProfileView.vue` | Create |
+| `frontend/src/router/index.ts` | Update — add `/profile` route |
+| `frontend/src/ui/layout/AppHeader.vue` | Update — add "My Profile" menu item |
+| `frontend/src/composables/__tests__/useProfile.spec.ts` | Create |
+| `frontend/src/features/profile/__tests__/profileSchemas.spec.ts` | Create |
+| `frontend/e2e/tests/profile.spec.ts` | Create |
+
+### OpenAPI spec additions (Task 1)
+
+```yaml
+# Add to paths section in api/openapi.yaml
+
+  /users/me:
+    get:
+      operationId: getMe
+      summary: Get current authenticated user's profile
+      tags: [users]
+      responses:
+        "200":
+          description: Current user profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+    put:
+      operationId: updateMe
+      summary: Update current authenticated user's profile
+      tags: [users]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateMeRequest"
+      responses:
+        "200":
+          description: Profile updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /users/me/password:
+    put:
+      operationId: changeMyPassword
+      summary: Change current authenticated user's password
+      tags: [users]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangePasswordRequest"
+      responses:
+        "204":
+          description: Password changed successfully
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+# Add to components/schemas section in api/openapi.yaml
+
+    UpdateMeRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+          example: Jane Smith
+        email:
+          type: string
+          format: email
+          example: jane@example.com
+
+    ChangePasswordRequest:
+      type: object
+      required:
+        - current_password
+        - new_password
+      properties:
+        current_password:
+          type: string
+          format: password
+          example: oldP@ss1
+        new_password:
+          type: string
+          format: password
+          minLength: 8
+          example: newP@ss1
+```
+
+### Zod Validation Schemas
+
+```typescript
+// ProfileInfoForm.vue
+const profileInfoSchema = toTypedSchema(
+  z.object({
+    name: z.string().min(1, 'Name is required').max(255, 'Name must be 255 characters or less'),
+    email: z.string().min(1, 'Email is required').email('Invalid email format'),
+  })
+)
+
+// ChangePasswordForm.vue
+const changePasswordSchema = toTypedSchema(
+  z
+    .object({
+      current_password: z.string().min(1, 'Current password is required'),
+      new_password: z.string().min(8, 'Password must be at least 8 characters'),
+      confirm_password: z.string().min(1, 'Please confirm your new password'),
+    })
+    .refine((data) => data.new_password === data.confirm_password, {
+      message: 'Passwords do not match',
+      path: ['confirm_password'],
+    })
+)
+```
+
+### Auth Store Additions
+
+```typescript
+// frontend/src/stores/auth.ts — additions to existing actions object
+
+async fetchMe(): Promise<void> {
+  this.loading = true
+  this.error = null
+  try {
+    const { data, error: apiError } = await apiClient.GET('/users/me')
+    if (apiError) {
+      this.error = 'Failed to load profile'
+      return
+    }
+    this.user = { ...data, role: data.role ?? 'member' } as User
+  } catch {
+    this.error = 'Network error. Please try again.'
+  } finally {
+    this.loading = false
+  }
+},
+
+async updateMe(payload: { name?: string; email?: string }): Promise<User> {
+  const { data, error: apiError } = await apiClient.PUT('/users/me', {
+    body: payload,
+  })
+  if (apiError || !data) {
+    throw new Error('Failed to update profile')
+  }
+  const updated = { ...data, role: data.role ?? 'member' } as User
+  this.user = updated
+  return updated
+},
+```
+
+### useProfile Composable
+
+```typescript
+// frontend/src/composables/useProfile.ts
+import { computed } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+import { useAsyncAction } from '@/composables/useAsyncAction'
+import { apiClient } from '@/api/client'
+
+export function useProfile() {
+  const store = useAuthStore()
+
+  const fetchMe = useAsyncAction(() => store.fetchMe())
+  const updateMe = useAsyncAction((payload: { name?: string; email?: string }) =>
+    store.updateMe(payload)
+  )
+  const changePassword = useAsyncAction(
+    async (payload: { current_password: string; new_password: string }) => {
+      const { error: apiError } = await apiClient.PUT('/users/me/password', {
+        body: payload,
+      })
+      if (apiError) {
+        throw new Error('Failed to change password. Check your current password and try again.')
+      }
+    }
+  )
+
+  return {
+    user: computed(() => store.user),
+    fetchMe,
+    updateMe,
+    changePassword,
+  }
+}
+```
+
+### Component Structure / Layout
+
+```
+ProfileView.vue  (route: /profile)
+├── <h1>My Profile</h1>
+├── Skeleton x3  (v-if="fetchMe.isLoading && !user")
+├── Message severity="error" + Button retry  (v-else-if="fetchMe.error && !user")
+└── div.grid.grid-cols-1.md:grid-cols-2.gap-6  (v-else-if="user")
+    ├── Card header="Profile Information"
+    │   └── ProfileInfoForm
+    │       ├── label "Name" + InputText#profile-name
+    │       ├── label "Email" + InputText#profile-email type="email"
+    │       ├── read-only: Tag (role) + member since
+    │       └── Button "Save Changes"
+    └── Card header="Change Password"
+        └── ChangePasswordForm
+            ├── label "Current Password" + Password#current-password
+            ├── label "New Password" + Password#new-password
+            ├── label "Confirm New Password" + Password#confirm-password
+            └── Button "Update Password"
+└── Toast
+```
+
+**Responsive layout:** use `class="grid grid-cols-1 gap-6 md:grid-cols-2"` for the cards container. On small screens both cards stack vertically; on medium+ they sit side by side.
+
+### PrimeVue Components Used
+
+| Component | Import path | Usage |
+|-----------|-------------|-------|
+| `Card` | `primevue/card` | Section containers for profile info and password change |
+| `InputText` | `primevue/inputtext` | Name and email fields |
+| `Password` | `primevue/password` | Current, new, and confirm password fields (use `inputId` prop) |
+| `Button` | `primevue/button` | Save Changes, Update Password, Retry |
+| `Tag` | `primevue/tag` | Read-only role display (severity="info" for member, severity="danger" for admin) |
+| `Message` | `primevue/message` | Error state display |
+| `Skeleton` | `primevue/skeleton` | Loading state |
+| `Toast` | `primevue/toast` | Success/error notifications |
+
+**Password component note:** always use `inputId` (not `id`) for PrimeVue `Password` to correctly associate the `<label for="...">`. Example:
+```vue
+<label for="current-password" class="text-sm font-medium">Current Password</label>
+<Password inputId="current-password" v-model="currentPassword" :feedback="false" toggle-mask :invalid="!!currentPasswordError" input-class="w-full" class="w-full" />
+```
+
+### API Calls (openapi-fetch patterns)
+
+```typescript
+// GET /users/me
+const { data, error } = await apiClient.GET('/users/me')
+
+// PUT /users/me
+const { data, error } = await apiClient.PUT('/users/me', {
+  body: { name: 'Jane Smith', email: 'jane@example.com' },
+})
+
+// PUT /users/me/password
+const { error } = await apiClient.PUT('/users/me/password', {
+  body: { current_password: 'old', new_password: 'new' },
+})
+// 204 No Content — only check for error, data is undefined
+```
+
+### Router Additions
+
+```typescript
+// frontend/src/router/index.ts
+// Add before the catch-all route { path: '/:pathMatch(.*)*', ... }
+{
+  path: '/profile',
+  name: 'profile',
+  component: () => import('@/views/ProfileView.vue'),
+  meta: { requiresAuth: true },
+},
+```
+
+### AppHeader User Menu Update
+
+```typescript
+// frontend/src/ui/layout/AppHeader.vue — update menuItems
+const menuItems: MenuItem[] = [
+  {
+    label: 'My Profile',
+    icon: 'pi pi-user-edit',
+    command: () => router.push({ name: 'profile' }),
+  },
+  {
+    label: 'Logout',
+    icon: 'pi pi-sign-out',
+    command: async () => {
+      await authStore.logout()
+      router.push('/login')
+    },
+  },
+]
+```
+
+The user's display name (from `authStore.user?.name`) can optionally be shown above the menu items using the `label` at the top of the `Menu` model — but this is optional for MVP.
+
+### Testing Requirements
+
+**Unit tests (Vitest):**
+
+| Test file | Coverage target | What to test |
+|-----------|----------------|--------------|
+| `composables/__tests__/useProfile.spec.ts` | 95%+ | `fetchMe` success/error, `updateMe` success/error/store update, `changePassword` success/error |
+| `features/profile/__tests__/profileSchemas.spec.ts` | 100% | All validation rules for both Zod schemas |
+
+**E2E tests (Playwright) — `frontend/e2e/tests/profile.spec.ts`:**
+
+```typescript
+// Pattern: mock /api/v1/auth/me (auth guard) + mock /api/v1/users/me (profile data)
+
+const userFixture = {
+  id: '1',
+  email: 'test@example.com',
+  name: 'Test User',
+  role: 'member',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/v1/auth/me', (route) =>
+    route.fulfill({ status: 200, json: userFixture })
+  )
+  await page.route('**/api/v1/users/me', (route) =>
+    route.fulfill({ status: 200, json: userFixture })
+  )
+})
+```
+
+Test cases:
+1. Navigate to `/profile` — page heading "My Profile" visible, name and email inputs pre-filled
+2. Edit name, click "Save Changes" (mock PUT 200) — Toast "Profile updated" appears
+3. Click "Save Changes" with mock PUT 400 — Toast error appears
+4. Open user menu from header — "My Profile" item visible, click navigates to `/profile`
+5. Fill valid current + new + confirm password, click "Update Password" (mock PUT 204) — Toast "Password updated" appears, password fields cleared
+6. Submit password form with mismatched passwords — "Passwords do not match" error shown, button disabled
+
+**Manual verification checklist:**
+1. `npm run dev` — navigate to `/profile` via user menu "My Profile" item
+2. Verify form pre-filled with current user name and email
+3. Edit name, click "Save Changes" — success Toast; reload page, new name persists
+4. Clear name field — "Name is required" error, Save button disabled
+5. Enter invalid email — "Invalid email format" error, Save button disabled
+6. Fill password change form with mismatched passwords — "Passwords do not match" error
+7. Fill password change form correctly — Toast "Password updated", fields clear
+8. `npm run build` — no TypeScript errors
+9. `npm run lint` — no ESLint errors
+10. `npm run type-check` — no type errors
+11. `npm run test:unit` — all new tests pass
+
+## Dev Agent Record
+
+## Change Log

--- a/_bmad-output/implementation-artifacts/feat-6-reset-password-pages.md
+++ b/_bmad-output/implementation-artifacts/feat-6-reset-password-pages.md
@@ -1,0 +1,423 @@
+# Story feat-6: [FRONT] Reset password pages (forgot + reset)
+
+Status: ready-for-dev
+
+## Story
+
+As an unauthenticated user,
+I want to request a password reset and set a new password via a secure link,
+so that I can regain access to my account without admin intervention.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Forgot Password — form submission**
+- **Given** I am on `/forgot-password`
+- **When** I enter a valid email address and click "Send reset link"
+- **Then** the form calls `POST /auth/forgot-password` with the email
+- **And** a success message is displayed regardless of whether the email is registered
+- **And** the form is hidden (replaced by the success message)
+
+**AC2: Forgot Password — validation**
+- **Given** I am on `/forgot-password`
+- **When** I submit the form with an empty or malformed email
+- **Then** an inline validation error appears under the email field
+- **And** no API call is made
+
+**AC3: Forgot Password — navigation**
+- **Given** I am on `/forgot-password`
+- **When** I click "Back to login"
+- **Then** I am redirected to `/login`
+
+**AC4: Login page — "Forgot password?" link**
+- **Given** I am on `/login`
+- **When** I look at the form
+- **Then** I can see a "Forgot password?" link
+- **And** clicking it navigates me to `/forgot-password`
+
+**AC5: Reset Password — successful submission**
+- **Given** I arrive on `/reset-password?token=<valid_token>`
+- **When** I enter a valid new password and matching confirmation, then submit
+- **Then** `POST /auth/reset-password` is called with `{ token, password }`
+- **And** on success I am redirected to `/login` with a query param `?reset=success`
+- **And** the login page displays a success banner "Password reset successfully. Please sign in."
+
+**AC6: Reset Password — validation**
+- **Given** I am on `/reset-password`
+- **When** I submit with mismatched passwords or a password shorter than 8 characters
+- **Then** inline validation errors appear and no API call is made
+
+**AC7: Reset Password — missing or invalid token**
+- **Given** I navigate to `/reset-password` with no token query param
+- **Then** an error message is displayed explaining the link is invalid or expired
+- **And** a "Request a new link" button links back to `/forgot-password`
+
+## Tasks / Subtasks
+
+- [ ] [FRONT] Task 1: Add `forgotPassword` and `resetPassword` actions to the auth store (AC: #1, #5)
+  - [ ] Add `forgotPassword(email: string): Promise<boolean>` to `frontend/src/stores/auth.ts` — calls `POST /api/v1/auth/forgot-password`, always returns `true` (no error surfaced to user)
+  - [ ] Add `resetPassword(token: string, password: string): Promise<boolean>` to `frontend/src/stores/auth.ts` — calls `POST /api/v1/auth/reset-password`, returns `true` on 200, `false` on 400/422
+  - [ ] Expose both methods via `frontend/src/composables/useAuth.ts`
+
+- [ ] [FRONT] Task 2: Create `ForgotPasswordView.vue` at `frontend/src/views/ForgotPasswordView.vue` (AC: #1, #2, #3)
+  - [ ] Use `vee-validate` + `zod` for email validation (same pattern as `LoginView.vue`)
+  - [ ] On submit success: hide form, show static success message (see wireframe)
+  - [ ] On submit error (network): show inline `Message` with `severity="error"`
+  - [ ] "Back to login" `RouterLink` to `/login`
+  - [ ] No loading indicator needed when success state is shown — only on submission
+
+- [ ] [FRONT] Task 3: Create `ResetPasswordView.vue` at `frontend/src/views/ResetPasswordView.vue` (AC: #5, #6, #7)
+  - [ ] Read `token` from `route.query.token` on mount; if absent, render error state (see wireframe)
+  - [ ] Two fields: new password (PrimeVue `Password` with `toggle-mask`, no strength feedback) + confirm password (`Password` with `toggle-mask`, no strength feedback)
+  - [ ] Zod schema validates min length 8 and `passwords match` cross-field rule
+  - [ ] On success: redirect to `/login?reset=success`
+  - [ ] On API error (400/422): show inline `Message` with `severity="error"` (e.g., "Token expired or invalid")
+
+- [ ] [FRONT] Task 4: Register routes in `frontend/src/router/index.ts` (AC: #1, #5)
+  - [ ] Add `/forgot-password` route with `meta: { requiresAuth: false }`
+  - [ ] Add `/reset-password` route with `meta: { requiresAuth: false }`
+  - [ ] Both routes must redirect to `/` when the user is already authenticated (existing guard logic handles this automatically via `to.path === '/login'` pattern — verify it also redirects other public paths or update guard logic)
+
+- [ ] [FRONT] Task 5: Modify `LoginView.vue` to add "Forgot password?" link and success banner (AC: #4, #5)
+  - [ ] Add `RouterLink` "Forgot password?" below the password field, aligned to the right
+  - [ ] Read `route.query.reset`; if `=== 'success'`, display a `Message` with `severity="success"` above the form: "Password reset successfully. Please sign in."
+
+- [ ] [FRONT] Task 6: Unit tests (AC: #1, #2, #6)
+  - [ ] `frontend/src/stores/__tests__/auth.spec.ts` — add tests for `forgotPassword` and `resetPassword` actions (mock `fetch`, cover success and error paths)
+  - [ ] `frontend/src/composables/__tests__/useAuth.spec.ts` — verify new methods are exposed
+
+## Dev Notes
+
+### Dependencies (feat-3-reset-password-api)
+
+The backend endpoints must exist before this story can be tested end-to-end:
+
+- `POST /api/v1/auth/forgot-password` — body: `{ email: string }` — always returns 200 (no disclosure)
+- `POST /api/v1/auth/reset-password` — body: `{ token: string, password: string }` — returns 200 on success, 400/422 on invalid/expired token
+
+These endpoints are NOT yet in `api/openapi.yaml` — they will be added by feat-3. The frontend auth store calls the API directly via `fetch` (same pattern as the existing `login` action in `stores/auth.ts`) to avoid blocking on generated types. Once feat-3 merges and the spec is updated, the store can be migrated to `apiClient.POST(...)`.
+
+### File Paths
+
+| File | Action |
+|------|--------|
+| `frontend/src/views/ForgotPasswordView.vue` | Create |
+| `frontend/src/views/ResetPasswordView.vue` | Create |
+| `frontend/src/stores/auth.ts` | Modify — add `forgotPassword`, `resetPassword` actions |
+| `frontend/src/composables/useAuth.ts` | Modify — expose new actions |
+| `frontend/src/router/index.ts` | Modify — add two public routes |
+| `frontend/src/views/LoginView.vue` | Modify — add link + success banner |
+| `frontend/src/stores/__tests__/auth.spec.ts` | Create or extend |
+
+### Zod Validation Schemas (forgot + reset forms)
+
+**Forgot Password schema** (`ForgotPasswordView.vue`):
+
+```typescript
+const forgotSchema = toTypedSchema(
+  z.object({
+    email: z.string().min(1, 'Email is required').email('Invalid email format'),
+  }),
+)
+```
+
+**Reset Password schema** (`ResetPasswordView.vue`):
+
+```typescript
+const resetSchema = toTypedSchema(
+  z.object({
+    password: z.string().min(8, 'Password must be at least 8 characters'),
+    confirmPassword: z.string().min(1, 'Please confirm your password'),
+  }).refine((data) => data.password === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  }),
+)
+```
+
+### Page Layouts (ASCII wireframes)
+
+**ForgotPasswordView — initial state:**
+
+```
+┌──────────────────────────────────────┐
+│                                      │
+│          hopeitworks                 │  ← h1, same as LoginView
+│                                      │
+│  Reset your password                 │  ← h2 or subtitle
+│                                      │
+│  Email                               │
+│  ┌────────────────────────────────┐  │
+│  │ you@example.com                │  │  ← InputText id="email"
+│  └────────────────────────────────┘  │
+│  <inline error if invalid>           │
+│                                      │
+│  ┌────────────────────────────────┐  │
+│  │     Send reset link            │  │  ← Button type="submit" :loading
+│  └────────────────────────────────┘  │
+│                                      │
+│  ← Back to login                     │  ← RouterLink to="/login"
+│                                      │
+└──────────────────────────────────────┘
+```
+
+**ForgotPasswordView — success state (form hidden, replaced by):**
+
+```
+┌──────────────────────────────────────┐
+│                                      │
+│          hopeitworks                 │
+│                                      │
+│  ╔══════════════════════════════╗    │
+│  ║  Check your email            ║    │  ← Message severity="success"
+│  ║  If an account exists for    ║    │
+│  ║  that email, you will        ║    │
+│  ║  receive a reset link.       ║    │
+│  ╚══════════════════════════════╝    │
+│                                      │
+│  ← Back to login                     │
+│                                      │
+└──────────────────────────────────────┘
+```
+
+**ResetPasswordView — normal state:**
+
+```
+┌──────────────────────────────────────┐
+│                                      │
+│          hopeitworks                 │
+│                                      │
+│  Set new password                    │
+│                                      │
+│  New password                        │
+│  ┌────────────────────────────────┐  │
+│  │ ••••••••              [👁]     │  │  ← Password inputId="password" toggle-mask
+│  └────────────────────────────────┘  │
+│  <inline error if invalid>           │
+│                                      │
+│  Confirm new password                │
+│  ┌────────────────────────────────┐  │
+│  │ ••••••••              [👁]     │  │  ← Password inputId="confirmPassword" toggle-mask
+│  └────────────────────────────────┘  │
+│  <inline error if mismatch>          │
+│                                      │
+│  ┌────────────────────────────────┐  │
+│  │     Set new password           │  │  ← Button type="submit" :loading
+│  └────────────────────────────────┘  │
+│                                      │
+│  ╔══════════════════════════╗        │  ← Message v-if="error" severity="error"
+│  ║ Token expired or invalid ║        │
+│  ╚══════════════════════════╝        │
+│                                      │
+└──────────────────────────────────────┘
+```
+
+**ResetPasswordView — missing/invalid token state (shown immediately on mount):**
+
+```
+┌──────────────────────────────────────┐
+│                                      │
+│          hopeitworks                 │
+│                                      │
+│  ╔══════════════════════════════╗    │  ← Message severity="error" :closable="false"
+│  ║  Invalid or expired link     ║    │
+│  ║  This password reset link    ║    │
+│  ║  is invalid or has expired.  ║    │
+│  ╚══════════════════════════════╝    │
+│                                      │
+│  ┌────────────────────────────────┐  │
+│  │   Request a new link           │  │  ← RouterLink styled as Button to="/forgot-password"
+│  └────────────────────────────────┘  │
+│                                      │
+└──────────────────────────────────────┘
+```
+
+**LoginView modification — "Forgot password?" link placement:**
+
+```
+│  Password                            │
+│  ┌────────────────────────────────┐  │
+│  │ ••••••••              [👁]     │  │
+│  └────────────────────────────────┘  │
+│  <inline error>          Forgot password? →│  ← RouterLink, text-sm, aligned right
+│                                      │
+│  [Sign In button]                    │
+│                                      │
+│  ╔══════════════════╗                │  ← v-if="route.query.reset === 'success'"
+│  ║  Password reset  ║                │    Message severity="success" above form
+│  ║  successfully.   ║                │
+│  ╚══════════════════╝                │
+```
+
+### PrimeVue Components Used
+
+| Component | Import | Usage |
+|-----------|--------|-------|
+| `InputText` | `primevue/inputtext` | Email field in ForgotPasswordView |
+| `Password` | `primevue/password` | Password fields in ResetPasswordView |
+| `Button` | `primevue/button` | Submit buttons, "Request new link" |
+| `Message` | `primevue/message` | Success/error feedback, `:closable="false"` |
+
+All imports follow the existing pattern in `LoginView.vue`. Do NOT import `RouterLink` — it is globally registered by Vue Router.
+
+### Router additions (public routes)
+
+Add to `frontend/src/router/index.ts` after the `login` route:
+
+```typescript
+import ForgotPasswordView from '@/views/ForgotPasswordView.vue'
+import ResetPasswordView from '@/views/ResetPasswordView.vue'
+
+// Inside routes array, after the login route:
+{
+  path: '/forgot-password',
+  name: 'forgot-password',
+  component: ForgotPasswordView,
+  meta: { requiresAuth: false },
+},
+{
+  path: '/reset-password',
+  name: 'reset-password',
+  component: ResetPasswordView,
+  meta: { requiresAuth: false },
+},
+```
+
+Note: The existing auth guard in `frontend/src/router/guards.ts` redirects authenticated users away from `/login` specifically. It does NOT auto-redirect from other public pages. Since it is reasonable to allow authenticated users to access these pages (e.g., if they opened a stale reset link), no change to the guard is required. If desired, add an explicit redirect for authenticated users reaching `/forgot-password` or `/reset-password` — but this is optional for MVP.
+
+### Login page modification (add "Forgot password?" link)
+
+In `frontend/src/views/LoginView.vue`:
+
+1. Add `useRoute` import (already present).
+2. Replace the password `<div class="flex flex-col gap-1">` block to include the link:
+
+```vue
+<div class="flex flex-col gap-1">
+  <div class="flex items-center justify-between">
+    <label for="password" class="text-sm font-medium">Password</label>
+    <RouterLink to="/forgot-password" class="text-sm">Forgot password?</RouterLink>
+  </div>
+  <Password
+    inputId="password"
+    v-model="password"
+    :feedback="false"
+    toggle-mask
+    :invalid="!!passwordError"
+    input-class="w-full"
+    class="w-full"
+  />
+  <small v-if="passwordError" class="text-red-500">{{ passwordError }}</small>
+</div>
+```
+
+3. Add success banner above the `<form>` tag:
+
+```vue
+<Message
+  v-if="route.query.reset === 'success'"
+  severity="success"
+  :closable="false"
+>
+  Password reset successfully. Please sign in.
+</Message>
+```
+
+### Auth store additions (`frontend/src/stores/auth.ts`)
+
+Add to the `actions` object:
+
+```typescript
+async forgotPassword(email: string): Promise<boolean> {
+  this.loading = true
+  this.error = null
+  try {
+    await fetch('/api/v1/auth/forgot-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    })
+    // Always return true — never disclose whether email is registered
+    return true
+  } catch {
+    // Network error: still return true to avoid disclosure
+    return true
+  } finally {
+    this.loading = false
+  }
+},
+
+async resetPassword(token: string, password: string): Promise<boolean> {
+  this.loading = true
+  this.error = null
+  try {
+    const res = await fetch('/api/v1/auth/reset-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, password }),
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => null)
+      this.error = body?.error?.message ?? 'Token expired or invalid. Please request a new link.'
+      return false
+    }
+    return true
+  } catch {
+    this.error = 'Network error. Please try again.'
+    return false
+  } finally {
+    this.loading = false
+  }
+},
+```
+
+Expose in `frontend/src/composables/useAuth.ts`:
+
+```typescript
+export function useAuth() {
+  const store = useAuthStore()
+  return {
+    // ... existing fields ...
+    forgotPassword: store.forgotPassword.bind(store),
+    resetPassword: store.resetPassword.bind(store),
+  }
+}
+```
+
+### Security notes (don't reveal if email exists)
+
+- `forgotPassword` in the store ALWAYS returns `true` and displays the same success message, regardless of the API response code or network error. This prevents user enumeration attacks.
+- The success message must be generic: "If an account exists for that email, you will receive a reset link shortly."
+- Do NOT display different messages for "email not found" vs "email found".
+- The `resetPassword` action MAY surface a generic error ("Token expired or invalid") because at that point the user already has the token — no enumeration risk.
+
+### Testing Requirements
+
+**Unit tests — `frontend/src/stores/__tests__/auth.spec.ts`:**
+
+```typescript
+describe('forgotPassword', () => {
+  it('returns true on 200', async () => { /* mock fetch 200 */ })
+  it('returns true on 404 (no disclosure)', async () => { /* mock fetch 404 */ })
+  it('returns true on network error (no disclosure)', async () => { /* mock fetch throws */ })
+  it('never sets error state', async () => { /* verify store.error stays null */ })
+})
+
+describe('resetPassword', () => {
+  it('returns true on 200', async () => { /* mock fetch 200 */ })
+  it('returns false and sets error on 400', async () => { /* mock fetch 400 */ })
+  it('returns false and sets error on 422', async () => { /* mock fetch 422 */ })
+  it('returns false and sets generic error on network failure', async () => { /* mock throws */ })
+})
+```
+
+**No E2E tests required for this story** — the backend dependency (feat-3) must be merged first. Add E2E coverage once the full flow is testable against the real stack.
+
+## Dev Agent Record
+
+_This section is populated by the implementing agent._
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-02-21 | Story created | orchestrator |

--- a/_bmad-output/implementation-artifacts/fix-8-nav-visible-unauthenticated.md
+++ b/_bmad-output/implementation-artifacts/fix-8-nav-visible-unauthenticated.md
@@ -1,0 +1,158 @@
+# Story fix-8: [FRONT] Hide navigation when user is not authenticated
+
+Status: ready-for-dev
+
+## Story
+
+As an unauthenticated user visiting the login page,
+I want the navigation sidebar and header to be hidden,
+so that the UI does not expose application chrome before I have signed in.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Navigation hidden on /login (unauthenticated)**
+- **Given** the user is not authenticated (auth store `user` is null)
+- **When** the user visits `/login`
+- **Then** `AppHeader`, `AppSidebar`, the mobile bottom nav, and `AppStatusBar` are not rendered — only the login form is visible
+
+**AC2: Navigation visible after successful login**
+- **Given** the user was on the login page with no navigation visible
+- **When** the user submits valid credentials and is redirected to a protected route
+- **Then** the full `AppShell` (header, sidebar, status bar) is visible
+
+**AC3: Navigation visible on all authenticated routes**
+- **Given** the user is authenticated (`auth store user !== null`)
+- **When** the user navigates to any protected route (e.g. `/`, `/projects`)
+- **Then** `AppHeader`, `AppSidebar`, and `AppStatusBar` are rendered normally
+
+**AC4: Login page uses a bare, full-screen layout**
+- **Given** the user is on `/login`
+- **Then** the page occupies the full viewport with no sidebar/header offset — the existing `LoginView.vue` centred layout (`flex min-h-screen items-center justify-center`) fills the screen without being constrained inside the shell's `<main>` element
+
+**AC5: Navigation hidden on the 404 catch-all route when unauthenticated**
+- **Given** the user is not authenticated
+- **When** the user lands on an unknown route that maps to `NotFoundView`
+- **Then** navigation chrome is not shown
+
+## Tasks / Subtasks
+
+- [ ] [FRONT] Task 1: Conditionally render app chrome in `AppShell.vue` based on auth state (AC: #1, #2, #3, #4)
+  - [ ] Import `useAuth` composable (or `useAuthStore`) in `AppShell.vue`
+  - [ ] Add `const { isAuthenticated } = useAuth()` (uses the existing `useAuthStore` getter)
+  - [ ] Wrap `<AppHeader>`, `<AppSidebar>`, the mobile bottom `<nav>`, and `<AppStatusBar>` with `v-if="isAuthenticated"`
+  - [ ] When unauthenticated, render `<router-view />` directly inside the root `<div>` without the shell layout structure (no sidebar offset, no header height offset) — `LoginView.vue` already owns `min-h-screen` so it fills the viewport
+
+- [ ] [FRONT] Task 2: Add Playwright E2E test for unauthenticated shell visibility (AC: #1, #5)
+  - [ ] In `frontend/e2e/tests/login.spec.ts`, add a test: "should not render AppHeader or AppSidebar on /login when unauthenticated"
+  - [ ] Mock `**/api/v1/auth/me` as 401
+  - [ ] Navigate to `/login`
+  - [ ] Assert `header` element is not visible (or not present)
+  - [ ] Assert sidebar nav element is not visible (or not present)
+  - [ ] Add a test: "should render AppHeader and AppSidebar after successful login"
+  - [ ] Mock login 200 + `/auth/me` 200, submit credentials, assert header visible at `/`
+
+- [ ] [FRONT] Task 3: Verify existing app-shell E2E tests still pass (AC: #2, #3)
+  - [ ] Run `npm run test:e2e` in `frontend/` and confirm `app-shell.spec.ts` is green
+  - [ ] Confirm `login.spec.ts` is green including new tests
+
+## Dev Notes
+
+### Dependencies
+
+- `useAuth` composable: `frontend/src/composables/useAuth.ts` — exposes `isAuthenticated: ComputedRef<boolean>` sourced from `useAuthStore().isAuthenticated` (getter: `state.user !== null`)
+- `useAuthStore`: `frontend/src/stores/auth.ts` — Options API store, `isAuthenticated` getter already defined
+- Auth guard: `frontend/src/router/guards.ts` performs `auth.checkAuth()` on first navigation; by the time `AppShell` renders, `isAuthenticated` is already resolved — no additional async guard needed inside the component
+
+### File Paths
+
+| File | Change |
+|------|--------|
+| `frontend/src/ui/layout/AppShell.vue` | Add `isAuthenticated` check; conditionally render shell chrome |
+| `frontend/e2e/tests/login.spec.ts` | Add two new E2E tests for shell visibility |
+
+### Architecture / Implementation Details
+
+**Current `AppShell.vue` template structure (lines 91-158):**
+
+```html
+<div class="flex h-screen flex-col overflow-hidden">
+  <a href="#main-content" ...>Skip to main content</a>
+  <AppHeader ... />
+  <div class="flex min-h-0 flex-1">
+    <AppSidebar ... />
+    <main id="main-content" class="flex-1 overflow-auto bg-surface-100 p-4">
+      <router-view />
+    </main>
+  </div>
+  <!-- Mobile bottom nav (v-if="isMobile") -->
+  <AppStatusBar v-if="!isMobile" />
+  <Toast ... />
+</div>
+```
+
+**Target structure after fix:**
+
+```html
+<div class="flex h-screen flex-col overflow-hidden">
+  <template v-if="isAuthenticated">
+    <a href="#main-content" ...>Skip to main content</a>
+    <AppHeader ... />
+    <div class="flex min-h-0 flex-1">
+      <AppSidebar ... />
+      <main id="main-content" class="flex-1 overflow-auto bg-surface-100 p-4">
+        <router-view />
+      </main>
+    </div>
+    <!-- Mobile bottom nav (v-if="isMobile") -->
+    <AppStatusBar v-if="!isMobile" />
+    <Toast ... />
+  </template>
+
+  <template v-else>
+    <router-view />
+  </template>
+</div>
+```
+
+Key points:
+- Using `<template v-if>` blocks avoids adding wrapper DOM nodes.
+- The `<Toast>` component is inside the authenticated block intentionally — no toast notifications are expected in the unauthenticated state. If future requirements need toasts on the login page, move it outside the `v-if`.
+- `LoginView.vue` already wraps itself in `<div class="flex min-h-screen items-center justify-center p-4">` so removing the shell's `<main>` wrapper causes no visual regression — it fills the viewport naturally.
+- The skip-navigation link is intentionally hidden in unauthenticated mode (no navigable content to skip to).
+- The `useKeyboard` shortcut (`[` to toggle sidebar) still fires when unauthenticated — this is harmless since the sidebar is not rendered, but if desired, the keyboard handler can be wrapped with an `isAuthenticated` check inside `useKeyboard`.
+
+**Script addition in `AppShell.vue`:**
+
+```typescript
+import { useAuth } from '@/composables/useAuth'
+
+const { isAuthenticated } = useAuth()
+```
+
+This uses the existing composable — no new state, no new API call.
+
+### Testing Requirements
+
+**Manual verification:**
+1. Start the dev stack: `cd deploy && docker-compose up -d`
+2. Open the app in the browser without being logged in — confirm no sidebar, no header
+3. Log in with valid credentials — confirm sidebar and header appear immediately after redirect to `/`
+4. Log out (if logout is wired in the header) — confirm sidebar disappears and the login page has no chrome
+5. Navigate directly to a protected route while unauthenticated (e.g., `/projects`) — confirm the auth guard redirects to `/login` with no nav chrome
+
+**E2E (Playwright):**
+
+```bash
+cd frontend && npm run test:e2e -- --grep "login"
+cd frontend && npm run test:e2e -- --grep "App Shell"
+```
+
+## Dev Agent Record
+
+_To be filled by the implementing agent._
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-21 | story-writer | Initial story created |

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -161,6 +161,16 @@ development_status:
   fix-6-e2e-selector-refinements: done
   fix-7-pipeline-config-seed-data: done
 
+  # Post-MVP: Auth Enhancements
+  post-mvp-auth: backlog
+  fix-8-nav-visible-unauthenticated: backlog
+  feat-1-logout-api: backlog
+  feat-2-user-profile-api: backlog
+  feat-3-reset-password-api: backlog
+  feat-4-logout-ui: backlog
+  feat-5-user-profile-page: backlog
+  feat-6-reset-password-pages: backlog
+
 # PARALLEL EXECUTION WAVES
 # ========================
 # Stories in the same wave can run simultaneously in separate containers.
@@ -176,6 +186,8 @@ development_status:
 #   Phase 2 (Waves 5-9):  Core Platform - Epics 2, 3, 6 in parallel
 #   Phase 3 (Waves 10-12): Extensions - Epics 4, 5, 7, 8, 9
 #   Phase 4 (Waves 13-15): Validation - Epic 10
+#   Phase 5 (Waves 16-19): Post-MVP Bug Fixes
+#   Phase 6 (Waves 20-21): Auth Enhancements
 #
 # Launch a single story in a container:
 #   ./scripts/bmad-dev.sh -p "/bmad-bmm-dev-story"
@@ -666,3 +678,49 @@ parallel_waves:
     container_count: 2
     depends_on: [wave-18]
     notes: "Final test fixes: selector refinements + pipeline config 404 — parallel"
+
+  # ============================================================
+  # PHASE 6: AUTH ENHANCEMENTS (Post-MVP features)
+  # ============================================================
+
+  wave-20:
+    phase: 6-auth-enhancements
+    stories:
+      - key: fix-8-nav-visible-unauthenticated
+        domain: front
+        status: backlog
+        cross_epic_deps: [1-9-login-page-auth-guard, 1-8-app-shell-layout-header-sidebar-status-bar]
+      - key: feat-1-logout-api
+        domain: back
+        status: backlog
+        cross_epic_deps: [1-3-users-table-jwt-auth-api-register-login-auth-middleware]
+      - key: feat-2-user-profile-api
+        domain: back
+        status: backlog
+        cross_epic_deps: [1-3-users-table-jwt-auth-api-register-login-auth-middleware]
+      - key: feat-3-reset-password-api
+        domain: back
+        status: backlog
+        cross_epic_deps: [1-3-users-table-jwt-auth-api-register-login-auth-middleware]
+    container_count: 4
+    depends_on: [wave-19]
+    notes: "Auth enhancements: nav fix (front), logout+profile+reset-password APIs (back) — all parallel"
+
+  wave-21:
+    phase: 6-auth-enhancements
+    stories:
+      - key: feat-4-logout-ui
+        domain: front
+        status: backlog
+        explicit_deps: [feat-1-logout-api]
+      - key: feat-5-user-profile-page
+        domain: front
+        status: backlog
+        explicit_deps: [feat-2-user-profile-api]
+      - key: feat-6-reset-password-pages
+        domain: front
+        status: backlog
+        explicit_deps: [feat-3-reset-password-api]
+    container_count: 3
+    depends_on: [wave-20]
+    notes: "Auth frontend: logout button, profile page, forgot/reset password pages — all parallel"


### PR DESCRIPTION
## Summary
- Add 7 story files for auth enhancements (waves 20-21, phase 6)
- Wave 20: fix-8 (nav auth), feat-1 (logout API), feat-2 (profile API), feat-3 (reset password API)
- Wave 21: feat-4 (logout UI), feat-5 (profile page), feat-6 (reset password pages)
- Update sprint-status.yaml with wave definitions and phase 6

## Test plan
- [x] Story files follow existing format conventions
- [x] Sprint status YAML is valid
- [ ] CI passes (docs-only change, no code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)