### PR TITLE
docs(stories): add runtime stories and update sprint status

### DIFF
--- a/_bmad-output/implementation-artifacts/runtime-1-agent-docker-image.md
+++ b/_bmad-output/implementation-artifacts/runtime-1-agent-docker-image.md
@@ -1,0 +1,230 @@
+# Story runtime-1: Agent Docker Image and Entrypoint
+
+**Status:** ready-for-dev
+**Branch:** `feat/runtime-1-agent-docker-image`
+**Commit scope:** `agent`
+
+---
+
+## Story
+
+As the hopeitworks pipeline executor, I need a Docker image (`hopeitworks/agent:latest`) that can be launched as a container, clone a git repository, check out the correct branch, inject a CLAUDE.md file, execute a Claude Code agent with a rendered prompt, stream structured NDJSON logs back to the platform, and exit with an appropriate code — so that `AgentRunAction` can orchestrate real agent runs end-to-end.
+
+---
+
+## Acceptance Criteria
+
+**AC #1 — Image builds without error**
+- Given `agent/Dockerfile` exists in the repository root
+- When `docker build -t hopeitworks/agent:latest agent/` is executed
+- Then the build succeeds and the image is tagged `hopeitworks/agent:latest`
+
+**AC #2 — Container starts and clones repo**
+- Given the image is built and env vars `REPO_URL`, `BRANCH_NAME`, `GITHUB_TOKEN` are provided
+- When the container starts
+- Then it clones `REPO_URL`, checks out `BRANCH_NAME` (creating the branch if it does not exist), and prints a structured startup message to stdout
+
+**AC #3 — CLAUDE.md is injected before agent launch**
+- Given env var `CLAUDE_MD_CONTENT` is set (multi-line string)
+- When the entrypoint runs
+- Then it writes `CLAUDE_MD_CONTENT` to `/workspace/CLAUDE.md` before invoking Claude Code
+
+**AC #4 — Agent is invoked with PROMPT_CONTENT**
+- Given env var `PROMPT_CONTENT` contains the rendered agent prompt
+- When the entrypoint runs
+- Then Claude Code is invoked with `--print --dangerously-skip-permissions` passing the prompt via stdin or file
+
+**AC #5 — Logs are streamed as NDJSON**
+- Given the agent is running
+- When it emits output
+- Then each line is either a valid JSON object (`{"type":"log","message":"..."}`) or forwarded as-is if already JSON — compatible with `DockerLogStreamer`'s NDJSON parsing
+
+**AC #6 — Cost events are emitted**
+- Given the agent session completes
+- When Claude Code outputs token usage information
+- Then the entrypoint emits a JSON line `{"type":"cost","input_tokens":N,"output_tokens":N,"model":"..."}` to stdout
+
+**AC #7 — Exit code propagation**
+- Given the agent exits with code 0 (success) or non-zero (failure)
+- When the container exits
+- Then the container exit code matches the agent exit code — allowing `AgentRunAction.streamAndWait()` to detect failure
+
+**AC #8 — Non-root execution**
+- Given the container is started
+- When Claude Code runs
+- Then it runs as a non-root user (Claude Code refuses root with `--dangerously-skip-permissions`)
+
+**AC #9 — GitHub auth configured**
+- Given `GITHUB_TOKEN` or `CLAUDE_CODE_OAUTH_TOKEN` env vars are set
+- When git push or gh CLI commands are executed by the agent
+- Then they authenticate successfully without interactive prompts
+
+---
+
+## Tasks / Subtasks
+
+- [ ] **T1.** Create `agent/Dockerfile` — multi-stage build (AC: #1, #2, #8)
+  - [ ] T1.1 Base stage: `node:22-bookworm` with git, curl, jq, gh CLI
+  - [ ] T1.2 Install Claude Code CLI: `npm install -g @anthropic-ai/claude-code`
+  - [ ] T1.3 Create non-root user `agent` with home `/home/agent`, workspace `/workspace`
+  - [ ] T1.4 Copy `agent/entrypoint.sh` and make executable
+  - [ ] T1.5 Set `ENTRYPOINT ["/entrypoint.sh"]` and `USER agent`
+
+- [ ] **T2.** Create `agent/entrypoint.sh` — runtime entrypoint (AC: #2, #3, #4, #5, #6, #7, #9)
+  - [ ] T2.1 Clone `REPO_URL` with token injection for HTTPS auth (same pattern as `scripts/entrypoint.sh` lines 26-29)
+  - [ ] T2.2 Check out `BRANCH_NAME` — create if it does not exist on remote, fetch if it does
+  - [ ] T2.3 Configure git user identity (`GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL` with defaults)
+  - [ ] T2.4 Write `CLAUDE_MD_CONTENT` env var to `/workspace/CLAUDE.md`
+  - [ ] T2.5 Write `PROMPT_CONTENT` env var to `/tmp/prompt.md`
+  - [ ] T2.6 Configure `gh auth` via token (export `GH_TOKEN=$GITHUB_TOKEN`)
+  - [ ] T2.7 Invoke Claude Code: `claude --dangerously-skip-permissions --print < /tmp/prompt.md`
+  - [ ] T2.8 Capture exit code and exit with it (propagate to container exit code)
+  - [ ] T2.9 Emit cost event line to stdout after agent completes (parse from Claude Code output or emit placeholder)
+
+- [ ] **T3.** Build and tag image locally (AC: #1)
+  - [ ] T3.1 Run `docker build -t hopeitworks/agent:latest agent/` from repo root
+  - [ ] T3.2 Verify image size is reasonable (< 2GB)
+
+- [ ] **T4.** Smoke test the container (AC: #2, #3, #7)
+  - [ ] T4.1 Run container with a real (or test) `REPO_URL`, `BRANCH_NAME`, `CLAUDE_MD_CONTENT`, `PROMPT_CONTENT`
+  - [ ] T4.2 Verify it clones, writes CLAUDE.md, invokes Claude, exits with correct code
+  - [ ] T4.3 Verify container logs contain NDJSON lines
+
+---
+
+## Dev Notes
+
+### Dependencies
+
+- Docker must be available on the build machine
+- `CLAUDE_CODE_OAUTH_TOKEN` required for Claude Code authentication at runtime
+- `GITHUB_TOKEN` required for git clone/push of private repos
+
+### File Paths
+
+| File | Purpose |
+|------|---------|
+| `agent/Dockerfile` | New file — runtime agent image |
+| `agent/entrypoint.sh` | New file — container entrypoint |
+| `scripts/Dockerfile.dev-agent` | REFERENCE only — do NOT modify |
+| `scripts/entrypoint.sh` | REFERENCE only — do NOT modify |
+| `backend/internal/adapter/action/agent_run.go` | Consumer of this image — reads exit code and NDJSON logs |
+
+### Technical Specifications
+
+**Dockerfile structure:**
+
+```dockerfile
+FROM node:22-bookworm
+
+# System dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update && apt-get install -y gh && rm -rf /var/lib/apt/lists/*
+
+# Claude Code CLI
+RUN npm install -g @anthropic-ai/claude-code
+
+# Non-root user (claude --dangerously-skip-permissions refuses root)
+RUN useradd -m -s /bin/bash agent \
+    && mkdir -p /workspace /home/agent/.config/gh \
+    && chown -R agent:agent /workspace /home/agent
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+USER agent
+WORKDIR /workspace
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+**Environment variables consumed by the container:**
+
+| Var | Required | Description |
+|-----|----------|-------------|
+| `REPO_URL` | Yes | HTTPS URL of the git repository to clone |
+| `BRANCH_NAME` | Yes | Branch to checkout (create if absent) |
+| `CLAUDE_MD_CONTENT` | Yes | Full content of CLAUDE.md to inject |
+| `PROMPT_CONTENT` | Yes | Rendered agent prompt |
+| `GITHUB_TOKEN` | Yes | Token for git clone/push and gh CLI auth |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Yes | OAuth token for Claude Code |
+| `STORY_KEY` | No | Used for git commit context (passed via env) |
+| `GIT_AUTHOR_NAME` | No | Git author name (default: `hopeitworks-agent`) |
+| `GIT_AUTHOR_EMAIL` | No | Git author email (default: `agent@hopeitworks.local`) |
+
+**NDJSON log format expected by `DockerLogStreamer`:**
+
+Each line from the container that is valid JSON is parsed. The `agent_run.go` consumer reads:
+- `{"type":"log","message":"..."}` — forwarded to event system
+- `{"type":"cost","input_tokens":N,"output_tokens":N,"model":"..."}` — accumulated for cost recording
+
+Lines that are not valid JSON are wrapped as `{"type":"log","message":"<raw line>"}` by the log streamer.
+
+**Token injection for git clone (from `scripts/entrypoint.sh` reference):**
+
+```bash
+CLONE_URL="$REPO_URL"
+if [[ -n "${GITHUB_TOKEN:-}" ]] && [[ "$CLONE_URL" == https://github.com/* ]]; then
+    CLONE_URL="${CLONE_URL/https:\/\/github.com/https://${GITHUB_TOKEN}@github.com}"
+fi
+git clone --branch develop --single-branch "$CLONE_URL" /workspace
+```
+
+**Branch checkout logic:**
+
+```bash
+if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+    git fetch origin "$BRANCH_NAME:$BRANCH_NAME"
+    git checkout "$BRANCH_NAME"
+else
+    git checkout -b "$BRANCH_NAME"
+fi
+```
+
+**Claude Code invocation:**
+
+```bash
+echo "$PROMPT_CONTENT" | claude --dangerously-skip-permissions --print
+EXIT_CODE=$?
+```
+
+The `--print` flag runs Claude Code non-interactively. The prompt is passed via stdin.
+
+**Cost event emission:**
+
+After the agent exits, parse Claude Code's final output for token usage or emit a cost event. Claude Code outputs token usage in JSON when `--output-format json` is used. If not parseable, emit a zero-cost placeholder so the log streamer is not blocked:
+
+```bash
+echo '{"type":"cost","input_tokens":0,"output_tokens":0,"model":"unknown"}'
+```
+
+### Key Difference vs `scripts/Dockerfile.dev-agent`
+
+The dev-agent image (`scripts/Dockerfile.dev-agent`) is for the BMAD development pipeline — it includes Go tooling, sqlc, oapi-codegen, golangci-lint, and pipeline orchestration scripts. It is heavy (~several GB) and runs the full dev→review→merge cycle.
+
+The **runtime agent image** (`agent/Dockerfile`) is intentionally minimal:
+- Only: Node.js + git + gh CLI + Claude Code
+- No Go toolchain, no build tools
+- Purpose: run a single agent step (implement OR review OR merge) as directed by `PROMPT_CONTENT`
+- The prompt template determines what the agent does — the image is generic
+
+### Testing Requirements
+
+- Build the image locally and verify it exits 0
+- Run with a mock prompt: `PROMPT_CONTENT="echo hello" REPO_URL=... BRANCH_NAME=test-branch ...`
+- Verify `/workspace/CLAUDE.md` exists inside the container after entrypoint executes (use `docker run --entrypoint bash` for inspection)
+- Verify non-root user with `docker run ... whoami`
+
+### References
+
+- `scripts/Dockerfile.dev-agent` — reference BMAD dev image (heavier, not for runtime)
+- `scripts/entrypoint.sh` — reference BMAD entrypoint (pipeline mode, not for runtime)
+- `backend/internal/adapter/action/agent_run.go` — how the image is launched (env vars, container opts)
+- `backend/internal/adapter/docker/` — DockerContainerManager and DockerLogStreamer implementations

--- a/_bmad-output/implementation-artifacts/runtime-2-action-wiring-and-action-type-mapping.md
+++ b/_bmad-output/implementation-artifacts/runtime-2-action-wiring-and-action-type-mapping.md
@@ -1,0 +1,218 @@
+# Story runtime-2: Action Wiring and action_type Mapping
+
+**Status:** ready-for-dev
+**Branch:** `feat/runtime-2-action-wiring-action-type-mapping`
+**Commit scope:** `pipeline`
+
+---
+
+## Story
+
+As the pipeline executor, I need all action types defined in the pipeline config (`implement`, `review`, `merge`, `ci_poll`, `hitl_gate`) to resolve correctly from the action registry — so that launching a run on the todo app does not fail with `ACTION_NOT_FOUND` for any step.
+
+Currently:
+- `ci_poll` and `hitl_gate` adapters exist with tests but are never registered in `main.go`
+- The default pipeline config uses `action_type: implement/review/merge` but the registry only contains `agent_run` and `incremental_retry`
+- `pipeline_executor.go` resolves actions via `actionReg.Get(step.Action)` where `step.Action = stepCfg.ActionType` (set in `run_service.go` line 336)
+
+---
+
+## Acceptance Criteria
+
+**AC #1 — `ci_poll` is registered at startup**
+- Given the backend starts with a valid Docker connection
+- When `actionReg.Get("ci_poll")` is called
+- Then it returns the `CIPollAction` instance (not an error)
+
+**AC #2 — `hitl_gate` is registered at startup**
+- Given the backend starts
+- When `actionReg.Get("hitl_gate")` is called
+- Then it returns the `HITLGateAction` instance (not an error)
+
+**AC #3 — `implement` resolves to `AgentRunAction`**
+- Given the action registry is populated
+- When the pipeline executor processes a step with `action = "implement"`
+- Then `actionReg.Get("implement")` returns the `AgentRunAction` (same instance as `agent_run`)
+
+**AC #4 — `review` resolves to `AgentRunAction`**
+- Given the action registry is populated
+- When the pipeline executor processes a step with `action = "review"`
+- Then `actionReg.Get("review")` returns the `AgentRunAction`
+
+**AC #5 — `merge` resolves to `AgentRunAction`**
+- Given the action registry is populated
+- When the pipeline executor processes a step with `action = "merge"`
+- Then `actionReg.Get("merge")` returns the `AgentRunAction`
+
+**AC #6 — Template name is derived from action_type**
+- Given an `AgentRunAction` executing a step with `action = "review"`
+- When `resolveTemplateName` is called on the run context
+- Then it returns `service.TemplateNameReview` (not `service.TemplateNameImplement`)
+
+**AC #7 — `agent_run` still resolves (no regression)**
+- Given the registry after all changes
+- When `actionReg.Get("agent_run")` is called
+- Then it still returns the `AgentRunAction`
+
+**AC #8 — No panics or nil pointer dereferences at startup**
+- Given all actions are registered
+- When the backend starts and the action registry is fully wired
+- Then `golangci-lint run ./...` passes and `go test ./... -short` passes
+
+**AC #9 — `validatePipelineConfigYAML` does not reject `ci_poll` or `hitl_gate`**
+- Given `action_type: ci_poll` or `action_type: hitl_gate` in a pipeline config
+- When `validatePipelineConfigYAML` is called
+- Then validation passes (these are now valid action types)
+
+---
+
+## Tasks / Subtasks
+
+- [ ] **T1.** Register `ci_poll` in `backend/cmd/api/main.go` (AC: #1)
+  - [ ] T1.1 After the `hitlRepo` line (~line 255 in main.go), instantiate `CIPollConfig` with defaults (`DefaultPollInterval: 30*time.Second`, `DefaultTimeout: 15*time.Minute`)
+  - [ ] T1.2 Instantiate `NewCIPollAction(gitProvider, eventRepo, ciPollCfg, logger)` — need to wire a `GitProvider` first (see T1.3)
+  - [ ] T1.3 Instantiate the GitHub adapter `githubadapter.NewGitProvider(runner, logger)` in main.go (currently missing — needed for `CIPollAction`)
+  - [ ] T1.4 Register: `actionReg.Register(ciPollAction)` with log line `logger.Info("ci_poll action registered")`
+
+- [ ] **T2.** Register `hitl_gate` in `backend/cmd/api/main.go` (AC: #2)
+  - [ ] T2.1 Instantiate `NewHITLGateAction(hitlRepo, runRepo, gitProvider, eventRepo, storyRepo, logger)`
+  - [ ] T2.2 Register: `actionReg.Register(hitlGateAction)` with log line `logger.Info("hitl_gate action registered")`
+  - [ ] T2.3 Place registration OUTSIDE the `if containerMgr != nil` block — `hitl_gate` does not require Docker
+
+- [ ] **T3.** Add `RegisterAlias` to `InMemoryActionRegistry` (AC: #3, #4, #5, #7)
+  - [ ] T3.1 Add method `RegisterAlias(alias string, action model.Action)` to `InMemoryActionRegistry` in `backend/internal/domain/service/action_registry.go`
+  - [ ] T3.2 Method stores the action under the alias key (same `actions` map)
+  - [ ] T3.3 Update `port.ActionRegistry` interface in `backend/internal/domain/port/` to include `RegisterAlias` if it exists, OR just use `Register` with a wrapper action (see T3-alt below)
+
+  **Alternative T3-alt (simpler, no interface change):** In `main.go`, after registering `agentRunAction`, call `actionReg.Register` with a thin wrapper type for each alias:
+  ```go
+  // Register action_type aliases for the default pipeline config
+  for _, alias := range []string{"implement", "review", "merge"} {
+      actionReg.RegisterAlias(alias, agentRunAction)
+  }
+  ```
+  Prefer the `RegisterAlias` approach on `InMemoryActionRegistry` directly (no interface change needed since `InMemoryActionRegistry` is used concretely in main.go).
+
+- [ ] **T4.** Propagate `action_type` as `template_name` metadata in `run_service.go` (AC: #6)
+  - [ ] T4.1 In `RunService.LaunchRun()`, when creating `RunStep`, set metadata field to carry the template name derived from `action_type`
+  - [ ] T4.2 Map: `implement` → `service.TemplateNameImplement`, `review` → `service.TemplateNameReview`, `merge` → `service.TemplateNameMerge`
+  - [ ] T4.3 The `RunStep` model may not have a `Metadata` field — if so, store the mapping as `step.Action` stays as-is but inject a `template_name` key into the `metadata` map passed to `RunContext` in `pipeline_executor.go`
+
+  **Investigation note:** Check whether `RunStep.Metadata` or `RunContext.Metadata` is the right place. Looking at `agent_run.go` line 110: `templateName` is read from `runCtx.Metadata["template_name"]`. The `RunContext.Metadata` is a `map[string]any` initialized per-run in `pipeline_executor.go` line 106. The cleanest fix: in `pipeline_executor.go`'s `executeStep()`, before calling `action.Execute()`, set `runCtx.Metadata["template_name"]` based on `step.Action` for the known aliases.
+
+- [ ] **T5.** Update `model.ValidActionTypes` to include `ci_poll` and `hitl_gate` (AC: #9)
+  - [ ] T5.1 In `backend/internal/domain/model/pipeline_config.go`, add `"ci_poll": true` and `"hitl_gate": true` to `ValidActionTypes`
+
+- [ ] **T6.** Lint and test (AC: #8)
+  - [ ] T6.1 Run `cd backend && golangci-lint run ./...` — must pass
+  - [ ] T6.2 Run `cd backend && go test ./... -short` — must pass
+  - [ ] T6.3 Run `cd backend && go test ./internal/integration/ -v -run TestIntegration_PipelineValidation` — must pass
+
+---
+
+## Dev Notes
+
+### Dependencies
+
+- `GitProvider` adapter (`github.com/zakari/hopeitworks/backend/internal/adapter/github`) must be instantiated in `main.go` — it is currently NOT wired (only `AgentRunAction` uses it implicitly via `AgentConfig`, but `CIPollAction` needs it directly)
+- `CommandRunner` from `pkg/exec` is needed by the GitHub adapter
+
+### File Paths
+
+| File | Change |
+|------|--------|
+| `backend/cmd/api/main.go` | Register `ci_poll`, `hitl_gate`; add GitProvider wiring; register aliases `implement`, `review`, `merge` |
+| `backend/internal/domain/service/action_registry.go` | Add `RegisterAlias` method |
+| `backend/internal/domain/service/pipeline_executor.go` | Inject `template_name` into metadata based on `step.Action` aliases |
+| `backend/internal/domain/model/pipeline_config.go` | Add `ci_poll`, `hitl_gate` to `ValidActionTypes` |
+| `backend/internal/domain/port/action.go` (if exists) | No change needed if `RegisterAlias` is not on the interface |
+
+### Technical Specifications
+
+**Wiring `CIPollAction` in `main.go`:**
+
+```go
+// GitHub provider (needed by ci_poll and hitl_gate)
+cmdRunner := exec.NewCommandRunner()
+githubProvider := githubadapter.NewGitProvider(cmdRunner, logger)
+
+// CI Poll action
+ciPollCfg := actionadapter.CIPollConfig{
+    DefaultPollInterval: 30 * time.Second,
+    DefaultTimeout:      15 * time.Minute,
+}
+ciPollAction := actionadapter.NewCIPollAction(githubProvider, eventRepo, ciPollCfg, logger)
+actionReg.Register(ciPollAction)
+logger.Info("ci_poll action registered")
+
+// HITL Gate action (outside containerMgr block — no Docker needed)
+hitlGateAction := actionadapter.NewHITLGateAction(hitlRepo, runRepo, githubProvider, eventRepo, storyRepo, logger)
+actionReg.Register(hitlGateAction)
+logger.Info("hitl_gate action registered")
+```
+
+**`RegisterAlias` in `action_registry.go`:**
+
+```go
+// RegisterAlias registers an action under an alias name.
+// The action is stored under the alias key; its own Name() is not affected.
+func (r *InMemoryActionRegistry) RegisterAlias(alias string, action model.Action) {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    r.actions[alias] = action
+}
+```
+
+**Template name injection in `pipeline_executor.go` `executeStep()`:**
+
+```go
+// actionTypeToTemplateName maps pipeline config action_type aliases to prompt template names.
+var actionTypeToTemplateName = map[string]string{
+    "implement": service.TemplateNameImplement,
+    "review":    service.TemplateNameReview,
+    "merge":     service.TemplateNameMerge,
+}
+
+// In executeStep(), before action.Execute():
+if tmplName, ok := actionTypeToTemplateName[step.Action]; ok {
+    if _, exists := runCtx.Metadata["template_name"]; !exists {
+        runCtx.Metadata["template_name"] = tmplName
+    }
+}
+```
+
+This ensures `implement`, `review`, `merge` steps pick the correct prompt template, while an explicit `template_name` in metadata (from incremental retry) still takes precedence.
+
+**Import paths to add in `main.go`:**
+
+```go
+githubadapter "github.com/zakari/hopeitworks/backend/internal/adapter/github"
+"github.com/zakari/hopeitworks/backend/pkg/exec"
+```
+
+**Verify `TemplateNameReview` and `TemplateNameMerge` exist:**
+
+Check `backend/internal/domain/service/template_service.go` for the `TemplateNameXxx` constants. If `TemplateNameReview` or `TemplateNameMerge` are missing, add them with values `"review"` and `"merge"`.
+
+**Check `CIPollAction` signature — `eventPub` vs `eventRepo`:**
+
+`NewCIPollAction` takes `port.EventPublisher`. In `main.go`, `eventRepo` is `pgadapter.NewEventRepo(queries)` which implements `port.EventPublisher`. Pass `eventRepo` directly.
+
+### Testing Requirements
+
+- `golangci-lint run ./...` must pass (errcheck, revive, staticcheck)
+- `go test ./... -short` must pass
+- `go test ./internal/integration/ -run TestIntegration_PipelineValidation -v` must pass — these tests use noop actions via the registry
+- Manual smoke: start the backend and check logs for all action registration lines
+
+### References
+
+- `backend/internal/adapter/action/ci_poll.go` — `NewCIPollAction` signature
+- `backend/internal/adapter/action/hitl_gate.go` — `NewHITLGateAction` signature
+- `backend/internal/adapter/action/agent_run.go` — `resolveTemplateName` reads `runCtx.Metadata["template_name"]`
+- `backend/internal/domain/service/action_registry.go` — current registry implementation
+- `backend/internal/domain/service/pipeline_executor.go` — where `actionReg.Get(step.Action)` is called (line 191)
+- `backend/internal/domain/service/run_service.go` — where `step.Action = stepCfg.ActionType` is set (line 336)
+- `backend/internal/domain/model/pipeline_config.go` — `ValidActionTypes` map
+- `backend/internal/domain/service/pipeline_config_service.go` — `DefaultPipelineConfigYAML` uses `implement`, `review`, `merge`
+- `backend/internal/adapter/github/` — GitProvider adapter

--- a/_bmad-output/implementation-artifacts/runtime-3-test-project-postgres-e2e-validation.md
+++ b/_bmad-output/implementation-artifacts/runtime-3-test-project-postgres-e2e-validation.md
@@ -1,0 +1,295 @@
+# Story runtime-3: Fix test-project and End-to-End Validation
+
+**Status:** ready-for-dev
+**Branch:** `feat/runtime-3-test-project-e2e-validation`
+**Commit scope:** `test-project`
+
+---
+
+## Story
+
+As a developer validating the hopeitworks pipeline, I need the todo app in `test-project/` to work as a single coherent stack — with PostgreSQL as its database, a correct `docker-compose.yml`, a clean Dockerfile, and accurate README — so that I can launch a real agent run against it and see a pass/fail end-to-end without any infrastructure confusion.
+
+---
+
+## Context: Current State of test-project
+
+The `test-project/` directory contains two coexisting implementations created at different times:
+
+**`src/` (old — SQLite, better-sqlite3):**
+- `src/app.js`, `src/db.js`, `src/routes/todos.js` — SQLite implementation
+- Root `package.json` points to `src/app.js` as `main`, uses `better-sqlite3`
+- Root `Dockerfile` copies `src/` and runs `src/app.js`
+- Root `docker-compose.yml` has `DB_PATH` env var (SQLite) and no Postgres service
+
+**`backend/` (new — PostgreSQL, pg driver):**
+- `backend/app.js`, `backend/server.js` — PostgreSQL implementation using `pg`
+- `backend/package.json` has `pg`, `cors`, `express` as deps
+- `init.sql` has the PostgreSQL schema (correct)
+- `CLAUDE.md` says tech stack is: Node.js + Express + pg (PostgreSQL)
+
+**The mismatch:** `docker-compose.yml` and the root `Dockerfile` still point to the SQLite implementation. `init.sql` is PostgreSQL DDL. The `CLAUDE.md` says PostgreSQL. The root `README.md` says SQLite (wrong).
+
+**Decision:** Consolidate to the **PostgreSQL implementation** (`backend/` directory). The `src/` directory is the legacy SQLite version and will be removed or left as-is if tests depend on it. The canonical entry point becomes `backend/server.js`.
+
+---
+
+## Acceptance Criteria
+
+**AC #1 — `docker-compose.yml` includes a Postgres service**
+- Given `test-project/docker-compose.yml`
+- When `docker compose up` is run from `test-project/`
+- Then a `postgres` service starts alongside `todo-app`, the app connects to it, and `GET /health` returns `{"status":"ok"}`
+
+**AC #2 — The app connects to PostgreSQL on startup**
+- Given the Postgres service is running with `DATABASE_URL` configured
+- When the todo-app container starts
+- Then `backend/server.js` connects without error and the `todos` table is initialized via `init.sql`
+
+**AC #3 — Schema initialization is automatic**
+- Given the postgres service starts fresh
+- When the todo-app connects
+- Then the `todos` table is created (via `init.sql` mounted or run in entrypoint) without manual intervention
+
+**AC #4 — CRUD endpoints work against Postgres**
+- Given the stack is running
+- When `POST /api/todos`, `GET /api/todos`, `PUT /api/todos/:id`, `DELETE /api/todos/:id` are called
+- Then they return correct HTTP responses using the PostgreSQL backend
+
+**AC #5 — `docker compose up` is the single command to start the stack**
+- Given `test-project/docker-compose.yml`
+- When `docker compose up -d` is run
+- Then both services start, the app is available on port 3000, and no manual db setup is required
+
+**AC #6 — Root `Dockerfile` builds the PostgreSQL app**
+- Given `test-project/Dockerfile`
+- When `docker build .` is run from `test-project/`
+- Then the resulting image runs `backend/server.js` (not `src/app.js`)
+
+**AC #7 — `backend/` tests pass**
+- Given `test-project/backend/`
+- When `cd test-project/backend && npm test` is run against a running Postgres
+- Then all tests in `backend/test/todos.test.js` pass
+
+**AC #8 — README reflects actual tech stack**
+- Given `test-project/README.md`
+- When a developer reads it
+- Then it accurately describes PostgreSQL (not SQLite), the correct `docker compose` commands, and the correct test commands
+
+**AC #9 — `CLAUDE.md` is consistent**
+- Given `test-project/CLAUDE.md`
+- When an agent reads it
+- Then it correctly describes `backend/server.js` as the entry point and PostgreSQL as the database (already accurate — verify no changes needed)
+
+---
+
+## Tasks / Subtasks
+
+- [ ] **T1.** Update `test-project/docker-compose.yml` to add Postgres and fix app config (AC: #1, #2, #5)
+  - [ ] T1.1 Add `postgres` service: `image: postgres:16-alpine`, env `POSTGRES_DB=todo`, `POSTGRES_USER=todo`, `POSTGRES_PASSWORD=todo`
+  - [ ] T1.2 Add healthcheck to postgres service: `pg_isready -U todo`
+  - [ ] T1.3 Update `todo-app` service: remove `DB_PATH` env var, add `DATABASE_URL=postgres://todo:todo@postgres:5432/todo`
+  - [ ] T1.4 Add `depends_on: postgres: condition: service_healthy` to `todo-app`
+  - [ ] T1.5 Add `ports: - "5432:5432"` to postgres for local debugging
+  - [ ] T1.6 Add named volume `postgres_data` and mount it in postgres service
+  - [ ] T1.7 Add `networks` section with a single `todo-net` bridge network; attach both services
+
+- [ ] **T2.** Fix schema initialization — mount `init.sql` into Postgres init dir (AC: #3)
+  - [ ] T2.1 Mount `init.sql` into `/docker-entrypoint-initdb.d/init.sql` in the postgres service via volumes
+  - [ ] T2.2 Verify `init.sql` uses PostgreSQL DDL (currently correct: `SERIAL PRIMARY KEY`, `TIMESTAMPTZ`, `NOW()`)
+
+- [ ] **T3.** Update `test-project/Dockerfile` to point to `backend/server.js` (AC: #6)
+  - [ ] T3.1 Change `COPY src/ ./src/` to `COPY backend/ ./backend/`
+  - [ ] T3.2 Change `RUN npm install --omit=dev` to use `backend/package.json`
+  - [ ] T3.3 Change `CMD ["node", "src/app.js"]` to `CMD ["node", "backend/server.js"]`
+  - [ ] T3.4 Add `HEALTHCHECK` pointing to `http://localhost:3000/health`
+
+  **Note:** The root `package.json` uses `better-sqlite3`. After this change, the root `package.json` is no longer the app's entry point. The `docker-compose.yml` `build: .` context uses the root `Dockerfile`, which will install `backend/package.json` deps. Adjust accordingly.
+
+- [ ] **T4.** Verify `backend/server.js` uses `DATABASE_URL` env var (AC: #2, #4)
+  - [ ] T4.1 Confirm `backend/server.js` reads `process.env.DATABASE_URL` (already does: line 5)
+  - [ ] T4.2 Confirm `backend/app.js` handles all 5 CRUD routes + health check (already does)
+  - [ ] T4.3 No code changes needed in `backend/` — it is already correct
+
+- [ ] **T5.** Update `test-project/README.md` (AC: #8)
+  - [ ] T5.1 Replace "SQLite (via better-sqlite3)" with "PostgreSQL 16"
+  - [ ] T5.2 Remove references to `npm run seed` / `seed.sql` for SQLite
+  - [ ] T5.3 Update "Getting Started" to use `docker compose up` as the primary path
+  - [ ] T5.4 Update test commands to reflect `cd backend && npm test`
+  - [ ] T5.5 Correct CI pipeline description (remove Jest/supertest references if not used, verify current test runner is `node --test`)
+  - [ ] T5.6 Add "Prerequisites: Docker + Docker Compose" section
+  - [ ] T5.7 Add "End-to-End with hopeitworks" section explaining how to register this project in the platform and launch a run
+
+- [ ] **T6.** Smoke test the full stack (AC: #1, #4, #5)
+  - [ ] T6.1 Run `docker compose up -d` from `test-project/`
+  - [ ] T6.2 Wait for health checks to pass
+  - [ ] T6.3 Run: `curl -s http://localhost:3000/health` → `{"status":"ok"}`
+  - [ ] T6.4 Run: `curl -s -X POST http://localhost:3000/api/todos -H "Content-Type: application/json" -d '{"title":"test"}'` → 201
+  - [ ] T6.5 Run: `curl -s http://localhost:3000/api/todos` → list with the created todo
+  - [ ] T6.6 Run: `docker compose down -v` to clean up
+
+- [ ] **T7.** Document end-to-end pipeline validation steps (AC: #8)
+  - [ ] T7.1 Add section to README: how to register `test-project/` as a hopeitworks project (repo URL, pipeline config)
+  - [ ] T7.2 Document which stories in `stories/todo-stories.md` to use for validation
+  - [ ] T7.3 Document the expected pipeline run flow: implement → review → merge
+
+---
+
+## Dev Notes
+
+### Dependencies
+
+- Docker and Docker Compose v2 must be available
+- No backend (Go) changes required for this story
+- No frontend (Vue) changes required for this story
+
+### File Paths
+
+| File | Change |
+|------|--------|
+| `test-project/docker-compose.yml` | Add postgres service, fix todo-app env, add network |
+| `test-project/Dockerfile` | Point to `backend/server.js` instead of `src/app.js` |
+| `test-project/README.md` | Correct tech stack, commands, add hopeitworks integration docs |
+| `test-project/backend/server.js` | No change (already uses `DATABASE_URL`) |
+| `test-project/backend/app.js` | No change (already correct pg implementation) |
+| `test-project/init.sql` | No change (already PostgreSQL DDL) |
+| `test-project/src/` | Leave as-is (legacy SQLite, not used by Docker) |
+
+### Technical Specifications
+
+**Updated `test-project/docker-compose.yml`:**
+
+```yaml
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: todo-postgres
+    environment:
+      POSTGRES_DB: todo
+      POSTGRES_USER: todo
+      POSTGRES_PASSWORD: todo
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U todo -d todo"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - todo-net
+
+  todo-app:
+    build: .
+    container_name: todo-app
+    ports:
+      - "3000:3000"
+    environment:
+      PORT: 3000
+      DATABASE_URL: postgres://todo:todo@postgres:5432/todo
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - todo-net
+
+volumes:
+  postgres_data:
+
+networks:
+  todo-net:
+    driver: bridge
+```
+
+**Updated `test-project/Dockerfile`:**
+
+```dockerfile
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install backend deps
+COPY backend/package.json backend/package-lock.json ./backend/
+RUN cd backend && npm install --omit=dev
+
+# Copy backend source
+COPY backend/ ./backend/
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s \
+  CMD wget -qO- http://localhost:3000/health || exit 1
+
+CMD ["node", "backend/server.js"]
+```
+
+**Postgres service healthcheck pattern (from `deploy/docker-compose.yml` reference):**
+
+```yaml
+healthcheck:
+  test: ["CMD-SHELL", "pg_isready -U todo -d todo"]
+  interval: 5s
+  timeout: 5s
+  retries: 5
+```
+
+**Schema auto-initialization:**
+
+PostgreSQL's official Docker image runs any `.sql` files found in `/docker-entrypoint-initdb.d/` on first start (when the data directory is empty). Mounting `init.sql` there is the standard pattern — no entrypoint script change needed.
+
+**`seed.sql` note:**
+
+The current `seed.sql` uses SQLite syntax (`INSERT OR REPLACE`, integer boolean `0/1`). It is NOT compatible with PostgreSQL. Do NOT mount it in `/docker-entrypoint-initdb.d/`. If seed data is needed for tests, create a separate `seed.postgres.sql` with standard SQL. This is out of scope for this story — leave the existing `seed.sql` as-is.
+
+**`backend/test/todos.test.js` — requires running Postgres:**
+
+The backend tests require a Postgres instance. They can be run:
+1. Against the compose stack: `docker compose up -d && cd backend && DATABASE_URL=postgres://todo:todo@localhost:5432/todo npm test`
+2. Against a test container (future improvement)
+
+For this story, document option 1 in the README. Full test isolation via testcontainers is deferred.
+
+### End-to-End Validation with hopeitworks
+
+To run a real pipeline on the todo app after runtime-1 and runtime-2 are complete:
+
+1. Ensure `hopeitworks/agent:latest` is built (runtime-1)
+2. Ensure actions are wired (runtime-2)
+3. Start the hopeitworks dev stack: `cd deploy && docker compose up -d`
+4. Register `test-project/` as a project in hopeitworks (via UI or API):
+   - `repo_url`: the GitHub URL of the hopeitworks repo (since `test-project/` is a subdirectory)
+   - The pipeline will implement stories that modify files in `test-project/`
+5. Import a story from `test-project/stories/todo-stories.md` (e.g., `TODO-1`)
+6. Launch a run via UI → `POST /api/v1/projects/{id}/stories/{story_id}/runs`
+7. Observe the pipeline: implement step → container spawns `hopeitworks/agent:latest` → agent clones repo → runs claude → pushes branch → CI polls → HITL gate → merge
+
+### Known Issue: `src/` vs `backend/` coexistence
+
+The `src/` directory (SQLite version) remains in the repo for now. It does not affect the Docker build since the Dockerfile explicitly copies `backend/`. However, the root `package.json` still references `src/app.js` — this is fine for local SQLite development but confusing. A future cleanup story (not in scope here) should:
+- Remove `src/` entirely
+- Update root `package.json` to point to `backend/server.js`
+- Consolidate to a single implementation
+
+For now: the Docker path is authoritative. `src/` is legacy.
+
+### Testing Requirements
+
+- `docker compose up -d` from `test-project/` succeeds
+- `GET http://localhost:3000/health` returns 200
+- `POST /api/todos` creates a record in Postgres (verify via `docker exec todo-postgres psql -U todo -d todo -c "SELECT * FROM todos"`)
+- `GET /api/todos` returns the created record
+- `docker compose down -v` cleans up without error
+- `cd test-project/backend && DATABASE_URL=postgres://todo:todo@localhost:5432/todo npm test` passes (requires running stack)
+
+### References
+
+- `test-project/backend/server.js` — PostgreSQL server (already correct)
+- `test-project/backend/app.js` — Express routes (already correct)
+- `test-project/init.sql` — PostgreSQL schema (already correct)
+- `test-project/CLAUDE.md` — agent scoping (already says PostgreSQL)
+- `test-project/stories/todo-stories.md` — pipeline validation stories
+- `deploy/docker-compose.yml` — reference for postgres service pattern in this project
+- `backend/internal/integration/` — pipeline integration tests that reference test-project stories

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -177,9 +177,20 @@ development_status:
   refactor-2-migrate-consumers-to-runner: done
   refactor-3-db-migration-workload-handle-cleanup: done
 
+  # Post-MVP: Smoke Tests & Monaco Fix
+  post-mvp-smoke-monaco: done
+  fix-smoke-tests-green: done
+  fix-monaco-native-editor: done
+
   # Post-MVP: DX Improvements
   post-mvp-dx: backlog
   1-22-auto-migrate-on-startup: ready-for-dev
+
+  # Post-MVP: Agent Runtime & E2E Pipeline
+  post-mvp-agent-runtime: backlog
+  runtime-1-agent-docker-image: ready-for-dev
+  runtime-2-action-wiring-and-action-type-mapping: ready-for-dev
+  runtime-3-test-project-postgres-e2e-validation: ready-for-dev
 
   # Post-MVP: E2E Usability Fixes
   post-mvp-e2e-usability: done
@@ -708,19 +719,19 @@ parallel_waves:
     stories:
       - key: fix-8-nav-visible-unauthenticated
         domain: front
-        status: backlog
+        status: done
         cross_epic_deps: [1-9-login-page-auth-guard, 1-8-app-shell-layout-header-sidebar-status-bar]
       - key: feat-1-logout-api
         domain: back
-        status: backlog
+        status: done
         cross_epic_deps: [1-3-users-table-jwt-auth-api-register-login-auth-middleware]
       - key: feat-2-user-profile-api
         domain: back
-        status: backlog
+        status: done
         cross_epic_deps: [1-3-users-table-jwt-auth-api-register-login-auth-middleware]
       - key: feat-3-reset-password-api
         domain: back
-        status: backlog
+        status: done
         cross_epic_deps: [1-3-users-table-jwt-auth-api-register-login-auth-middleware]
     container_count: 4
     depends_on: [wave-19]
@@ -731,15 +742,15 @@ parallel_waves:
     stories:
       - key: feat-4-logout-ui
         domain: front
-        status: backlog
+        status: done
         explicit_deps: [feat-1-logout-api]
       - key: feat-5-user-profile-page
         domain: front
-        status: backlog
+        status: done
         explicit_deps: [feat-2-user-profile-api]
       - key: feat-6-reset-password-pages
         domain: front
-        status: backlog
+        status: done
         explicit_deps: [feat-3-reset-password-api]
     container_count: 3
     depends_on: [wave-20]
@@ -818,3 +829,31 @@ parallel_waves:
     container_count: 1
     depends_on: [wave-25]
     notes: "DB migration container_id → workload_handle, sqlc regen, final cleanup"
+
+  # =====================================================
+  # PHASE 9: AGENT RUNTIME (Last mile for real pipeline execution)
+  # =====================================================
+
+  wave-27:
+    phase: 9-agent-runtime
+    stories:
+      - key: runtime-1-agent-docker-image
+        domain: shared
+        status: ready-for-dev
+      - key: runtime-2-action-wiring-and-action-type-mapping
+        domain: back
+        status: ready-for-dev
+    container_count: 2
+    depends_on: [wave-26]
+    notes: "Agent Docker image + action wiring — parallel, independent"
+
+  wave-28:
+    phase: 9-agent-runtime
+    stories:
+      - key: runtime-3-test-project-postgres-e2e-validation
+        domain: shared
+        status: ready-for-dev
+        explicit_deps: [runtime-1-agent-docker-image, runtime-2-action-wiring-and-action-type-mapping]
+    container_count: 1
+    depends_on: [wave-27]
+    notes: "Fix test-project + validate real end-to-end pipeline run"


### PR DESCRIPTION
## Summary
- Add runtime-1 (agent Docker image), runtime-2 (action wiring), runtime-3 (test-project e2e validation) stories
- Update sprint status with agent runtime phase (waves 27-28) and mark completed waves as done

## Test plan
- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)