### PR TITLE
fix(ui): hide navigation chrome when user is unauthenticated

### DIFF
--- a/frontend/e2e/tests/login.spec.ts
+++ b/frontend/e2e/tests/login.spec.ts
@@ -165,6 +165,57 @@ test.describe('Login Page', () => {
     await expect(page).toHaveURL(/\/login\?redirect=/)
   })
 
+  test('should not render AppHeader or AppSidebar on /login when unauthenticated', async ({
+    page,
+  }) => {
+    await page.goto('/login')
+
+    // Login form should be visible
+    await expect(page.locator('h1')).toHaveText('hopeitworks')
+
+    // Header and sidebar should not be present
+    await expect(page.locator('header')).toHaveCount(0)
+    await expect(page.locator('aside')).toHaveCount(0)
+
+    // Status bar footer should not be present
+    await expect(page.locator('footer')).toHaveCount(0)
+
+    // Mobile navigation should not be present
+    await expect(page.locator('nav[aria-label="Mobile navigation"]')).toHaveCount(0)
+  })
+
+  test('should render AppHeader and AppSidebar after successful login', async ({ page }) => {
+    // Mock successful login
+    await page.route('**/api/v1/auth/login', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: '1',
+          email: 'test@test.com',
+          name: 'Test User',
+        }),
+      })
+    })
+
+    await page.goto('/login')
+
+    // Verify no shell chrome before login
+    await expect(page.locator('header')).toHaveCount(0)
+
+    // Fill valid credentials and submit
+    await page.locator('#email').fill('test@test.com')
+    await page.locator('#password').fill('password123')
+    await page.getByRole('button', { name: 'Sign In' }).click()
+
+    // Should redirect to dashboard
+    await expect(page).toHaveURL('/')
+
+    // Header and sidebar should now be visible
+    await expect(page.locator('header')).toBeVisible()
+    await expect(page.locator('aside')).toBeVisible()
+  })
+
   test('should redirect authenticated users from /login to / (already logged in)', async ({
     page,
   }) => {

--- a/frontend/src/ui/layout/AppShell.vue
+++ b/frontend/src/ui/layout/AppShell.vue
@@ -11,11 +11,13 @@ import { useLayoutStore } from '@/stores/layout'
 import { useHITLStore } from '@/stores/hitl'
 import { useKeyboard } from '@/composables/useKeyboard'
 import { useBreakpoint } from '@/composables/useBreakpoint'
+import { useAuth } from '@/composables/useAuth'
 
 const layoutStore = useLayoutStore()
 const hitlStore = useHITLStore()
 const toast = useToast()
 const { isMobile } = useBreakpoint()
+const { isAuthenticated } = useAuth()
 const mobileSidebarOpen = ref(false)
 const router = useRouter()
 
@@ -90,70 +92,76 @@ function toggleMobileSidebar() {
 
 <template>
   <div class="flex h-screen flex-col overflow-hidden">
-    <!-- Skip navigation link -->
-    <a
-      href="#main-content"
-      class="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:bg-primary focus:px-4 focus:py-2 focus:text-white"
-    >
-      Skip to main content
-    </a>
-
-    <AppHeader
-      :show-hamburger="isMobile"
-      @toggle-sidebar="toggleMobileSidebar"
-    />
-
-    <div class="flex min-h-0 flex-1">
-      <AppSidebar
-        :collapsed="layoutStore.sidebarCollapsed"
-        :mobile-open="mobileSidebarOpen"
-        @close="mobileSidebarOpen = false"
-      />
-
-      <main
-        id="main-content"
-        class="flex-1 overflow-auto bg-surface-100 p-4"
+    <template v-if="isAuthenticated">
+      <!-- Skip navigation link -->
+      <a
+        href="#main-content"
+        class="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:bg-primary focus:px-4 focus:py-2 focus:text-white"
       >
-        <router-view />
-      </main>
-    </div>
+        Skip to main content
+      </a>
 
-    <!-- Mobile bottom nav -->
-    <nav
-      v-if="isMobile"
-      class="flex h-14 items-center justify-around border-t border-surface-200 bg-surface-0"
-      aria-label="Mobile navigation"
-    >
-      <Button
-        v-for="item in mobileNavItems"
-        :key="item.route"
-        :icon="item.icon"
-        :label="item.label"
-        text
-        class="flex flex-col items-center gap-0.5 text-xs"
-        @click="router.push(item.route)"
+      <AppHeader
+        :show-hamburger="isMobile"
+        @toggle-sidebar="toggleMobileSidebar"
       />
-    </nav>
 
-    <AppStatusBar v-if="!isMobile" />
+      <div class="flex min-h-0 flex-1">
+        <AppSidebar
+          :collapsed="layoutStore.sidebarCollapsed"
+          :mobile-open="mobileSidebarOpen"
+          @close="mobileSidebarOpen = false"
+        />
 
-    <!-- Global toast for SSE notifications (HITL approvals) -->
-    <Toast position="top-right" group="hitl">
-      <template #message="slotProps">
-        <div class="flex flex-col gap-2">
-          <div class="flex items-center gap-2">
-            <i class="pi pi-exclamation-triangle" />
-            <span class="font-semibold">{{ slotProps.message.summary }}</span>
+        <main
+          id="main-content"
+          class="flex-1 overflow-auto bg-surface-100 p-4"
+        >
+          <router-view />
+        </main>
+      </div>
+
+      <!-- Mobile bottom nav -->
+      <nav
+        v-if="isMobile"
+        class="flex h-14 items-center justify-around border-t border-surface-200 bg-surface-0"
+        aria-label="Mobile navigation"
+      >
+        <Button
+          v-for="item in mobileNavItems"
+          :key="item.route"
+          :icon="item.icon"
+          :label="item.label"
+          text
+          class="flex flex-col items-center gap-0.5 text-xs"
+          @click="router.push(item.route)"
+        />
+      </nav>
+
+      <AppStatusBar v-if="!isMobile" />
+
+      <!-- Global toast for SSE notifications (HITL approvals) -->
+      <Toast position="top-right" group="hitl">
+        <template #message="slotProps">
+          <div class="flex flex-col gap-2">
+            <div class="flex items-center gap-2">
+              <i class="pi pi-exclamation-triangle" />
+              <span class="font-semibold">{{ slotProps.message.summary }}</span>
+            </div>
+            <span>{{ slotProps.message.detail }}</span>
+            <Button
+              label="Review Now"
+              size="small"
+              severity="warn"
+              @click="navigateToApproval()"
+            />
           </div>
-          <span>{{ slotProps.message.detail }}</span>
-          <Button
-            label="Review Now"
-            size="small"
-            severity="warn"
-            @click="navigateToApproval()"
-          />
-        </div>
-      </template>
-    </Toast>
+        </template>
+      </Toast>
+    </template>
+
+    <template v-else>
+      <router-view />
+    </template>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Wraps `AppHeader`, `AppSidebar`, mobile nav, `AppStatusBar`, and `Toast` in `v-if="isAuthenticated"` inside `AppShell.vue` so unauthenticated users see only the login form
- When unauthenticated, `<router-view />` renders directly without the shell layout, allowing `LoginView.vue` to fill the full viewport
- Adds two Playwright E2E tests verifying shell chrome is hidden on `/login` and appears after successful login

## Test plan
- [x] ESLint passes (`npm run lint`)
- [x] TypeScript type-check passes (`vue-tsc --noEmit`)
- [x] All 11 login E2E tests pass (including 2 new tests)
- [x] All 9 app-shell E2E tests pass (no regressions)
- [ ] Manual verification: visit `/login` unauthenticated — no header/sidebar/footer visible
- [ ] Manual verification: log in — header/sidebar/footer appear after redirect

Refs: fix-8-nav-visible-unauthenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)