### PR TITLE
feat(ui): add logout button UI and user identity menu

### DIFF
--- a/frontend/e2e/tests/app-shell.spec.ts
+++ b/frontend/e2e/tests/app-shell.spec.ts
@@ -121,6 +121,59 @@ test.describe('App Shell Layout', () => {
     })
   })
 
+  test.describe('Logout flow', () => {
+    test('should logout and redirect to /login on success', async ({ page }) => {
+      await page.route('**/api/v1/auth/logout', async (route) => {
+        await route.fulfill({ status: 204 })
+      })
+      // After logout, /me should return 401 so guard redirects
+      await page.unroute('**/api/v1/auth/me')
+      await page.route('**/api/v1/auth/me', async (route) => {
+        await route.fulfill({ status: 401 })
+      })
+      await page.getByTestId('user-menu-button').click()
+      await page.getByRole('menuitem', { name: 'Logout' }).click()
+      await expect(page).toHaveURL('/login')
+    })
+
+    test('should logout even when backend returns 500', async ({ page }) => {
+      await page.route('**/api/v1/auth/logout', async (route) => {
+        await route.fulfill({ status: 500 })
+      })
+      await page.unroute('**/api/v1/auth/me')
+      await page.route('**/api/v1/auth/me', async (route) => {
+        await route.fulfill({ status: 401 })
+      })
+      await page.getByTestId('user-menu-button').click()
+      await page.getByRole('menuitem', { name: 'Logout' }).click()
+      await expect(page).toHaveURL('/login')
+    })
+
+    test('should redirect to /login with redirect param after logout', async ({ page }) => {
+      await page.route('**/api/v1/auth/logout', async (route) => {
+        await route.fulfill({ status: 204 })
+      })
+      await page.unroute('**/api/v1/auth/me')
+      await page.route('**/api/v1/auth/me', async (route) => {
+        await route.fulfill({ status: 401 })
+      })
+      // Logout first
+      await page.getByTestId('user-menu-button').click()
+      await page.getByRole('menuitem', { name: 'Logout' }).click()
+      await expect(page).toHaveURL('/login')
+      // Try to navigate to a protected route
+      await page.goto('/')
+      await expect(page).toHaveURL(/\/login\?redirect=/)
+    })
+
+    test('should display user name and email in user menu', async ({ page }) => {
+      await page.getByTestId('user-menu-button').click()
+      const userMenu = page.getByTestId('user-menu')
+      await expect(userMenu).toContainText('Test')
+      await expect(userMenu).toContainText('test@test.com')
+    })
+  })
+
   test.describe('Layout Integration', () => {
     test('should render Dashboard view at root route', async ({ page }) => {
       // Already at root route from beforeEach

--- a/frontend/src/stores/__tests__/auth.spec.ts
+++ b/frontend/src/stores/__tests__/auth.spec.ts
@@ -160,4 +160,35 @@ describe('useAuthStore', () => {
       expect(store.loading).toBe(false)
     })
   })
+
+  describe('logout()', () => {
+    it('clears user and error state on success', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
+      const store = useAuthStore()
+      store.user = { id: '1', email: 'a@b.com', name: 'A', role: 'member' }
+      store.error = 'some previous error'
+      await store.logout()
+      expect(store.user).toBeNull()
+      expect(store.error).toBeNull()
+    })
+
+    it('clears user state even when fetch throws', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'))
+      const store = useAuthStore()
+      store.user = { id: '1', email: 'a@b.com', name: 'A', role: 'member' }
+      await store.logout()
+      expect(store.user).toBeNull()
+      expect(store.error).toBeNull()
+    })
+
+    it('calls POST /api/v1/auth/logout with credentials include', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
+      const store = useAuthStore()
+      await store.logout()
+      expect(fetchSpy).toHaveBeenCalledWith('/api/v1/auth/logout', {
+        method: 'POST',
+        credentials: 'include',
+      })
+    })
+  })
 })

--- a/frontend/src/ui/layout/AppHeader.vue
+++ b/frontend/src/ui/layout/AppHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import Button from 'primevue/button'
 import Menu from 'primevue/menu'
@@ -18,7 +18,18 @@ const router = useRouter()
 const authStore = useAuthStore()
 const userMenu = ref<InstanceType<typeof Menu> | null>(null)
 
-const menuItems: MenuItem[] = [
+const menuItems = computed<MenuItem[]>(() => [
+  {
+    label: authStore.user?.name ?? 'User',
+    disabled: true,
+    class: 'font-semibold',
+  },
+  {
+    label: authStore.user?.email ?? '',
+    disabled: true,
+    class: 'text-surface-500 text-sm',
+  },
+  { separator: true },
   {
     label: 'Logout',
     icon: 'pi pi-sign-out',
@@ -27,7 +38,7 @@ const menuItems: MenuItem[] = [
       router.push('/login')
     },
   },
-]
+])
 
 function toggleUserMenu(event: Event) {
   userMenu.value?.toggle(event)


### PR DESCRIPTION
## Summary
- **AppHeader.vue**: Convert `menuItems` from static array to `computed<MenuItem[]>` that reactively displays the authenticated user's name and email as non-clickable header items above the Logout action
- **E2E tests**: Add 4 Playwright tests covering successful logout redirect, error-swallowing (500 response), post-logout auth guard redirect with `?redirect=` param, and user identity display in menu
- **Unit tests**: Add 3 Vitest tests for `authStore.logout()` verifying state clearing on success, state clearing on fetch error, and correct API call with `credentials: 'include'`

## Test plan
- [x] Unit tests pass: `npx vitest run src/stores/__tests__/auth.spec.ts` (3/3 passing)
- [x] ESLint passes: `npm run lint`
- [ ] E2E tests: `npm run test:e2e` (requires running dev server)
- [ ] Manual: open user menu → verify name/email shown → click Logout → verify redirect to /login

Refs: feat-4-logout-ui

🤖 Generated with [Claude Code](https://claude.com/claude-code)