### PR TITLE
docs(stories): add runner refactoring stories and update sprint status

### DIFF
--- a/_bmad-output/implementation-artifacts/refactor-1-runner-interface-agent-spec-model.md
+++ b/_bmad-output/implementation-artifacts/refactor-1-runner-interface-agent-spec-model.md
@@ -1,0 +1,245 @@
+# Story refactor-1: Create Runner Interface and AgentSpec Model
+
+**Status:** ready-for-dev
+
+## Story
+
+As a backend developer, I want to replace the `ContainerManager` port (6 methods, Docker-coupled) with a new `Runner` port (4 methods, runtime-agnostic), and introduce `AgentSpec` as the canonical input model, so that the domain layer no longer leaks Docker terminology and a future Kubernetes adapter can be plugged in without touching any consumer code.
+
+This story covers only the creation of the new abstractions and the Docker implementation. Consumers (`agent_run.go`, `orphan_cleaner.go`, `timeout_enforcer.go`) are **not** modified in this story — they continue to use `ContainerManager` until story refactor-2.
+
+## Acceptance Criteria
+
+**AC1: `port/runner.go` exists with the correct interface**
+- Given the file `backend/internal/domain/port/runner.go` exists
+- When another package imports it
+- Then it exports a `Runner` interface with exactly 4 methods: `Submit`, `Wait`, `Terminate`, `List`
+- And it exports a `RunnerInfo` struct with fields `Handle string`, `Labels map[string]string`, `CreatedAt time.Time`
+
+**AC2: `model/agent_spec.go` exists with the correct types**
+- Given the file `backend/internal/domain/model/agent_spec.go` exists
+- When another package imports it
+- Then it exports `AgentSpec` with fields `Image string`, `Env []string`, `Labels map[string]string`, `Resources AgentResources`
+- And it exports `AgentResources` with fields `Memory int64`, `CPUs float64`
+- And `AgentSpec` does NOT contain a `NetworkName` field (network is constructor-level config)
+
+**AC3: `adapter/docker/runner.go` implements `port.Runner`**
+- Given `DockerRunner` is created via `NewDockerRunner(host, network, logger)`
+- When `Submit(ctx, spec)` is called with a valid `AgentSpec`
+- Then it creates AND starts the container in a single atomic operation
+- And it enforces `managed_by=hopeitworks` label unconditionally
+- And it sets `Privileged=false` and `Binds=nil` (security constraints preserved)
+- And it returns an opaque handle (the container ID)
+
+**AC4: `Submit` and `Terminate` are atomic**
+- Given a `DockerRunner`
+- When `Submit` is called, the container is both created and started before the handle is returned
+- When `Terminate` is called with a valid handle, it stops (SIGTERM, 10s) then removes the container (force + volumes) in one call
+- And `Terminate` is idempotent: calling it twice on the same handle does not return an error
+
+**AC5: `port/log_streamer.go` uses `handle` instead of `containerID`**
+- Given `port/log_streamer.go` is updated
+- When `StreamLogs` is called
+- Then the first parameter name is `handle string` (not `containerID string`)
+- And the semantic contract is identical
+
+**AC6: `adapter/docker/log_streamer.go` is updated to match**
+- Given `adapter/docker/log_streamer.go` is updated
+- When `StreamLogs` is called with a `handle`
+- Then it passes the handle directly to `ContainerLogs` and `ContainerWait` (Docker container ID = handle for the Docker adapter)
+- And all internal log fields use `handle` instead of `container_id`
+
+**AC7: `port.ContainerManager` and `model.ContainerOpts` are NOT removed**
+- Given this story is only additive
+- When the code compiles
+- Then `port/container_manager.go` still exists and is unchanged
+- And `model/container.go` still exists and is unchanged
+- And all existing tests still pass
+
+**AC8: Unit tests for `DockerRunner` cover the new interface**
+- Given `adapter/docker/runner_test.go` exists
+- When the test suite runs with `go test ./... -short`
+- Then it covers: `Submit` success (labels, resources, network, security), `Submit` error propagation, `Wait` success (exit 0 and non-zero), `Wait` error, `Wait` context cancellation, `Terminate` success, `Terminate` idempotent (not found is not an error), `List` success, `List` error
+
+## Tasks / Subtasks
+
+- [ ] Create `backend/internal/domain/port/runner.go` with `Runner` interface and `RunnerInfo` struct (AC: #1)
+- [ ] Create `backend/internal/domain/model/agent_spec.go` with `AgentSpec` and `AgentResources` (AC: #2)
+- [ ] Create `backend/internal/adapter/docker/runner.go` implementing `port.Runner` (AC: #3, #4)
+  - [ ] `NewDockerRunner(host string, network string, logger *slog.Logger) (*DockerRunner, error)`
+  - [ ] `Submit`: ContainerCreate + ContainerStart, enforce `managed_by` label, security constraints
+  - [ ] `Wait`: wrap `ContainerWait` with context cancellation handling
+  - [ ] `Terminate`: stop (10s grace) then remove (force + volumes); treat "container not found" as success
+  - [ ] `List`: wrap `ContainerList` with label filters, map to `[]port.RunnerInfo`
+- [ ] Update `backend/internal/domain/port/log_streamer.go`: rename `containerID` param to `handle` (AC: #5)
+- [ ] Update `backend/internal/adapter/docker/log_streamer.go`: rename `containerID` to `handle` in all method signatures and internal log fields (AC: #6)
+- [ ] Create `backend/internal/adapter/docker/runner_test.go` with unit tests using `mockDockerClient` pattern (AC: #8)
+- [ ] Verify `go test ./... -short` passes and `golangci-lint run ./...` is clean
+
+## Dev Notes
+
+### Dependencies
+
+- No new Go dependencies — uses the existing `github.com/docker/docker` SDK already in `go.mod`
+- `port/container_manager.go` and `model/container.go` must NOT be touched in this story
+
+### File Paths
+
+| Action | Path |
+|--------|------|
+| CREATE | `backend/internal/domain/port/runner.go` |
+| CREATE | `backend/internal/domain/model/agent_spec.go` |
+| CREATE | `backend/internal/adapter/docker/runner.go` |
+| CREATE | `backend/internal/adapter/docker/runner_test.go` |
+| MODIFY | `backend/internal/domain/port/log_streamer.go` |
+| MODIFY | `backend/internal/adapter/docker/log_streamer.go` |
+
+### Technical Specifications
+
+#### `port/runner.go`
+
+```go
+package port
+
+import (
+    "context"
+    "time"
+
+    "github.com/zakari/hopeitworks/backend/internal/domain/model"
+)
+
+// RunnerInfo represents metadata about a submitted workload.
+type RunnerInfo struct {
+    Handle    string
+    Labels    map[string]string
+    CreatedAt time.Time
+}
+
+// Runner abstracts workload lifecycle operations, agnostic of the underlying runtime.
+// For Docker, a handle is the container ID. For Kubernetes, it would be namespace/job-name.
+type Runner interface {
+    // Submit creates and starts a workload from the given spec.
+    // Returns an opaque handle identifying the workload.
+    Submit(ctx context.Context, spec model.AgentSpec) (string, error)
+
+    // Wait blocks until the workload identified by handle exits.
+    // Returns the exit code.
+    Wait(ctx context.Context, handle string) (int, error)
+
+    // Terminate stops and removes the workload identified by handle.
+    // Terminate is idempotent: if the workload does not exist, no error is returned.
+    Terminate(ctx context.Context, handle string) error
+
+    // List returns all workloads matching the specified labels.
+    List(ctx context.Context, labels map[string]string) ([]RunnerInfo, error)
+}
+```
+
+#### `model/agent_spec.go`
+
+```go
+package model
+
+// AgentSpec specifies the configuration for a workload submitted to a Runner.
+type AgentSpec struct {
+    // Image is the container image (e.g., "hopeitworks/agent:latest").
+    Image string
+
+    // Env is a list of environment variables in KEY=VALUE format.
+    Env []string
+
+    // Labels are key-value pairs for workload metadata.
+    // Standard labels: managed_by, run_id, step_id, story_key.
+    Labels map[string]string
+
+    // Resources defines resource limits for the workload.
+    Resources AgentResources
+}
+
+// AgentResources defines resource constraints for a workload.
+type AgentResources struct {
+    // Memory is the memory limit in bytes (0 = unlimited).
+    Memory int64
+
+    // CPUs is the CPU limit as a float (0 = unlimited, 1.0 = 1 CPU).
+    CPUs float64
+}
+```
+
+#### `adapter/docker/runner.go` — key implementation notes
+
+- The `dockerClient` interface in `runner.go` must mirror the one in `container_manager.go` (same Docker SDK methods) — do not share the interface type to keep the files independent
+- `Submit` must enforce `managed_by=hopeitworks` even if `spec.Labels` is nil (initialize map first)
+- `Terminate` must use `errdefs.IsNotFound(err)` from `github.com/docker/docker/errdefs` to detect "container not found" and return nil in that case
+- `Wait` selects on `statusCh`, `errCh`, and `ctx.Done()` — same pattern as the existing `ContainerManager.Wait`
+- Constructor: `NewDockerRunner(host string, network string, logger *slog.Logger) (*DockerRunner, error)`
+- The network is stored in the struct field `network string` and applied in `Submit` only (not in the interface)
+
+#### `log_streamer.go` — rename only
+
+The change in `port/log_streamer.go` is purely a parameter rename: `containerID string` → `handle string`. The semantic contract is identical — for the Docker adapter, handle == container ID. This is a source-compatible change within the package since the interface method is called via the port interface.
+
+The change in `adapter/docker/log_streamer.go`:
+- Rename all occurrences of `containerID` parameter to `handle` in `StreamLogs`, `streamLoop`, and `handleContainerExit`
+- Update all `slog.String("container_id", ...)` log fields to `slog.String("handle", ...)`
+- The value passed to `client.ContainerLogs` and `client.ContainerWait` remains the same (`handle`)
+
+#### `Terminate` idempotency
+
+```go
+import "github.com/docker/docker/errdefs"
+
+func (r *DockerRunner) Terminate(ctx context.Context, handle string) error {
+    timeout := stopTimeoutSeconds
+    if err := r.client.ContainerStop(ctx, handle, dockercontainer.StopOptions{Timeout: &timeout}); err != nil {
+        if !errdefs.IsNotFound(err) {
+            return apperrors.NewContainerError(...)
+        }
+        // Already gone — skip remove, return nil
+        return nil
+    }
+    if err := r.client.ContainerRemove(ctx, handle, dockercontainer.RemoveOptions{Force: true, RemoveVolumes: true}); err != nil {
+        if !errdefs.IsNotFound(err) {
+            return apperrors.NewContainerError(...)
+        }
+    }
+    return nil
+}
+```
+
+#### Compile-time interface check
+
+Add at the top of `runner.go`:
+```go
+var _ port.Runner = (*DockerRunner)(nil)
+```
+
+### Testing Requirements
+
+- Test file: `backend/internal/adapter/docker/runner_test.go`
+- Use the same `mockDockerClient` pattern as `container_manager_test.go` (the mock must implement the `dockerClient` interface defined in `runner.go`)
+- The mock for `runner_test.go` is a separate type in the same package — do NOT reuse the one from `container_manager_test.go` to avoid coupling
+- Required test cases:
+  - `TestSubmit_Success`: verifies container created+started, `managed_by` label set, image/env passed correctly, security constraints (Privileged=false, Binds=nil)
+  - `TestSubmit_LabelsNil`: verifies `managed_by` is still set when `spec.Labels` is nil
+  - `TestSubmit_MemoryAndCPULimits`: verifies NanoCPUs and Memory passed to HostConfig
+  - `TestSubmit_Network`: verifies NetworkingConfig has the runner's network
+  - `TestSubmit_CreateError`: Docker create error → `DomainError` with code `CONTAINER_OPERATION_FAILED`
+  - `TestSubmit_StartError`: Docker start error → `DomainError`
+  - `TestWait_SuccessExitZero`: returns 0
+  - `TestWait_SuccessNonZeroExit`: returns non-zero exit code without error
+  - `TestWait_Error`: Docker wait error → `DomainError`
+  - `TestWait_ContextCancelled`: context cancelled → `DomainError`
+  - `TestTerminate_Success`: stop then remove called in order
+  - `TestTerminate_NotFound`: container not found on stop → returns nil (idempotent)
+  - `TestTerminate_StopError`: non-notfound stop error → returns `DomainError`
+  - `TestList_Success`: returns correct `RunnerInfo` slice with handles and labels
+  - `TestList_Empty`: returns empty slice, no error
+  - `TestList_Error`: Docker list error → `DomainError`
+
+### References
+
+- Existing implementation to mirror: `backend/internal/adapter/docker/container_manager.go`
+- Existing test pattern to follow: `backend/internal/adapter/docker/container_manager_test.go`
+- `errdefs` package: `github.com/docker/docker/errdefs` (already in `go.mod` transitively via Docker SDK)
+- Stories consuming this interface: refactor-2 (migration of consumers)

--- a/_bmad-output/implementation-artifacts/refactor-2-migrate-consumers-to-runner.md
+++ b/_bmad-output/implementation-artifacts/refactor-2-migrate-consumers-to-runner.md
@@ -1,0 +1,321 @@
+# Story refactor-2: Migrate Consumers to Runner
+
+**Status:** ready-for-dev
+
+**Blocked by:** refactor-1 (Runner interface and DockerRunner must be merged first)
+
+## Story
+
+As a backend developer, I want to migrate all consumers of `ContainerManager` to use the new `Runner` interface, so that the domain layer no longer references Docker-specific types, and the old `ContainerManager` port, `ContainerOpts` model, and their Docker adapter can be deleted.
+
+This story assumes that `port/runner.go`, `model/agent_spec.go`, and `adapter/docker/runner.go` are already in place (story refactor-1 merged). The DB column rename is handled in story refactor-3.
+
+## Acceptance Criteria
+
+**AC1: `adapter/action/agent_run.go` uses `port.Runner` instead of `port.ContainerManager`**
+- Given `AgentRunAction` is updated
+- When an agent run is executed
+- Then `AgentRunAction` holds a `runner port.Runner` field (not `containerMgr port.ContainerManager`)
+- And `createContainer + Start` is replaced by a single `runner.Submit(ctx, spec)` call returning a handle
+- And `cleanupContainer` is replaced by `runner.Terminate(ctx, handle)` (Stop+Remove collapsed into one call)
+- And `AgentConfig.NetworkName` is removed (network is now in the `DockerRunner` constructor)
+- And the handle returned by `Submit` is persisted to `run_steps.container_id` via `runRepo.UpdateRunStepContainerInfo` (column rename happens in refactor-3; field name in domain model `RunStep.ContainerID` remains for now)
+
+**AC2: `service/orphan_cleaner.go` uses `port.Runner`**
+- Given `OrphanCleaner` is updated
+- When `CleanupOrphans` is called
+- Then it calls `runner.List(ctx, {"managed_by": "hopeitworks"})` instead of `containerMgr.ListContainers`
+- And it calls `runner.Terminate(ctx, info.Handle)` instead of `containerMgr.Remove`
+- And the orphan detection logic (run_id label, run status check) is unchanged
+
+**AC3: `service/timeout_enforcer.go` uses `port.Runner`**
+- Given `TimeoutEnforcer` is updated
+- When `CheckTimeouts` is called
+- Then it calls `runner.List(ctx, {"managed_by": "hopeitworks"})` instead of `containerMgr.ListContainers`
+- And it calls `runner.Terminate(ctx, info.Handle)` instead of `containerMgr.Stop` (Stop+Remove collapsed)
+- And the timeout detection logic (started_at, project timeout override) is unchanged
+
+**AC4: `cmd/api/main.go` wiring uses `DockerRunner`**
+- Given `main.go` is updated
+- When the application starts
+- Then `NewDockerRunner(cfg.Docker.Host, cfg.Docker.AgentNetwork, logger)` is called once
+- And the resulting `runner` is passed to `NewAgentRunAction`, `NewOrphanCleaner`, and `NewTimeoutEnforcer`
+- And the separate `NewDockerLogStreamerFromHost` call remains unchanged (log streamer is independent)
+- And `AgentConfig.NetworkName` field and its usage are removed from `main.go`
+
+**AC5: Old files are deleted**
+- Given the migration is complete
+- When the repository is inspected
+- Then `backend/internal/domain/port/container_manager.go` does not exist
+- And `backend/internal/domain/model/container.go` does not exist
+- And `backend/internal/adapter/docker/container_manager.go` does not exist
+- And `backend/internal/adapter/docker/container_manager_test.go` does not exist
+
+**AC6: Existing tests are updated and pass**
+- Given the consumer test files reference `mockContainerManager` and `port.ContainerInfo`
+- When those files are updated
+- Then `adapter/action/agent_run_test.go` uses `mockRunner` implementing `port.Runner`
+- And `service/timeout_enforcer_test.go` (and its shared mock) uses `mockRunner`
+- And `service/orphan_cleaner_test.go` uses `mockRunner`
+- And `go test ./... -short` passes with zero failures
+
+**AC7: `golangci-lint run ./...` passes**
+- Given all files are updated
+- When the linter runs
+- Then there are zero lint errors
+
+## Tasks / Subtasks
+
+- [ ] Update `backend/internal/adapter/action/agent_run.go` (AC: #1)
+  - [ ] Replace `containerMgr port.ContainerManager` field with `runner port.Runner`
+  - [ ] Replace `NewAgentRunAction` signature (remove `containerMgr`, add `runner port.Runner`; remove `AgentConfig.NetworkName`)
+  - [ ] Replace `createContainer + containerMgr.Start` with `runner.Submit(ctx, spec)` building `model.AgentSpec`
+  - [ ] Replace `cleanupContainer` (`Stop` + `Remove`) with `runner.Terminate(ctx, handle)`
+  - [ ] Persist handle via `runRepo.UpdateRunStepContainerInfo(ctx, stepID, &handle, nil)` (field name unchanged for now)
+  - [ ] Remove `AgentConfig.NetworkName` from the struct
+- [ ] Update `backend/internal/domain/service/orphan_cleaner.go` (AC: #2)
+  - [ ] Replace `containerMgr port.ContainerManager` with `runner port.Runner`
+  - [ ] Replace `ListContainers` with `runner.List`, update loop variable from `.ID` to `.Handle`
+  - [ ] Replace `containerMgr.Remove(ctx, container.ID)` with `runner.Terminate(ctx, info.Handle)`
+  - [ ] Update `NewOrphanCleaner` constructor signature
+- [ ] Update `backend/internal/domain/service/timeout_enforcer.go` (AC: #3)
+  - [ ] Replace `containerMgr port.ContainerManager` with `runner port.Runner`
+  - [ ] Replace `ListContainers` with `runner.List`, update loop variable from `.ID` to `.Handle`
+  - [ ] Replace `containerMgr.Stop(ctx, container.ID)` with `runner.Terminate(ctx, info.Handle)`
+  - [ ] Update `NewTimeoutEnforcer` constructor signature
+- [ ] Update `backend/cmd/api/main.go` (AC: #4)
+  - [ ] Replace `NewDockerContainerManager` call with `NewDockerRunner(cfg.Docker.Host, cfg.Docker.AgentNetwork, logger)`
+  - [ ] Pass `runner` to `NewAgentRunAction`, `NewOrphanCleaner`, `NewTimeoutEnforcer`
+  - [ ] Remove `AgentConfig.NetworkName` from the `AgentConfig` literal
+- [ ] Update `backend/internal/adapter/action/agent_run_test.go` (AC: #6)
+  - [ ] Replace `mockContainerManager` with `mockRunner` implementing `port.Runner`
+  - [ ] Update all test cases: `Submit` replaces `Create`+`Start`, `Terminate` replaces `Stop`+`Remove`
+- [ ] Update `backend/internal/domain/service/timeout_enforcer_test.go` (AC: #6)
+  - [ ] Replace `mockContainerManager` with `mockRunner`; update `listFn`, `stopCalls` → `terminateCalls`
+- [ ] Update `backend/internal/domain/service/orphan_cleaner_test.go` (AC: #6)
+  - [ ] Replace `mockContainerManager` with `mockRunner`; update `removeCalls` → `terminateCalls`
+- [ ] Delete `backend/internal/domain/port/container_manager.go` (AC: #5)
+- [ ] Delete `backend/internal/domain/model/container.go` (AC: #5)
+- [ ] Delete `backend/internal/adapter/docker/container_manager.go` (AC: #5)
+- [ ] Delete `backend/internal/adapter/docker/container_manager_test.go` (AC: #5)
+- [ ] Run `go build ./...` to confirm zero compilation errors (AC: #6)
+- [ ] Run `go test ./... -short` and confirm all tests pass (AC: #6)
+- [ ] Run `golangci-lint run ./...` and confirm zero errors (AC: #7)
+
+## Dev Notes
+
+### Dependencies
+
+- Story refactor-1 must be merged before starting this story
+- No new Go dependencies
+- `model/run.go` field `RunStep.ContainerID *string` is NOT renamed in this story (DB rename is story refactor-3)
+
+### File Paths
+
+| Action | Path |
+|--------|------|
+| MODIFY | `backend/internal/adapter/action/agent_run.go` |
+| MODIFY | `backend/internal/adapter/action/agent_run_test.go` |
+| MODIFY | `backend/internal/domain/service/orphan_cleaner.go` |
+| MODIFY | `backend/internal/domain/service/orphan_cleaner_test.go` |
+| MODIFY | `backend/internal/domain/service/timeout_enforcer.go` |
+| MODIFY | `backend/internal/domain/service/timeout_enforcer_test.go` |
+| MODIFY | `backend/cmd/api/main.go` |
+| DELETE | `backend/internal/domain/port/container_manager.go` |
+| DELETE | `backend/internal/domain/model/container.go` |
+| DELETE | `backend/internal/adapter/docker/container_manager.go` |
+| DELETE | `backend/internal/adapter/docker/container_manager_test.go` |
+
+### Technical Specifications
+
+#### `agent_run.go` — `createContainer` becomes `buildSpec`
+
+The `createContainer` method currently builds `model.ContainerOpts` and calls `containerMgr.Create`. Replace it with a `buildSpec` method that builds `model.AgentSpec`:
+
+```go
+func (a *AgentRunAction) buildSpec(
+    runCtx *model.RunContext,
+    project *model.Project,
+    story *model.Story,
+    claudeMD, prompt, branchName string,
+) model.AgentSpec {
+    repoURL := ""
+    if project.RepoURL != nil {
+        repoURL = *project.RepoURL
+    }
+    return model.AgentSpec{
+        Image: a.config.DefaultImage,
+        Resources: model.AgentResources{
+            Memory: a.config.DefaultMemory,
+            CPUs:   a.config.DefaultCPUs,
+        },
+        Env: []string{
+            "CLAUDE_MD_CONTENT=" + claudeMD,
+            "REPO_URL=" + repoURL,
+            "BRANCH_NAME=" + branchName,
+            "STORY_KEY=" + story.Key,
+            "PROMPT_CONTENT=" + prompt,
+            "GITHUB_TOKEN=" + os.Getenv("GITHUB_TOKEN"),
+            "CLAUDE_CODE_OAUTH_TOKEN=" + os.Getenv("CLAUDE_CODE_OAUTH_TOKEN"),
+        },
+        Labels: map[string]string{
+            "managed_by": "hopeitworks",
+            "run_id":     runCtx.Run.ID.String(),
+            "step_id":    runCtx.RunStep.ID.String(),
+            "story_key":  story.Key,
+        },
+    }
+}
+```
+
+The `Execute` method changes from:
+```go
+containerID, err := a.createContainer(...)
+defer a.cleanupContainer(containerID)
+a.containerMgr.Start(ctx, containerID)
+a.persistContainerID(ctx, runCtx.RunStep.ID, containerID)
+```
+To:
+```go
+spec := a.buildSpec(runCtx, project, story, claudeMD, prompt, branchName)
+handle, err := a.runner.Submit(ctx, spec)
+if err != nil {
+    return fmt.Errorf("submit agent workload: %w", err)
+}
+defer a.cleanupWorkload(handle)
+a.persistHandle(ctx, runCtx.RunStep.ID, handle)
+```
+
+#### `AgentConfig` struct cleanup
+
+Remove `NetworkName string` from `AgentConfig` since the network is now in the `DockerRunner` constructor. The field was previously used in `createContainer` → `ContainerOpts.NetworkName`.
+
+#### `cleanupContainer` → `cleanupWorkload`
+
+```go
+func (a *AgentRunAction) cleanupWorkload(handle string) {
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
+    if err := a.runner.Terminate(ctx, handle); err != nil {
+        a.logger.Warn("failed to terminate agent workload during cleanup",
+            "handle", handle, "error", err)
+    }
+    a.logger.Debug("agent workload cleaned up", "handle", handle)
+}
+```
+
+#### `persistContainerID` → `persistHandle`
+
+```go
+func (a *AgentRunAction) persistHandle(ctx context.Context, stepID uuid.UUID, handle string) {
+    if _, err := a.runRepo.UpdateRunStepContainerInfo(ctx, stepID, &handle, nil); err != nil {
+        a.logger.Warn("failed to persist workload handle to run step",
+            "step_id", stepID, "handle", handle, "error", err)
+    }
+}
+```
+
+#### `orphan_cleaner.go` — List + Terminate
+
+```go
+func (o *OrphanCleaner) CleanupOrphans(ctx context.Context) error {
+    workloads, err := o.runner.List(ctx, map[string]string{"managed_by": "hopeitworks"})
+    if err != nil {
+        return err
+    }
+    orphanCount := 0
+    for _, w := range workloads {
+        runIDStr := w.Labels["run_id"]
+        // ... same orphan detection logic, but use w.Handle instead of container.ID ...
+        o.terminateOrphan(ctx, w.Handle, reason)
+    }
+    ...
+}
+
+func (o *OrphanCleaner) terminateOrphan(ctx context.Context, handle, reason string) {
+    if err := o.runner.Terminate(ctx, handle); err != nil {
+        o.logger.Error("failed to terminate orphan workload", "handle", handle, "reason", reason, "error", err)
+    } else {
+        o.logger.Info("terminated orphan workload", "handle", handle, "reason", reason)
+    }
+}
+```
+
+#### `timeout_enforcer.go` — List + Terminate
+
+```go
+func (t *TimeoutEnforcer) CheckTimeouts(ctx context.Context) error {
+    workloads, err := t.runner.List(ctx, map[string]string{"managed_by": "hopeitworks"})
+    if err != nil {
+        return err
+    }
+    for _, w := range workloads {
+        runIDStr := w.Labels["run_id"]
+        stepIDStr := w.Labels["step_id"]
+        // ... same timeout logic, use w.Handle ...
+        if err := t.runner.Terminate(ctx, w.Handle); err != nil {
+            t.logger.Error("failed to terminate timed-out workload", "handle", w.Handle, "error", err)
+            continue
+        }
+        // ... update run step and run status ...
+    }
+    return nil
+}
+```
+
+Note: the old `TimeoutEnforcer` called `Stop` only (not `Remove`). With `Terminate`, the container is also removed. This is intentional — a timed-out container should be cleaned up completely.
+
+#### Test mocks
+
+The `mockRunner` in service tests follows the same pattern as `mockContainerManager`:
+
+```go
+type mockRunner struct {
+    mu              sync.Mutex
+    listFn          func(ctx context.Context, labels map[string]string) ([]port.RunnerInfo, error)
+    terminateCalls  []string
+    terminateFn     func(ctx context.Context, handle string) error
+    submitFn        func(ctx context.Context, spec model.AgentSpec) (string, error)
+    waitFn          func(ctx context.Context, handle string) (int, error)
+}
+```
+
+Methods `getTerminateCalls()` and `getSubmitCalls()` follow the same mutex-protected copy pattern.
+
+In `agent_run_test.go`, the `mockContainerManager` type is replaced by `mockRunner`. All tests that set `createFn`/`startFn` are updated to set `submitFn`. All tests that check `stopCalls`/`removeCalls` are updated to check `terminateCalls`.
+
+#### `main.go` wiring diff (key changes)
+
+```go
+// Before:
+containerMgr, err := dockeradapter.NewDockerContainerManager(cfg.Docker.Host, logger)
+// ...
+agentCfg := actionadapter.AgentConfig{
+    NetworkName: cfg.Docker.AgentNetwork,
+    // ...
+}
+agentRunAction := actionadapter.NewAgentRunAction(containerMgr, logStreamer, ...)
+// ...
+orphanCleaner := service.NewOrphanCleaner(containerMgr, runRepo, logger)
+timeoutEnforcer := service.NewTimeoutEnforcer(containerMgr, ...)
+
+// After:
+runner, err := dockeradapter.NewDockerRunner(cfg.Docker.Host, cfg.Docker.AgentNetwork, logger)
+// ...
+agentCfg := actionadapter.AgentConfig{
+    // NetworkName removed
+    // ...
+}
+agentRunAction := actionadapter.NewAgentRunAction(runner, logStreamer, ...)
+// ...
+orphanCleaner := service.NewOrphanCleaner(runner, runRepo, logger)
+timeoutEnforcer := service.NewTimeoutEnforcer(runner, ...)
+```
+
+### References
+
+- `port/runner.go` created in story refactor-1
+- `model/agent_spec.go` created in story refactor-1
+- `adapter/docker/runner.go` created in story refactor-1
+- DB column rename deferred to story refactor-3
+- `model/run.go` `RunStep.ContainerID` field stays as-is until story refactor-3

--- a/_bmad-output/implementation-artifacts/refactor-3-db-migration-workload-handle-cleanup.md
+++ b/_bmad-output/implementation-artifacts/refactor-3-db-migration-workload-handle-cleanup.md
@@ -1,0 +1,226 @@
+# Story refactor-3: DB Migration and Final Cleanup
+
+**Status:** ready-for-dev
+
+**Blocked by:** refactor-2 (all consumers must be on `Runner` before renaming the DB column)
+
+## Story
+
+As a backend developer, I want to rename the `container_id` column in `run_steps` to `workload_handle`, update the sqlc queries and generated code, align the domain model field name, and delete all remaining dead code, so that the codebase is fully consistent with the new runtime-agnostic vocabulary.
+
+## Acceptance Criteria
+
+**AC1: Migration `000024` renames the column**
+- Given migration `000024_rename_container_id_to_workload_handle.up.sql` is applied
+- When the `run_steps` table is inspected
+- Then the column `container_id` is renamed to `workload_handle`
+- And the rollback migration `000024_rename_container_id_to_workload_handle.down.sql` renames it back to `container_id`
+- And the column type (`VARCHAR(255)`) and nullability (`NULL`) are unchanged
+
+**AC2: sqlc queries reference `workload_handle`**
+- Given `backend/queries/run_steps.sql` is updated
+- When sqlc code generation runs (`cd backend && sqlc generate`)
+- Then all references to `container_id` are replaced with `workload_handle`
+- And the queries `UpdateRunStepStatus` and `UpdateRunStepContainerInfo` use `workload_handle`
+- And the `sqlc.narg('container_id')` expressions are updated to `sqlc.narg('workload_handle')`
+
+**AC3: Generated sqlc code is regenerated**
+- Given `backend/internal/adapter/postgres/db/` contains sqlc-generated files
+- When `sqlc generate` is run
+- Then the generated Go structs no longer have a `ContainerID pgtype.Text` field
+- And they have a `WorkloadHandle pgtype.Text` field instead
+- And the generated params types (`UpdateRunStepStatusParams`, `UpdateRunStepContainerInfoParams`) reflect the rename
+
+**AC4: `model/run.go` renames `ContainerID` to `WorkloadHandle`**
+- Given `RunStep` struct is updated
+- When the domain model is used
+- Then `RunStep.ContainerID *string` is renamed to `RunStep.WorkloadHandle *string`
+
+**AC5: `adapter/postgres/run_repo.go` is updated**
+- Given `run_repo.go` is updated
+- When `UpdateRunStepContainerInfo` is called
+- Then the params struct field `ContainerID` is referenced as `WorkloadHandle`
+- And `toDomainRunStep` maps `row.WorkloadHandle` to `step.WorkloadHandle`
+- And the method signature remains `UpdateRunStepContainerInfo(ctx, id, handle *string, logTail *string) (*model.RunStep, error)`
+
+**AC6: `adapter/action/agent_run.go` is updated**
+- Given `persistHandle` in `agent_run.go` calls `runRepo.UpdateRunStepContainerInfo`
+- When the code compiles
+- Then it continues to compile without modification (the method signature is unchanged; only the internal implementation changes)
+
+**AC7: No remaining references to `ContainerID` or `container_id` in domain/adapter code**
+- Given the rename is complete
+- When the codebase is grep'd for `ContainerID` in `internal/domain` and `internal/adapter`
+- Then zero occurrences are found (except in comments and migration rollback file)
+
+**AC8: All tests pass and lint is clean**
+- Given the migration and code updates are applied
+- When `go test ./... -short` runs
+- Then all tests pass
+- And `golangci-lint run ./...` reports zero errors
+
+## Tasks / Subtasks
+
+- [ ] Create migration `000024_rename_container_id_to_workload_handle.up.sql` (AC: #1)
+- [ ] Create migration `000024_rename_container_id_to_workload_handle.down.sql` (AC: #1)
+- [ ] Update `backend/queries/run_steps.sql`: replace `container_id` with `workload_handle` (AC: #2)
+- [ ] Run `cd backend && sqlc generate` to regenerate `internal/adapter/postgres/db/` (AC: #3)
+- [ ] Update `backend/internal/domain/model/run.go`: rename `ContainerID *string` to `WorkloadHandle *string` in `RunStep` (AC: #4)
+- [ ] Update `backend/internal/adapter/postgres/run_repo.go` (AC: #5)
+  - [ ] Update `UpdateRunStepContainerInfo` to use `params.WorkloadHandle` instead of `params.ContainerID`
+  - [ ] Update `toDomainRunStep` to map `row.WorkloadHandle` to `step.WorkloadHandle`
+  - [ ] Update `UpdateRunStepStatus` params if `container_id` appears there too
+- [ ] Verify `adapter/action/agent_run.go` still compiles without changes (AC: #6)
+- [ ] Grep for residual `ContainerID` and `container_id` references in `internal/` (AC: #7)
+- [ ] Run `go build ./...` (AC: #8)
+- [ ] Run `go test ./... -short` (AC: #8)
+- [ ] Run `golangci-lint run ./...` (AC: #8)
+
+## Dev Notes
+
+### Dependencies
+
+- Story refactor-2 must be merged before this story
+- `sqlc` must be installed in the dev environment (`cd backend && sqlc generate`)
+- Migration numbering: the last migration is `000023` (two files: `create_password_reset_tokens_table` and `create_revoked_tokens_table` both use `000023`). Use `000024` for this migration.
+
+### File Paths
+
+| Action | Path |
+|--------|------|
+| CREATE | `backend/migrations/000024_rename_container_id_to_workload_handle.up.sql` |
+| CREATE | `backend/migrations/000024_rename_container_id_to_workload_handle.down.sql` |
+| MODIFY | `backend/queries/run_steps.sql` |
+| REGENERATE | `backend/internal/adapter/postgres/db/` (via `sqlc generate`) |
+| MODIFY | `backend/internal/domain/model/run.go` |
+| MODIFY | `backend/internal/adapter/postgres/run_repo.go` |
+
+### Technical Specifications
+
+#### Migration files
+
+`000024_rename_container_id_to_workload_handle.up.sql`:
+```sql
+ALTER TABLE run_steps RENAME COLUMN container_id TO workload_handle;
+```
+
+`000024_rename_container_id_to_workload_handle.down.sql`:
+```sql
+ALTER TABLE run_steps RENAME COLUMN workload_handle TO container_id;
+```
+
+Simple `RENAME COLUMN` — no data migration needed, no type change, no constraint change.
+
+#### `queries/run_steps.sql` — updated queries
+
+The two queries that reference `container_id` are `UpdateRunStepStatus` and `UpdateRunStepContainerInfo`. After the rename:
+
+```sql
+-- name: UpdateRunStepStatus :one
+UPDATE run_steps
+SET status = $2,
+    started_at = COALESCE(sqlc.narg('started_at'), started_at),
+    completed_at = COALESCE(sqlc.narg('completed_at'), completed_at),
+    error_message = COALESCE(sqlc.narg('error_message'), error_message),
+    workload_handle = COALESCE(sqlc.narg('workload_handle'), workload_handle),
+    log_tail = COALESCE(sqlc.narg('log_tail'), log_tail)
+WHERE id = $1
+RETURNING *;
+
+-- name: UpdateRunStepContainerInfo :one
+UPDATE run_steps
+SET workload_handle = COALESCE(sqlc.narg('workload_handle'), workload_handle),
+    log_tail = COALESCE(sqlc.narg('log_tail'), log_tail)
+WHERE id = $1
+RETURNING *;
+```
+
+All other queries (`CreateRunStep`, `GetRunStep`, `ListRunStepsByRun`, `CreateRetryRunStep`, `ListRetryStepsByParent`) use `SELECT *` or explicit column lists that do not include `container_id` by name — verify with `grep` and update if needed.
+
+#### `model/run.go` — field rename
+
+```go
+// RunStep struct
+type RunStep struct {
+    ID             uuid.UUID
+    RunID          uuid.UUID
+    StepName       string
+    StepOrder      int
+    Action         string
+    Status         StepStatus
+    StartedAt      *time.Time
+    CompletedAt    *time.Time
+    ErrorMessage   *string
+    WorkloadHandle *string   // renamed from ContainerID
+    LogTail        *string
+    RetryCount     int
+    RetryType      *string
+    ParentStepID   *uuid.UUID
+    CreatedAt      time.Time
+}
+```
+
+#### `adapter/postgres/run_repo.go` — diff
+
+```go
+// UpdateRunStepContainerInfo
+func (r *RunRepo) UpdateRunStepContainerInfo(ctx context.Context, id uuid.UUID, handle *string, logTail *string) (*model.RunStep, error) {
+    params := UpdateRunStepContainerInfoParams{ID: id}
+    if handle != nil {
+        params.WorkloadHandle = pgtype.Text{String: *handle, Valid: true}  // was ContainerID
+    }
+    if logTail != nil {
+        params.LogTail = pgtype.Text{String: *logTail, Valid: true}
+    }
+    row, err := r.queries.UpdateRunStepContainerInfo(ctx, params)
+    // ...
+    return toDomainRunStep(row), nil
+}
+
+// toDomainRunStep
+func toDomainRunStep(s RunStep) *model.RunStep {
+    step := &model.RunStep{
+        // ...
+    }
+    if s.WorkloadHandle.Valid {                         // was s.ContainerID
+        step.WorkloadHandle = &s.WorkloadHandle.String  // was step.ContainerID
+    }
+    // ...
+    return step
+}
+```
+
+Also update `UpdateRunStepStatus` params if the generated struct includes `WorkloadHandle` (check generated code after `sqlc generate`).
+
+#### sqlc generation
+
+After editing `queries/run_steps.sql`, run:
+```bash
+cd backend && sqlc generate
+```
+
+The generated files in `internal/adapter/postgres/db/` are auto-generated — do NOT manually edit them. If sqlc generates a `ContainerID` field anywhere, it means the query file still contains `container_id` — fix the query and regenerate.
+
+#### Residual reference check
+
+After all edits, run the following to confirm no stale references remain:
+```bash
+grep -rn "ContainerID\|container_id" \
+  backend/internal/domain/ \
+  backend/internal/adapter/ \
+  --include="*.go"
+```
+
+Expected: zero matches. The only legitimate occurrence of `container_id` is in the rollback migration file and possibly in SQL comments — both are acceptable.
+
+#### `UpdateRunStepStatus` in `run_steps.sql`
+
+The existing query includes `container_id = COALESCE(sqlc.narg('container_id'), container_id)`. This line should be removed from `UpdateRunStepStatus` unless there is a concrete use case that still needs to set the handle via this query. At the time of writing (stories refactor-1 through refactor-3), the handle is only set via `UpdateRunStepContainerInfo`. Remove the `workload_handle` line from `UpdateRunStepStatus` to keep the query minimal, unless existing callers rely on it. Verify with `grep -rn "UpdateRunStepStatus"` in the codebase before removing.
+
+### References
+
+- Migration naming convention: `backend/migrations/000001_create_users_table.up.sql` (zero-padded 6 digits, underscore-separated description)
+- sqlc config: `backend/sqlc.yaml`
+- Generated output directory: `backend/internal/adapter/postgres/db/`
+- `run_repo.go` method `toDomainRunStep` at line ~312 maps `ContainerID.Valid` to `step.ContainerID`
+- Stories refactor-1 and refactor-2 must be fully merged and CI green before starting this story

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -171,6 +171,12 @@ development_status:
   feat-5-user-profile-page: done
   feat-6-reset-password-pages: done
 
+  # Post-MVP: Runner Abstraction Refactoring
+  post-mvp-runner-refactor: done
+  refactor-1-runner-interface-agent-spec-model: done
+  refactor-2-migrate-consumers-to-runner: done
+  refactor-3-db-migration-workload-handle-cleanup: done
+
   # Post-MVP: E2E Usability Fixes
   post-mvp-e2e-usability: backlog
 
@@ -773,3 +779,39 @@ parallel_waves:
     container_count: 3
     depends_on: [wave-22]
     notes: "Frontend fixes: regen API types, project repo form, runs page + dashboard + sidebar — all parallel"
+
+  # =====================================================
+  # PHASE 8: RUNNER ABSTRACTION (Container → Runner refactoring)
+  # =====================================================
+
+  wave-24:
+    phase: 8-runner-refactor
+    stories:
+      - key: refactor-1-runner-interface-agent-spec-model
+        domain: back
+        status: done
+    container_count: 1
+    depends_on: [wave-23]
+    notes: "Create Runner interface (4 methods), AgentSpec model, Docker adapter — additive, no breaking changes"
+
+  wave-25:
+    phase: 8-runner-refactor
+    stories:
+      - key: refactor-2-migrate-consumers-to-runner
+        domain: back
+        status: done
+        explicit_deps: [refactor-1-runner-interface-agent-spec-model]
+    container_count: 1
+    depends_on: [wave-24]
+    notes: "Migrate agent_run, orphan_cleaner, timeout_enforcer to Runner — delete ContainerManager"
+
+  wave-26:
+    phase: 8-runner-refactor
+    stories:
+      - key: refactor-3-db-migration-workload-handle-cleanup
+        domain: back
+        status: done
+        explicit_deps: [refactor-2-migrate-consumers-to-runner]
+    container_count: 1
+    depends_on: [wave-25]
+    notes: "DB migration container_id → workload_handle, sqlc regen, final cleanup"


### PR DESCRIPTION
## Summary
- Add 3 story files for the ContainerManager → Runner abstraction refactor (refactor-1/2/3)
- Update sprint-status.yaml with new phase 8 waves (24-25-26), all marked done
- Resolve stash conflict on Epic 10 status

## Test plan
- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)