### PR TITLE
feat(api): add user profile self-service endpoints

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -257,6 +257,64 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /users/me:
+    get:
+      operationId: getMyProfile
+      summary: Get the current user's profile
+      tags: [users]
+      responses:
+        "200":
+          description: Current user profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+    put:
+      operationId: updateMyProfile
+      summary: Update the current user's profile (name and/or email)
+      tags: [users]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateMyProfileRequest"
+      responses:
+        "200":
+          description: Updated user profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /users/me/password:
+    put:
+      operationId: changeMyPassword
+      summary: Change the current user's password
+      tags: [users]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangePasswordRequest"
+      responses:
+        "204":
+          description: Password changed successfully
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   # ── Projects ────────────────────────────────────────────────────────────
   /projects:
     get:
@@ -1771,6 +1829,29 @@ components:
         role:
           type: string
           enum: [admin, user]
+
+    UpdateMyProfileRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        email:
+          type: string
+          format: email
+      minProperties: 1
+
+    ChangePasswordRequest:
+      type: object
+      required: [current_password, new_password]
+      properties:
+        current_password:
+          type: string
+          minLength: 1
+        new_password:
+          type: string
+          minLength: 8
 
     UserList:
       type: object

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -133,6 +133,7 @@ func run() error {
 	// User service
 	userService := service.NewUserService(userRepo)
 	userHandler := handler.NewUserHandler(userService)
+	profileHandler := handler.NewProfileHandler(userService)
 
 	// Application-wide context for background services
 	appCtx, appCancel := context.WithCancel(ctx)
@@ -260,7 +261,7 @@ func run() error {
 	epicRunService := service.NewEpicRunService(epicRunRepo, storyRepo, epicRepo, schedulerService, parallelGroupExecutor, eventRepo, logger)
 	epicRunHandler := handler.NewEpicRunHandler(epicRunService)
 
-	server := handler.NewServer(authHandler, projectHandler, userHandler, epicHandler, storyHandler, promptTemplateHandler, runHandler, pipelineConfigHandler, hitlHandler, costHandler, notificationHandler, epicRunHandler)
+	server := handler.NewServer(authHandler, projectHandler, userHandler, profileHandler, epicHandler, storyHandler, promptTemplateHandler, runHandler, pipelineConfigHandler, hitlHandler, costHandler, notificationHandler, epicRunHandler)
 
 	// Project user handler
 	projectUserHandler := handler.NewProjectUserHandler(projectUserService)

--- a/backend/internal/adapter/postgres/user_repository.go
+++ b/backend/internal/adapter/postgres/user_repository.go
@@ -82,6 +82,13 @@ func (r *UserRepository) Update(ctx context.Context, user *model.User) (*model.U
 	return toDomainUser(row), nil
 }
 
+func (r *UserRepository) UpdatePasswordHash(ctx context.Context, id uuid.UUID, hash string) error {
+	return r.q.UpdateUserPasswordHash(ctx, UpdateUserPasswordHashParams{
+		ID:           id,
+		PasswordHash: hash,
+	})
+}
+
 func (r *UserRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	return r.q.DeleteUser(ctx, id)
 }

--- a/backend/internal/adapter/postgres/users.sql.go
+++ b/backend/internal/adapter/postgres/users.sql.go
@@ -181,3 +181,20 @@ func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) (User, e
 	)
 	return i, err
 }
+
+const updateUserPasswordHash = `-- name: UpdateUserPasswordHash :exec
+UPDATE users
+SET password_hash = $2,
+    updated_at    = now()
+WHERE id = $1 AND deleted_at IS NULL
+`
+
+type UpdateUserPasswordHashParams struct {
+	ID           uuid.UUID `json:"id"`
+	PasswordHash string    `json:"password_hash"`
+}
+
+func (q *Queries) UpdateUserPasswordHash(ctx context.Context, arg UpdateUserPasswordHashParams) error {
+	_, err := q.db.Exec(ctx, updateUserPasswordHash, arg.ID, arg.PasswordHash)
+	return err
+}

--- a/backend/internal/api/handler/auth_handler_test.go
+++ b/backend/internal/api/handler/auth_handler_test.go
@@ -80,6 +80,8 @@ func (m *mockRepo) Update(_ context.Context, user *model.User) (*model.User, err
 	return existing, nil
 }
 
+func (m *mockRepo) UpdatePasswordHash(_ context.Context, _ uuid.UUID, _ string) error { return nil }
+
 func (m *mockRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
 
 type pgDupError struct{}

--- a/backend/internal/api/handler/gen_server.go
+++ b/backend/internal/api/handler/gen_server.go
@@ -246,6 +246,12 @@ const (
 	GetProjectCostSummaryParamsPeriodN90d GetProjectCostSummaryParamsPeriod = "90d"
 )
 
+// ChangePasswordRequest defines model for ChangePasswordRequest.
+type ChangePasswordRequest struct {
+	CurrentPassword string `json:"current_password"`
+	NewPassword     string `json:"new_password"`
+}
+
 // CostDataPoint defines model for CostDataPoint.
 type CostDataPoint struct {
 	Date         openapi_types.Date `json:"date"`
@@ -859,6 +865,12 @@ type UpdateEpicRequest struct {
 // UpdateEpicRequestStatus defines model for UpdateEpicRequest.Status.
 type UpdateEpicRequestStatus string
 
+// UpdateMyProfileRequest defines model for UpdateMyProfileRequest.
+type UpdateMyProfileRequest struct {
+	Email *openapi_types.Email `json:"email,omitempty"`
+	Name  *string              `json:"name,omitempty"`
+}
+
 // UpdateNotificationConfigRequest defines model for UpdateNotificationConfigRequest.
 type UpdateNotificationConfigRequest struct {
 	ChannelType  UpdateNotificationConfigRequestChannelType `json:"channel_type"`
@@ -1181,6 +1193,12 @@ type CreatePromptTemplateJSONRequestBody = CreatePromptTemplateRequest
 // UpdatePromptTemplateJSONRequestBody defines body for UpdatePromptTemplate for application/json ContentType.
 type UpdatePromptTemplateJSONRequestBody = UpdatePromptTemplateRequest
 
+// UpdateMyProfileJSONRequestBody defines body for UpdateMyProfile for application/json ContentType.
+type UpdateMyProfileJSONRequestBody = UpdateMyProfileRequest
+
+// ChangeMyPasswordJSONRequestBody defines body for ChangeMyPassword for application/json ContentType.
+type ChangeMyPasswordJSONRequestBody = ChangePasswordRequest
+
 // UpdateUserJSONRequestBody defines body for UpdateUser for application/json ContentType.
 type UpdateUserJSONRequestBody = UpdateUserRequest
 
@@ -1428,6 +1446,15 @@ type ServerInterface interface {
 	// List all users
 	// (GET /users)
 	ListUsers(w http.ResponseWriter, r *http.Request, params ListUsersParams)
+	// Get the current user's profile
+	// (GET /users/me)
+	GetMyProfile(w http.ResponseWriter, r *http.Request)
+	// Update the current user's profile (name and/or email)
+	// (PUT /users/me)
+	UpdateMyProfile(w http.ResponseWriter, r *http.Request)
+	// Change the current user's password
+	// (PUT /users/me/password)
+	ChangeMyPassword(w http.ResponseWriter, r *http.Request)
 	// Delete a user
 	// (DELETE /users/{id})
 	DeleteUser(w http.ResponseWriter, r *http.Request, id IdPath)
@@ -1800,6 +1827,24 @@ func (_ Unimplemented) ListRunsByStory(w http.ResponseWriter, r *http.Request, s
 // List all users
 // (GET /users)
 func (_ Unimplemented) ListUsers(w http.ResponseWriter, r *http.Request, params ListUsersParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get the current user's profile
+// (GET /users/me)
+func (_ Unimplemented) GetMyProfile(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Update the current user's profile (name and/or email)
+// (PUT /users/me)
+func (_ Unimplemented) UpdateMyProfile(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Change the current user's password
+// (PUT /users/me/password)
+func (_ Unimplemented) ChangeMyPassword(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -4038,6 +4083,66 @@ func (siw *ServerInterfaceWrapper) ListUsers(w http.ResponseWriter, r *http.Requ
 	handler.ServeHTTP(w, r)
 }
 
+// GetMyProfile operation middleware
+func (siw *ServerInterfaceWrapper) GetMyProfile(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetMyProfile(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateMyProfile operation middleware
+func (siw *ServerInterfaceWrapper) UpdateMyProfile(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateMyProfile(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ChangeMyPassword operation middleware
+func (siw *ServerInterfaceWrapper) ChangeMyPassword(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ChangeMyPassword(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // DeleteUser operation middleware
 func (siw *ServerInterfaceWrapper) DeleteUser(w http.ResponseWriter, r *http.Request) {
 
@@ -4425,6 +4530,15 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/users", wrapper.ListUsers)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/users/me", wrapper.GetMyProfile)
+	})
+	r.Group(func(r chi.Router) {
+		r.Put(options.BaseURL+"/users/me", wrapper.UpdateMyProfile)
+	})
+	r.Group(func(r chi.Router) {
+		r.Put(options.BaseURL+"/users/me/password", wrapper.ChangeMyPassword)
+	})
+	r.Group(func(r chi.Router) {
 		r.Delete(options.BaseURL+"/users/{id}", wrapper.DeleteUser)
 	})
 	r.Group(func(r chi.Router) {
@@ -4440,145 +4554,149 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x9iW4cubXorxD1HvBsoFvd2jwzeggQ2fI4yvXM6Ep25iYTo8GuYnczqiZrSJbkjiEg",
-	"/3DvF+ZLLrhUFVnF2lq9yAsQZCyJRR6ec3h4dn4KQrpMKEFE8ODsU5BABpdIIKZ+ep3g8DK6gmIhf4oQ",
-	"DxlOBKYkOFN/A+/fX14EgwDLXyRy2CAgcImCswCpT4NBwNDvKWYoCs4ES9Eg4OECLaGcb0bZEorgLEhT",
-	"LEeKVSK/5IJhMg8eHgZqjeuUNILAUtIChprhkZD86fLd22v0e4q4qINGDgFMj2mAaIFFnM/0SKjqQLlG",
-	"nKYsRA1g4Meu/TMVeIZDKJesg8MeA0JKZnjeABJxZnwkeFdwjq4kM1ehkn8CJF1OEcsA+T1FbFVAksA5",
-	"Cuz1IjSDaSyCs8NBsMQEL9Ol+rdZFxOB5ojphRFrWPtSoCUHCWLArOFdHrFJPQhH40GwhB8NDONxO0SM",
-	"/gOFtXxr/txAmCSb4JE0aTjK142nmG3gBN9QJl6uasjyI0ZxBAQFnDIBpqsawsi/TtRfPXQJQoagQNEE",
-	"Cj8AAiVN2+cCJQ044OrzxyJBULaqA0L9sREC9fEjQXiHlkkMBWpgx2UigDDDGuAR+UyPAulBfswTSjhS",
-	"l95LGBn5LH8KKRGIqH/CJImNeBr9g0tgP1nL/F+GZsFZ8H9GxYU60n/lo9eMUaaXcjf7EkbZlRE8DIJX",
-	"lMxiHO5g4fyGCM2S4Bk6mB+AKNVLIYCWEMfPJVQ/UjbFUYTI9sHKlwJDAKMlJgCGIeIc5OTVN8+PNCXR",
-	"DrFEqAAztebDIHhPYCoWlOF/oh3A4Kwm/2y+kBO+olxcQAGvKNbrJ4wmiAmsOTmCAsn/oo9wmcSS6Y/G",
-	"Ry+G46Ph4TgYFAdDjascjEEgqIDxJKRcTFIeOTONDw6Pjk/sOWg6ja1ZzP2qT1d2NH/Ll3Jn/pB/Rqfy",
-	"ptFngYubdLmEbFXdGbyb66/lVank0voQDoJpGs2RmMR4ias7PRx3miNBDNNogkhUg/Hv3o3HZ+p/fyvj",
-	"fijw0ksAMykXkIk6Qq4xrYX9JSViUdnz8cHJ6YvvOu27gUcOD46OT077znKP0K2HmKcvvvu+P7uVoCth",
-	"1KHaoI6pvMyprnplnhRXRenw2afYJp2yWmaUAXmuERGZfjxDUKQM8UCpd28Rmcvr8WgsNbwKCfUVaE/7",
-	"niMGzp0pSzOdnipVMfv50DMtF1Ck3FVrpjC8jek8GASISCXzN+s3mEwSRucMcQl2RAmy0GVd+jZNFOj1",
-	"SLVthlfKZKhFcbiAhKB4omf6lMMXYR5SJkl6j6YLSm/lcgWmij9X9q9tFCVhoghLEGB85axZ+SSf91OQ",
-	"slgaeEIk/Gw0MsschHQ5ggkeGVj46ODgQPF8ef+IwGmsr5Qc+1qZydfQP5ovp5TGCBL16Z28TCYzHAvE",
-	"HL74TSrPEoYkRgIpTSklBzOI5UofBgGWBol3Y+YXkDG4qhDRQX2OtzIg9VQ2Rkf/03MOuPonMEaJy+OH",
-	"XU/LTytw5Zug/ZD042atzWY6b+12qwBeaA4Al/LnJSIC6Kn6n+lMTZ5Yekqxzl9pCiBDAGfrYDIHSviB",
-	"T5+0ELxFq4cHybTtS5UOYj6pUtCFMqUYusPoXs6FmDJxw5QLunSPqP1hB/x7Nmm+q6fMdUpqyZHgBMWY",
-	"qNmMPHAHSGNM/SM/PiX9JMw4t5YXO23LzOPbRePx1PD5PtMkxVE3Y82d03w5qOCnHsvKpqzFs1TuEwFJ",
-	"iCYhwwIxDL04i1CCSMQnGqVdRdZAef+67XUQ3KKVezJuhuND97Sd+mSL3jG+Q16IeEjdIyHvTq1uzJhi",
-	"VflPvoAMRZ6r076Rm6wHheYbPVTiATKp0M5wjHg/jAks4pIkKiRQTOeYZI6rshRqZh6J3Wx2H7dIpchz",
-	"wRceFY/2ezg8PH13OD477qf9PkYxq0yGS+r+d9+N0fcn4/EQHf0wHZ4cRidD+N3hi+HJyYsXp6cnJ+Px",
-	"2DG96rixq35XNRn0rTYpA/bixWYAK/ixqzZYwFCM9EwrhUtIUxOHaGX2V3rowyBIk2jTTFJiXi3zCsQO",
-	"MvFskFECf+B6Ai346jj/4vzN62iOPPeMcj94XHXaLaHv6Vu0As+0iEQkXD0PBlUpVj34SkRUZ36nfu+b",
-	"WVQmPmq/MzT8+XINCPiZRh4EPFJ4VwbGcKUVZHfXf0OMDqeQowigjyhM1blXYwEmEfpo73xcdbI7x6IL",
-	"u3cXsx0405atFk/qrTZg/Np4PatYR9G8dHE0uq4sDvZcKYRG/SdT3NCm5eiZBwbcup2+xdzvG4O9gPJt",
-	"LYFzTGB2kzTNcFWM9LjEYODMVbeT65ScK41JG4klmkldh6WkIvl/+GFbkl9uLkpj+XdHzlu/rxH1GHEt",
-	"LR1QT73hKxtX9iZL4reYsgF9F0hAHHsUjcw+NreI95IgaRxLC71khlveA0dd6aaN9FFROw5zVYA16Crl",
-	"vSYeSwnR/7I9CMZ7IHk25VpvLYhffFxH+V7H7jol6r5vFQbVSzpDrcUozsWcgdPAL3rpCrvMGU2Tib4Z",
-	"Nn+XFIe4TLtWDvRdQy0EWXXnE+MMqG75PcG/p5k6gqWugGcYMXCPxUJeZSbCrEJMAyDv5i5KSr39aeM/",
-	"37SXjCqqUpWV/l+HRgWxlO6b19eTn395N/nxl/c/X/itCSlReL3L0KFUAdkScQ7nPh1fIg1cXgA4DQ+P",
-	"jq3QUxuCFPjFzFV8lIWpwoIPbT9SNqfiCnJ+T1lUa76rEKG7g5Qj9kfz40FIl/bFooe37UKP8kFl5eC0",
-	"mYodLUE8m9lesQpTzzCKgBwFzCgwY3QJxAIBOJc/spR0OZZzKFDhpc6RBZOE0TsY707WM6ScFZRMGIIm",
-	"PtkKPUOcxnePvBu1228zk7B1xWO9ZPUO5QIlm7hFNZ21810RoNed2QcGS0K320J6eIv/So3ZqLliY7bY",
-	"nw29u6x9fPxXeYuw2IABYIue/doBl8uEMnGjVZd6aVgn1K7hPVhCdhvRe5ILNXXj/PX8p7dA+SSXUAjE",
-	"zG0+jWl4yzvcPXrBDiBzFdjyXsndVcNizpXJnKhSxaip1axEFSsGdAaMBgjEAgqghwNBAVaTBz7dTP+p",
-	"eVaC7uMVMPyZreGdzbiGmiYzQ3JQn92iFYAxQzBaAfQRc4Gi50Gr4ZTDXSxq6fEG+c3EW71u1prcHfwE",
-	"wwUmaCgBlTIZqDWA0VHqHDi+hDTlhFrCFZgigJaJWAE8U78MaRpHSj+Sf/koGAxdZBTTW9pWKWk3XUJS",
-	"BtIe0s2xnc0/0NjwIfKtFJNbVqWk9NA6mzsVR2HK0NUfOT+0Z8kHd9PJrNl9G/xJ46Deq+RVeS9nQCww",
-	"1+lmAHPA0FwyNUPRAEDAEEcCxJjcggXkYIoQAbxLXLBeCx4EP9EIxa8oFy8ZgkoUeoCVY1xQwximERrS",
-	"JOXDk+ELf2bNLSJ8gkmSuq6N4/FYhaZz3GMiXpx4hYKZg6aiPMlpjzmyvJf+uUxlRCpEOFOW9lkG2Yfy",
-	"albHF5/OsZXglZUj8gSSQrYX/9p2GGsfQaNuOTMFjfvFkaonbAN6r+fYtvnh1Pw+AK8cJbmUcFG+Fw59",
-	"Ui2vi7BHHo1rBaAz7uSoVUnSHw2y8o98Oe9utMlm1wUJtNygX0JJn4pP4vqtVFClFay8EMo38QzPwNW1",
-	"Vgb583pnQkO5kkqx72QTdzZFt2S21lmUDcZki6VYpeQGDk4Ne/gyLiqcetzKqMZU1J9692QSdOqu2u1n",
-	"CZTzoxqRZaC9ESjxoahZWB9tQFg7cloD3ypwHahrMsAmzRlxpUw4gZRy1TMhbhDAVNCJcTI5GJrBmHtV",
-	"gzLdv/9+M3QvtGaz36rObH7DKSFIDE+Gp8XvFhDfpsOT4bG79w56dzVdphFhKhdxktAYh6s25ryWY6/0",
-	"UK/0cVL1sss905od0pQW9jKVSUqt3iOYhSkWk6k0WRCbwNxn54r1XxdILBBTt4P5BphvpHUVpowhIuIV",
-	"EAwnibb+W9mlvHgeuq3zWoTSAgxTCSLIkgWVg8XkUdkBsLx60XuRl5deQk/I7d2CIb6gcaTSt+zFszXB",
-	"FM0oQ3rX2tVqy9umCsrBjtPQPBnOrWlnm5LbS/hxoqthfB4dVXMK9N8VpiWTZcE9TMD7mwvwDBO9ijK2",
-	"ACWxm5B0OPbaoDWu+6JCpCWFu5qWeU/yOEHxzenpZ2U+GNGS76XuJA7qxIP//PQzLAySG+uxpqtJLvo7",
-	"XfkeF4zn4p+uJiwlnSe9TkmXKXkW1O80qck2bJm26eBkBdbm4Kgys20fF9cBVJKW8m9A/i2DIj/LqhzK",
-	"Wf/ooE8FV+748q2o/gi0r6hhydNxTzdX4Snzrar/2r7sYddla0vMAhcLJfAs1ssZe1AcnIaTtwlzxAjK",
-	"/cau3GKYHaV7b0vV7VWys3P/1iaLfvZS5rPXvO66aqLeF6fF7ps5xfb52e9hvjZxmq2HtKoH7c+QIHBB",
-	"Uf9auHXDY9a03/cOlg3qiwSvVTpIY2JTkahT7k0gf68uNJPVQ+bqarMde6WSvXEb7GYxP6gctaeE2Qgu",
-	"22gIEHQPshHgmTG6wPcgXEAVvGXczQsk6P5G0wZyfnh03EYJE4nyL65DiWoAYChE+A5FYLoCGb2siNKb",
-	"v/wzenU4nh6JeIoPl9PjSxEu//LPv/3Xf/6hVahoCFpipbZToRp6hB8nUoxm5yj3dDt9f9oMZ+1qKItq",
-	"QomyKMjQWMbBIIDxPVxxVzI7A1oirRa4zrLejadkzezrzWRbM0bZxApEr51351ZATjiBCV9Q0TsPNC+Y",
-	"qpoNiIWICDhH2qNicKT6BHHwbPzvf/334Xj8fKD+lMq/QAFUwyIgt38Q1LaJ8vJL/6xx1hf73TLNTVJ5",
-	"Tcp5CEmI4rhn1nnnJGdX6diITmHlLefJa1aZXB+NomLgbiTc1CusU80vt8n02JTEmryF44PD0/6ZC1ZY",
-	"yM4sNCRw7LaWEJHBe131SM+4GO/he0BJq+thOzhz0FNfTm4wc03vH4kWW5p429z0t/x2x6yefjXj9foj",
-	"NfOshaZOPZSuU7IBs0Pe2Xu2NVLSFGXzXuRrKhWUCIgL1/HT0jpiOp9kIshj2zBEhJ20Xmo9eSH1CGkh",
-	"UIYlumPdclCl32Guku0EWwE6+/+ApHGsTQtKBcgCov3z7ZUyWBMt+nWBw4VZEwppcosclmeHuoLqeR0o",
-	"NUvX6r9l20kuygWDAs1XQOobxjMo8aBhqVs5d3qQkCnfhUoZmaWx8uFtsgRheypWi2Y1CO4hlvbkJK9Q",
-	"6VWuUNPixPyVskino7WlLFdTO/Ky+3yavEVK98qA65T8isXiJruJYRz/MgvOfusiBNv7wLTM4U9x6Ni9",
-	"5YPpItqmA/pupONOXvz1sl63dHv3ySCyuK6je7E2VfdwE6m6R2uk6m5OiyiV15hjU2TyNiTvDoJGjaKm",
-	"ILZrI5+1suF20PynX5uJXRS/tjUW6muuf619iLZi0td03OhjynvCyp4uY+uWZ69taZ8eHJ2uI28sF0dh",
-	"t1hrNKKgNq1A3v6tuUYR5gKTUBXjmlIuTFSeU6SC3LyU6+Nr3tIDz49DXCVQ7t4Y64W9ixzn9ULYFvm6",
-	"R7ML2jTQNmvnVMoWMY1xWpJeTQuplg4hdp1fa18Fpf+25JmXkFN08Sn050h70YuCCf/+N2B71/S+2Kn1",
-	"ne/lF3aDyTz2G1QpIxzkQ5XdFMt//J4ihhEfAMoAV5/rUWrELVqBmNLbNFFBCdRBES8wK9XxDrj7kG3h",
-	"pmdz23Z6F1LhvZL26zUEfm9KPN2yw7V6AJuZVCe7n43Wt24H4PW7/VY4SMP1rbPv06jaWquVb7GJD7UE",
-	"dqsOaom7yeKAzn1PDYTrth1uPaM1nYc/p4TabI9ZvuI6AuShCfXrdUK2wFomYk2x1pwPlS2RPzpiRu2i",
-	"6XFnBH4+rXS/0Ja47R1vayj3nvdLkyLofqh+valcqZslVg/n9Dw0jMYOodSLLNK05U5jyUYEcMR2lOi5",
-	"qXyzbdUMNOax9ca9u8k95k9meDRORgV3P1eI5JENmEqK1fZpKUnRhMKUYbG6kTNm3nh6i9F56nvr6s+/",
-	"vjMJaRwRASAHkACpZf5C4hXQaYlAT5A9gZX/lD2CZdLNsl0n+D/QSr8jJBWHrBkQ1DVl5qM/0QRdil8p",
-	"u+XgHYLLwPMwlZLJ4PzqMldM7K8yJWUJCZxrr5y8OSUTHfydvDNhPPmVsfnMQ0p0BgRLxSKfVC4gAWQw",
-	"FAd/lzuJcYhM/xAD7k+X7yQXOTo4TRDRcx5QNh+Zj/hIji2EtrPT86vLYBDcIcb1HscHhwdjdV8liMAE",
-	"B2fB8cH44FjRWSwU9UYwFYvRTPXDG9rJjYlxAEl2zV4sPCs1zjPPkiEuXtJotbGnovzd+R5clpVaX/ll",
-	"s6Px0caAKHd78b+ehYRp7BJhnkARLlAEnul8Q8CUzwBF4N//+h+QMG1umOFS6hm8qifITsbjOoDyHY6s",
-	"h9vssxic/fZhEPDMxxiYMQAWqahWl5k7DPOMUAHnXMleeXg/yDk1Oyj/cz0TqE4/77VU3gb9nU5Cncg+",
-	"3tjaWshWaa1gAjxVr7XNUom9BYKReUf2BonhKy24KjIwF3dSGObSrYCm8lyfYofDdnaoPpxWwxBv6Vwa",
-	"W5DoFgqYzEF2p9YzANWu11oOoKnIWcChxUkVBW/pfI4iQFNhYTBeBevv1NmbnFeVA+va37bNaS3FWKzu",
-	"vt4g8UpP4t/b9vnslbUHkPVe3QCe3iAHR/HKfgQCRW04y5pW1bNEVi6xRblQrsjoJBoOt04y1dS26Orl",
-	"sviWxUTPW0N+8kP7J/kznc3XjN4xgKrsoZWBOOqiYDhVGFvjI0+lx47vmQ7qRQZh0SKxIjs3pzTcIGEI",
-	"mSsNqdRs8xZ1uR5eJfACi3hoCMVrZau0gKxCIJUlbj3G/lv1yeJYctd05RT8gDwY7X2/OE8kzYnQuVtt",
-	"xRT0Y7aAeVQ8g91lsP1s9sOHLbJWudGPl7WUmYciHcKiMwfHG7lwVJDMmRVoT7suSirS1A0/SSby8dNo",
-	"uhpygZLRJ/1A9EPT5W1t/eVKOdQrTNZCJusR610RyUcgh+UfpwbIj07aP8ofHfbrDQ5A6g0pwMyb3l2I",
-	"+En+mDWK6kzD3tSz21F9I6JDROiScLrSPdH6Um5ktWHy3+DnesAXSsb88lhX/do+6ddS8nJeMeQr8cs6",
-	"nKIv1yZVr1wbvCk+2YbKWIZ1x/piHx7NtZovlUc1NTqxqPHjNqulV9mgvgz4CA2wffwNZeLlagcKo92G",
-	"pZOymCN1U3oijONi0oKO+a8+PAxqhIjz2vKW7EXvi847dj7kDW489DGhChOS2t2pd+iokZTZkEXfsiop",
-	"7WM5+oS1NhihGOmWOS59L9TvC/r2O5/12sNJfRsrDUq0F01NbxfAZgwOapXnzSNqvEsW3r+SnMX9yvqx",
-	"K4pSD/adBKzHEWDzIsybHbZjFaYD/bOnO56u4uKwjMZq22mtyLuR6Vk4ND0LtXPUVpQ9cUbu7XjKhQTg",
-	"mcpT/8N4AHRbxD+oRqfPAae6XCDvUKoqCEJIwBRlZaAoAnAOMTkA59ESkyEl8QogEiUUExOw9nhoX2k4",
-	"XmowtiuXX5X2rP2RGwgkyY+O2z/6kbIpjiJEHssuOl7sI6N2qPTgIvMvaWbpEpBCvfUnrsP5nKG50uJU",
-	"Y8QICpjnKPAEhfotuEz80Tvl2Bd4mbUSHOhXlKZZNQ/XXjzKVgPJVgMASQRUBd4BeGk1guS6ERsJ4zQy",
-	"VchuwmeEeRLDFYAxJXOOIwRSDufIx3rFBfeK8nXU9QxrmvsGlS5KxXY1SQzSdDKsz+Gct1ksRGCRe/9d",
-	"ZKXdqx+Ox/L/fxh7Hc47uHvtYiSPGD4vmCRjhJxZ9ncn13Gu78Dow9B2WkbhAjLR5IS08PVKjd02q6mt",
-	"KbCAScXaELttgdE6ZaupfjJQwCt5j3jy2ivMdwFxvLJIrC6g/amCkRccTStFJoZIhJhpE9CP/eQ13JH7",
-	"ruXQbTMfS4l10LfJek86qPa4FjJZm6C9Zmh2cN7kxGb0fn/Hi6VkGKM7ZPo052rFYyU7L0ptO5yu7C78",
-	"pkh09oV9hhqEgsD8an3+QgkOh1Jyjz4h/Xh6SyDTPLG+AeZq+eB1Bs72fThmKdMozsMAqjJTihjjytFW",
-	"Q4LYUPeP4HnByn6USQJQBqFy8dTAV/CFHN7KF83hhddqxNbZ4MsIRkhkdY9EKORrGmr6hbokf1OBCT2/",
-	"IzM8q1W5pTlcIff4WH74sM1Yh13nveNAh8JNnWDZeYhjPRfR+pFNJ4qiJBUm3uuqm1jSV9VllxDLJniy",
-	"21XVy/mnyP74iMwu3XxZDEdfNV7h0KQy7JsI490c5b2HeowmUA70WBK8PsqzJzptKy7UW9zviEf2Eg7a",
-	"sqh43P2QRZxqZUvH+2AUwXmb7XJx/ubLkkUX52+a8u0vzt9o3Y7QCHEVz0DRHPEd5kQdba5+8TVj1F9h",
-	"tApjJMWvyhGT+oXWZXXjBERCLLfsTQLOh6zAnMFkAZ5dnL95rtXjR3Nk5hStqTiDKQkXOzWp69nyaNP2",
-	"9LlqbqFMkHqLWn4TpbEqysjHf+2sqfkCQDCFIlwoPCl2jGP1LUY8K32UaHwG+YqEzx/JpaNPTDl/Ruol",
-	"h/q4/ZX8M7d9Dgfg1QLHkdXJbwHvECCq/bLqMauipQsURwNwv8CxXbBn2nWBsJhCkgOTFAFBswc0MCUH",
-	"IIv6nox/AFj3xM7dHpir9bRdAVMOpzHSeQS+kKvaw16OXfvoHfm8VGfkhnOp3/PYVELCDpUJRVvJnpgM",
-	"s75nOZ9YZ0RJ5jWPCEM8XaLG3JZ0KQ9JhsbiqFzpX1jsLs+GnjDS1/NH9QwuJflBML4god5i+ijcG4um",
-	"SdejkdG07lhosL+di6ZzkVHq8zsYmrpVnuxxJhZYxKOs5rA1OSeOixwt/fxRIfZNq3p1rS3SJSQga1p/",
-	"AC4Qx3Ni0mrClMX6VQHw6u0luKfsdhbTe676T9jV3vqMQKvSWJ2mUIKhXgjI0r/ktcIRAvfypiIIRRzo",
-	"Rl++I6ES6fWGm8s81/BzbisrpgJunef5bZb5rr/YSLlkf2Oz6p924Mn4wqq4rAl2eQokHO4lVifL5thG",
-	"teflk6Z4Fdw2ituoAKHZ4T6cVgogHzS1VHap2BaUqKLmSYco6put7jhg4cGbh51+rhJuP9GM9RmwiE14",
-	"9tKVB7uJnNEn+8dO8YvNs2+7ovWzA2SPqIaPG55E2YmHtM0Cpd5H/qQIsi3P+SOl0PgJSKHPteaiH6uu",
-	"KXdGIutp6r053yGfBvSEBY8E2MUcR2Q/hLxBJAIQiDJE6xAxM54a0/6c5t1P2ixxIfUlwmTGoub7lJmU",
-	"0T02CEm8INVXtpjhw0ylbqur2zz1tlZl5+0Sv+tiuzV56IuMufoukM3wbK1Eakzxl6bcdUr4y9W65aK7",
-	"TA7csg+xe7KfwummMvuUQ7mO0sa712wwb8Dzu1UL+TolezKJazzD1yn5fG1edO+U0baxTqNgyKMj5drN",
-	"itJi6kp2kD28u6CB9dJ4HZPQvGGWnZ+NkqJOZH+6DhVQF61wqw9aHZQ96gv6RJZvsnpw3YMNipQDQU24",
-	"4gC8cxq9migZmevnkItQmRM0HoBpKhVxxek6BgEZArGKr8tJPYGz5nAyeLZMuQBTlEWun9cGmHcSRNtv",
-	"WOz6C4gU5ykIOi2jX0RsrbBwEeGlsyIep+Qvo0vFhDHkAuSPRinW7cCs3QK8XwlffjmR2nUY0+QJNWrr",
-	"N2bMEy/iKaVT0eUSDjmSX9h6tL4w9AUwy7vsmvd7zWt4g0xmd++066n1Ld1aiji3aCUXjim9BWkCnjFz",
-	"VLN3NOSgulX1s6v1S27z/FRfiexktGRZaMXrkJpHpwoT+4skZnB5aptoYlpzGM1C84hb6Z4dmjYjSb9R",
-	"+ZTNJOfZsR0bSuYFzyof6aPydZU7mQfG/fVOBb+1yfERXiaUNTjtL9XfNyTRt8SaDox7ciGWYOBp7PXT",
-	"6GFKh4hFpZxWaxQ6W48x1eikKNB8miztcOjLNL4FmqMKkSlVzyVkumGB2vFfz396C9TrfksohPMSQg/O",
-	"/aSQ1incvRG52qHsVwPUI8J0YzK2P8eKPS2Cam65OhfN06DEeFd30v5bNOb6k1O35ygk9XGkvVFrW9Gm",
-	"/urLzljlW/leXfleg6Dpfkm0e48VGXbkP96tfGppQ2PUZ6vvyxPyF2v5BUNGuU79ZrrHV2dPcZUTyrVz",
-	"JT+A0rJVjYVJF85d1trRGyGG71BU+NTMYv+Pl0OkWpEjv6colRPyFQkLH53X7WZ2GzMEoxVY6CdAdZtS",
-	"3TfyZDx2x2KeD48oQXLEiTuCsgpcxrM3k1TwZqcrP/ZO/HktJ2GjYbZfsVjcqDfhm+NtpXIZQ8FvotlT",
-	"SOiJ8tmOmx6Oxey19dbHB6x34/lXmwrg4qHXYwTLRIAC2ZvKEChP3NSld5mIYQFBh+cKrK0+ae+YC+r+",
-	"Hj+w8eVvIG7T6ivznJU4tc6H5uHTdtk1+pT987LjSw0bZO12+fQuB67fSw8Ovj5Tb0WJ7G0SqaEf5hMj",
-	"2XiPkuNJPEHhQOR5isJz3TQ+SbF/+m7xSYt176d9ctk314hoeEuju1ST95edWNKSS9eb+XeXm9FqyTkN",
-	"VbkeuTcZVeqfigU3IHmto3qHRUt69HreWscA/5Ya/ZjU6AaTN+XmVfNaGr5XI77ON/Xk3ruTT+Nyf20E",
-	"YBwbGApS658tWnd8q+093/aDQOrB/c9UZy89k58huV473zA6N8vhPu421HmsFr1L6ug7TdKiomwXBGrQ",
-	"sB9Po22pxxKyPSnFjfzxtVSZ1R54NRqFKcNipbhFN+I5T8UiOPvtg+QKjthdxkulVxauLsHdIZhCjkAi",
-	"mWgQpCwOzoIRTPDo7lAxlVmx8m3RCEhHAiLz0E6eZCnR5skmVXRbQgLnaImI8H2ZXWN1L2s2f229Kuvt",
-	"At38tW7k51nbduc3T2GUqDZvUesuXCOlLg+2eZosINywIbdo0QdKuV6xOtmf0iUkQ0yGYoGGMaVJ0UTI",
-	"M6FqG1SdxNNVoAEqt6jbl7XMBRAMhreq0yWJAJ3KowCnOMZi5ZtSR0wfPjz8bwAAAP//0981VO4BAQA=",
+	"H4sIAAAAAAAC/+x9i27cOLbgrxDaBW4CVLmq/Eh3ezHAdex0xneTbq+dTO9MT1BgSawqjiVSTVJ2aoIA",
+	"8w+7XzhfcsGHJEqiXvV0HsBgOrYp8vCcw8Pz5ifPp1FMCSKCe+efvBgyGCGBmPrpVYz96+AGiqX8KUDc",
+	"ZzgWmBLvXP0NvH9/feUNPCx/EcthA4/ACHnnHlKfegOPoT8SzFDgnQuWoIHH/SWKoJxvTlkEhXfuJQmW",
+	"I8Uqll9ywTBZeJ8/D9QatwlpBIElpAUMNcOGkPz5+t2bW/RHgriog0YOAUyPaYBoiUWYzbQhVHWg3CJO",
+	"E+ajBjDwpmv/QgWeYx/KJevgsMcAn5I5XjSARAozbgjeDVygG8nMVajknwBJohliKSB/JIitckhiuECe",
+	"vV6A5jAJhXc+GXgRJjhKIvVvsy4mAi0Q0wsj1rD2tUARBzFiwKzhXB6xaT0Ix+OBF8GPBobxuB0iRv+B",
+	"/Fq+NX9uIEycTrAhTRqO8m3jKWZbOMF3lImXqxqy/IxRGABBAadMgNmqhjDyr1P1VwddPJ8hKFAwhcIN",
+	"gEBx0/a5QHEDDrj6fFMkCMpWdUCoPzZCoD7eEIR3KIpDKFADO0axAMIMa4BHZDNtBNJn+TGPKeFIXXov",
+	"YWDks/zJp0Qgov4J4zg04mn0Dy6B/WQt8z8Zmnvn3v8Y5RfqSP+Vj14xRpleqrjZlzBIrwzv88C7pGQe",
+	"Yn8PC2c3hG+WBM/Q0eIIBIleCgEUQRw+l1D9TNkMBwEiuwcrWwoMAQwiTAD0fcQ5yMirb56faUKCPWKJ",
+	"UAHmas3PA+89gYlYUob/ifYAQ2E1+WfzhZzwcgmJvGo4f6TM5tqY0RgxgTVH+wljiIhpbAbK30WYvEFk",
+	"IU/gpHImBh5Bj3XDf3Sd6vz4/V5drjTdh2wCOpP3iuZ8Lq6ggDcUE8cOAiiQ/C/6CKM4lJ8ej49fDMfH",
+	"w8nYG+RHXI1zbEdQAcOpT7mYJjwozDQ+mhyfnNpz0GQWWrMYTaG8y3Sp4sx1e7tLogiyVXVn8GGhv5aX",
+	"vpKw60M48GZJsEBiGuIIV3c6GXeaI0YM02CKSFCD8R/ejcfn6n9/K+N+KHDkJICZlAvIRB0h15jWwn5E",
+	"iVhW9nxydHr24odO+27gkcnR8cnpWd9ZHhG6dxDz7MUPP/ZntxJ0JYwWqDaoYyoncyqlRRladeKjII9s",
+	"0in7a04ZkBIKEZFq+nMERcIQ95SimsqN47HUVauSRl3m9rTvOWLgojBlaaazs0GbAOMCioQXFbQZ9O9D",
+	"uvAGHiJSXf7d+g0m05jRBUNcgh1Qgix01Qg6BXo9Um3r51IZP/USegkJQeFUz/Qpgy/A3NcS9BHNlpTe",
+	"y+VyTOV/ruxfW1tKwgQBliDA8KawZuWTbN5PXsJCaaoKEfPz0cgsc+TTaARjPDKw8NHR0ZHi+fL+EYGz",
+	"UF+OGfa1WpatoX80X84oDREk6tMHeS1O5zgUiBX44ndpBkgY4hAJpHS+hBzNIZYrfRh4WJpWzo2ZX0DG",
+	"4Kp6W9moz/BWBqSeysZ86n96LgBX/wTGvCry+KTraXm7AjeuCdoPST9u1np5qr3XbrcK4JXmAHAtf44Q",
+	"EUBP1f9Mpwr/1NK48nX+ShMAGQI4XQeTBVDCD3z6pIXgPVp9/iyZtn2p0kHMJlWmhlBGIUMPGD3KuRBT",
+	"xrqfcEGj4hG1P+yAf8cmzXf1lLlNSC05YhyjEBM1m5EHxQHSrFT/yI5PST/xU86t5cVO2zLzuHbReDw1",
+	"fK7PNElx0M3sLM5pvhxU8FOPZWUd1+JZmimxgMRHU59hgRiGTpwFKEYk4FON0q4ia6D8mN32OvDu0ap4",
+	"Mu6G40nxtJ25ZIveMX5AToi4T4tHQt6dWt2YM8Wq8p98CRkKHFenfSM32UEKzXd6qMQDZFKhneMQ8X4Y",
+	"E1iEJUmUS6CQLjBJXXBlKdTMPBK76ewubpFKkeOCz31DDu13MpycvZuMz0/6ab+bKGaVyXBJ3f/hhzH6",
+	"8XQ8HqLjn2bD00lwOoQ/TF4MT09fvDg7Oz0dj8cF06uOG7vqd1WTQd9q0zJgL15sB7CcH7tqgzkM+UjH",
+	"tFK4+DQxEZVWZr/UQz8PvCQOts0kJebVMi9H7CAVzwYZJfAHRZ+mBV8d519dvH4VLJDjnlGOFIfTUTtY",
+	"9D19j1bgmRaRiPir596gKsWqB1+JiOrM79TvXTOLysTH7XeGhj9brgEBv9DAgYANhXdlYAhXWkEu7vpv",
+	"iNHhDHIUAPQR+Yk692oswCRAH+2dj6vhgsKx6MLu3cVsB860ZavFk3qrDRi/Nf7bKtZRsChdHI1OOIuD",
+	"HVcKoUH/yRQ3tGk5euaBAbdup28wd/vGYC+gXFuL4QITmN4kTTPc5CMdLjHoFeaq28ltQi6UxqSNxBLN",
+	"pK7DElKR/D/9tCvJLzcXJKH8e0HOW7+vEfUYcS0tC6CeOQNxNq7sTZbEbz5lA/qukIA4dCgaqX1sbhHn",
+	"JUGSMJQWeskMt7wHBXWlmzbSR0XtOKyoAqxBVynvNfFYQoj+l+1BMN4DybMJ13prTvz84zrK9zp2twlR",
+	"932rMKhe0ilqLUYpXMwpOA38opeusMuC0SSe6pth+3dJfojLtGvlQNc11EKQVXc+Mc6A6pbfE/xHkqoj",
+	"WOoKeI4RA49YLOVVZmLlKlg2APJu7qKk1NufNv6zTTvJqOJDVVnp/rVvVBBL6b57dTv95dd3059/ff/L",
+	"lduakBKF17sMC5TKIYsQ53Dh0vEl0sD1FYAzf3J8YgXRWiNIEvx85io+ysJUYcGFtp8pW1DRGiFTwc7i",
+	"DhKO2H+aH498GtkXix7etgs9ygWVlU3UZip2tATxfG57xSpMPccoAHIUMKPAnNEIiCUCcCF/ZAnpciwX",
+	"UKDcS50hC8Yxow8w3J+sZ0g5KyiZMgRNpLUVeoY4DR82vBu12287k7B1xWO9ZHUO5QLF27hFNZ21810R",
+	"oNed2QcGS0K320J6eIv/So3ZqrliYzbfnw19cVn7+Liv8hZhsQUDwBY9h7UDrqOYMnGnVZd6aVgn1G7h",
+	"I4gguw/oI8mEmrpx/nrx9g1QPskICoGYuc1nIfXveYe7Ry/YAWSuAlvOK7m7apjPuTI5IFWqGDW1ml+p",
+	"YsWAzoHRAIFYQgH0cCAowGpyz6Wb6T81z0rQY7gChj/TNZyzGddQ02RmSAbqs3u0AjBkCAYrgD5iLlDw",
+	"3Gs1nDK480UtPd4gv5l4q1fNWlNxB2+hv8QEDSWgUiYDtQYwOkqdA8eVWqecUBFcgRkCKIrFCuC5+qVP",
+	"kzBQ+pH8y0fBoF9ERj69pW2V0o+TCJIykPaQbo7tdP6BxoYLkW+kmNyxKiWlR559ZBnkyE8YuvlPzif2",
+	"LFaqURedzJrdtcG3Ggf1XiWnyns9B2KJuU6cA5gDhhaSqRkKBgAChjgSIMTkHiwhBzOECOBd4oL1WvDA",
+	"e0sDFF5SLl4yBJUodAArxxRB9UOYBGhI44QPT4cv3Jk194jwKSZxUnRtnIzHKjSd4R4T8eLUKRTMHDQR",
+	"5UnOesyR5r30z2UqI1IhojBlaZ9lkF0or2Z1fPXpHDsJXlk5Ik8gKWR38a9dh7EOETTqljOT07hfHKl6",
+	"wrag9zqObZsfTs3vAvCmoCSXEi7K98LEJdWyCg975PG4VgAWxp0etypJ+qNBWsiSLefcjTbZ7AongaIt",
+	"+iWU9Kn4JG7fSAVVWsHKC6F8E8/wHNzcamWQP693JjQUXqligU42cWdTdEdma51F2WBMtliKVUpu4eDU",
+	"sIcr46LCqSetjGpMRf2pc08mQafuqt19lkA5P6oRWQbaO4FiF4qahfXxFoR1QU5r4FsFbgHqmgywaXNG",
+	"XCkTTiClXPVMiBt4MBF0apxMBQzNYcidqkGZ7j/+uB2651qz2W9VZza/4ZQQJIanw7P8d0uI75Ph6fCk",
+	"uPcOenc1XaYRYSoXcRrTEPurNua8lWNv9FCn9Cmk6qWXe6o1F0hTWtjJVCYptXqPYOYnWExn0mRBbAoz",
+	"n11RrP+2RGKJmLodzDfAfCOtK1NlEq6AYDiOtfXfyi7lxbPQbZ3XwpcWoJ9IEEGaLKgcLCaPyg6AZXWY",
+	"zou8vHQEHSG3d0uG+JKGgUrfshdP1wQzNKcM6V1rV6stb5tqQQd7TkNzZDi3pp1tS25H8ONUV8O4PDqq",
+	"ehbovytMSyZLg3uYgPd3V+AZJnoVZWwBSsJiQtJk7LRBa1z3eYVISwp3NS3zkWRxgvybs7MvynwwoiXb",
+	"S91JHNSJB/f56WdYGCQ31mPNVtNM9He68h0uGMfFP1tNWUI6T3qbkC5T8jSo32lSk23YMm3TwUlLxc3B",
+	"UWVmuz4uRQdQSVrKvwH5txSK7CyrcqjC+sdHfSq4MseXa0X1R6B9RQ1Lno17urlyT5lrVf3X9mUnXZet",
+	"LTHzilgogWexXsbYg/zgNJy8bZgjRlAeNnZVLIbZU7r3rlTdXiU7e/dvbbPo5yBlPgfN666rJup9cVrs",
+	"vp1TbJ+fwx7mWxOn2XlIq3rQ/gsSBK4o6l8Lt254rE8hfyVYNqgvErxV6SCNiU15ok65y4L8vbrQTFYP",
+	"WairzXbslUr2xm2wm8XcoHLUnhJmI7hsoyFA0CNIR4BnxugCPwJ/CVXwlvFiXiBBj3eaNpDzyfFJGyVM",
+	"JMq9uA4lqgGAIR/hBxSA2Qqk9LIiSq//8s/gcjKeHYtwhifR7ORa+NFf/vm3//t//tQqVDQELbFS26lQ",
+	"DT3Cj1MpRtNzlHm6Cx2M2gxn7Wooi2pCibIoyNBYxt7Ag+EjXPGiZC4MaIm0WuAWlnVuPCFrZl9vJ9ua",
+	"McqmViB67by7YgXklBMY8yUVvfNAs4KpqtmAmI+IgAukPSoGR6rjEQfPxv/+1/+bjMfPB+pPifwLFEC1",
+	"XgJy+0debcMrJ7/0zxpnfbHfLdPcJJXXpJz7kPgoDHtmnXdOci4qHVvRKay85Sx5zSqT66NRVAzcrYSb",
+	"eoV1qvnlNpk2TUmsyVs4OZqc9c9csMJCdmahIUHBbmsJERm811WP9IyL8R6+BxS3uh52g7MCeurLyQ1m",
+	"bunjhmixpYmzzU1/y29/zOroVzNerz9SM89aaOrUQ+k2IVswO+SdfWBbIyFNUTbnRb6mUkGJgDh3HT8t",
+	"rSOki2kqghy2jeofZkXeS000r6QeIS0EyrBEd6ibJ6r0O8xVsp1gK0Dn/wuQJAy1aUGpAGlAtH++vVIG",
+	"a6JFvy2xvzRrQiFNbpHB8myiK6ie14FSs3St/lu2neSiXDAo0GIFpL5hPIMSDxqWupUzpwfxmfJdqJSR",
+	"eRIqH942SxB2p2K1aFYD7xFiaU9OswqVXuUKNS1OzF8pC3Q6WlvKcjW1Iyu7z6bJWqR0rwy4TchvWCzv",
+	"0psYhuGvc+/89y5CsL0PTMsc7hSHjt1bPph+qG06oOtGOunkxV8v63VHt3efDCKL6zq6F2tTdSfbSNU9",
+	"XiNVd3taRKm8xhybPJO3IXl34DVqFDUFsV0b+ayVDbeH5j/92kzso/i1rbFQX3P9W+1DtBOTvqbjRh9T",
+	"3hFWdnQZW7c8e21L++zo+GwdeWO5OHK7xVqjEQW1aQXy9m/NNQowF5j4qhjXlHJhovKcAhXk5qVcH1fz",
+	"lh543gxxlUB58cZYL+yd5zivF8K2yNc9mp3TpoG2aTunUraIaYzTkvRqWki1dAix6/xa+yoo/bclz7yE",
+	"nLyLT64/B9qLnhdMuPe/Bdu7pvfFXq3vbC+/sjtMFqHboEoY4SAbquymUP7jjwQxjPgAUAa4+lyPUiPu",
+	"0QqElN4nsQpKoA6KeI5ZqY53wN2HdAt3PZvbttM7lwrvlbRfryHwe1PiWSw7XKsHsJlJdbL7xWh963YA",
+	"Xr/bb4WDNFxvVzeMSl3AQlGEiR0kmQzqgsjd48R9u7nWQPu9D/HTqDFbq/FwvokPtQQu1kjUEnebpQyd",
+	"u7QaCNdtktwqUWr6JH9J6b/pHtPsynXE3ecm1K/Xt9kCK4rFmkK4OXsrXSJ77MWM2keL5s4I/HIa/36l",
+	"DXzb+/PWUO4975fURdDjUP16W5lddxFWDxb1PDSMhgVCqZdwpCHOC20wGxHAEdtTWuq2suN2VeHQmHXX",
+	"G/fFTR4w2zPFo3GJKrj7OW4kj2zBsFOsdki7Toom5CcMi9WdnDGNHdB7jC4S1xtj//XbO5M+xxERAHIA",
+	"CZBa5q8kXAGdRAn0BOnTY9lP6eNjJjku3XWM/zda6febpOKQti6CugLOfPRnGqNr8Rtl9xy8QzDyHA+C",
+	"KZkMLm6uM8XE/ipVUiJI4EL7EOXNKZno6O/knQk6yq+MhWoesKJzIFgiltmkcgEJIIO+OPq73EmIfWS6",
+	"nRhw316/k1xU0MFpjIie84iyxch8xEdybC60Czu9uLn2Bt4DYlzvcXw0ORqr+ypGBMbYO/dOjsZHJ4rO",
+	"YqmoN4KJWI7mqnvf0E7FjI27SrJr+lLkeanNn3kODnHxkgarrT3R5e4l+LnIslLrK78odzw+3hoQ5d40",
+	"7lfLkDBtaALMYyj8JQrAM50dCZjycKAA/Ptf/x/ETJsbZriUegav6um30/G4DqBshyPrwTz7LHrnv38Y",
+	"eDz1iHpmDIB54qzVE+cBwyx/VcAFV7JXHt4Pck7NDspbXs8Eqi/Rey2Vd0H/Qt+jTmQfb21tLWSrtFYw",
+	"AZ6oV/LmicTeEsHAvN97h8TwUguuigzMxJ0Uhpl0y6GpPJOo2GHSzg7VB+tqGOINXUhjCxLd8AGTBUjv",
+	"1HoGoNpRXMsBNBEZCxRocVpFwRu6WKAA0ERYGAxX3vo7LexNzquKl3WlctvmtJZiLNbivl4jcaknce9t",
+	"93x2ae0BpJ1it4Cn16iAo3BlP1mBgjacpS226lkiLe7YoVwo1490Eg2TnZNMteDNe5AVWXzHYqLnrSE/",
+	"+an9k+x51OZrRu8YQFWk0cpAHHVRMAo1IzvjI0ddyp7vmQ7qRQph3tCxIju3pzTcIWEImSkNidRss4Z6",
+	"mR5eJfASi3BoCMVrZau0gKyyJZXTbj2C/3v1qehQctdsVShPAlno3PludJb2mhGhc2/diinoxmwO8yh/",
+	"frzLYPu58s8fdsha5bZETtZSZh4KdMCNzgs43sqFo0J6hVmB9rTrEqo8qd7wk2QiFz+NZqshFygefdIP",
+	"c39uurytrb9cKYd6hclayGQ9Hr4vIrkIVGD5zdQA+dFp+0fZY89uvaEAkHrxCjDzlnoXIn6SP6ZtrTrT",
+	"sDf17OZZ34lYICIsknC20h3c+lJuZDWNct/gF3rAV0rG7PJYV/3aPenXUvIyXjHkK/HLOpyiL9cmVa9c",
+	"ybwtPtmFyliGdc/6Yh8ezbSar5VHNTU6sajx4zarpTfpoL4MuIEG2D7+jjLxcrUHhdFuGtNJWcyQui09",
+	"EYZhPmlOx+xXHz4PaoRI4W3oHdmLzven9+x8yNrxOOhjQhUmJLW/U1+go0ZSakPmXdaqpLSP5egT1tpg",
+	"gEKkG/wU6Xulfp/Tt9/5rNceTuubbmlQgoNoanq7ADZjcFCrPG8fUeN9svDhleQ07lfWj4uiKHFgv5CA",
+	"tRkBti/CnNlhe1ZhOtA/fWjk6SouBZbRWG07rRV5NzIdFoemw6J2jtqKsiPOyJ39WbmQADxTWfV/Gg+A",
+	"buL4J9WW9TngVBc3ZP1UVb2DDwmYobRoFQUALiAmR+AiiDAZUhKuACJBTDExAWuHh/ZSw/FSg7FbuXxZ",
+	"2rP2R24hkCQ/Omn/6GfKZjgIENmUXXS82EVG7VDpwUXmX9LM0gUruXrrTrOHiwVDC6XFqTaOARQwy1Hg",
+	"MfL1y3Wp+KMPyrEvcJQ2PhzoN59mae0R1148ylYDyVYDAEkAVL3gEXhpta3kum0c8cMkMDXTxYTPAPM4",
+	"hCsAQ0oWHAcIJBwukIv18gvukvJ11PUUa5r7BpWeT/l2NUkM0nQyrMvhnDWFzEVgXinwQ2AVCagfTsby",
+	"/38aOx3Oe7h77dIphxi+yJkkZYSMWQ53J9dxruvA6MPQdlpG/hIy0eSEtPB1qcbumtXU1hRYwKRibYnd",
+	"dsBonbLVVPcbKOCNvEccee0V5ruCOFxZJFYX0OFUwcAJjqaVIhNDJEDMNDXox37yGu7Ifbdy6K6ZjyXE",
+	"Oui7ZL0nHVTbrOFN2tTooBmaHZw3GbEZfTzc8WIJGYboAZmu0plasalk53lhcIfTld6F3xWJzr6wL1CD",
+	"UBCYX63PXyjG/lBK7tEnpJ96bwlkmgfht8BcLR+8SsHZvQ/HLGXa2jkYQNWRShFjXDnaaogRG+puFzwr",
+	"WDmMMkkASiFULp4a+HK+kMNb+aI5vPBKjdg5G3wdwQiJrO6RCIV8TUNNP183ENhWYELPX5AZjtWq3NIc",
+	"rpB73JQfPuwy1mFXpe850KFwUydY9h7iWM9FtH5ksxBFUZIKE+d11U0s6avqukuIZRs82e2q6uX8U2Tf",
+	"PCKzTzdfGsPRV41TODSpDIcmwng/R/ngoR6jCZQDPZYEr4/yHIhOu4oL9Rb3e+KRg4SDdiwqNrsf0ohT",
+	"rWzpeB+MArhos12uLl5/XbLo6uJ1U7791cVrrdsRGiCu4hkoWCC+x5yo4+3VL75ijLorjFZ+iKT4VTli",
+	"Ur/QuqxunICIj+WWnUnA2ZAVWDAYL8Gzq4vXz7V6vDFHpk7RmoozmBB/uVeTup4tj7dtT1+o5hbKBKm3",
+	"qOU3QRKqooxs/LfOmpovAAQzKPylwpNixzBU32LE09JHicZnkK+I/3xDLh19Ysr5M1LvTtTH7W/kn7nt",
+	"czgCl0scBlbfwSV8QICoZtGqI66Kli5RGAzA4xKHdsGeaS4G/HwKSQ5MEgQETZ/7wJQcgTTqezr+CWDd",
+	"wTtze2Cu1tN2BUw4nIVI5xG4Qq5qDwc5du2j9+TzUn2cG86lfn1kWwkJe1QmFG0le2IyTLu0ZXxinREl",
+	"mdc8IgzxJEKNuS1JJA9Jisb8qNzoX1jsLs+GnjDQ1/NH9WgvJdlBML4goV6O+iiKNxZN4q5HI6Vp3bHQ",
+	"YH8/F03nIqXUl3cwNHWrPNnjTCyxCEdpzWFrck4Y5jla+rGmXOybxvrqWlsmESQgbbF/BK4Qxwti0mr8",
+	"hIX6DQRw+eYaPFJ2Pw/pI1f9J+xqb31GoFVprE6TL8FQ7xmk6V/yWuEIgUd5UxGEAg50oy/XkVCJ9HrD",
+	"zWWea/g5d5UVUwG3zvP8Js18119spVyyv7FZ9U8X4En5wqq4rAl2OQokCtxLrE6WzbGNas/LJ03xKrht",
+	"FLdRAXyzw0M4rRRALmhqqVykYltQooqaJx2iqG+2uueAhQNvDnb6pUq4w0Qz1mfAPDbh2EtXHuwmckaf",
+	"7B87xS+2z77titYvBSB7RDVc3PAkyk4cpG0WKPU+8idFkF15zjeUQuMnIIW+1JqLfqy6ptwZibSnqfPm",
+	"fIdcGtATFjwS4CLmOCKHIeQdIgGAQJQhWoeIqfHUmPZXaN79pM2SIqSuRJjUWNR8nzCTMnrABiGxE6T6",
+	"yhYzfJiq1G11ddun3s6q7Jxd4vddbLcmD32VMVfXBbIdnq2VSI0p/tKUu00If7lat1x0n8mBO/Yhdk/2",
+	"UzjdVmafcijXUdp495oN5i14fndqId8m5EAmcY1n+DYhX67Nix4LZbRtrNMoGLLoSLl2s6K0mLqSPWQP",
+	"7y9oYL2LXsckNGuYZednozivEzmcrkMF1EUr3OqDVgdlj/qCPpHlu7QeXPdggyLhQFATrjgC7wqNXk2U",
+	"jCz04815qKwQNB6AWSIVccXpOgYBGQKhiq/LSR2Bs+ZwMngWJVyAGUoj189rA8x7CaIdNix2+xVEirMU",
+	"BJ2W0S8itlZYOI/w0nkej1Pyl9FIMWEIuQDZo1GKdTswa7cA7zfCl19PpHYdxjR5Qo3a+p0Z88SLeErp",
+	"VDSK4JAj+YWtR+sLQ18A86zLrnlt2LzdN0hldvdOu45a39KtpYhzj1Zy4ZDSe5DE4BkzRzV9R0MOqltV",
+	"PxJbv+Quz0/1TctORkuahZa/Zal5dKYwcbhIYgqXo7aJxqY1h9EsNI8UK93TQ9NmJOkXNZ+ymVR4dmzP",
+	"hpJ5b7TKR/qofFvlTuY5dHe9U85vbXJ8hKOYsgan/bX6+5Yk+o5YswDjgVyIJRh4Ejr9NHqY0iFCUSmn",
+	"1RqFztZjTDU6yQs0nyZLFzj0ZRLeA81RuciUqmcEmW5YoHb814u3b4B63S+CQhReQujBuZ8U0jqFu7ci",
+	"VzuU/WqAekSY7kzG9pdYsadFUM0tV+eieRqUGO/rTjp8i8ZMfyrU7RUUkvo40sGotatoU3/1ZW+s8r18",
+	"r658r0HQdL8k2r3Higx78h/vVz61tKEx6rPV9+UJ+Yu1/II+o1ynfjPd46uzp7jKCeXauZIfQGnZqsbC",
+	"pAtnLmvt6A0Qww8oyH1qZrH/4OUQqVbkyB8JSuSEfEX83EfndLuZ3YYMwWAFlvoJUN2mVPeNPB2Pi2Mx",
+	"z4YHlCA54rQ4grIKXMazN5dUcGanKz/2Xvx5LSdhq2G237BY3qk34ZvjbaVyGUPB76LZUUjoiPLZjpse",
+	"jsX0tfXWxwesd+P5N5sKUMRDr8cIoliAHNnbyhAoT9zUpTeKxTCHoMNzBdZWn7R3rAjq4R4/sPHlbiBu",
+	"0+ob85yVOLXOh+bg03bZNfqU/vO640sNW2Ttdvn0LgOu30sPBXx9od6KEtnbJFJDP8wnRrLxASXHk3iC",
+	"ogCR4ykKx3XT+CTF4em7wyct1r2fDsll310jouEtje5STd5fdmJJSy5db+bfX25GqyVXaKjK9ciDyahS",
+	"/1QsuAHJaR3VOyxa0qPX89YWDPDvqdGbpEY3mLwJN6+a19LwvRrxbb6pJ/fenXwal4drIwDD0MCQk1r/",
+	"bNF6FDXWV71d3TA6xyHydoxWZ+cone2qNiFvEAXHFs5DWt3kW/P/B89WqGKrURMromhXKlG2yoG0oToa",
+	"vTfP2FdptC8FaGPtpJ4VwDMCI9VHZUQZQBHE4fOWwzRKX9pXnnsX11wuIVlIeqYDd+TpUcuki/TiGpdx",
+	"beYBvprWlVW6/8cpFShO8uWoradVt0cqFd/v9CU0ucKX6qxIeCErJpeXdffJltG5B/mmqbOp+2Cf1NHK",
+	"vBLIZS9Dpwttcxrt6hKUkD21+0+i+Vspr6098Go08hOGxUpxi+5AdpGIpXf++wfJFRyxh5SXSs/L3FyD",
+	"hwmYQY5ALJlo4CUs9M69EYzx6GGimMqsWPk274CmQ6CBeWEsyy6XaHOk0Su6RZDABYrkzeH4MtXf654U",
+	"bv7aek7b2f6++WvdwdSxth3HbJ7CWI9tbvLWXRS9M3UFAM3TpJkwDRsqVmu7QCkXalcn+3MSQTLEZCiW",
+	"aBhSGufd0xwTqn5p1Ukc7VQaoCp2s3CVa3ABBIP+vWrxSwJAZ/IowBkOsVi5ptSpIp8/fP7vAAAA///Y",
+	"SAC5XwgBAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/backend/internal/api/handler/profile_handler.go
+++ b/backend/internal/api/handler/profile_handler.go
@@ -1,0 +1,116 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/zakari/hopeitworks/backend/internal/api/middleware"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// ProfileHandler handles self-service profile endpoints for the authenticated user.
+type ProfileHandler struct {
+	userService *service.UserService
+}
+
+// NewProfileHandler creates a new ProfileHandler.
+func NewProfileHandler(svc *service.UserService) *ProfileHandler {
+	return &ProfileHandler{userService: svc}
+}
+
+// GetMyProfile handles GET /users/me.
+func (h *ProfileHandler) GetMyProfile(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.UserIDFromContext(r.Context())
+	if !ok {
+		writeErrorResponse(w, errors.NewUnauthorized("authentication required"))
+		return
+	}
+
+	user, err := h.userService.GetByID(r.Context(), userID)
+	if err != nil {
+		writeErrorResponse(w, errors.NewUnauthorized("user not found"))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toAPIUser(user))
+}
+
+// UpdateMyProfile handles PUT /users/me.
+func (h *ProfileHandler) UpdateMyProfile(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.UserIDFromContext(r.Context())
+	if !ok {
+		writeErrorResponse(w, errors.NewUnauthorized("authentication required"))
+		return
+	}
+
+	var req UpdateMyProfileRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErrorResponse(w, errors.NewValidation("body", "invalid JSON"))
+		return
+	}
+
+	if req.Name == nil && req.Email == nil {
+		writeErrorResponse(w, errors.NewValidation("body", "at least one field (name or email) must be provided"))
+		return
+	}
+
+	params := service.UpdateProfileParams{
+		ID: userID,
+	}
+	if req.Name != nil {
+		params.Name = req.Name
+	}
+	if req.Email != nil {
+		email := string(*req.Email)
+		params.Email = &email
+	}
+
+	user, err := h.userService.UpdateProfile(r.Context(), params)
+	if err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toAPIUser(user))
+}
+
+// ChangeMyPassword handles PUT /users/me/password.
+func (h *ProfileHandler) ChangeMyPassword(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.UserIDFromContext(r.Context())
+	if !ok {
+		writeErrorResponse(w, errors.NewUnauthorized("authentication required"))
+		return
+	}
+
+	var req ChangePasswordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErrorResponse(w, errors.NewValidation("body", "invalid JSON"))
+		return
+	}
+
+	if req.CurrentPassword == "" {
+		writeErrorResponse(w, errors.NewValidation("current_password", "must not be empty"))
+		return
+	}
+	if req.NewPassword == "" {
+		writeErrorResponse(w, errors.NewValidation("new_password", "must not be empty"))
+		return
+	}
+
+	err := h.userService.ChangePassword(r.Context(), userID, req.CurrentPassword, req.NewPassword)
+	if err != nil {
+		if err == service.ErrInvalidCurrentPassword {
+			writeErrorResponse(w, &errors.DomainError{
+				Category: errors.CategoryUnauthorized,
+				Code:     "INVALID_CREDENTIALS",
+				Message:  "current password is incorrect",
+			})
+			return
+		}
+		writeErrorResponse(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/internal/api/handler/profile_handler_test.go
+++ b/backend/internal/api/handler/profile_handler_test.go
@@ -1,0 +1,293 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/zakari/hopeitworks/backend/internal/api/middleware"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+)
+
+func setupProfileHandler() (*ProfileHandler, *mockUserRepo) {
+	repo := newMockUserRepo()
+	svc := service.NewUserService(repo)
+	h := NewProfileHandler(svc)
+	return h, repo
+}
+
+func seedTestUserWithPassword(repo *mockUserRepo, name, email, password string, role model.Role) *model.User {
+	hash, _ := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	u := seedTestUser(repo, name, email, role)
+	u.PasswordHash = string(hash)
+	return u
+}
+
+func TestGetMyProfile(t *testing.T) {
+	h, repo := setupProfileHandler()
+	user := seedTestUser(repo, "Alice", "alice@example.com", model.RoleUser)
+
+	tests := []struct {
+		name       string
+		userID     uuid.UUID
+		hasAuth    bool
+		wantStatus int
+	}{
+		{
+			name:       "authenticated user gets profile",
+			userID:     user.ID,
+			hasAuth:    true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "no auth context returns 401",
+			hasAuth:    false,
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "user not found returns 401",
+			userID:     uuid.New(),
+			hasAuth:    true,
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me", nil)
+			if tt.hasAuth {
+				ctx := middleware.SetUserContext(req.Context(), tt.userID, model.RoleUser)
+				req = req.WithContext(ctx)
+			}
+
+			rec := httptest.NewRecorder()
+			h.GetMyProfile(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d. Body: %s", tt.wantStatus, rec.Code, rec.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				var resp User
+				if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp.Name != "Alice" {
+					t.Errorf("expected name 'Alice', got %q", resp.Name)
+				}
+				if string(resp.Email) != "alice@example.com" {
+					t.Errorf("expected email 'alice@example.com', got %q", resp.Email)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateMyProfile(t *testing.T) {
+	h, repo := setupProfileHandler()
+	user := seedTestUser(repo, "Alice", "alice@example.com", model.RoleUser)
+
+	tests := []struct {
+		name       string
+		userID     uuid.UUID
+		hasAuth    bool
+		body       string
+		wantStatus int
+	}{
+		{
+			name:       "update name only",
+			userID:     user.ID,
+			hasAuth:    true,
+			body:       `{"name":"Alice Updated"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "update email only",
+			userID:     user.ID,
+			hasAuth:    true,
+			body:       `{"email":"new@example.com"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "no auth returns 401",
+			hasAuth:    false,
+			body:       `{"name":"Alice Updated"}`,
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "empty body returns 400",
+			userID:     user.ID,
+			hasAuth:    true,
+			body:       `{}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "invalid JSON returns 400",
+			userID:     user.ID,
+			hasAuth:    true,
+			body:       `{invalid}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "empty name returns 400",
+			userID:     user.ID,
+			hasAuth:    true,
+			body:       `{"name":""}`,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/users/me",
+				bytes.NewBufferString(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+
+			if tt.hasAuth {
+				ctx := middleware.SetUserContext(req.Context(), tt.userID, model.RoleUser)
+				req = req.WithContext(ctx)
+			}
+
+			rec := httptest.NewRecorder()
+			h.UpdateMyProfile(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d. Body: %s", tt.wantStatus, rec.Code, rec.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				var resp User
+				if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp.Id != user.ID {
+					t.Errorf("expected user ID %v, got %v", user.ID, resp.Id)
+				}
+			}
+		})
+	}
+}
+
+func TestChangeMyPassword(t *testing.T) {
+	h, repo := setupProfileHandler()
+	user := seedTestUserWithPassword(repo, "Alice", "alice@example.com", "oldpassword", model.RoleUser)
+
+	tests := []struct {
+		name       string
+		userID     uuid.UUID
+		hasAuth    bool
+		body       string
+		wantStatus int
+		resetPw    bool
+	}{
+		{
+			name:       "successful password change",
+			userID:     user.ID,
+			hasAuth:    true,
+			body:       `{"current_password":"oldpassword","new_password":"newpassword123"}`,
+			wantStatus: http.StatusNoContent,
+			resetPw:    true,
+		},
+		{
+			name:       "wrong current password",
+			userID:     user.ID,
+			hasAuth:    true,
+			body:       `{"current_password":"wrongpassword","new_password":"newpassword123"}`,
+			wantStatus: http.StatusUnauthorized,
+			resetPw:    true,
+		},
+		{
+			name:       "new password too short",
+			userID:     user.ID,
+			hasAuth:    true,
+			body:       `{"current_password":"oldpassword","new_password":"short"}`,
+			wantStatus: http.StatusBadRequest,
+			resetPw:    true,
+		},
+		{
+			name:       "no auth returns 401",
+			hasAuth:    false,
+			body:       `{"current_password":"oldpassword","new_password":"newpassword123"}`,
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "empty current password returns 400",
+			userID:     user.ID,
+			hasAuth:    true,
+			body:       `{"current_password":"","new_password":"newpassword123"}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "empty new password returns 400",
+			userID:     user.ID,
+			hasAuth:    true,
+			body:       `{"current_password":"oldpassword","new_password":""}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "invalid JSON returns 400",
+			userID:     user.ID,
+			hasAuth:    true,
+			body:       `{invalid}`,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset password hash before tests that need the original password
+			if tt.resetPw {
+				hash, _ := bcrypt.GenerateFromPassword([]byte("oldpassword"), bcrypt.DefaultCost)
+				user.PasswordHash = string(hash)
+			}
+
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/users/me/password",
+				bytes.NewBufferString(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+
+			if tt.hasAuth {
+				ctx := middleware.SetUserContext(req.Context(), tt.userID, model.RoleUser)
+				req = req.WithContext(ctx)
+			}
+
+			rec := httptest.NewRecorder()
+			h.ChangeMyPassword(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d. Body: %s", tt.wantStatus, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestChangeMyPassword_VerifyErrorCode(t *testing.T) {
+	h, repo := setupProfileHandler()
+	user := seedTestUserWithPassword(repo, "Alice", "alice@example.com", "oldpassword", model.RoleUser)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/users/me/password",
+		bytes.NewBufferString(`{"current_password":"wrongpassword","new_password":"newpassword123"}`))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := middleware.SetUserContext(req.Context(), user.ID, model.RoleUser)
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	h.ChangeMyPassword(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+
+	var errResp Error
+	if err := json.NewDecoder(rec.Body).Decode(&errResp); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if errResp.Error.Code != "INVALID_CREDENTIALS" {
+		t.Errorf("expected error code INVALID_CREDENTIALS, got %q", errResp.Error.Code)
+	}
+}

--- a/backend/internal/api/handler/project_handler_test.go
+++ b/backend/internal/api/handler/project_handler_test.go
@@ -167,6 +167,10 @@ func (m *mockUserRepoForHandler) Update(_ context.Context, user *model.User) (*m
 	return user, nil
 }
 
+func (m *mockUserRepoForHandler) UpdatePasswordHash(_ context.Context, _ uuid.UUID, _ string) error {
+	return nil
+}
+
 func (m *mockUserRepoForHandler) Delete(_ context.Context, _ uuid.UUID) error { return nil }
 
 func setupHandler() (*ProjectHandler, *mockProjectRepo) {

--- a/backend/internal/api/handler/server.go
+++ b/backend/internal/api/handler/server.go
@@ -9,6 +9,7 @@ type Server struct {
 	auth            *AuthHandler
 	projects        *ProjectHandler
 	users           *UserHandler
+	profile         *ProfileHandler
 	epics           *EpicHandler
 	stories         *StoryHandler
 	promptTemplates *PromptTemplateHandler
@@ -21,8 +22,8 @@ type Server struct {
 }
 
 // NewServer creates a new Server with the given handlers.
-func NewServer(auth *AuthHandler, projects *ProjectHandler, users *UserHandler, epics *EpicHandler, stories *StoryHandler, promptTemplates *PromptTemplateHandler, runs *RunHandler, pipelineConfig *PipelineConfigHandler, hitl *HITLHandler, costs *CostHandler, notifications *NotificationHandler, epicRuns *EpicRunHandler) *Server {
-	return &Server{auth: auth, projects: projects, users: users, epics: epics, stories: stories, promptTemplates: promptTemplates, runs: runs, pipelineConfig: pipelineConfig, hitl: hitl, costs: costs, notifications: notifications, epicRuns: epicRuns}
+func NewServer(auth *AuthHandler, projects *ProjectHandler, users *UserHandler, profile *ProfileHandler, epics *EpicHandler, stories *StoryHandler, promptTemplates *PromptTemplateHandler, runs *RunHandler, pipelineConfig *PipelineConfigHandler, hitl *HITLHandler, costs *CostHandler, notifications *NotificationHandler, epicRuns *EpicRunHandler) *Server {
+	return &Server{auth: auth, projects: projects, users: users, profile: profile, epics: epics, stories: stories, promptTemplates: promptTemplates, runs: runs, pipelineConfig: pipelineConfig, hitl: hitl, costs: costs, notifications: notifications, epicRuns: epicRuns}
 }
 
 // RegisterUser delegates to AuthHandler.
@@ -98,6 +99,21 @@ func (s *Server) UpdateUser(w http.ResponseWriter, r *http.Request, id IdPath) {
 // DeleteUser delegates to UserHandler.
 func (s *Server) DeleteUser(w http.ResponseWriter, r *http.Request, id IdPath) {
 	s.users.DeleteUser(w, r, id)
+}
+
+// GetMyProfile delegates to ProfileHandler.
+func (s *Server) GetMyProfile(w http.ResponseWriter, r *http.Request) {
+	s.profile.GetMyProfile(w, r)
+}
+
+// UpdateMyProfile delegates to ProfileHandler.
+func (s *Server) UpdateMyProfile(w http.ResponseWriter, r *http.Request) {
+	s.profile.UpdateMyProfile(w, r)
+}
+
+// ChangeMyPassword delegates to ProfileHandler.
+func (s *Server) ChangeMyPassword(w http.ResponseWriter, r *http.Request) {
+	s.profile.ChangeMyPassword(w, r)
 }
 
 // ListEpics delegates to EpicHandler.

--- a/backend/internal/api/handler/user_handler_test.go
+++ b/backend/internal/api/handler/user_handler_test.go
@@ -78,6 +78,16 @@ func (m *mockUserRepo) Update(_ context.Context, user *model.User) (*model.User,
 	return user, nil
 }
 
+func (m *mockUserRepo) UpdatePasswordHash(_ context.Context, id uuid.UUID, hash string) error {
+	u, ok := m.users[id]
+	if !ok {
+		return errors.NewNotFound("user", id)
+	}
+	u.PasswordHash = hash
+	u.UpdatedAt = time.Now()
+	return nil
+}
+
 func (m *mockUserRepo) Delete(_ context.Context, id uuid.UUID) error {
 	delete(m.users, id)
 	return nil

--- a/backend/internal/api/middleware/auth_test.go
+++ b/backend/internal/api/middleware/auth_test.go
@@ -40,7 +40,7 @@ func (r *noopRepo) Update(_ context.Context, _ *model.User) (*model.User, error)
 	return nil, nil
 }
 func (r *noopRepo) UpdatePasswordHash(_ context.Context, _ uuid.UUID, _ string) error { return nil }
-func (r *noopRepo) Delete(_ context.Context, _ uuid.UUID) error                      { return nil }
+func (r *noopRepo) Delete(_ context.Context, _ uuid.UUID) error                       { return nil }
 
 type noopTokenRepo struct{}
 

--- a/backend/internal/api/middleware/auth_test.go
+++ b/backend/internal/api/middleware/auth_test.go
@@ -39,7 +39,8 @@ func (r *noopRepo) Count(_ context.Context) (int64, error) { return 0, nil }
 func (r *noopRepo) Update(_ context.Context, _ *model.User) (*model.User, error) {
 	return nil, nil
 }
-func (r *noopRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
+func (r *noopRepo) UpdatePasswordHash(_ context.Context, _ uuid.UUID, _ string) error { return nil }
+func (r *noopRepo) Delete(_ context.Context, _ uuid.UUID) error                      { return nil }
 
 type noopTokenRepo struct{}
 

--- a/backend/internal/domain/port/user_repository.go
+++ b/backend/internal/domain/port/user_repository.go
@@ -15,5 +15,6 @@ type UserRepository interface {
 	List(ctx context.Context, limit, offset int32) ([]*model.User, error)
 	Count(ctx context.Context) (int64, error)
 	Update(ctx context.Context, user *model.User) (*model.User, error)
+	UpdatePasswordHash(ctx context.Context, id uuid.UUID, hash string) error
 	Delete(ctx context.Context, id uuid.UUID) error
 }

--- a/backend/internal/domain/service/auth_service_test.go
+++ b/backend/internal/domain/service/auth_service_test.go
@@ -89,6 +89,15 @@ func (m *mockUserRepository) Update(_ context.Context, user *model.User) (*model
 	return existing, nil
 }
 
+func (m *mockUserRepository) UpdatePasswordHash(_ context.Context, id uuid.UUID, hash string) error {
+	u, ok := m.users[id.String()]
+	if !ok {
+		return errors.New("no rows")
+	}
+	u.PasswordHash = hash
+	return nil
+}
+
 func (m *mockUserRepository) Delete(_ context.Context, id uuid.UUID) error {
 	u, ok := m.users[id.String()]
 	if !ok {

--- a/backend/internal/domain/service/project_user_service_test.go
+++ b/backend/internal/domain/service/project_user_service_test.go
@@ -108,6 +108,9 @@ func (m *mockProjectUserServiceUserRepo) Count(_ context.Context) (int64, error)
 func (m *mockProjectUserServiceUserRepo) Update(_ context.Context, user *model.User) (*model.User, error) {
 	return user, nil
 }
+func (m *mockProjectUserServiceUserRepo) UpdatePasswordHash(_ context.Context, _ uuid.UUID, _ string) error {
+	return nil
+}
 func (m *mockProjectUserServiceUserRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
 
 func setupProjectUserService() (*ProjectUserService, *mockProjectUserRepo, *mockProjectRepo, *mockProjectUserServiceUserRepo) {

--- a/backend/internal/domain/service/user_service.go
+++ b/backend/internal/domain/service/user_service.go
@@ -4,10 +4,15 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
 	"github.com/zakari/hopeitworks/backend/internal/domain/port"
 	"github.com/zakari/hopeitworks/backend/pkg/errors"
 )
+
+// ErrInvalidCurrentPassword is returned when the current password does not match.
+var ErrInvalidCurrentPassword = errors.NewUnauthorized("current password is incorrect")
 
 // UserService provides business logic for user management (admin CRUD).
 type UserService struct {
@@ -105,6 +110,71 @@ func (s *UserService) Update(ctx context.Context, params UpdateUserParams) (*mod
 	}
 
 	return s.repo.Update(ctx, existing)
+}
+
+// UpdateProfileParams holds parameters for self-service profile updates.
+// Role is intentionally excluded — users cannot change their own role.
+type UpdateProfileParams struct {
+	ID    uuid.UUID
+	Name  *string
+	Email *string
+}
+
+// UpdateProfile validates and applies a self-service profile update.
+func (s *UserService) UpdateProfile(ctx context.Context, params UpdateProfileParams) (*model.User, error) {
+	existing, err := s.repo.GetByID(ctx, params.ID)
+	if err != nil {
+		return nil, errors.NewUnauthorized("user not found")
+	}
+
+	if params.Name != nil {
+		if *params.Name == "" {
+			return nil, errors.NewValidation("name", "must not be empty")
+		}
+		if len(*params.Name) > 255 {
+			return nil, errors.NewValidation("name", "must be 255 characters or less")
+		}
+		existing.Name = *params.Name
+	}
+
+	if params.Email != nil {
+		if *params.Email == "" {
+			return nil, errors.NewValidation("email", "must not be empty")
+		}
+		existing.Email = *params.Email
+	}
+
+	updated, err := s.repo.Update(ctx, existing)
+	if err != nil {
+		if isDuplicateKeyError(err) {
+			return nil, errors.NewConflict("email", *params.Email)
+		}
+		return nil, err
+	}
+	return updated, nil
+}
+
+// ChangePassword verifies the current password and sets a new bcrypt hash.
+func (s *UserService) ChangePassword(ctx context.Context, userID uuid.UUID, currentPassword, newPassword string) error {
+	user, err := s.repo.GetByID(ctx, userID)
+	if err != nil {
+		return errors.NewUnauthorized("user not found")
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(currentPassword)); err != nil {
+		return ErrInvalidCurrentPassword
+	}
+
+	if len(newPassword) < 8 {
+		return errors.NewValidation("new_password", "must be at least 8 characters")
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	if err != nil {
+		return errors.NewInternal("failed to hash password", err)
+	}
+
+	return s.repo.UpdatePasswordHash(ctx, userID, string(hash))
 }
 
 // Delete soft-deletes a user by ID.

--- a/backend/internal/domain/service/user_service_test.go
+++ b/backend/internal/domain/service/user_service_test.go
@@ -14,11 +14,11 @@ import (
 
 // mockUserRepo is a mock implementation of port.UserRepository for testing.
 type mockUserRepo struct {
-	users              map[uuid.UUID]*model.User
-	createFn           func(ctx context.Context, u *model.User) (*model.User, error)
-	updateFn           func(ctx context.Context, u *model.User) (*model.User, error)
-	deleteFn           func(ctx context.Context, id uuid.UUID) error
-	updatePasswordFn   func(ctx context.Context, id uuid.UUID, hash string) error
+	users            map[uuid.UUID]*model.User
+	createFn         func(ctx context.Context, u *model.User) (*model.User, error)
+	updateFn         func(ctx context.Context, u *model.User) (*model.User, error)
+	deleteFn         func(ctx context.Context, id uuid.UUID) error
+	updatePasswordFn func(ctx context.Context, id uuid.UUID, hash string) error
 }
 
 func newMockUserRepo() *mockUserRepo {

--- a/backend/internal/domain/service/user_service_test.go
+++ b/backend/internal/domain/service/user_service_test.go
@@ -6,16 +6,19 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
 	"github.com/zakari/hopeitworks/backend/pkg/errors"
 )
 
 // mockUserRepo is a mock implementation of port.UserRepository for testing.
 type mockUserRepo struct {
-	users    map[uuid.UUID]*model.User
-	createFn func(ctx context.Context, u *model.User) (*model.User, error)
-	updateFn func(ctx context.Context, u *model.User) (*model.User, error)
-	deleteFn func(ctx context.Context, id uuid.UUID) error
+	users              map[uuid.UUID]*model.User
+	createFn           func(ctx context.Context, u *model.User) (*model.User, error)
+	updateFn           func(ctx context.Context, u *model.User) (*model.User, error)
+	deleteFn           func(ctx context.Context, id uuid.UUID) error
+	updatePasswordFn   func(ctx context.Context, id uuid.UUID, hash string) error
 }
 
 func newMockUserRepo() *mockUserRepo {
@@ -75,6 +78,19 @@ func (m *mockUserRepo) Update(ctx context.Context, user *model.User) (*model.Use
 	user.UpdatedAt = time.Now()
 	m.users[user.ID] = user
 	return user, nil
+}
+
+func (m *mockUserRepo) UpdatePasswordHash(ctx context.Context, id uuid.UUID, hash string) error {
+	if m.updatePasswordFn != nil {
+		return m.updatePasswordFn(ctx, id, hash)
+	}
+	u, ok := m.users[id]
+	if !ok {
+		return errors.NewNotFound("user", id)
+	}
+	u.PasswordHash = hash
+	u.UpdatedAt = time.Now()
+	return nil
 }
 
 func (m *mockUserRepo) Delete(ctx context.Context, id uuid.UUID) error {
@@ -299,5 +315,195 @@ func TestUserService_Delete(t *testing.T) {
 	}
 	if domainErr.Code != "USER_NOT_FOUND" {
 		t.Errorf("expected USER_NOT_FOUND, got %q", domainErr.Code)
+	}
+}
+
+func TestUserService_UpdateProfile(t *testing.T) {
+	repo := newMockUserRepo()
+	svc := NewUserService(repo)
+
+	user := seedUser(repo, "Alice", "alice@example.com", model.RoleUser)
+
+	newName := "Alice Updated"
+	newEmail := "alice-new@example.com"
+	emptyName := ""
+	longName := string(make([]byte, 256))
+
+	tests := []struct {
+		name    string
+		params  UpdateProfileParams
+		wantErr bool
+		errCode string
+	}{
+		{
+			name:    "update name only",
+			params:  UpdateProfileParams{ID: user.ID, Name: &newName},
+			wantErr: false,
+		},
+		{
+			name:    "update email only",
+			params:  UpdateProfileParams{ID: user.ID, Email: &newEmail},
+			wantErr: false,
+		},
+		{
+			name:    "update both name and email",
+			params:  UpdateProfileParams{ID: user.ID, Name: &newName, Email: &newEmail},
+			wantErr: false,
+		},
+		{
+			name:    "empty name",
+			params:  UpdateProfileParams{ID: user.ID, Name: &emptyName},
+			wantErr: true,
+			errCode: "VALIDATION_ERROR",
+		},
+		{
+			name:    "name too long",
+			params:  UpdateProfileParams{ID: user.ID, Name: &longName},
+			wantErr: true,
+			errCode: "VALIDATION_ERROR",
+		},
+		{
+			name:    "user not found",
+			params:  UpdateProfileParams{ID: uuid.New(), Name: &newName},
+			wantErr: true,
+			errCode: "UNAUTHORIZED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := svc.UpdateProfile(context.Background(), tt.params)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				domainErr, ok := err.(*errors.DomainError)
+				if !ok {
+					t.Fatalf("expected DomainError, got %T", err)
+				}
+				if domainErr.Code != tt.errCode {
+					t.Errorf("expected error code %q, got %q", tt.errCode, domainErr.Code)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+		})
+	}
+}
+
+func TestUserService_UpdateProfile_DuplicateEmail(t *testing.T) {
+	repo := newMockUserRepo()
+	// Override update to simulate duplicate key error
+	repo.updateFn = func(_ context.Context, _ *model.User) (*model.User, error) {
+		return nil, &pgDuplicateKeyError{}
+	}
+	svc := NewUserService(repo)
+
+	user := seedUser(repo, "Alice", "alice@example.com", model.RoleUser)
+	email := "taken@example.com"
+
+	_, err := svc.UpdateProfile(context.Background(), UpdateProfileParams{
+		ID:    user.ID,
+		Email: &email,
+	})
+	if err == nil {
+		t.Fatal("expected error for duplicate email")
+	}
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected DomainError, got %T", err)
+	}
+	if domainErr.Code != "EMAIL_ALREADY_EXISTS" {
+		t.Errorf("expected EMAIL_ALREADY_EXISTS, got %q", domainErr.Code)
+	}
+}
+
+func TestUserService_ChangePassword(t *testing.T) {
+	repo := newMockUserRepo()
+	svc := NewUserService(repo)
+
+	// Seed user with a known bcrypt hash for "oldpassword"
+	hash, _ := bcrypt.GenerateFromPassword([]byte("oldpassword"), bcrypt.DefaultCost)
+	user := seedUser(repo, "Alice", "alice@example.com", model.RoleUser)
+	user.PasswordHash = string(hash)
+
+	tests := []struct {
+		name            string
+		userID          uuid.UUID
+		currentPassword string
+		newPassword     string
+		wantErr         bool
+		errCode         string
+	}{
+		{
+			name:            "successful password change",
+			userID:          user.ID,
+			currentPassword: "oldpassword",
+			newPassword:     "newpassword123",
+			wantErr:         false,
+		},
+		{
+			name:            "wrong current password",
+			userID:          user.ID,
+			currentPassword: "wrongpassword",
+			newPassword:     "newpassword123",
+			wantErr:         true,
+			errCode:         "UNAUTHORIZED",
+		},
+		{
+			name:            "new password too short",
+			userID:          user.ID,
+			currentPassword: "oldpassword",
+			newPassword:     "short",
+			wantErr:         true,
+			errCode:         "VALIDATION_ERROR",
+		},
+		{
+			name:            "user not found",
+			userID:          uuid.New(),
+			currentPassword: "oldpassword",
+			newPassword:     "newpassword123",
+			wantErr:         true,
+			errCode:         "UNAUTHORIZED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset password hash for repeated tests
+			if tt.name == "successful password change" || tt.name == "new password too short" {
+				h, _ := bcrypt.GenerateFromPassword([]byte("oldpassword"), bcrypt.DefaultCost)
+				user.PasswordHash = string(h)
+			}
+
+			err := svc.ChangePassword(context.Background(), tt.userID, tt.currentPassword, tt.newPassword)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				domainErr, ok := err.(*errors.DomainError)
+				if !ok {
+					t.Fatalf("expected DomainError, got %T", err)
+				}
+				if domainErr.Code != tt.errCode {
+					t.Errorf("expected error code %q, got %q", tt.errCode, domainErr.Code)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Verify the password hash was updated
+			updatedUser := repo.users[tt.userID]
+			if bcrypt.CompareHashAndPassword([]byte(updatedUser.PasswordHash), []byte(tt.newPassword)) != nil {
+				t.Error("password hash was not updated correctly")
+			}
+		})
 	}
 }

--- a/backend/queries/users.sql
+++ b/backend/queries/users.sql
@@ -24,5 +24,11 @@ SET name = COALESCE(sqlc.narg('name'), name),
 WHERE id = $1 AND deleted_at IS NULL
 RETURNING *;
 
+-- name: UpdateUserPasswordHash :exec
+UPDATE users
+SET password_hash = $2,
+    updated_at    = now()
+WHERE id = $1 AND deleted_at IS NULL;
+
 -- name: DeleteUser :exec
 UPDATE users SET deleted_at = now() WHERE id = $1 AND deleted_at IS NULL;


### PR DESCRIPTION
## Summary
- Add `GET /users/me`, `PUT /users/me`, and `PUT /users/me/password` endpoints for self-service profile management
- Authenticated users can view/update their own profile (name, email) and change their password without admin access
- Full validation: empty name, name length, email format, password strength, current password verification
- Proper error codes: `VALIDATION_ERROR` (400), `UNAUTHORIZED` (401), `INVALID_CREDENTIALS` (401 for wrong password), `CONFLICT` (409 for duplicate email)

## Changes
- **OpenAPI spec**: 3 new paths + 2 new schemas (`UpdateMyProfileRequest`, `ChangePasswordRequest`)
- **Database**: New `UpdateUserPasswordHash` sqlc query
- **Domain layer**: `UpdatePasswordHash` on `UserRepository` port + postgres adapter
- **Service layer**: `UpdateProfile` and `ChangePassword` methods on `UserService` with bcrypt verification
- **Handler layer**: New `ProfileHandler` with `GetMyProfile`, `UpdateMyProfile`, `ChangeMyPassword`
- **Wiring**: `ProfileHandler` added to `Server` struct and `main.go`
- **Tests**: Unit tests for `UserService.UpdateProfile`, `UserService.ChangePassword`, and all `ProfileHandler` endpoints
- **Mock updates**: All existing `UserRepository` mocks updated to satisfy new `UpdatePasswordHash` method

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -short` — all tests pass (service + handler + middleware + adapter)
- [x] `go vet ./...` passes
- [x] `gofmt` clean on all modified files
- [ ] CI golangci-lint (environment version mismatch in dev container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)