### PR TITLE
feat(ui): add runs dashboard, sidebar routing fixes, and project runs tab

### DIFF
--- a/_bmad-output/implementation-artifacts/fix-14-runs-dashboard-routing.md
+++ b/_bmad-output/implementation-artifacts/fix-14-runs-dashboard-routing.md
@@ -308,10 +308,34 @@ import RunsView from '@/views/RunsView.vue'
 
 ## Dev Agent Record
 
-_To be filled by the implementing agent._
+**Agent:** Claude Opus 4.6
+**Branch:** feat/fix-14-runs-dashboard-routing
+**Date:** 2026-02-22
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/src/ui/layout/AppSidebar.vue` | Remapped "Settings" route from `/settings` to `/profile` |
+| `frontend/src/router/index.ts` | Added `/runs` top-level route; added `project-runs` child route under `/projects/:id` |
+| `frontend/src/utils/runStatus.ts` | New — shared run status severity mapping |
+| `frontend/src/features/runs/composables/useRecentRuns.ts` | New — composable for fetching recent runs (project-scoped or cross-project fan-out) |
+| `frontend/src/views/RunsView.vue` | New — cross-project runs list page |
+| `frontend/src/views/DashboardView.vue` | Replaced placeholder with full dashboard (recent runs, pending approvals, projects) |
+| `frontend/src/views/ProjectRunsView.vue` | New — project-scoped runs tab content with duration column |
+| `frontend/src/views/ProjectDetailView.vue` | Added "Runs" tab to tabs array |
+| `frontend/src/views/RunDetailView.vue` | Refactored to import shared `runStatusSeverity` from utils |
+| `frontend/src/features/runs/__tests__/useRecentRuns.spec.ts` | New — 8 unit tests covering all composable branches |
+| `frontend/src/api/schema.d.ts` | Regenerated from OpenAPI spec |
+
+### Notes
+
+- No global `GET /runs` endpoint exists in the OpenAPI spec. The cross-project runs view uses a fan-out strategy: fetch up to 5 projects, then concurrently fetch runs per project, merge by `created_at` desc, and take top N.
+- All 523 tests pass (62 test files). ESLint and TypeScript type-check clean.
 
 ## Change Log
 
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-02-22 | story-writer | Initial story created |
+| 2026-02-22 | dev-agent | Implementation complete — all ACs addressed |

--- a/frontend/e2e/tests/app-shell.spec.ts
+++ b/frontend/e2e/tests/app-shell.spec.ts
@@ -25,6 +25,29 @@ test.describe('App Shell Layout', () => {
       })
     })
 
+    // Mock Dashboard API calls (Dashboard loads projects, HITL requests, and runs on mount)
+    await page.route('**/api/v1/projects*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [],
+          pagination: { total: 0, page: 1, per_page: 5 },
+        }),
+      })
+    })
+
+    await page.route('**/api/v1/hitl-requests*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [],
+          pagination: { total: 0, page: 1, per_page: 20 },
+        }),
+      })
+    })
+
     // Navigate to the root route (Dashboard)
     await page.goto('/')
   })

--- a/frontend/e2e/tests/app-shell.spec.ts
+++ b/frontend/e2e/tests/app-shell.spec.ts
@@ -72,11 +72,12 @@ test.describe('App Shell Layout', () => {
       // Set viewport to desktop size
       await page.setViewportSize({ width: 1280, height: 720 })
 
-      // Check for all navigation items
-      const dashboardButton = page.getByRole('button', { name: 'Dashboard' })
-      const projectsButton = page.getByRole('button', { name: 'Projects' })
-      const runsButton = page.getByRole('button', { name: 'Runs' })
-      const settingsButton = page.getByRole('button', { name: 'Settings' })
+      // Check for all navigation items in the sidebar specifically
+      const sidebar = page.locator('aside')
+      const dashboardButton = sidebar.getByRole('button', { name: 'Dashboard' })
+      const projectsButton = sidebar.getByRole('button', { name: 'Projects' })
+      const runsButton = sidebar.getByRole('button', { name: 'Runs' })
+      const settingsButton = sidebar.getByRole('button', { name: 'Settings' })
 
       await expect(dashboardButton).toBeVisible()
       await expect(projectsButton).toBeVisible()
@@ -90,15 +91,16 @@ test.describe('App Shell Layout', () => {
       // Set viewport to desktop size
       await page.setViewportSize({ width: 1280, height: 720 })
 
-      // Click on Projects navigation item
-      const projectsButton = page.getByRole('button', { name: 'Projects' })
+      // Click on Projects navigation item in sidebar
+      const sidebar = page.locator('aside')
+      const projectsButton = sidebar.getByRole('button', { name: 'Projects' })
       await projectsButton.click()
 
       // Verify URL changed to /projects
       await expect(page).toHaveURL('/projects')
 
       // Navigate back to Dashboard
-      const dashboardButton = page.getByRole('button', { name: 'Dashboard' })
+      const dashboardButton = sidebar.getByRole('button', { name: 'Dashboard' })
       await dashboardButton.click()
 
       // Verify URL changed back to /

--- a/frontend/e2e/tests/login.spec.ts
+++ b/frontend/e2e/tests/login.spec.ts
@@ -90,6 +90,29 @@ test.describe('Login Page', () => {
       })
     })
 
+    // Mock Dashboard API calls
+    await page.route('**/api/v1/projects*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [],
+          pagination: { total: 0, page: 1, per_page: 5 },
+        }),
+      })
+    })
+
+    await page.route('**/api/v1/hitl-requests*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [],
+          pagination: { total: 0, page: 1, per_page: 20 },
+        }),
+      })
+    })
+
     await page.goto('/login')
 
     // Fill valid credentials
@@ -198,6 +221,29 @@ test.describe('Login Page', () => {
       })
     })
 
+    // Mock Dashboard API calls
+    await page.route('**/api/v1/projects*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [],
+          pagination: { total: 0, page: 1, per_page: 5 },
+        }),
+      })
+    })
+
+    await page.route('**/api/v1/hitl-requests*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [],
+          pagination: { total: 0, page: 1, per_page: 20 },
+        }),
+      })
+    })
+
     await page.goto('/login')
 
     // Verify no shell chrome before login
@@ -228,6 +274,29 @@ test.describe('Login Page', () => {
           id: '1',
           email: 'test@test.com',
           name: 'Test User',
+        }),
+      })
+    })
+
+    // Mock Dashboard API calls
+    await page.route('**/api/v1/projects*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [],
+          pagination: { total: 0, page: 1, per_page: 5 },
+        }),
+      })
+    })
+
+    await page.route('**/api/v1/hitl-requests*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [],
+          pagination: { total: 0, page: 1, per_page: 20 },
         }),
       })
     })

--- a/frontend/e2e/tests/profile.spec.ts
+++ b/frontend/e2e/tests/profile.spec.ts
@@ -33,6 +33,29 @@ test.describe('Profile Page', () => {
         await route.fallback()
       }
     })
+
+    // Mock Dashboard API calls (for tests that navigate to /)
+    await page.route('**/api/v1/projects*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [],
+          pagination: { total: 0, page: 1, per_page: 5 },
+        }),
+      })
+    })
+
+    await page.route('**/api/v1/hitl-requests*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [],
+          pagination: { total: 0, page: 1, per_page: 20 },
+        }),
+      })
+    })
   })
 
   test('should display profile page with pre-filled data', async ({ page }) => {

--- a/frontend/e2e/tests/routing.spec.ts
+++ b/frontend/e2e/tests/routing.spec.ts
@@ -144,7 +144,8 @@ test.describe('Application Routing', () => {
       await expect(page.locator('h1')).toHaveText('Dashboard')
 
       // Navigate to Projects using sidebar button
-      await page.getByRole('button', { name: 'Projects' }).click()
+      const sidebar = page.locator('aside')
+      await sidebar.getByRole('button', { name: 'Projects' }).click()
       await expect(page).toHaveURL('/projects')
       await expect(page.locator('h1')).toHaveText('Projects')
     })

--- a/frontend/e2e/tests/routing.spec.ts
+++ b/frontend/e2e/tests/routing.spec.ts
@@ -15,6 +15,29 @@ test.describe('Application Routing', () => {
           }),
         })
       })
+
+      // Mock Dashboard API calls
+      await page.route('**/api/v1/projects*', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: [],
+            pagination: { total: 0, page: 1, per_page: 5 },
+          }),
+        })
+      })
+
+      await page.route('**/api/v1/hitl-requests*', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: [],
+            pagination: { total: 0, page: 1, per_page: 20 },
+          }),
+        })
+      })
     })
 
     test('should render Dashboard view at /', async ({ page }) => {
@@ -85,6 +108,29 @@ test.describe('Application Routing', () => {
             id: '1',
             email: 'test@test.com',
             name: 'Test User',
+          }),
+        })
+      })
+
+      // Mock Dashboard API calls
+      await page.route('**/api/v1/projects*', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: [],
+            pagination: { total: 0, page: 1, per_page: 5 },
+          }),
+        })
+      })
+
+      await page.route('**/api/v1/hitl-requests*', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: [],
+            pagination: { total: 0, page: 1, per_page: 20 },
           }),
         })
       })

--- a/frontend/src/features/runs/__tests__/useRecentRuns.spec.ts
+++ b/frontend/src/features/runs/__tests__/useRecentRuns.spec.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { useRecentRuns } from '../composables/useRecentRuns'
+
+const mockGet = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+  },
+}))
+
+/** Wraps composable that calls onMounted in a simulated lifecycle */
+function withSetup<T>(composable: () => T): T {
+  let result!: T
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { createApp, defineComponent } = require('vue')
+  const app = createApp(
+    defineComponent({
+      setup() {
+        result = composable()
+        return () => null
+      },
+    }),
+  )
+  app.mount(document.createElement('div'))
+  return result
+}
+
+const mockRuns = [
+  {
+    id: 'run-1',
+    project_id: 'proj-1',
+    story_id: 'story-1',
+    status: 'running',
+    progress: 50,
+    created_at: '2026-02-17T10:00:00Z',
+    updated_at: '2026-02-17T10:00:00Z',
+  },
+  {
+    id: 'run-2',
+    project_id: 'proj-1',
+    story_id: 'story-2',
+    status: 'completed',
+    progress: 100,
+    created_at: '2026-02-16T09:00:00Z',
+    updated_at: '2026-02-16T09:30:00Z',
+  },
+]
+
+const mockProjects = [
+  { id: 'proj-1', name: 'Project Alpha' },
+  { id: 'proj-2', name: 'Project Beta' },
+]
+
+describe('useRecentRuns', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+  })
+
+  it('fetches runs for a specific project when projectId is provided', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockRuns, pagination: { total: 2, page: 1, per_page: 10 } },
+      error: undefined,
+    })
+
+    const { runs, isLoading } = withSetup(() => useRecentRuns({ projectId: 'proj-1' }))
+    await flushPromises()
+
+    expect(runs.value).toHaveLength(2)
+    expect(runs.value[0].id).toBe('run-1')
+    expect(isLoading.value).toBe(false)
+    expect(mockGet).toHaveBeenCalledTimes(1)
+    expect(mockGet).toHaveBeenCalledWith('/projects/{projectId}/runs', {
+      params: { path: { projectId: 'proj-1' }, query: { per_page: 10, page: 1 } },
+    })
+  })
+
+  it('fetches projects then fans out per-project when no projectId is provided', async () => {
+    // First call: GET /projects
+    mockGet.mockImplementation((path: string) => {
+      if (path === '/projects') {
+        return Promise.resolve({
+          data: { data: mockProjects, pagination: { total: 2, page: 1, per_page: 5 } },
+          error: undefined,
+        })
+      }
+      // Per-project calls
+      return Promise.resolve({
+        data: { data: mockRuns.slice(0, 1), pagination: { total: 1, page: 1, per_page: 10 } },
+        error: undefined,
+      })
+    })
+
+    const { runs } = withSetup(() => useRecentRuns())
+    await flushPromises()
+
+    // Should have called GET /projects + GET /projects/{projectId}/runs for each project
+    expect(mockGet).toHaveBeenCalledWith('/projects', {
+      params: { query: { per_page: 5, page: 1 } },
+    })
+    // 1 projects call + 2 per-project runs calls = 3 total
+    expect(mockGet).toHaveBeenCalledTimes(3)
+    expect(runs.value.length).toBeGreaterThan(0)
+  })
+
+  it('sets isLoading true during fetch and false after', async () => {
+    let resolvePromise: (value: unknown) => void
+    mockGet.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePromise = resolve
+      }),
+    )
+
+    const { isLoading } = withSetup(() => useRecentRuns({ projectId: 'proj-1' }))
+    expect(isLoading.value).toBe(true)
+
+    resolvePromise!({
+      data: { data: [], pagination: { total: 0, page: 1, per_page: 10 } },
+      error: undefined,
+    })
+    await flushPromises()
+
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('populates runs on success', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockRuns, pagination: { total: 2, page: 1, per_page: 10 } },
+      error: undefined,
+    })
+
+    const { runs } = withSetup(() => useRecentRuns({ projectId: 'proj-1' }))
+    await flushPromises()
+
+    expect(runs.value).toHaveLength(2)
+    expect(runs.value[0]).toMatchObject({ id: 'run-1', status: 'running' })
+    expect(runs.value[1]).toMatchObject({ id: 'run-2', status: 'completed' })
+  })
+
+  it('sets error on API failure', async () => {
+    mockGet.mockResolvedValue({
+      data: undefined,
+      error: { error: { code: 'SERVER_ERROR', message: 'Internal error' } },
+    })
+
+    const { runs, error } = withSetup(() => useRecentRuns({ projectId: 'proj-1' }))
+    await flushPromises()
+
+    expect(runs.value).toHaveLength(0)
+    expect(error.value).toBeInstanceOf(Error)
+    expect(error.value?.message).toBe('Failed to load runs')
+  })
+
+  it('returns empty runs when no projects exist (global mode)', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: [], pagination: { total: 0, page: 1, per_page: 5 } },
+      error: undefined,
+    })
+
+    const { runs } = withSetup(() => useRecentRuns())
+    await flushPromises()
+
+    expect(runs.value).toHaveLength(0)
+  })
+
+  it('refresh() re-fetches runs', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockRuns, pagination: { total: 2, page: 1, per_page: 10 } },
+      error: undefined,
+    })
+
+    const { refresh } = withSetup(() => useRecentRuns({ projectId: 'proj-1' }))
+    await flushPromises()
+
+    expect(mockGet).toHaveBeenCalledTimes(1)
+
+    mockGet.mockClear()
+    mockGet.mockResolvedValue({
+      data: { data: mockRuns, pagination: { total: 2, page: 1, per_page: 10 } },
+      error: undefined,
+    })
+
+    await refresh()
+    expect(mockGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('respects custom limit parameter', async () => {
+    mockGet.mockResolvedValue({
+      data: { data: mockRuns, pagination: { total: 2, page: 1, per_page: 5 } },
+      error: undefined,
+    })
+
+    withSetup(() => useRecentRuns({ projectId: 'proj-1', limit: 5 }))
+    await flushPromises()
+
+    expect(mockGet).toHaveBeenCalledWith('/projects/{projectId}/runs', {
+      params: { path: { projectId: 'proj-1' }, query: { per_page: 5, page: 1 } },
+    })
+  })
+})

--- a/frontend/src/features/runs/__tests__/useRecentRuns.spec.ts
+++ b/frontend/src/features/runs/__tests__/useRecentRuns.spec.ts
@@ -68,7 +68,7 @@ describe('useRecentRuns', () => {
     await flushPromises()
 
     expect(runs.value).toHaveLength(2)
-    expect(runs.value[0].id).toBe('run-1')
+    expect(runs.value[0]?.id).toBe('run-1')
     expect(isLoading.value).toBe(false)
     expect(mockGet).toHaveBeenCalledTimes(1)
     expect(mockGet).toHaveBeenCalledWith('/projects/{projectId}/runs', {

--- a/frontend/src/features/runs/composables/useRecentRuns.ts
+++ b/frontend/src/features/runs/composables/useRecentRuns.ts
@@ -1,0 +1,109 @@
+import { ref, onMounted } from 'vue'
+import { apiClient } from '@/api/client'
+
+/** Lightweight run shape for list views (matches OpenAPI Run schema fields). */
+export interface RunSummary {
+  id: string
+  project_id: string
+  story_id: string
+  status: string
+  progress: number
+  started_at?: string
+  completed_at?: string
+  created_at: string
+  updated_at: string
+  project_name?: string
+  story_key?: string
+}
+
+/**
+ * Composable for fetching recent runs.
+ *
+ * When `projectId` is provided, fetches runs for that single project.
+ * When omitted, fetches the user's projects and fans out per-project run
+ * fetches, then merges and sorts by created_at descending.
+ */
+export function useRecentRuns(options?: { projectId?: string; limit?: number }) {
+  const projectId = options?.projectId
+  const limit = options?.limit ?? 10
+
+  const runs = ref<RunSummary[]>([])
+  const isLoading = ref(false)
+  const error = ref<Error | null>(null)
+
+  async function fetchRuns() {
+    isLoading.value = true
+    error.value = null
+    try {
+      if (projectId) {
+        await fetchProjectRuns(projectId)
+      } else {
+        await fetchGlobalRuns()
+      }
+    } catch (e) {
+      error.value = e instanceof Error ? e : new Error(String(e))
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function fetchProjectRuns(pid: string) {
+    const { data, error: apiError } = await apiClient.GET(
+      '/projects/{projectId}/runs',
+      {
+        params: {
+          path: { projectId: pid },
+          query: { per_page: limit, page: 1 },
+        },
+      },
+    )
+    if (apiError) throw new Error('Failed to load runs')
+    runs.value = ((data?.data ?? []) as RunSummary[]).map((r) => ({ ...r, project_id: r.project_id ?? pid }))
+  }
+
+  async function fetchGlobalRuns() {
+    // Fetch up to 5 projects to fan out run fetches
+    const { data: projectsData, error: projError } = await apiClient.GET('/projects', {
+      params: { query: { per_page: 5, page: 1 } },
+    })
+    if (projError) throw new Error('Failed to load projects')
+
+    interface ProjectItem { id: string; name: string }
+    const projects = (projectsData?.data ?? []) as ProjectItem[]
+    if (projects.length === 0) {
+      runs.value = []
+      return
+    }
+
+    // Fan out: fetch runs from each project concurrently
+    const results = await Promise.allSettled(
+      projects.map(async (proj) => {
+        const { data } = await apiClient.GET('/projects/{projectId}/runs', {
+          params: {
+            path: { projectId: proj.id },
+            query: { per_page: limit, page: 1 },
+          },
+        })
+        return ((data?.data ?? []) as RunSummary[]).map((r) => ({
+          ...r,
+          project_id: r.project_id ?? proj.id,
+          project_name: proj.name,
+        }))
+      }),
+    )
+
+    // Merge successful results, sort by created_at desc, take top N
+    const allRuns: RunSummary[] = []
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        allRuns.push(...result.value)
+      }
+    }
+    allRuns.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+    runs.value = allRuns.slice(0, limit)
+  }
+
+  onMounted(fetchRuns)
+
+  return { runs, isLoading, error, refresh: fetchRuns }
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -8,6 +8,7 @@ import ProjectDetailView from '@/views/ProjectDetailView.vue'
 import RunDetailView from '@/views/RunDetailView.vue'
 import StoryDetailView from '@/views/StoryDetailView.vue'
 import ApprovalsView from '@/views/ApprovalsView.vue'
+import RunsView from '@/views/RunsView.vue'
 import PipelineConfigView from '@/views/PipelineConfigView.vue'
 import PromptTemplatesView from '@/views/PromptTemplatesView.vue'
 import BoardView from '@/views/BoardView.vue'
@@ -62,6 +63,11 @@ const router = createRouter({
           path: 'board',
           name: 'project-board',
           component: BoardView,
+        },
+        {
+          path: 'runs',
+          name: 'project-runs',
+          component: () => import('@/views/ProjectRunsView.vue'),
         },
         {
           path: 'epics/:epicId',
@@ -132,6 +138,12 @@ const router = createRouter({
       path: '/approvals',
       name: 'approvals',
       component: ApprovalsView,
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/runs',
+      name: 'runs',
+      component: RunsView,
       meta: { requiresAuth: true },
     },
     {

--- a/frontend/src/ui/layout/AppSidebar.vue
+++ b/frontend/src/ui/layout/AppSidebar.vue
@@ -34,7 +34,7 @@ const navItems = [
   { label: 'Projects', icon: 'pi pi-folder', route: '/projects' },
   { label: 'Runs', icon: 'pi pi-play', route: '/runs' },
   { label: 'Approvals', icon: 'pi pi-bell', route: '/approvals' },
-  { label: 'Settings', icon: 'pi pi-cog', route: '/settings' },
+  { label: 'Settings', icon: 'pi pi-cog', route: '/profile' },
 ]
 
 const adminNavItems = [

--- a/frontend/src/utils/runStatus.ts
+++ b/frontend/src/utils/runStatus.ts
@@ -1,0 +1,9 @@
+/** Severity mapping for run status badges (PrimeVue Tag component). */
+export const runStatusSeverity: Record<string, 'info' | 'success' | 'warn' | 'danger' | 'secondary'> = {
+  pending: 'secondary',
+  running: 'info',
+  paused: 'warn',
+  completed: 'success',
+  failed: 'danger',
+  cancelled: 'warn',
+}

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,5 +1,209 @@
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import DataTable from 'primevue/datatable'
+import Column from 'primevue/column'
+import Tag from 'primevue/tag'
+import ProgressBar from 'primevue/progressbar'
+import Skeleton from 'primevue/skeleton'
+import Message from 'primevue/message'
+import Button from 'primevue/button'
+import Card from 'primevue/card'
+import { useRecentRuns } from '@/features/runs/composables/useRecentRuns'
+import { useHITLStore } from '@/stores/hitl'
+import { useProjects } from '@/composables/useProjects'
+import { runStatusSeverity } from '@/utils/runStatus'
+import { formatRelativeDate } from '@/utils/formatDate'
+import type { RunSummary } from '@/features/runs/composables/useRecentRuns'
+
+const router = useRouter()
+
+// Recent runs (cross-project, limit 10)
+const { runs, isLoading: runsLoading, error: runsError, refresh: refreshRuns } = useRecentRuns({ limit: 10 })
+
+// Pending approvals
+const hitlStore = useHITLStore()
+onMounted(() => hitlStore.fetchPending())
+
+// Projects (quick access, limit 5)
+const { projects, isLoading: projectsLoading, error: projectsError, fetchProjects } = useProjects()
+onMounted(() => fetchProjects({ per_page: 5, page: 1 }))
+
+const activeRunCount = computed(() => runs.value.filter((r) => r.status === 'running').length)
+const projectCount = computed(() => projects.value.length)
+
+function onRunRowClick(row: RunSummary) {
+  router.push({ name: 'run-detail', params: { id: row.id }, query: { projectId: row.project_id } })
+}
+</script>
+
 <template>
-  <div class="p-6">
-    <h1 class="text-2xl font-bold">Dashboard</h1>
+  <div class="flex flex-col gap-6 p-6">
+    <!-- Header -->
+    <div>
+      <h1 class="text-2xl font-bold">Dashboard</h1>
+      <p class="text-surface-500 mt-1">Welcome back</p>
+    </div>
+
+    <!-- Stat cards row -->
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <Card class="shadow-sm">
+        <template #content>
+          <div class="flex items-center gap-3">
+            <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-orange-100 text-orange-600">
+              <i class="pi pi-bell text-lg" />
+            </div>
+            <div>
+              <p class="text-sm text-surface-500">Pending Approvals</p>
+              <p class="text-2xl font-bold">{{ hitlStore.pendingCount }}</p>
+            </div>
+          </div>
+          <Button
+            v-if="hitlStore.pendingCount > 0"
+            label="View approvals"
+            text
+            size="small"
+            class="mt-2 !p-0"
+            @click="router.push({ name: 'approvals' })"
+          />
+        </template>
+      </Card>
+
+      <Card class="shadow-sm">
+        <template #content>
+          <div class="flex items-center gap-3">
+            <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100 text-blue-600">
+              <i class="pi pi-play text-lg" />
+            </div>
+            <div>
+              <p class="text-sm text-surface-500">Active Runs</p>
+              <p class="text-2xl font-bold">{{ activeRunCount }}</p>
+            </div>
+          </div>
+        </template>
+      </Card>
+
+      <Card class="shadow-sm">
+        <template #content>
+          <div class="flex items-center gap-3">
+            <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-green-100 text-green-600">
+              <i class="pi pi-folder text-lg" />
+            </div>
+            <div>
+              <p class="text-sm text-surface-500">Projects</p>
+              <p class="text-2xl font-bold">{{ projectCount }}</p>
+            </div>
+          </div>
+        </template>
+      </Card>
+    </div>
+
+    <!-- Main content grid -->
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+      <!-- Recent Runs (wide column) -->
+      <div class="lg:col-span-2">
+        <div class="flex items-center justify-between mb-3">
+          <h2 class="text-lg font-semibold">Recent Runs</h2>
+          <Button
+            v-if="!runsLoading && !runsError"
+            icon="pi pi-refresh"
+            text
+            rounded
+            size="small"
+            severity="secondary"
+            aria-label="Refresh runs"
+            @click="refreshRuns"
+          />
+        </div>
+
+        <!-- Loading -->
+        <div v-if="runsLoading" class="flex flex-col gap-2">
+          <Skeleton v-for="i in 4" :key="i" width="100%" height="2.5rem" />
+        </div>
+
+        <!-- Error -->
+        <Message v-else-if="runsError" severity="error" :closable="false">
+          <div class="flex items-center gap-3">
+            <span>{{ runsError.message }}</span>
+            <Button label="Retry" icon="pi pi-refresh" text size="small" @click="refreshRuns" />
+          </div>
+        </Message>
+
+        <!-- Empty -->
+        <div v-else-if="runs.length === 0" class="flex flex-col items-center py-8 text-surface-400">
+          <i class="pi pi-play text-3xl mb-2" />
+          <p>No runs yet</p>
+        </div>
+
+        <!-- Table -->
+        <DataTable
+          v-else
+          :value="runs"
+          :rows="10"
+          row-hover
+          class="cursor-pointer"
+          data-testid="dashboard-runs-table"
+          @row-click="onRunRowClick($event.data)"
+        >
+          <Column field="project_name" header="Project" />
+          <Column field="story_key" header="Story Key" />
+          <Column field="status" header="Status">
+            <template #body="{ data }">
+              <Tag :value="data.status" :severity="runStatusSeverity[data.status]" />
+            </template>
+          </Column>
+          <Column field="progress" header="Progress">
+            <template #body="{ data }">
+              <ProgressBar :value="data.progress ?? 0" :show-value="false" style="height: 0.5rem; width: 6rem" />
+            </template>
+          </Column>
+          <Column field="started_at" header="Started">
+            <template #body="{ data }">
+              {{ data.started_at ? formatRelativeDate(data.started_at) : '-' }}
+            </template>
+          </Column>
+        </DataTable>
+      </div>
+
+      <!-- Projects quick-access (narrow column) -->
+      <div>
+        <h2 class="text-lg font-semibold mb-3">Projects</h2>
+
+        <!-- Loading -->
+        <div v-if="projectsLoading" class="flex flex-col gap-2">
+          <Skeleton v-for="i in 3" :key="i" width="100%" height="2rem" />
+        </div>
+
+        <!-- Error -->
+        <Message v-else-if="projectsError" severity="error" :closable="false" class="text-sm">
+          Failed to load projects
+        </Message>
+
+        <!-- Empty -->
+        <div v-else-if="projects.length === 0" class="text-surface-400 text-sm py-4">
+          No projects yet
+        </div>
+
+        <!-- List -->
+        <div v-else class="flex flex-col gap-1">
+          <Button
+            v-for="project in projects"
+            :key="project.id"
+            :label="project.name"
+            icon="pi pi-folder"
+            text
+            class="w-full justify-start"
+            @click="router.push({ name: 'project-overview', params: { id: project.id } })"
+          />
+          <Button
+            label="View all projects"
+            text
+            size="small"
+            class="mt-2 !p-0 text-primary"
+            @click="router.push({ name: 'projects' })"
+          />
+        </div>
+      </div>
+    </div>
   </div>
 </template>

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -23,6 +23,7 @@ provide('project', project)
 const tabs = [
   { label: 'Overview', icon: 'pi pi-home', route: 'project-overview' },
   { label: 'Board', icon: 'pi pi-th-large', route: 'project-board' },
+  { label: 'Runs', icon: 'pi pi-play', route: 'project-runs' },
   { label: 'Pipeline', icon: 'pi pi-cog', route: 'project-pipeline' },
   { label: 'Templates', icon: 'pi pi-file', route: 'project-templates' },
   { label: 'Costs', icon: 'pi pi-dollar', route: 'project-costs' },

--- a/frontend/src/views/ProjectRunsView.vue
+++ b/frontend/src/views/ProjectRunsView.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import DataTable from 'primevue/datatable'
+import Column from 'primevue/column'
+import Tag from 'primevue/tag'
+import ProgressBar from 'primevue/progressbar'
+import Skeleton from 'primevue/skeleton'
+import Message from 'primevue/message'
+import Button from 'primevue/button'
+import { differenceInSeconds } from 'date-fns'
+import { useRecentRuns } from '@/features/runs/composables/useRecentRuns'
+import { runStatusSeverity } from '@/utils/runStatus'
+import { formatRelativeDate } from '@/utils/formatDate'
+import type { RunSummary } from '@/features/runs/composables/useRecentRuns'
+
+const route = useRoute()
+const router = useRouter()
+const projectId = computed(() => route.params.id as string)
+
+const { runs, isLoading, error, refresh } = useRecentRuns({ projectId: projectId.value, limit: 20 })
+
+function onRowClick(row: RunSummary) {
+  router.push({ name: 'run-detail', params: { id: row.id }, query: { projectId: row.project_id } })
+}
+
+/** Format duration between started_at and completed_at (or now if still running). */
+function formatDuration(run: RunSummary): string {
+  if (!run.started_at) return '-'
+  const end = run.completed_at ? new Date(run.completed_at) : new Date()
+  const seconds = differenceInSeconds(end, new Date(run.started_at))
+  if (seconds < 60) return `${seconds}s`
+  const mins = Math.floor(seconds / 60)
+  const secs = seconds % 60
+  return `${mins}m ${secs}s`
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-6 p-6">
+    <div class="flex items-center justify-between">
+      <h2 class="text-lg font-semibold">Run History</h2>
+      <Button
+        v-if="!isLoading && !error"
+        icon="pi pi-refresh"
+        text
+        rounded
+        size="small"
+        severity="secondary"
+        aria-label="Refresh runs"
+        @click="refresh"
+      />
+    </div>
+
+    <!-- Loading state -->
+    <div v-if="isLoading" class="flex flex-col gap-3">
+      <Skeleton v-for="i in 5" :key="i" width="100%" height="2.5rem" />
+    </div>
+
+    <!-- Error state -->
+    <Message v-else-if="error" severity="error" :closable="false">
+      <div class="flex items-center gap-3">
+        <span>{{ error.message }}</span>
+        <Button label="Retry" icon="pi pi-refresh" text size="small" @click="refresh" />
+      </div>
+    </Message>
+
+    <!-- Empty state -->
+    <div v-else-if="runs.length === 0" class="flex flex-col items-center justify-center py-12 text-surface-400">
+      <i class="pi pi-play text-4xl mb-3" />
+      <p class="text-lg font-medium">No runs yet</p>
+      <p class="text-sm">Pipeline runs for this project will appear here once triggered.</p>
+    </div>
+
+    <!-- Data table -->
+    <DataTable
+      v-else
+      :value="runs"
+      :rows="20"
+      :paginator="runs.length > 20"
+      row-hover
+      class="cursor-pointer"
+      data-testid="project-runs-table"
+      @row-click="onRowClick($event.data)"
+    >
+      <Column header="Run ID">
+        <template #body="{ data }">
+          <code class="text-xs bg-surface-100 px-1.5 py-0.5 rounded font-mono">
+            {{ data.id.substring(0, 8) }}
+          </code>
+        </template>
+      </Column>
+      <Column field="story_key" header="Story Key" />
+      <Column field="status" header="Status">
+        <template #body="{ data }">
+          <Tag :value="data.status" :severity="runStatusSeverity[data.status]" />
+        </template>
+      </Column>
+      <Column field="progress" header="Progress">
+        <template #body="{ data }">
+          <ProgressBar :value="data.progress ?? 0" :show-value="false" style="height: 0.5rem; width: 6rem" />
+        </template>
+      </Column>
+      <Column field="started_at" header="Started">
+        <template #body="{ data }">
+          {{ data.started_at ? formatRelativeDate(data.started_at) : '-' }}
+        </template>
+      </Column>
+      <Column header="Duration">
+        <template #body="{ data }">
+          <span v-if="data.status === 'running'" class="text-blue-500">running...</span>
+          <span v-else>{{ formatDuration(data) }}</span>
+        </template>
+      </Column>
+    </DataTable>
+  </div>
+</template>

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -12,6 +12,7 @@ import { differenceInSeconds } from 'date-fns'
 import { useRunDetail } from '@/features/runs/composables/useRunDetail'
 import { useRunsStore } from '@/stores/runs'
 import RunLogViewer from '@/features/runs/RunLogViewer.vue'
+import { runStatusSeverity } from '@/utils/runStatus'
 import type { RunStep } from '@/features/runs/composables/useRunDetail'
 
 const route = useRoute()
@@ -23,15 +24,6 @@ const toast = useToast()
 
 const { run: runRef, isLoading, error, retry } = useRunDetail(runId.value)
 const run = computed(() => runRef.value)
-
-const runStatusSeverity: Record<string, 'info' | 'success' | 'warn' | 'danger' | 'secondary'> = {
-  pending: 'secondary',
-  running: 'info',
-  paused: 'warn',
-  completed: 'success',
-  failed: 'danger',
-  cancelled: 'warn',
-}
 
 const stepSeverity: Record<string, string> = {
   completed: 'success',

--- a/frontend/src/views/RunsView.vue
+++ b/frontend/src/views/RunsView.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import DataTable from 'primevue/datatable'
+import Column from 'primevue/column'
+import Tag from 'primevue/tag'
+import ProgressBar from 'primevue/progressbar'
+import Skeleton from 'primevue/skeleton'
+import Message from 'primevue/message'
+import Button from 'primevue/button'
+import { useRecentRuns } from '@/features/runs/composables/useRecentRuns'
+import { runStatusSeverity } from '@/utils/runStatus'
+import { formatRelativeDate } from '@/utils/formatDate'
+import type { RunSummary } from '@/features/runs/composables/useRecentRuns'
+
+const router = useRouter()
+const { runs, isLoading, error, refresh } = useRecentRuns()
+
+function onRowClick(row: RunSummary) {
+  router.push({ name: 'run-detail', params: { id: row.id }, query: { projectId: row.project_id } })
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-6 p-6">
+    <div class="flex items-center justify-between">
+      <h1 class="text-2xl font-bold">Runs</h1>
+      <Button
+        v-if="!isLoading && !error"
+        icon="pi pi-refresh"
+        text
+        rounded
+        severity="secondary"
+        aria-label="Refresh runs"
+        @click="refresh"
+      />
+    </div>
+
+    <!-- Loading state -->
+    <div v-if="isLoading" class="flex flex-col gap-3">
+      <Skeleton v-for="i in 5" :key="i" width="100%" height="2.5rem" />
+    </div>
+
+    <!-- Error state -->
+    <Message v-else-if="error" severity="error" :closable="false">
+      <div class="flex items-center gap-3">
+        <span>{{ error.message }}</span>
+        <Button label="Retry" icon="pi pi-refresh" text size="small" @click="refresh" />
+      </div>
+    </Message>
+
+    <!-- Empty state -->
+    <div v-else-if="runs.length === 0" class="flex flex-col items-center justify-center py-12 text-surface-400">
+      <i class="pi pi-play text-4xl mb-3" />
+      <p class="text-lg font-medium">No runs yet</p>
+      <p class="text-sm">Pipeline runs will appear here once triggered from a project.</p>
+    </div>
+
+    <!-- Data table -->
+    <DataTable
+      v-else
+      :value="runs"
+      :rows="20"
+      row-hover
+      class="cursor-pointer"
+      data-testid="runs-table"
+      @row-click="onRowClick($event.data)"
+    >
+      <Column field="project_name" header="Project" />
+      <Column field="story_key" header="Story Key" />
+      <Column field="status" header="Status">
+        <template #body="{ data }">
+          <Tag :value="data.status" :severity="runStatusSeverity[data.status]" />
+        </template>
+      </Column>
+      <Column field="progress" header="Progress">
+        <template #body="{ data }">
+          <ProgressBar :value="data.progress ?? 0" :show-value="false" style="height: 0.5rem; width: 6rem" />
+        </template>
+      </Column>
+      <Column field="started_at" header="Started">
+        <template #body="{ data }">
+          {{ data.started_at ? formatRelativeDate(data.started_at) : '-' }}
+        </template>
+      </Column>
+    </DataTable>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

- **Fix sidebar routing**: "Settings" now navigates to `/profile` (no more 404), "Runs" navigates to new `/runs` page
- **Dashboard with real content**: replaced placeholder with stat cards (pending approvals, active runs, projects count), recent runs table, and projects quick-access list
- **Cross-project runs list**: new `/runs` page showing recent runs across all projects using fan-out fetch strategy
- **Project runs tab**: new "Runs" tab in project detail view at `/projects/:id/runs` with run history table including duration column
- **Shared utils**: extracted `runStatusSeverity` mapping to `utils/runStatus.ts` for reuse across views
- **useRecentRuns composable**: fetches runs per-project or cross-project (fans out to up to 5 projects, merges by created_at)

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/ui/layout/AppSidebar.vue` | Remap "Settings" route `/settings` → `/profile` |
| `frontend/src/router/index.ts` | Add `/runs` route + `project-runs` child route |
| `frontend/src/utils/runStatus.ts` | New — shared run status severity mapping |
| `frontend/src/features/runs/composables/useRecentRuns.ts` | New — composable for recent runs |
| `frontend/src/views/RunsView.vue` | New — cross-project runs list page |
| `frontend/src/views/DashboardView.vue` | Full dashboard implementation |
| `frontend/src/views/ProjectRunsView.vue` | New — project-scoped runs tab |
| `frontend/src/views/ProjectDetailView.vue` | Add "Runs" tab entry |
| `frontend/src/views/RunDetailView.vue` | Import shared `runStatusSeverity` |
| `frontend/src/features/runs/__tests__/useRecentRuns.spec.ts` | New — 8 unit tests |

## Test plan

- [x] All 523 unit tests pass (62 test files)
- [x] ESLint passes with no errors
- [x] TypeScript type-check passes (`vue-tsc --noEmit`)
- [ ] Click "Runs" in sidebar → `/runs` renders a list (or empty state)
- [ ] Click "Settings" in sidebar → `/profile` renders (no 404)
- [ ] Visit `/` → dashboard shows Recent Runs, Pending Approvals card, Projects list
- [ ] Navigate to any project → "Runs" tab visible → click → `/projects/:id/runs` shows run history
- [ ] Click any run row → navigates to run detail page

Refs: fix-14

🤖 Generated with [Claude Code](https://claude.com/claude-code)