### PR TITLE
docs(stories): reconcile sprint status — mark fix-9 through fix-14 as done

### DIFF
--- a/_bmad-output/implementation-artifacts/1-21-sprint-status-reconciliation.md
+++ b/_bmad-output/implementation-artifacts/1-21-sprint-status-reconciliation.md
@@ -1,0 +1,68 @@
+# Story 1-21: [SHARED] Sprint status reconciliation — mark merged stories as done
+
+Status: done
+
+## Story
+
+As a project maintainer,
+I want the sprint-status.yaml to accurately reflect the actual state of all merged stories,
+so that project tracking is reliable and future pipeline decisions use correct dependency data.
+
+## Context
+
+The sprint-status.yaml file has drifted from reality. Multiple stories (fix-9 through fix-14, refactor-1 through refactor-3, and the post-mvp-e2e-usability epic) are shown as "backlog", "review", or "dev-complete" despite being fully implemented, merged via PRs, and present on the develop branch.
+
+This was discovered during a codebase health audit: all 536 frontend tests pass, all backend tests pass with race detection, lint and type-check are clean, but the tracking file is stale.
+
+### Affected stories (all confirmed merged to develop)
+
+| Story | Was | Now | PR |
+|-------|-----|-----|----|
+| fix-9-backend-wiring | review | done | #119 |
+| fix-10-openapi-project-fields | review | done | #118 |
+| fix-11-missing-service-methods | dev-complete | done | #120 |
+| fix-12-frontend-api-regen | backlog | done | #121 |
+| fix-13-project-repo-form | backlog | done | #123 |
+| fix-14-runs-dashboard-routing | backlog | done | #122 |
+| post-mvp-e2e-usability (epic) | backlog | done | — |
+
+## Acceptance Criteria (BDD)
+
+**AC1: All merged stories are marked as done**
+- **Given** stories fix-9 through fix-14 have been merged to develop via PRs
+- **When** the sprint-status.yaml is updated
+- **Then** all six stories show `status: done` and the `post-mvp-e2e-usability` epic shows `done`
+
+**AC2: Wave statuses reflect completion**
+- **Given** all stories in wave-22 and wave-23 are done
+- **When** the sprint-status.yaml is updated
+- **Then** wave-22 and wave-23 story entries show `status: done`
+
+**AC3: No false positives**
+- **Given** the update is based on git log evidence (merged PRs)
+- **When** compared against the develop branch
+- **Then** no story is marked done unless its corresponding PR commit exists on develop
+
+## Tasks / Subtasks
+
+- [x] [SHARED] Task 1: Audit develop branch git log to confirm merged PRs (AC: #3)
+- [x] [SHARED] Task 2: Update sprint-status.yaml — mark fix-9 through fix-14 and epic as done (AC: #1, #2)
+
+## Dev Agent Record
+
+**Agent:** Claude Opus 4.6
+**Branch:** feat/1-21
+**Date:** 2026-02-22
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `_bmad-output/implementation-artifacts/sprint-status.yaml` | Mark fix-9 through fix-14 as done, mark post-mvp-e2e-usability epic as done |
+| `_bmad-output/implementation-artifacts/1-21-sprint-status-reconciliation.md` | New — story definition |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-22 | dev-agent | Story created and implemented |

--- a/_bmad-output/implementation-artifacts/fix-10-openapi-project-fields.md
+++ b/_bmad-output/implementation-artifacts/fix-10-openapi-project-fields.md
@@ -1,6 +1,6 @@
 # Story fix-10: [SHARED] Expose project infrastructure fields in OpenAPI spec
 
-Status: review
+Status: done
 
 ## Story
 

--- a/_bmad-output/implementation-artifacts/fix-11-missing-service-methods.md
+++ b/_bmad-output/implementation-artifacts/fix-11-missing-service-methods.md
@@ -1,6 +1,6 @@
 # Story fix-11: Missing service methods for 501 endpoints
 
-Status: dev-complete
+Status: done
 
 ## Story
 

--- a/_bmad-output/implementation-artifacts/fix-12-frontend-api-regen.md
+++ b/_bmad-output/implementation-artifacts/fix-12-frontend-api-regen.md
@@ -1,6 +1,6 @@
 # Story fix-12: [FRONT] Regenerate API schema and fix type safety issues
 
-Status: ready-for-dev
+Status: done
 
 ## Story
 

--- a/_bmad-output/implementation-artifacts/fix-13-project-repo-form.md
+++ b/_bmad-output/implementation-artifacts/fix-13-project-repo-form.md
@@ -1,6 +1,6 @@
 # Story fix-13: [FRONT] Expose repo URL and pipeline config fields in project forms
 
-Status: ready-for-dev
+Status: done
 
 ## Story
 

--- a/_bmad-output/implementation-artifacts/fix-14-runs-dashboard-routing.md
+++ b/_bmad-output/implementation-artifacts/fix-14-runs-dashboard-routing.md
@@ -1,6 +1,6 @@
 # Story fix-14: [FRONT] Runs dashboard, sidebar routing, and project runs tab
 
-Status: ready-for-dev
+Status: done
 
 ## Story
 

--- a/_bmad-output/implementation-artifacts/fix-9-backend-wiring.md
+++ b/_bmad-output/implementation-artifacts/fix-9-backend-wiring.md
@@ -1,6 +1,6 @@
 # Story fix-9: [BACK] Fix backend wiring — missing server.go delegations, nil pipeline executor dependencies, and missing role in auth response
 
-Status: review
+Status: done
 
 ## Story
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,4 +1,4 @@
-# generated: 2026-02-21
+# generated: 2026-02-22
 # project: hopeitworks
 # project_key: NOKEY
 # tracking_system: file-system
@@ -33,7 +33,7 @@
 # - SM typically creates next story after previous one is 'done' to incorporate learnings
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
-generated: 2026-02-21
+generated: 2026-02-22
 project: hopeitworks
 project_key: NOKEY
 tracking_system: file-system
@@ -178,14 +178,13 @@ development_status:
   refactor-3-db-migration-workload-handle-cleanup: done
 
   # Post-MVP: E2E Usability Fixes
-  post-mvp-e2e-usability: backlog
-
-  fix-9-backend-wiring: review
-  fix-10-openapi-project-fields: review
-  fix-11-missing-service-methods: dev-complete
-  fix-12-frontend-api-regen: backlog
-  fix-13-project-repo-form: backlog
-  fix-14-runs-dashboard-routing: backlog
+  post-mvp-e2e-usability: done
+  fix-9-backend-wiring: done
+  fix-10-openapi-project-fields: done
+  fix-11-missing-service-methods: done
+  fix-12-frontend-api-regen: done
+  fix-13-project-repo-form: done
+  fix-14-runs-dashboard-routing: done
 
 # PARALLEL EXECUTION WAVES
 # =================
@@ -751,13 +750,13 @@ parallel_waves:
     stories:
       - key: fix-9-backend-wiring
         domain: back
-        status: backlog
+        status: done
       - key: fix-10-openapi-project-fields
         domain: shared
-        status: backlog
+        status: done
       - key: fix-11-missing-service-methods
         domain: back
-        status: backlog
+        status: done
     container_count: 3
     depends_on: [wave-21]
     notes: "Backend fixes: server.go delegations, PipelineExecutor nil, auth role, OpenAPI project fields, missing service methods — all parallel"
@@ -767,15 +766,15 @@ parallel_waves:
     stories:
       - key: fix-12-frontend-api-regen
         domain: front
-        status: backlog
+        status: done
         explicit_deps: [fix-10-openapi-project-fields]
       - key: fix-13-project-repo-form
         domain: front
-        status: backlog
+        status: done
         explicit_deps: [fix-10-openapi-project-fields, fix-12-frontend-api-regen]
       - key: fix-14-runs-dashboard-routing
         domain: front
-        status: backlog
+        status: done
     container_count: 3
     depends_on: [wave-22]
     notes: "Frontend fixes: regen API types, project repo form, runs page + dashboard + sidebar — all parallel"


### PR DESCRIPTION
## Summary

- Reconcile `sprint-status.yaml` with actual develop branch state — 6 stories (fix-9 through fix-14) were merged via PRs #118–#123 but still showed as backlog/review/dev-complete
- Mark `post-mvp-e2e-usability` epic and all its stories as `done` in both the development_status section and parallel_waves section
- Update individual story files (fix-9 through fix-14) to `Status: done`
- Add story artifact `1-21-sprint-status-reconciliation.md` documenting the reconciliation

## Test plan

- [x] Verify YAML file is syntactically valid and all status values are correct
- [x] Cross-reference each story status change against git log (PRs #118–#123 confirmed merged)
- [x] Confirm no code changes — documentation/tracking only
- [x] Backend builds and tests pass (all 24 test packages green)
- [x] Frontend lint, type-check, and tests pass (536 tests, 62 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)