### PR TITLE
feat(ui): add user profile page with edit and password change

### DIFF
--- a/frontend/e2e/tests/profile.spec.ts
+++ b/frontend/e2e/tests/profile.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect } from '@playwright/test'
+
+const userFixture = {
+  id: '1',
+  email: 'test@example.com',
+  name: 'Test User',
+  role: 'user',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+test.describe('Profile Page', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock auth check as authenticated
+    await page.route('**/api/v1/auth/me', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(userFixture),
+      })
+    })
+
+    // Mock GET /users/me for profile data
+    await page.route('**/api/v1/users/me', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(userFixture),
+        })
+      } else {
+        // Let PUT requests fall through to specific test handlers
+        await route.fallback()
+      }
+    })
+  })
+
+  test('should display profile page with pre-filled data', async ({ page }) => {
+    await page.goto('/profile')
+
+    // Check heading
+    await expect(page.locator('h1')).toHaveText('My Profile')
+
+    // Check name field is pre-filled
+    const nameInput = page.locator('#profile-name')
+    await expect(nameInput).toBeVisible()
+    await expect(nameInput).toHaveValue('Test User')
+
+    // Check email field is pre-filled
+    const emailInput = page.locator('#profile-email')
+    await expect(emailInput).toBeVisible()
+    await expect(emailInput).toHaveValue('test@example.com')
+  })
+
+  test('should show success toast on profile update', async ({ page }) => {
+    const updatedUser = { ...userFixture, name: 'Updated Name' }
+
+    await page.route('**/api/v1/users/me', async (route) => {
+      if (route.request().method() === 'PUT') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(updatedUser),
+        })
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(userFixture),
+        })
+      }
+    })
+
+    await page.goto('/profile')
+
+    // Edit name
+    const nameInput = page.locator('#profile-name')
+    await nameInput.clear()
+    await nameInput.fill('Updated Name')
+
+    // Click save
+    await page.getByRole('button', { name: 'Save Changes' }).click()
+
+    // Check success toast
+    await expect(page.getByText('Profile updated')).toBeVisible()
+  })
+
+  test('should show error toast on profile update failure', async ({ page }) => {
+    await page.route('**/api/v1/users/me', async (route) => {
+      if (route.request().method() === 'PUT') {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: { code: 'BAD_REQUEST', message: 'Invalid email' } }),
+        })
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(userFixture),
+        })
+      }
+    })
+
+    await page.goto('/profile')
+
+    // Edit name to trigger dirty state
+    const nameInput = page.locator('#profile-name')
+    await nameInput.clear()
+    await nameInput.fill('New Name')
+
+    // Click save
+    await page.getByRole('button', { name: 'Save Changes' }).click()
+
+    // Check error toast
+    await expect(page.getByText('Error')).toBeVisible()
+  })
+
+  test('should navigate to profile from user menu', async ({ page }) => {
+    await page.goto('/')
+
+    // Open user menu
+    await page.getByTestId('user-menu-button').click()
+
+    // Click "My Profile"
+    await page.getByText('My Profile').click()
+
+    // Should navigate to /profile
+    await expect(page).toHaveURL('/profile')
+    await expect(page.locator('h1')).toHaveText('My Profile')
+  })
+
+  test('should show success toast on password change', async ({ page }) => {
+    await page.route('**/api/v1/users/me/password', async (route) => {
+      await route.fulfill({ status: 204, body: '' })
+    })
+
+    await page.goto('/profile')
+
+    // Fill password fields
+    await page.locator('#current-password').fill('oldpassword')
+    await page.locator('#new-password').fill('newpassword123')
+    await page.locator('#confirm-password').fill('newpassword123')
+
+    // Click update password
+    await page.getByRole('button', { name: 'Update Password' }).click()
+
+    // Check success toast
+    await expect(page.getByText('Password updated')).toBeVisible()
+
+    // Password fields should be cleared
+    await expect(page.locator('#current-password')).toHaveValue('')
+    await expect(page.locator('#new-password')).toHaveValue('')
+    await expect(page.locator('#confirm-password')).toHaveValue('')
+  })
+
+  test('should show validation error for mismatched passwords', async ({ page }) => {
+    await page.goto('/profile')
+
+    // Fill password fields with mismatch
+    await page.locator('#current-password').fill('oldpassword')
+    await page.locator('#new-password').fill('newpassword123')
+    await page.locator('#confirm-password').fill('differentpassword')
+
+    // Try to submit - button should be disabled due to validation
+    // Trigger validation by clicking submit anyway
+    await page.getByRole('button', { name: 'Update Password' }).click()
+
+    // Check validation error
+    await expect(page.getByText('Passwords do not match')).toBeVisible()
+  })
+})

--- a/frontend/e2e/tests/profile.spec.ts
+++ b/frontend/e2e/tests/profile.spec.ts
@@ -4,7 +4,7 @@ const userFixture = {
   id: '1',
   email: 'test@example.com',
   name: 'Test User',
-  role: 'user',
+  role: 'member',
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 }

--- a/frontend/e2e/tests/profile.spec.ts
+++ b/frontend/e2e/tests/profile.spec.ts
@@ -162,11 +162,13 @@ test.describe('Profile Page', () => {
     await page.locator('#new-password').fill('newpassword123')
     await page.locator('#confirm-password').fill('differentpassword')
 
-    // Try to submit - button should be disabled due to validation
-    // Trigger validation by clicking submit anyway
-    await page.getByRole('button', { name: 'Update Password' }).click()
+    // Trigger validation by blurring the field
+    await page.locator('#confirm-password').blur()
 
     // Check validation error
     await expect(page.getByText('Passwords do not match')).toBeVisible()
+
+    // Button should be disabled
+    await expect(page.getByRole('button', { name: 'Update Password' })).toBeDisabled()
   })
 })

--- a/frontend/src/composables/__tests__/useProfile.spec.ts
+++ b/frontend/src/composables/__tests__/useProfile.spec.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useProfile } from '../useProfile'
+import { useAuthStore } from '@/stores/auth'
+
+const mockApiClient = {
+  GET: vi.fn(),
+  PUT: vi.fn(),
+  POST: vi.fn(),
+  DELETE: vi.fn(),
+}
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockApiClient.GET(...args),
+    PUT: (...args: unknown[]) => mockApiClient.PUT(...args),
+    POST: (...args: unknown[]) => mockApiClient.POST(...args),
+    DELETE: (...args: unknown[]) => mockApiClient.DELETE(...args),
+  },
+}))
+
+const userFixture = {
+  id: '1',
+  email: 'test@example.com',
+  name: 'Test User',
+  role: 'user' as const,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+describe('useProfile', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('exposes user as a computed ref', () => {
+    const { user } = useProfile()
+    expect(user.value).toBeNull()
+  })
+
+  describe('fetchMe', () => {
+    it('populates user on success', async () => {
+      mockApiClient.GET.mockResolvedValueOnce({ data: userFixture, error: undefined })
+
+      const { user, fetchMe } = useProfile()
+      await fetchMe.execute()
+
+      expect(mockApiClient.GET).toHaveBeenCalledWith('/users/me')
+      expect(user.value).toBeTruthy()
+      expect(user.value?.email).toBe('test@example.com')
+      expect(fetchMe.error.value).toBeNull()
+    })
+
+    it('sets error on API error', async () => {
+      mockApiClient.GET.mockResolvedValueOnce({ data: undefined, error: { message: 'fail' } })
+
+      const { user, fetchMe } = useProfile()
+      await fetchMe.execute()
+
+      expect(user.value).toBeNull()
+    })
+
+    it('sets error on network failure', async () => {
+      mockApiClient.GET.mockRejectedValueOnce(new Error('Network error'))
+
+      const { user, fetchMe } = useProfile()
+      await fetchMe.execute()
+
+      expect(user.value).toBeNull()
+    })
+  })
+
+  describe('updateMe', () => {
+    it('updates store user on success', async () => {
+      const updatedUser = { ...userFixture, name: 'Updated Name' }
+      mockApiClient.GET.mockResolvedValueOnce({ data: userFixture, error: undefined })
+      mockApiClient.PUT.mockResolvedValueOnce({ data: updatedUser, error: undefined })
+
+      const { user, fetchMe, updateMe } = useProfile()
+      await fetchMe.execute()
+      const result = await updateMe.execute({ name: 'Updated Name' })
+
+      expect(mockApiClient.PUT).toHaveBeenCalledWith('/users/me', {
+        body: { name: 'Updated Name' },
+      })
+      expect(result).toBeTruthy()
+      expect(user.value?.name).toBe('Updated Name')
+      expect(updateMe.error.value).toBeNull()
+    })
+
+    it('sets error on API error', async () => {
+      mockApiClient.PUT.mockResolvedValueOnce({ data: undefined, error: { message: 'fail' } })
+
+      const { updateMe } = useProfile()
+      const result = await updateMe.execute({ name: 'Test' })
+
+      expect(result).toBeNull()
+      expect(updateMe.error.value).toBeTruthy()
+    })
+  })
+
+  describe('changePassword', () => {
+    it('resolves without error on success', async () => {
+      mockApiClient.PUT.mockResolvedValueOnce({ data: undefined, error: undefined })
+
+      const { changePassword } = useProfile()
+      await changePassword.execute({
+        current_password: 'old',
+        new_password: 'newpassword',
+      })
+
+      expect(mockApiClient.PUT).toHaveBeenCalledWith('/users/me/password', {
+        body: { current_password: 'old', new_password: 'newpassword' },
+      })
+      expect(changePassword.error.value).toBeNull()
+    })
+
+    it('sets error on API error', async () => {
+      mockApiClient.PUT.mockResolvedValueOnce({
+        data: undefined,
+        error: { message: 'Wrong password' },
+      })
+
+      const { changePassword } = useProfile()
+      await changePassword.execute({
+        current_password: 'wrong',
+        new_password: 'newpassword',
+      })
+
+      expect(changePassword.error.value).toBeTruthy()
+      expect(changePassword.error.value?.message).toContain('Failed to change password')
+    })
+  })
+})

--- a/frontend/src/composables/useProfile.ts
+++ b/frontend/src/composables/useProfile.ts
@@ -1,0 +1,31 @@
+import { computed } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+import { useAsyncAction } from '@/composables/useAsyncAction'
+import { apiClient } from '@/api/client'
+
+/** Composable for user profile self-service operations. */
+export function useProfile() {
+  const store = useAuthStore()
+
+  const fetchMe = useAsyncAction(() => store.fetchMe())
+  const updateMe = useAsyncAction((payload: { name?: string; email?: string }) =>
+    store.updateMe(payload),
+  )
+  const changePassword = useAsyncAction(
+    async (payload: { current_password: string; new_password: string }) => {
+      const { error: apiError } = await apiClient.PUT('/users/me/password', {
+        body: payload,
+      })
+      if (apiError) {
+        throw new Error('Failed to change password. Check your current password and try again.')
+      }
+    },
+  )
+
+  return {
+    user: computed(() => store.user),
+    fetchMe,
+    updateMe,
+    changePassword,
+  }
+}

--- a/frontend/src/features/profile/ChangePasswordForm.vue
+++ b/frontend/src/features/profile/ChangePasswordForm.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { watch } from 'vue'
+import { useForm, useField } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/zod'
+import { z } from 'zod'
+import Password from 'primevue/password'
+import Button from 'primevue/button'
+
+const props = defineProps<{
+  isSaving: boolean
+  resetKey: number
+}>()
+
+const emit = defineEmits<{
+  save: [payload: { current_password: string; new_password: string }]
+}>()
+
+const changePasswordSchema = z
+  .object({
+    current_password: z.string().min(1, 'Current password is required'),
+    new_password: z.string().min(8, 'Password must be at least 8 characters'),
+    confirm_password: z.string().min(1, 'Please confirm your new password'),
+  })
+  .refine((data) => data.new_password === data.confirm_password, {
+    message: 'Passwords do not match',
+    path: ['confirm_password'],
+  })
+
+const { handleSubmit, meta, resetForm } = useForm({
+  validationSchema: toTypedSchema(changePasswordSchema),
+})
+
+const { value: currentPassword, errorMessage: currentPasswordError } =
+  useField<string>('current_password')
+const { value: newPassword, errorMessage: newPasswordError } = useField<string>('new_password')
+const { value: confirmPassword, errorMessage: confirmPasswordError } =
+  useField<string>('confirm_password')
+
+watch(
+  () => props.resetKey,
+  () => {
+    resetForm()
+  },
+)
+
+const onSubmit = handleSubmit((values) => {
+  emit('save', {
+    current_password: values.current_password,
+    new_password: values.new_password,
+  })
+})
+</script>
+
+<template>
+  <form class="flex flex-col gap-4" @submit.prevent="onSubmit">
+    <div class="flex flex-col gap-1">
+      <label for="current-password" class="text-sm font-medium">Current Password</label>
+      <Password
+        inputId="current-password"
+        v-model="currentPassword"
+        :feedback="false"
+        toggle-mask
+        :invalid="!!currentPasswordError"
+        input-class="w-full"
+        class="w-full"
+      />
+      <small v-if="currentPasswordError" class="text-red-500">{{ currentPasswordError }}</small>
+    </div>
+
+    <div class="flex flex-col gap-1">
+      <label for="new-password" class="text-sm font-medium">New Password</label>
+      <Password
+        inputId="new-password"
+        v-model="newPassword"
+        :feedback="false"
+        toggle-mask
+        :invalid="!!newPasswordError"
+        input-class="w-full"
+        class="w-full"
+      />
+      <small v-if="newPasswordError" class="text-red-500">{{ newPasswordError }}</small>
+    </div>
+
+    <div class="flex flex-col gap-1">
+      <label for="confirm-password" class="text-sm font-medium">Confirm New Password</label>
+      <Password
+        inputId="confirm-password"
+        v-model="confirmPassword"
+        :feedback="false"
+        toggle-mask
+        :invalid="!!confirmPasswordError"
+        input-class="w-full"
+        class="w-full"
+      />
+      <small v-if="confirmPasswordError" class="text-red-500">{{ confirmPasswordError }}</small>
+    </div>
+
+    <Button
+      type="submit"
+      label="Update Password"
+      severity="secondary"
+      :loading="isSaving"
+      :disabled="!meta.dirty || !meta.valid"
+    />
+  </form>
+</template>

--- a/frontend/src/features/profile/ProfileInfoForm.vue
+++ b/frontend/src/features/profile/ProfileInfoForm.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { watch } from 'vue'
+import { useForm, useField } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/zod'
+import { z } from 'zod'
+import InputText from 'primevue/inputtext'
+import Button from 'primevue/button'
+import Tag from 'primevue/tag'
+import type { User } from '@/stores/auth'
+
+const props = defineProps<{
+  user: User
+  isSaving: boolean
+}>()
+
+const emit = defineEmits<{
+  save: [payload: { name: string; email: string }]
+}>()
+
+const profileInfoSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(255, 'Name must be 255 characters or less'),
+  email: z.string().min(1, 'Email is required').email('Invalid email format'),
+})
+
+const { handleSubmit, meta, resetForm } = useForm({
+  validationSchema: toTypedSchema(profileInfoSchema),
+  initialValues: {
+    name: props.user.name,
+    email: props.user.email,
+  },
+})
+
+const { value: name, errorMessage: nameError } = useField<string>('name')
+const { value: email, errorMessage: emailError } = useField<string>('email')
+
+watch(
+  () => props.user,
+  (u) => {
+    resetForm({ values: { name: u.name, email: u.email } })
+  },
+)
+
+const onSubmit = handleSubmit((values) => {
+  emit('save', { name: values.name, email: values.email })
+})
+
+function formatDate(dateStr?: string): string {
+  if (!dateStr) return 'N/A'
+  return new Date(dateStr).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+</script>
+
+<template>
+  <form class="flex flex-col gap-4" @submit.prevent="onSubmit">
+    <div class="flex flex-col gap-1">
+      <label for="profile-name" class="text-sm font-medium">Name</label>
+      <InputText id="profile-name" v-model="name" :invalid="!!nameError" />
+      <small v-if="nameError" class="text-red-500">{{ nameError }}</small>
+    </div>
+
+    <div class="flex flex-col gap-1">
+      <label for="profile-email" class="text-sm font-medium">Email</label>
+      <InputText id="profile-email" v-model="email" type="email" :invalid="!!emailError" />
+      <small v-if="emailError" class="text-red-500">{{ emailError }}</small>
+    </div>
+
+    <div class="flex items-center gap-4 text-sm text-surface-500">
+      <div class="flex items-center gap-2">
+        <span>Role:</span>
+        <Tag
+          :value="user.role"
+          :severity="user.role === 'admin' ? 'danger' : 'info'"
+        />
+      </div>
+      <div>
+        <span>Member since: {{ formatDate(user.created_at) }}</span>
+      </div>
+    </div>
+
+    <Button
+      type="submit"
+      label="Save Changes"
+      severity="primary"
+      :loading="isSaving"
+      :disabled="!meta.dirty || !meta.valid"
+    />
+  </form>
+</template>

--- a/frontend/src/features/profile/__tests__/profileSchemas.spec.ts
+++ b/frontend/src/features/profile/__tests__/profileSchemas.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+
+// Define schemas inline to test independently of Vue components
+const profileInfoSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(255, 'Name must be 255 characters or less'),
+  email: z.string().min(1, 'Email is required').email('Invalid email format'),
+})
+
+const changePasswordSchema = z
+  .object({
+    current_password: z.string().min(1, 'Current password is required'),
+    new_password: z.string().min(8, 'Password must be at least 8 characters'),
+    confirm_password: z.string().min(1, 'Please confirm your new password'),
+  })
+  .refine((data) => data.new_password === data.confirm_password, {
+    message: 'Passwords do not match',
+    path: ['confirm_password'],
+  })
+
+function getErrors(result: z.SafeParseReturnType<unknown, unknown>, field: string): string[] {
+  if (result.success) return []
+  return result.error.issues
+    .filter((i) => i.path.includes(field))
+    .map((i) => i.message)
+}
+
+describe('profileInfoSchema', () => {
+  it('accepts valid input', () => {
+    const result = profileInfoSchema.safeParse({ name: 'Jane Doe', email: 'jane@example.com' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty name', () => {
+    const result = profileInfoSchema.safeParse({ name: '', email: 'jane@example.com' })
+    expect(result.success).toBe(false)
+    expect(getErrors(result, 'name')).toContain('Name is required')
+  })
+
+  it('rejects name exceeding 255 characters', () => {
+    const result = profileInfoSchema.safeParse({
+      name: 'a'.repeat(256),
+      email: 'jane@example.com',
+    })
+    expect(result.success).toBe(false)
+    expect(getErrors(result, 'name')).toContain('Name must be 255 characters or less')
+  })
+
+  it('rejects empty email', () => {
+    const result = profileInfoSchema.safeParse({ name: 'Jane', email: '' })
+    expect(result.success).toBe(false)
+    expect(getErrors(result, 'email')).toContain('Email is required')
+  })
+
+  it('rejects invalid email format', () => {
+    const result = profileInfoSchema.safeParse({ name: 'Jane', email: 'not-an-email' })
+    expect(result.success).toBe(false)
+    expect(getErrors(result, 'email')).toContain('Invalid email format')
+  })
+})
+
+describe('changePasswordSchema', () => {
+  it('accepts valid input', () => {
+    const result = changePasswordSchema.safeParse({
+      current_password: 'oldpassword',
+      new_password: 'newpassword123',
+      confirm_password: 'newpassword123',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty current password', () => {
+    const result = changePasswordSchema.safeParse({
+      current_password: '',
+      new_password: 'newpassword123',
+      confirm_password: 'newpassword123',
+    })
+    expect(result.success).toBe(false)
+    expect(getErrors(result, 'current_password')).toContain('Current password is required')
+  })
+
+  it('rejects new password shorter than 8 characters', () => {
+    const result = changePasswordSchema.safeParse({
+      current_password: 'oldpassword',
+      new_password: 'short',
+      confirm_password: 'short',
+    })
+    expect(result.success).toBe(false)
+    expect(getErrors(result, 'new_password')).toContain('Password must be at least 8 characters')
+  })
+
+  it('rejects mismatched confirm password', () => {
+    const result = changePasswordSchema.safeParse({
+      current_password: 'oldpassword',
+      new_password: 'newpassword123',
+      confirm_password: 'differentpassword',
+    })
+    expect(result.success).toBe(false)
+    expect(getErrors(result, 'confirm_password')).toContain('Passwords do not match')
+  })
+
+  it('rejects empty confirm password', () => {
+    const result = changePasswordSchema.safeParse({
+      current_password: 'oldpassword',
+      new_password: 'newpassword123',
+      confirm_password: '',
+    })
+    expect(result.success).toBe(false)
+    expect(getErrors(result, 'confirm_password').length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -127,6 +127,12 @@ const router = createRouter({
       meta: { requiresAuth: true, requiresAdmin: true },
     },
     {
+      path: '/profile',
+      name: 'profile',
+      component: () => import('@/views/ProfileView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/:pathMatch(.*)*',
       name: 'not-found',
       component: NotFoundView,

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { apiClient } from '@/api/client'
 
 export interface User {
   id: string
@@ -77,6 +78,35 @@ export const useAuthStore = defineStore('auth', {
       } finally {
         this.loading = false
       }
+    },
+
+    async fetchMe(): Promise<void> {
+      this.loading = true
+      this.error = null
+      try {
+        const { data, error: apiError } = await apiClient.GET('/users/me')
+        if (apiError) {
+          this.error = 'Failed to load profile'
+          return
+        }
+        this.user = { ...data, role: data.role ?? 'member' } as User
+      } catch {
+        this.error = 'Network error. Please try again.'
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async updateMe(payload: { name?: string; email?: string }): Promise<User> {
+      const { data, error: apiError } = await apiClient.PUT('/users/me', {
+        body: payload,
+      })
+      if (apiError || !data) {
+        throw new Error('Failed to update profile')
+      }
+      const updated = { ...data, role: data.role ?? 'member' } as User
+      this.user = updated
+      return updated
     },
   },
 })

--- a/frontend/src/ui/layout/AppHeader.vue
+++ b/frontend/src/ui/layout/AppHeader.vue
@@ -20,6 +20,11 @@ const userMenu = ref<InstanceType<typeof Menu> | null>(null)
 
 const menuItems: MenuItem[] = [
   {
+    label: 'My Profile',
+    icon: 'pi pi-user-edit',
+    command: () => router.push({ name: 'profile' }),
+  },
+  {
     label: 'Logout',
     icon: 'pi pi-sign-out',
     command: async () => {

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import Card from 'primevue/card'
+import Button from 'primevue/button'
+import Skeleton from 'primevue/skeleton'
+import Message from 'primevue/message'
+import Toast from 'primevue/toast'
+import { useToast } from 'primevue/usetoast'
+import ProfileInfoForm from '@/features/profile/ProfileInfoForm.vue'
+import ChangePasswordForm from '@/features/profile/ChangePasswordForm.vue'
+import { useProfile } from '@/composables/useProfile'
+
+const toast = useToast()
+const { user, fetchMe, updateMe, changePassword } = useProfile()
+const passwordResetKey = ref(0)
+
+onMounted(() => {
+  fetchMe.execute()
+})
+
+async function handleProfileSave(payload: { name: string; email: string }) {
+  const result = await updateMe.execute(payload)
+  if (result !== null) {
+    toast.add({ severity: 'success', summary: 'Saved', detail: 'Profile updated', life: 3000 })
+  } else if (updateMe.error.value) {
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail: updateMe.error.value.message,
+      life: 5000,
+    })
+  }
+}
+
+async function handlePasswordSave(payload: {
+  current_password: string
+  new_password: string
+}) {
+  await changePassword.execute(payload)
+  if (changePassword.error.value) {
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail: changePassword.error.value.message,
+      life: 5000,
+    })
+  } else {
+    toast.add({
+      severity: 'success',
+      summary: 'Done',
+      detail: 'Password updated',
+      life: 3000,
+    })
+    passwordResetKey.value++
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-6 p-6">
+    <h1 class="text-2xl font-bold">My Profile</h1>
+
+    <!-- Loading state -->
+    <div v-if="fetchMe.isLoading.value && !user" class="flex flex-col gap-4">
+      <Skeleton height="2rem" />
+      <Skeleton height="2.5rem" />
+      <Skeleton height="2rem" />
+    </div>
+
+    <!-- Error state -->
+    <div v-else-if="fetchMe.error.value && !user" class="flex flex-col gap-4">
+      <Message severity="error" :closable="false">
+        {{ fetchMe.error.value.message }}
+      </Message>
+      <Button label="Retry" icon="pi pi-refresh" @click="fetchMe.execute()" />
+    </div>
+
+    <!-- Profile content -->
+    <div v-else-if="user" class="grid grid-cols-1 gap-6 md:grid-cols-2">
+      <Card>
+        <template #title>Profile Information</template>
+        <template #content>
+          <ProfileInfoForm
+            :user="user"
+            :is-saving="updateMe.isLoading.value"
+            @save="handleProfileSave"
+          />
+        </template>
+      </Card>
+
+      <Card>
+        <template #title>Change Password</template>
+        <template #content>
+          <ChangePasswordForm
+            :is-saving="changePassword.isLoading.value"
+            :reset-key="passwordResetKey"
+            @save="handlePasswordSave"
+          />
+        </template>
+      </Card>
+    </div>
+
+    <Toast />
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- Add self-service user profile page at `/profile` with profile info editing and password change
- Extend auth store with `fetchMe` and `updateMe` actions for `/users/me` endpoints
- Create `useProfile` composable, `ProfileInfoForm`, `ChangePasswordForm`, and `ProfileView` components
- Add "My Profile" link to the user menu in `AppHeader`
- Add unit tests (composable + Zod schemas) and E2E Playwright tests

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] `npm run test:unit` — all 498 tests pass (18 new)
- [ ] `npm run test:e2e` — profile E2E tests (6 scenarios: page load, profile save, save error, nav from menu, password change, validation errors)
- [ ] Manual: navigate to `/profile` via user menu, verify form pre-fill, edit name/email, change password

## Story
Refs: feat-5-user-profile-page

🤖 Generated with [Claude Code](https://claude.com/claude-code)