### PR TITLE
feat(auth): add forgot-password and reset-password pages

### DIFF
--- a/frontend/src/composables/__tests__/useAuth.spec.ts
+++ b/frontend/src/composables/__tests__/useAuth.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuth } from '../useAuth'
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('exposes forgotPassword method', () => {
+    const { forgotPassword } = useAuth()
+    expect(typeof forgotPassword).toBe('function')
+  })
+
+  it('exposes resetPassword method', () => {
+    const { resetPassword } = useAuth()
+    expect(typeof resetPassword).toBe('function')
+  })
+
+  it('exposes all expected properties and methods', () => {
+    const auth = useAuth()
+    expect(auth).toHaveProperty('user')
+    expect(auth).toHaveProperty('isAuthenticated')
+    expect(auth).toHaveProperty('loading')
+    expect(auth).toHaveProperty('error')
+    expect(auth).toHaveProperty('login')
+    expect(auth).toHaveProperty('logout')
+    expect(auth).toHaveProperty('checkAuth')
+    expect(auth).toHaveProperty('forgotPassword')
+    expect(auth).toHaveProperty('resetPassword')
+  })
+})

--- a/frontend/src/composables/useAuth.ts
+++ b/frontend/src/composables/useAuth.ts
@@ -11,5 +11,7 @@ export function useAuth() {
     login: store.login.bind(store),
     logout: store.logout.bind(store),
     checkAuth: store.checkAuth.bind(store),
+    forgotPassword: store.forgotPassword.bind(store),
+    resetPassword: store.resetPassword.bind(store),
   }
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,5 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import LoginView from '@/views/LoginView.vue'
+import ForgotPasswordView from '@/views/ForgotPasswordView.vue'
+import ResetPasswordView from '@/views/ResetPasswordView.vue'
 import DashboardView from '@/views/DashboardView.vue'
 import ProjectsView from '@/views/ProjectsView.vue'
 import ProjectDetailView from '@/views/ProjectDetailView.vue'
@@ -20,6 +22,18 @@ const router = createRouter({
       path: '/login',
       name: 'login',
       component: LoginView,
+      meta: { requiresAuth: false },
+    },
+    {
+      path: '/forgot-password',
+      name: 'forgot-password',
+      component: ForgotPasswordView,
+      meta: { requiresAuth: false },
+    },
+    {
+      path: '/reset-password',
+      name: 'reset-password',
+      component: ResetPasswordView,
       meta: { requiresAuth: false },
     },
     {

--- a/frontend/src/stores/__tests__/auth.spec.ts
+++ b/frontend/src/stores/__tests__/auth.spec.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '../auth'
+
+describe('useAuthStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('forgotPassword', () => {
+    it('returns true on 200', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
+
+      const store = useAuthStore()
+      const result = await store.forgotPassword('user@example.com')
+
+      expect(result).toBe(true)
+      expect(globalThis.fetch).toHaveBeenCalledWith('/api/v1/auth/forgot-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'user@example.com' }),
+      })
+    })
+
+    it('returns true on 404 (no disclosure)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 404 }))
+
+      const store = useAuthStore()
+      const result = await store.forgotPassword('unknown@example.com')
+
+      expect(result).toBe(true)
+    })
+
+    it('returns true on network error (no disclosure)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network failure'))
+
+      const store = useAuthStore()
+      const result = await store.forgotPassword('user@example.com')
+
+      expect(result).toBe(true)
+    })
+
+    it('never sets error state', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network failure'))
+
+      const store = useAuthStore()
+      await store.forgotPassword('user@example.com')
+
+      expect(store.error).toBeNull()
+    })
+
+    it('sets loading during request', async () => {
+      let resolvePromise: (value: Response) => void
+      vi.spyOn(globalThis, 'fetch').mockReturnValue(
+        new Promise((resolve) => {
+          resolvePromise = resolve
+        }),
+      )
+
+      const store = useAuthStore()
+      const promise = store.forgotPassword('user@example.com')
+
+      expect(store.loading).toBe(true)
+
+      resolvePromise!(new Response(null, { status: 200 }))
+      await promise
+
+      expect(store.loading).toBe(false)
+    })
+  })
+
+  describe('resetPassword', () => {
+    it('returns true on 200', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
+
+      const store = useAuthStore()
+      const result = await store.resetPassword('valid-token', 'newpassword123')
+
+      expect(result).toBe(true)
+      expect(store.error).toBeNull()
+      expect(globalThis.fetch).toHaveBeenCalledWith('/api/v1/auth/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: 'valid-token', password: 'newpassword123' }),
+      })
+    })
+
+    it('returns false and sets error on 400', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({ error: { message: 'Token expired' } }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+
+      const store = useAuthStore()
+      const result = await store.resetPassword('expired-token', 'newpassword123')
+
+      expect(result).toBe(false)
+      expect(store.error).toBe('Token expired')
+    })
+
+    it('returns false and sets error on 422', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({ error: { message: 'Invalid token format' } }),
+          { status: 422, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+
+      const store = useAuthStore()
+      const result = await store.resetPassword('bad-token', 'newpassword123')
+
+      expect(result).toBe(false)
+      expect(store.error).toBe('Invalid token format')
+    })
+
+    it('returns false with fallback error when API returns non-JSON body', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response('Bad Request', { status: 400 }),
+      )
+
+      const store = useAuthStore()
+      const result = await store.resetPassword('bad-token', 'newpassword123')
+
+      expect(result).toBe(false)
+      expect(store.error).toBe('Token expired or invalid. Please request a new link.')
+    })
+
+    it('returns false and sets generic error on network failure', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network failure'))
+
+      const store = useAuthStore()
+      const result = await store.resetPassword('token', 'newpassword123')
+
+      expect(result).toBe(false)
+      expect(store.error).toBe('Network error. Please try again.')
+    })
+
+    it('sets loading during request', async () => {
+      let resolvePromise: (value: Response) => void
+      vi.spyOn(globalThis, 'fetch').mockReturnValue(
+        new Promise((resolve) => {
+          resolvePromise = resolve
+        }),
+      )
+
+      const store = useAuthStore()
+      const promise = store.resetPassword('token', 'newpassword123')
+
+      expect(store.loading).toBe(true)
+
+      resolvePromise!(new Response(null, { status: 200 }))
+      await promise
+
+      expect(store.loading).toBe(false)
+    })
+  })
+})

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -60,6 +60,49 @@ export const useAuthStore = defineStore('auth', {
       this.error = null
     },
 
+    async forgotPassword(email: string): Promise<boolean> {
+      this.loading = true
+      this.error = null
+      try {
+        await fetch('/api/v1/auth/forgot-password', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email }),
+        })
+        // Always return true — never disclose whether email is registered
+        return true
+      } catch {
+        // Network error: still return true to avoid disclosure
+        return true
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async resetPassword(token: string, password: string): Promise<boolean> {
+      this.loading = true
+      this.error = null
+      try {
+        const res = await fetch('/api/v1/auth/reset-password', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token, password }),
+        })
+        if (!res.ok) {
+          const body = await res.json().catch(() => null)
+          this.error =
+            body?.error?.message ?? 'Token expired or invalid. Please request a new link.'
+          return false
+        }
+        return true
+      } catch {
+        this.error = 'Network error. Please try again.'
+        return false
+      } finally {
+        this.loading = false
+      }
+    },
+
     async checkAuth(): Promise<void> {
       this.loading = true
       try {

--- a/frontend/src/views/ForgotPasswordView.vue
+++ b/frontend/src/views/ForgotPasswordView.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useForm, useField } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/zod'
+import { z } from 'zod'
+import InputText from 'primevue/inputtext'
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import { useAuth } from '@/composables/useAuth'
+
+const { forgotPassword, loading } = useAuth()
+
+const submitted = ref(false)
+
+const forgotSchema = toTypedSchema(
+  z.object({
+    email: z.string().min(1, 'Email is required').email('Invalid email format'),
+  }),
+)
+
+const { handleSubmit } = useForm({ validationSchema: forgotSchema })
+
+const { value: email, errorMessage: emailError } = useField<string>('email')
+
+const onSubmit = handleSubmit(async (values) => {
+  await forgotPassword(values.email)
+  submitted.value = true
+})
+</script>
+
+<template>
+  <div class="flex min-h-screen items-center justify-center p-4">
+    <div class="flex w-full max-w-md flex-col gap-6">
+      <h1 class="text-center text-3xl font-bold">hopeitworks</h1>
+
+      <template v-if="!submitted">
+        <h2 class="text-center text-xl">Reset your password</h2>
+
+        <form class="flex flex-col gap-4" @submit.prevent="onSubmit">
+          <div class="flex flex-col gap-1">
+            <label for="email" class="text-sm font-medium">Email</label>
+            <InputText
+              id="email"
+              v-model="email"
+              type="email"
+              placeholder="you@example.com"
+              :invalid="!!emailError"
+            />
+            <small v-if="emailError" class="text-red-500">{{ emailError }}</small>
+          </div>
+
+          <Button
+            type="submit"
+            label="Send reset link"
+            :loading="loading"
+            :disabled="loading"
+            class="mt-2"
+          />
+        </form>
+      </template>
+
+      <Message v-if="submitted" severity="success" :closable="false">
+        Check your email. If an account exists for that email, you will receive a reset link
+        shortly.
+      </Message>
+
+      <RouterLink to="/login" class="text-sm">&larr; Back to login</RouterLink>
+    </div>
+  </div>
+</template>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -39,6 +39,10 @@ const onSubmit = handleSubmit(async (values) => {
     <div class="flex w-full max-w-md flex-col gap-6">
       <h1 class="text-center text-3xl font-bold">hopeitworks</h1>
 
+      <Message v-if="route.query.reset === 'success'" severity="success" :closable="false">
+        Password reset successfully. Please sign in.
+      </Message>
+
       <form class="flex flex-col gap-4" @submit.prevent="onSubmit">
         <div class="flex flex-col gap-1">
           <label for="email" class="text-sm font-medium">Email</label>
@@ -53,7 +57,10 @@ const onSubmit = handleSubmit(async (values) => {
         </div>
 
         <div class="flex flex-col gap-1">
-          <label for="password" class="text-sm font-medium">Password</label>
+          <div class="flex items-center justify-between">
+            <label for="password" class="text-sm font-medium">Password</label>
+            <RouterLink to="/forgot-password" class="text-sm">Forgot password?</RouterLink>
+          </div>
           <Password
             inputId="password"
             v-model="password"

--- a/frontend/src/views/ResetPasswordView.vue
+++ b/frontend/src/views/ResetPasswordView.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { useForm, useField } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/zod'
+import { z } from 'zod'
+import Password from 'primevue/password'
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import { useAuth } from '@/composables/useAuth'
+
+const router = useRouter()
+const route = useRoute()
+const { resetPassword, loading, error } = useAuth()
+
+const token = computed(() => (route.query.token as string) || '')
+const hasToken = computed(() => !!token.value)
+
+const resetSchema = toTypedSchema(
+  z
+    .object({
+      password: z.string().min(8, 'Password must be at least 8 characters'),
+      confirmPassword: z.string().min(1, 'Please confirm your password'),
+    })
+    .refine((data) => data.password === data.confirmPassword, {
+      message: 'Passwords do not match',
+      path: ['confirmPassword'],
+    }),
+)
+
+const { handleSubmit } = useForm({ validationSchema: resetSchema })
+
+const { value: password, errorMessage: passwordError } = useField<string>('password')
+const { value: confirmPassword, errorMessage: confirmPasswordError } =
+  useField<string>('confirmPassword')
+
+const onSubmit = handleSubmit(async (values) => {
+  const success = await resetPassword(token.value, values.password)
+  if (success) {
+    router.push('/login?reset=success')
+  }
+})
+</script>
+
+<template>
+  <div class="flex min-h-screen items-center justify-center p-4">
+    <div class="flex w-full max-w-md flex-col gap-6">
+      <h1 class="text-center text-3xl font-bold">hopeitworks</h1>
+
+      <template v-if="hasToken">
+        <h2 class="text-center text-xl">Set new password</h2>
+
+        <form class="flex flex-col gap-4" @submit.prevent="onSubmit">
+          <div class="flex flex-col gap-1">
+            <label for="password" class="text-sm font-medium">New password</label>
+            <Password
+              inputId="password"
+              v-model="password"
+              :feedback="false"
+              toggle-mask
+              :invalid="!!passwordError"
+              input-class="w-full"
+              class="w-full"
+            />
+            <small v-if="passwordError" class="text-red-500">{{ passwordError }}</small>
+          </div>
+
+          <div class="flex flex-col gap-1">
+            <label for="confirmPassword" class="text-sm font-medium">Confirm new password</label>
+            <Password
+              inputId="confirmPassword"
+              v-model="confirmPassword"
+              :feedback="false"
+              toggle-mask
+              :invalid="!!confirmPasswordError"
+              input-class="w-full"
+              class="w-full"
+            />
+            <small v-if="confirmPasswordError" class="text-red-500">
+              {{ confirmPasswordError }}
+            </small>
+          </div>
+
+          <Button
+            type="submit"
+            label="Set new password"
+            :loading="loading"
+            :disabled="loading"
+            class="mt-2"
+          />
+
+          <Message v-if="error" severity="error" :closable="false">
+            {{ error }}
+          </Message>
+        </form>
+      </template>
+
+      <template v-else>
+        <Message severity="error" :closable="false">
+          Invalid or expired link. This password reset link is invalid or has expired.
+        </Message>
+
+        <RouterLink to="/forgot-password" class="w-full">
+          <Button label="Request a new link" class="w-full" />
+        </RouterLink>
+      </template>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

- Add `ForgotPasswordView` with email validation (vee-validate + zod), API call to `POST /auth/forgot-password`, and generic success message (no user enumeration)
- Add `ResetPasswordView` with token validation from query params, password + confirm password fields with cross-field validation, and error handling for invalid/expired tokens
- Add `forgotPassword` and `resetPassword` actions to auth store, exposed via `useAuth` composable
- Register `/forgot-password` and `/reset-password` routes as public (no auth required)
- Add "Forgot password?" link to `LoginView` and display success banner on redirect from password reset
- Unit tests for auth store actions (14 tests) and useAuth composable

## Test plan

- [x] `npm run lint` passes
- [x] `npm run type-check` passes
- [x] Unit tests pass (14/14): `npx vitest run src/stores/__tests__/auth.spec.ts src/composables/__tests__/useAuth.spec.ts`
- [ ] Manual verification: navigate to `/forgot-password`, submit email, verify success message
- [ ] Manual verification: navigate to `/reset-password?token=test`, submit matching passwords
- [ ] Manual verification: navigate to `/reset-password` (no token), verify error state with "Request a new link" button
- [ ] Manual verification: on `/login`, click "Forgot password?" link navigates to `/forgot-password`
- [ ] Manual verification: after successful reset, `/login?reset=success` shows success banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)