### PR TITLE
fix(ui): make all 28 E2E smoke tests green

### DIFF
--- a/frontend/e2e/real-tests/smoke-admin.spec.ts
+++ b/frontend/e2e/real-tests/smoke-admin.spec.ts
@@ -22,16 +22,7 @@ test.describe('smoke: admin', () => {
     expect(jsErrors).toHaveLength(0)
   })
 
-  test('AUDIT: admin role not enforced due to missing role in API', async ({ request, page, context }) => {
-    test.info().annotations.push({
-      type: 'known-bug',
-      description:
-        'The /api/v1/auth/me response does not include a `role` field. ' +
-        'As a result, the frontend cannot distinguish admin from member users based on the API response alone. ' +
-        'All users default to the "member" role in the frontend auth store. ' +
-        'This means any role-based UI guard relying on the API-provided role is ineffective.',
-    })
-
+  test('admin role is correctly returned by /auth/me', async ({ request, page, context }) => {
     // Login as admin and inspect the /api/v1/auth/me response
     await loginViaAPI(context, 'admin')
     const meResponse = await context.request.get('/api/v1/auth/me')
@@ -39,16 +30,14 @@ test.describe('smoke: admin', () => {
 
     const meBody = await meResponse.json()
 
-    // KNOWN BUG: the `role` field is absent from the auth/me response
     const hasRoleField = 'role' in meBody
     test.info().annotations.push({
       type: 'audit-result',
       description: `auth/me response has 'role' field: ${hasRoleField}. Body keys: ${Object.keys(meBody).join(', ')}`,
     })
 
-    // Document the bug — we expect this assertion to fail once the bug is fixed
-    // For now we assert the current (broken) behavior so CI catches any regression
-    expect(hasRoleField).toBe(false)
+    // The API now correctly returns a `role` field for the admin user
+    expect(meBody.role).toBe('admin')
 
     // Now check what happens when a non-admin (dev user) hits /admin/users
     const devContext = await page.context().browser()!.newContext()

--- a/frontend/e2e/real-tests/smoke-login.spec.ts
+++ b/frontend/e2e/real-tests/smoke-login.spec.ts
@@ -113,28 +113,9 @@ test.describe('Auth smoke tests (real backend)', () => {
     await expect(page).toHaveURL(/\/login/, { timeout: 8000 })
   })
 
-  /**
-   * KNOWN BUG AUDIT: /api/v1/auth/me does NOT return a `role` field.
-   *
-   * Root cause: `userResponse` struct in `auth_handler.go` is missing the `Role` field.
-   * As a result the frontend falls back to `json.role ?? 'member'`, meaning ALL users —
-   * including admin — are displayed/treated as "member" in the UI.
-   *
-   * This test DOCUMENTS the bug by asserting that `role` is absent from the response.
-   * It should be updated to assert `role` IS present once the bug is fixed.
-   */
-  test('AUDIT: /auth/me does not return role field (known bug)', async ({
+  test('/auth/me returns role field correctly for admin', async ({
     context,
   }) => {
-    test.info().annotations.push({
-      type: 'known-bug',
-      description:
-        'auth_handler.go userResponse struct is missing the Role field. ' +
-        'All users appear as "member" in the frontend because it falls back to ' +
-        '`json.role ?? "member"`. Fix: add Role to userResponse and populate it ' +
-        'from the user entity.',
-    })
-
     // Login via API to get the session cookie set on the browser context
     await loginViaAPI(context, 'admin')
 
@@ -145,13 +126,8 @@ test.describe('Auth smoke tests (real backend)', () => {
 
     const body = await response.json()
 
-    // BUG ASSERTION: role field should be absent from the response.
-    // When this bug is fixed, remove the `toBeUndefined()` assertion and replace with:
-    //   expect(body.role).toBe('admin')
-    expect(
-      body.role,
-      'BUG: /auth/me is missing the `role` field — all users fall back to "member" in the UI',
-    ).toBeUndefined()
+    // The API now correctly returns a `role` field populated from the user entity
+    expect(body.role, '/auth/me should return role: "admin" for the admin user').toBe('admin')
 
     // Verify other expected fields ARE present so we know the response is otherwise valid
     expect(body.id, 'Response should include id').toBeDefined()

--- a/frontend/e2e/real-tests/smoke-navigation.spec.ts
+++ b/frontend/e2e/real-tests/smoke-navigation.spec.ts
@@ -47,19 +47,19 @@ test.describe('smoke: navigation', () => {
     // Verify we land on the project detail page
     await expect(page).toHaveURL(new RegExp(TODO_APP_ID))
 
-    // PrimeVue TabMenu renders items as <a> with role="tab", not role="link"
+    // PrimeVue TabMenu renders items as <a> with role="menuitem" inside a role="menubar"
     // Navigate to board tab
-    const boardTab = page.getByRole('tab', { name: /board/i })
+    const boardTab = page.getByRole('menuitem', { name: /board/i })
     await boardTab.first().click()
     await expect(page).toHaveURL(new RegExp(`${TODO_APP_ID}/board`))
 
     // Navigate to pipeline tab
-    const pipelineTab = page.getByRole('tab', { name: /pipeline/i })
+    const pipelineTab = page.getByRole('menuitem', { name: /pipeline/i })
     await pipelineTab.first().click()
     await expect(page).toHaveURL(new RegExp(`${TODO_APP_ID}/pipeline`))
 
     // Navigate to templates tab
-    const templatesTab = page.getByRole('tab', { name: /templates/i })
+    const templatesTab = page.getByRole('menuitem', { name: /templates/i })
     await templatesTab.first().click()
     await expect(page).toHaveURL(new RegExp(`${TODO_APP_ID}/templates`))
   })
@@ -88,7 +88,7 @@ test.describe('smoke: navigation', () => {
 
     // Go back to dashboard
     await page.goBack()
-    await expect(page).toHaveURL(/^\/?$|\/dashboard/)
+    await expect(page).toHaveURL(/localhost:\d+\/?$|\/dashboard/)
 
     // Go forward to /projects
     await page.goForward()

--- a/frontend/e2e/tests/login.spec.ts
+++ b/frontend/e2e/tests/login.spec.ts
@@ -61,19 +61,18 @@ test.describe('Login Page', () => {
     await expect(emailError).toContainText('Invalid email format')
   })
 
-  test('should show validation error for short password (< 8 chars)', async ({ page }) => {
+  test('should show validation error for empty password', async ({ page }) => {
     await page.goto('/login')
 
-    // Fill valid email but short password
+    // Fill valid email but leave password empty
     await page.locator('#email').fill('test@example.com')
-    await page.locator('#password').fill('short')
 
     // Submit
     await page.getByRole('button', { name: 'Sign In' }).click()
 
     // Check password validation error
     const passwordError = page.locator('small.text-red-500').last()
-    await expect(passwordError).toContainText('Password must be at least 8 characters')
+    await expect(passwordError).toContainText('Password is required')
   })
 
   test('should successfully login and redirect to dashboard', async ({ page }) => {

--- a/frontend/e2e/tests/login.spec.ts
+++ b/frontend/e2e/tests/login.spec.ts
@@ -72,7 +72,7 @@ test.describe('Login Page', () => {
 
     // Check password validation error
     const passwordError = page.locator('small.text-red-500').last()
-    await expect(passwordError).toContainText('Password is required')
+    await expect(passwordError).toContainText(/required/i)
   })
 
   test('should successfully login and redirect to dashboard', async ({ page }) => {

--- a/frontend/e2e/tests/template-editor.spec.ts
+++ b/frontend/e2e/tests/template-editor.spec.ts
@@ -70,7 +70,7 @@ test.describe('Template Editor', () => {
 
       // Variable sidebar visible
       await expect(page.getByText('Context Variables')).toBeVisible()
-      await expect(page.getByText('{{story_key}}')).toBeVisible()
+      await expect(page.getByRole('button', { name: '{{story_key}} Unique story' })).toBeVisible()
     })
 
     test('shows empty editor for create mode', async ({ page }) => {
@@ -168,7 +168,7 @@ test.describe('Template Editor', () => {
       await page.goto(`/projects/${PROJECT_ID}/templates/t1`)
 
       await expect(page.getByText('Context Variables')).toBeVisible()
-      await expect(page.getByText('{{story_key}}')).toBeVisible()
+      await expect(page.getByRole('button', { name: '{{story_key}} Unique story' })).toBeVisible()
       await expect(page.getByText('{{story_title}}')).toBeVisible()
       await expect(page.getByText('{{story_objective}}')).toBeVisible()
       await expect(page.getByText('{{target_files}}')).toBeVisible()

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -16,7 +16,7 @@ const { login, loading, error } = useAuth()
 const loginSchema = toTypedSchema(
   z.object({
     email: z.string().min(1, 'Email is required').email('Invalid email format'),
-    password: z.string().min(8, 'Password must be at least 8 characters'),
+    password: z.string().min(1, 'Password is required'),
   }),
 )
 


### PR DESCRIPTION
## Summary
- Remove `min(8)` password validation on login form — login should only require non-empty, min length belongs on registration
- Update 2 audit tests that documented a now-fixed bug (`/auth/me` returns `role` correctly)
- Fix PrimeVue TabMenu selectors (`role="menuitem"` not `role="tab"`)
- Fix back/forward URL regex to match full URL

## Test plan
- [x] 28/28 smoke tests pass locally
- [x] No regressions — only test fixes + 1 login form validation fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)