### PR TITLE
fix(api): add missing server.go delegations, wire pipeline executor deps, add auth role field

### DIFF
--- a/_bmad-output/implementation-artifacts/fix-9-backend-wiring.md
+++ b/_bmad-output/implementation-artifacts/fix-9-backend-wiring.md
@@ -1,6 +1,6 @@
 # Story fix-9: [BACK] Fix backend wiring — missing server.go delegations, nil pipeline executor dependencies, and missing role in auth response
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -50,30 +50,30 @@ An audit of the backend revealed three independent wiring bugs that collectively
 
 ## Tasks / Subtasks
 
-- [ ] [BACK] Task 1: Add missing delegations in `server.go` (AC: #1, #2)
-  - [ ] Add `ResetCircuitBreaker` delegation pointing to `s.projects.ResetCircuitBreaker` (handler already exists)
-  - [ ] Add `ListHITLRequests` delegation pointing to `s.hitl.ListHITLRequests` (stub to be implemented in fix-11)
-  - [ ] Add `GetHITLRequestByStep` delegation pointing to `s.hitl.GetHITLRequestByStep` (stub to be implemented in fix-11)
-  - [ ] Add `GetProjectCostChart` delegation pointing to `s.costs.GetProjectCostChart` (stub to be implemented in fix-11)
-  - [ ] Add `GetProjectCostRuns` delegation pointing to `s.costs.GetProjectCostRuns` (stub to be implemented in fix-11)
-  - [ ] Add `TestNotificationConfig` delegation pointing to `s.notifications.TestNotificationConfig` (stub to be implemented in fix-11)
-  - [ ] Add stub methods on each respective handler struct so the code compiles (return `501` with a `{"error":{"code":"NOT_IMPLEMENTED","message":"not implemented"}}` body using `writeErrorResponse`)
+- [x] [BACK] Task 1: Add missing delegations in `server.go` (AC: #1, #2)
+  - [x] Add `ResetCircuitBreaker` delegation pointing to `s.projects.ResetCircuitBreaker` (handler already exists)
+  - [x] Add `ListHITLRequests` delegation pointing to `s.hitl.ListHITLRequests` (stub to be implemented in fix-11)
+  - [x] Add `GetHITLRequestByStep` delegation pointing to `s.hitl.GetHITLRequestByStep` (stub to be implemented in fix-11)
+  - [x] Add `GetProjectCostChart` delegation pointing to `s.costs.GetProjectCostChart` (stub to be implemented in fix-11)
+  - [x] Add `GetProjectCostRuns` delegation pointing to `s.costs.GetProjectCostRuns` (stub to be implemented in fix-11)
+  - [x] Add `TestNotificationConfig` delegation pointing to `s.notifications.TestNotificationConfig` (stub to be implemented in fix-11)
+  - [x] Add stub methods on each respective handler struct so the code compiles (return `501` with a `{"error":{"code":"NOT_IMPLEMENTED","message":"not implemented"}}` body using `writeErrorResponse`)
 
-- [ ] [BACK] Task 2: Fix `PipelineExecutor` wiring in `main.go` (AC: #3, #4)
-  - [ ] Remove the early `service.NewPipelineExecutor(runRepo, nil, nil, logger)` call at line 153
-  - [ ] Build `eventPublisher` from `eventRepo` before constructing `pipelineExecutor` (the `pgadapter.EventRepo` already implements `port.EventPublisher` — cast or use it directly)
-  - [ ] Move `pipelineExecutor` construction to after `actionReg` is fully populated (after line 220) so the real `actionReg` and `eventPub` can be passed
-  - [ ] Pass the real `actionReg` and `eventPub` to `service.NewPipelineExecutor(runRepo, actionReg, eventPublisher, logger)`
-  - [ ] Verify that `pipelineExecutor.SetCircuitBreaker(circuitBreakerService)` is still called after the new construction site
-  - [ ] Ensure `river.AddWorker(workers, riveradapter.NewExecuteRunWorker(pipelineExecutor))` still uses the same (now properly wired) instance
+- [x] [BACK] Task 2: Fix `PipelineExecutor` wiring in `main.go` (AC: #3, #4)
+  - [x] Remove the early `service.NewPipelineExecutor(runRepo, nil, nil, logger)` call at line 153
+  - [x] Build `eventPublisher` from `eventRepo` before constructing `pipelineExecutor` (the `pgadapter.EventRepo` already implements `port.EventPublisher` — cast or use it directly)
+  - [x] Move `pipelineExecutor` construction to after `actionReg` is fully populated (after line 220) so the real `actionReg` and `eventPub` can be passed
+  - [x] Pass the real `actionReg` and `eventPub` to `service.NewPipelineExecutor(runRepo, actionReg, eventPublisher, logger)`
+  - [x] Verify that `pipelineExecutor.SetCircuitBreaker(circuitBreakerService)` is still called after the new construction site
+  - [x] Ensure `river.AddWorker(workers, riveradapter.NewExecuteRunWorker(pipelineExecutor))` still uses the same (now properly wired) instance
 
-- [ ] [BACK] Task 3: Add `role` field to `userResponse` in `auth_handler.go` (AC: #5)
-  - [ ] Add `Role string \`json:"role"\`` to the `userResponse` struct (lines 42–48)
-  - [ ] Populate `Role: string(u.Role)` in `toUserResponse()` (line 238–246)
+- [x] [BACK] Task 3: Add `role` field to `userResponse` in `auth_handler.go` (AC: #5)
+  - [x] Add `Role string \`json:"role"\`` to the `userResponse` struct (lines 42–48)
+  - [x] Populate `Role: string(u.Role)` in `toUserResponse()` (line 238–246)
 
-- [ ] [BACK] Task 4: Lint and compile check (AC: #6)
-  - [ ] Run `cd backend && go build ./...` — must succeed with zero errors
-  - [ ] Run `cd backend && golangci-lint run ./...` — must produce zero lint errors
+- [x] [BACK] Task 4: Lint and compile check (AC: #6)
+  - [x] Run `cd backend && go build ./...` — must succeed with zero errors
+  - [x] Run `cd backend && golangci-lint run ./...` — must produce zero lint errors
 
 ## Dev Notes
 
@@ -301,10 +301,44 @@ curl -s -H "Cookie: token=<valid-token>" http://localhost:8080/api/v1/auth/me | 
 
 ## Dev Agent Record
 
-_To be filled by the implementing agent._
+### Implementation Plan
+
+Three independent wiring bugs addressed in order:
+
+1. **server.go delegations**: Added 6 delegation methods (ResetCircuitBreaker, ListHITLRequests, GetHITLRequestByStep, GetProjectCostChart, GetProjectCostRuns, TestNotificationConfig). ResetCircuitBreaker delegates to the existing ProjectHandler implementation. The other 5 delegate to stub methods on their respective handler structs that return 501 Not Implemented.
+
+2. **PipelineExecutor wiring**: Moved the `pipelineExecutor` construction from line 153 (where actionReg and eventPub were nil) to after the action registry is fully populated (after agent_run and incremental_retry registration). The `eventRepo` (pgadapter.EventRepo) already implements `port.EventPublisher`, so it is passed directly. All downstream dependencies (SetCircuitBreaker, River workers, jobQueue, parallelGroupExecutor) remain properly connected.
+
+3. **auth role field**: Added `Role string` to `userResponse` struct and populated it with `string(u.Role)` in `toUserResponse()`.
+
+### Completion Notes
+
+- All 6 delegations added in server.go — follows Go naming conventions (projectID not projectId)
+- 5 stub methods added across hitl_handler.go (2), cost_handler.go (2), notification_handler.go (1) — all return 501 with standard error envelope
+- PipelineExecutor now receives real actionReg and eventRepo — eliminates nil pointer panics on step execution and event publishing
+- auth endpoints (register, login, me) now include `role` field in JSON response
+- 8 new unit tests: 3 for role field presence (register/login/me), 5 for stub 501 responses
+- Full test suite passes (all packages), zero lint errors
+
+## File List
+
+| File | Action |
+|------|--------|
+| `backend/internal/api/handler/server.go` | Modified — added 6 delegation methods |
+| `backend/internal/api/handler/hitl_handler.go` | Modified — added ListHITLRequests and GetHITLRequestByStep stubs |
+| `backend/internal/api/handler/cost_handler.go` | Modified — added GetProjectCostChart and GetProjectCostRuns stubs |
+| `backend/internal/api/handler/notification_handler.go` | Modified — added TestNotificationConfig stub |
+| `backend/cmd/api/main.go` | Modified — restructured PipelineExecutor construction |
+| `backend/internal/api/handler/auth_handler.go` | Modified — added Role to userResponse and toUserResponse |
+| `backend/internal/api/handler/auth_handler_test.go` | Modified — added 3 role field tests |
+| `backend/internal/api/handler/hitl_handler_test.go` | Modified — added 2 stub tests |
+| `backend/internal/api/handler/stub_handlers_test.go` | New — 3 tests for cost and notification stubs |
+| `_bmad-output/implementation-artifacts/fix-9-backend-wiring.md` | Modified — updated status, tasks, dev record |
+| `_bmad-output/implementation-artifacts/sprint-status.yaml` | Modified — fix-9 status: in-progress -> review |
 
 ## Change Log
 
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-02-22 | story-writer | Initial story created |
+| 2026-02-22 | dev-agent | Implemented all 4 tasks: server.go delegations, PipelineExecutor wiring, auth role field, tests |

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -173,7 +173,7 @@ development_status:
 
   # Post-MVP: E2E Usability Fixes
   post-mvp-e2e-usability: backlog
-  fix-9-backend-wiring: backlog
+  fix-9-backend-wiring: review
   fix-10-openapi-project-fields: backlog
   fix-11-missing-service-methods: backlog
   fix-12-frontend-api-regen: backlog

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -145,32 +145,8 @@ func run() error {
 	// Background cleanup of expired revoked tokens
 	startTokenCleanup(appCtx, authService, logger)
 
-	// Run service and job queue
+	// Run repository (shared by run service, pipeline executor, and other components)
 	runRepo := pgadapter.NewRunRepo(queries)
-
-	// Pipeline executor (will be used by River workers)
-	// NOTE: event publisher and action registry wiring deferred to later story
-	pipelineExecutor := service.NewPipelineExecutor(runRepo, nil, nil, logger)
-	pipelineExecutor.SetCircuitBreaker(circuitBreakerService)
-
-	// River job queue for async pipeline execution
-	workers := river.NewWorkers()
-	river.AddWorker(workers, riveradapter.NewExecuteRunWorker(pipelineExecutor))
-
-	jobQueue, err := riveradapter.NewJobQueue(pool, workers)
-	if err != nil {
-		logger.Warn("river job queue unavailable, run launching disabled", "error", err)
-	}
-	if jobQueue != nil {
-		go func() {
-			if startErr := jobQueue.Client().Start(appCtx); startErr != nil && startErr != context.Canceled {
-				logger.Error("river client failed", "error", startErr)
-			}
-		}()
-	}
-
-	runService := service.NewRunService(runRepo, projectRepo, storyRepo, pipelineConfigRepo, jobQueue, eventRepo)
-	runHandler := handler.NewRunHandler(runService)
 
 	// Cost service
 	costRepo := pgadapter.NewCostRepo(queries)
@@ -219,6 +195,29 @@ func run() error {
 			logger.Info("incremental_retry action registered")
 		}
 	}
+
+	// Pipeline executor: wired with the real action registry and event publisher
+	pipelineExecutor := service.NewPipelineExecutor(runRepo, actionReg, eventRepo, logger)
+	pipelineExecutor.SetCircuitBreaker(circuitBreakerService)
+
+	// River job queue for async pipeline execution
+	workers := river.NewWorkers()
+	river.AddWorker(workers, riveradapter.NewExecuteRunWorker(pipelineExecutor))
+
+	jobQueue, err := riveradapter.NewJobQueue(pool, workers)
+	if err != nil {
+		logger.Warn("river job queue unavailable, run launching disabled", "error", err)
+	}
+	if jobQueue != nil {
+		go func() {
+			if startErr := jobQueue.Client().Start(appCtx); startErr != nil && startErr != context.Canceled {
+				logger.Error("river client failed", "error", startErr)
+			}
+		}()
+	}
+
+	runService := service.NewRunService(runRepo, projectRepo, storyRepo, pipelineConfigRepo, jobQueue, eventRepo)
+	runHandler := handler.NewRunHandler(runService)
 
 	// Orphan cleanup and timeout enforcement (requires Docker)
 	if containerMgr != nil {

--- a/backend/internal/api/handler/auth_handler.go
+++ b/backend/internal/api/handler/auth_handler.go
@@ -43,6 +43,7 @@ type userResponse struct {
 	ID        string `json:"id"`
 	Email     string `json:"email"`
 	Name      string `json:"name"`
+	Role      string `json:"role"`
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
 }
@@ -240,6 +241,7 @@ func toUserResponse(u *model.User) userResponse {
 		ID:        u.ID.String(),
 		Email:     u.Email,
 		Name:      u.Name,
+		Role:      string(u.Role),
 		CreatedAt: u.CreatedAt.Format(time.RFC3339),
 		UpdatedAt: u.UpdatedAt.Format(time.RFC3339),
 	}

--- a/backend/internal/api/handler/auth_handler_test.go
+++ b/backend/internal/api/handler/auth_handler_test.go
@@ -381,6 +381,109 @@ func TestMeHandler_Unauthenticated(t *testing.T) {
 	}
 }
 
+// ── Role field tests ────────────────────────────────────────────────────
+
+func TestRegisterHandler_IncludesRole(t *testing.T) {
+	h, _ := newTestHandler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/register", bytes.NewBufferString(testRegisterBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.Register(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rec.Code)
+	}
+
+	var raw map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&raw); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	role, ok := raw["role"]
+	if !ok {
+		t.Fatal("response missing 'role' field")
+	}
+	roleStr, ok := role.(string)
+	if !ok || roleStr == "" {
+		t.Errorf("expected non-empty role string, got %v", role)
+	}
+}
+
+func TestLoginHandler_IncludesRole(t *testing.T) {
+	h, _ := newTestHandler()
+
+	// Register first
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/register", bytes.NewBufferString(testRegisterBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.Register(rec, req)
+
+	// Login
+	loginBody := `{"email":"test@example.com","password":"secureP@ss1"}`
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", bytes.NewBufferString(loginBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	h.Login(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var raw map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&raw); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	role, ok := raw["role"]
+	if !ok {
+		t.Fatal("login response missing 'role' field")
+	}
+	roleStr, ok := role.(string)
+	if !ok || roleStr == "" {
+		t.Errorf("expected non-empty role string, got %v", role)
+	}
+}
+
+func TestMeHandler_IncludesRole(t *testing.T) {
+	h, _ := newTestHandler()
+
+	// Register to create a user
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/register", bytes.NewBufferString(testRegisterBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.Register(rec, req)
+
+	var regResp userResponse
+	if err := json.NewDecoder(rec.Body).Decode(&regResp); err != nil {
+		t.Fatalf("failed to decode register response: %v", err)
+	}
+	userID, _ := uuid.Parse(regResp.ID)
+
+	// Call Me with context set
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/auth/me", nil)
+	ctx := context.WithValue(req.Context(), middleware.ContextKeyUserID, userID)
+	ctx = context.WithValue(ctx, middleware.ContextKeyRole, model.RoleUser)
+	req = req.WithContext(ctx)
+	rec = httptest.NewRecorder()
+	h.Me(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var raw map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&raw); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	role, ok := raw["role"]
+	if !ok {
+		t.Fatal("me response missing 'role' field")
+	}
+	roleStr, ok := role.(string)
+	if !ok || roleStr == "" {
+		t.Errorf("expected non-empty role string, got %v", role)
+	}
+}
+
 // ── ForgotPassword handler tests ────────────────────────────────────────
 
 func TestForgotPasswordHandler_ValidEmail(t *testing.T) {

--- a/backend/internal/api/handler/cost_handler.go
+++ b/backend/internal/api/handler/cost_handler.go
@@ -16,6 +16,16 @@ func NewCostHandler(svc *service.CostService) *CostHandler {
 	return &CostHandler{service: svc}
 }
 
+// GetProjectCostChart handles GET /projects/{projectId}/costs/chart — implementation deferred to fix-11.
+func (h *CostHandler) GetProjectCostChart(w http.ResponseWriter, _ *http.Request, _ ProjectIdPath, _ GetProjectCostChartParams) {
+	writeError(w, http.StatusNotImplemented, "NOT_IMPLEMENTED", "not implemented")
+}
+
+// GetProjectCostRuns handles GET /projects/{projectId}/costs/runs — implementation deferred to fix-11.
+func (h *CostHandler) GetProjectCostRuns(w http.ResponseWriter, _ *http.Request, _ ProjectIdPath, _ GetProjectCostRunsParams) {
+	writeError(w, http.StatusNotImplemented, "NOT_IMPLEMENTED", "not implemented")
+}
+
 // GetProjectCosts handles GET /projects/{projectId}/costs.
 func (h *CostHandler) GetProjectCosts(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, params GetProjectCostsParams) {
 	period := "7d"

--- a/backend/internal/api/handler/hitl_handler.go
+++ b/backend/internal/api/handler/hitl_handler.go
@@ -99,6 +99,16 @@ func (h *HITLHandler) RejectHITLRequest(w http.ResponseWriter, r *http.Request, 
 	writeJSON(w, http.StatusOK, toAPIHITLRequest(req))
 }
 
+// ListHITLRequests handles GET /hitl-requests — implementation deferred to fix-11.
+func (h *HITLHandler) ListHITLRequests(w http.ResponseWriter, _ *http.Request, _ ListHITLRequestsParams) {
+	writeError(w, http.StatusNotImplemented, "NOT_IMPLEMENTED", "not implemented")
+}
+
+// GetHITLRequestByStep handles GET /run-steps/{stepId}/hitl-request — implementation deferred to fix-11.
+func (h *HITLHandler) GetHITLRequestByStep(w http.ResponseWriter, _ *http.Request, _ StepIdPath) {
+	writeError(w, http.StatusNotImplemented, "NOT_IMPLEMENTED", "not implemented")
+}
+
 // toAPIHITLRequest converts a domain HITLRequest to the API HITLRequest type.
 func toAPIHITLRequest(req *model.HITLRequest) HITLRequest {
 	r := HITLRequest{

--- a/backend/internal/api/handler/hitl_handler_test.go
+++ b/backend/internal/api/handler/hitl_handler_test.go
@@ -447,3 +447,46 @@ func TestHITLHandler_RejectHITLRequest(t *testing.T) {
 		})
 	}
 }
+
+// ── Stub method tests (fix-9) ───────────────────────────────────────────
+
+func TestListHITLRequests_ReturnsNotImplemented(t *testing.T) {
+	h, _, _ := setupHITLHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hitl-requests", nil)
+	rec := httptest.NewRecorder()
+	h.ListHITLRequests(rec, req, ListHITLRequestsParams{})
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Errorf("expected 501, got %d", rec.Code)
+	}
+
+	var resp errorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Error.Code != codeNotImplemented {
+		t.Errorf("expected error code NOT_IMPLEMENTED, got %s", resp.Error.Code)
+	}
+}
+
+func TestGetHITLRequestByStep_ReturnsNotImplemented(t *testing.T) {
+	h, _, _ := setupHITLHandler()
+
+	stepID := uuid.New()
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/run-steps/%s/hitl-request", stepID), nil)
+	rec := httptest.NewRecorder()
+	h.GetHITLRequestByStep(rec, req, StepIdPath(stepID))
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Errorf("expected 501, got %d", rec.Code)
+	}
+
+	var resp errorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Error.Code != codeNotImplemented {
+		t.Errorf("expected error code NOT_IMPLEMENTED, got %s", resp.Error.Code)
+	}
+}

--- a/backend/internal/api/handler/notification_handler.go
+++ b/backend/internal/api/handler/notification_handler.go
@@ -20,6 +20,11 @@ func NewNotificationHandler(svc *service.NotificationConfigService) *Notificatio
 	return &NotificationHandler{service: svc}
 }
 
+// TestNotificationConfig handles POST /projects/{projectId}/notifications/{notificationId}/test — implementation deferred to fix-11.
+func (h *NotificationHandler) TestNotificationConfig(w http.ResponseWriter, _ *http.Request, _ ProjectIdPath, _ NotificationIdPath) {
+	writeError(w, http.StatusNotImplemented, "NOT_IMPLEMENTED", "not implemented")
+}
+
 // ListNotificationConfigs handles GET /projects/{projectId}/notifications.
 func (h *NotificationHandler) ListNotificationConfigs(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath) {
 	configs, err := h.service.ListByProject(r.Context(), projectID)

--- a/backend/internal/api/handler/server.go
+++ b/backend/internal/api/handler/server.go
@@ -325,3 +325,33 @@ func (s *Server) UpdateNotificationConfig(w http.ResponseWriter, r *http.Request
 func (s *Server) DeleteNotificationConfig(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, notificationID NotificationIdPath) {
 	s.notifications.DeleteNotificationConfig(w, r, projectID, notificationID)
 }
+
+// ResetCircuitBreaker delegates to ProjectHandler.
+func (s *Server) ResetCircuitBreaker(w http.ResponseWriter, r *http.Request, id IdPath) {
+	s.projects.ResetCircuitBreaker(w, r, id)
+}
+
+// ListHITLRequests delegates to HITLHandler.
+func (s *Server) ListHITLRequests(w http.ResponseWriter, r *http.Request, params ListHITLRequestsParams) {
+	s.hitl.ListHITLRequests(w, r, params)
+}
+
+// GetHITLRequestByStep delegates to HITLHandler.
+func (s *Server) GetHITLRequestByStep(w http.ResponseWriter, r *http.Request, stepID StepIdPath) {
+	s.hitl.GetHITLRequestByStep(w, r, stepID)
+}
+
+// GetProjectCostChart delegates to CostHandler.
+func (s *Server) GetProjectCostChart(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, params GetProjectCostChartParams) {
+	s.costs.GetProjectCostChart(w, r, projectID, params)
+}
+
+// GetProjectCostRuns delegates to CostHandler.
+func (s *Server) GetProjectCostRuns(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, params GetProjectCostRunsParams) {
+	s.costs.GetProjectCostRuns(w, r, projectID, params)
+}
+
+// TestNotificationConfig delegates to NotificationHandler.
+func (s *Server) TestNotificationConfig(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, notificationID NotificationIdPath) {
+	s.notifications.TestNotificationConfig(w, r, projectID, notificationID)
+}

--- a/backend/internal/api/handler/stub_handlers_test.go
+++ b/backend/internal/api/handler/stub_handlers_test.go
@@ -1,0 +1,84 @@
+package handler
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+)
+
+const codeNotImplemented = "NOT_IMPLEMENTED"
+
+func TestGetProjectCostChart_ReturnsNotImplemented(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	costSvc := service.NewCostService(nil, nil, nil, nil, logger)
+	h := NewCostHandler(costSvc)
+
+	projectID := uuid.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+projectID.String()+"/costs/chart", nil)
+	rec := httptest.NewRecorder()
+	h.GetProjectCostChart(rec, req, ProjectIdPath(projectID), GetProjectCostChartParams{})
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Errorf("expected 501, got %d", rec.Code)
+	}
+
+	var resp errorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Error.Code != codeNotImplemented {
+		t.Errorf("expected error code NOT_IMPLEMENTED, got %s", resp.Error.Code)
+	}
+}
+
+func TestGetProjectCostRuns_ReturnsNotImplemented(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	costSvc := service.NewCostService(nil, nil, nil, nil, logger)
+	h := NewCostHandler(costSvc)
+
+	projectID := uuid.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+projectID.String()+"/costs/runs", nil)
+	rec := httptest.NewRecorder()
+	h.GetProjectCostRuns(rec, req, ProjectIdPath(projectID), GetProjectCostRunsParams{})
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Errorf("expected 501, got %d", rec.Code)
+	}
+
+	var resp errorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Error.Code != codeNotImplemented {
+		t.Errorf("expected error code NOT_IMPLEMENTED, got %s", resp.Error.Code)
+	}
+}
+
+func TestTestNotificationConfig_ReturnsNotImplemented(t *testing.T) {
+	notifSvc := service.NewNotificationConfigService(nil)
+	h := NewNotificationHandler(notifSvc)
+
+	projectID := uuid.New()
+	notificationID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/projects/"+projectID.String()+"/notifications/"+notificationID.String()+"/test", nil)
+	rec := httptest.NewRecorder()
+	h.TestNotificationConfig(rec, req, ProjectIdPath(projectID), NotificationIdPath(notificationID))
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Errorf("expected 501, got %d", rec.Code)
+	}
+
+	var resp errorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Error.Code != codeNotImplemented {
+		t.Errorf("expected error code NOT_IMPLEMENTED, got %s", resp.Error.Code)
+	}
+}


### PR DESCRIPTION
## Story: fix-9-backend-wiring — Fix backend wiring

### Changes
- Add 6 missing delegation methods in `server.go` (ResetCircuitBreaker fully working + 5 stubs returning 501)
- Move PipelineExecutor construction after actionReg is populated, pass real `actionReg` and `eventRepo` — eliminates nil pointer panics
- Add `role` field to `userResponse` and `toUserResponse()` in `auth_handler.go` — required by OpenAPI spec

### Acceptance Criteria
- [x] AC1: ResetCircuitBreaker returns non-501 for authenticated admin
- [x] AC2: ListHITLRequests, GetHITLRequestByStep, GetProjectCostChart, GetProjectCostRuns, TestNotificationConfig return non-501 (501 stub, not Unimplemented fallthrough)
- [x] AC3: PipelineExecutor receives populated actionRegistry
- [x] AC4: PipelineExecutor publishes events via real eventPub
- [x] AC5: auth/me, auth/login, auth/register include role in response
- [x] AC6: Backend compiles and lints clean

### Files Changed
- `backend/internal/api/handler/server.go` — 6 new delegation methods
- `backend/internal/api/handler/hitl_handler.go` — 2 stub methods
- `backend/internal/api/handler/cost_handler.go` — 2 stub methods
- `backend/internal/api/handler/notification_handler.go` — 1 stub method
- `backend/cmd/api/main.go` — restructured PipelineExecutor construction
- `backend/internal/api/handler/auth_handler.go` — role field added

### Testing
- All tests passing locally: Yes
- Coverage: 8 new unit tests (3 role field, 5 stub 501 responses), 0 regressions
- Lint: golangci-lint passes with zero errors

---
*Generated by BMAD Dev Agent*