### PR TITLE
feat(pipeline): wire action registry with ci_poll, hitl_gate, and action_type aliases

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -16,6 +16,7 @@ import (
 	actionadapter "github.com/zakari/hopeitworks/backend/internal/adapter/action"
 	discordadapter "github.com/zakari/hopeitworks/backend/internal/adapter/discord"
 	dockeradapter "github.com/zakari/hopeitworks/backend/internal/adapter/docker"
+	gitadapter "github.com/zakari/hopeitworks/backend/internal/adapter/git"
 	hbadapter "github.com/zakari/hopeitworks/backend/internal/adapter/handlebars"
 	pgadapter "github.com/zakari/hopeitworks/backend/internal/adapter/postgres"
 	riveradapter "github.com/zakari/hopeitworks/backend/internal/adapter/river"
@@ -28,6 +29,7 @@ import (
 	"github.com/zakari/hopeitworks/backend/internal/domain/port"
 	"github.com/zakari/hopeitworks/backend/internal/domain/service"
 	"github.com/zakari/hopeitworks/backend/migrations"
+	pkgexec "github.com/zakari/hopeitworks/backend/pkg/exec"
 	pkglog "github.com/zakari/hopeitworks/backend/pkg/log"
 )
 
@@ -172,8 +174,29 @@ func run() error {
 		logger.Warn("docker container manager unavailable, timeout enforcer and orphan cleaner disabled", "error", err)
 	}
 
+	// HITL repository (created early because hitl_gate action needs it)
+	hitlRepo := pgadapter.NewHITLRepo(queries)
+
 	// Action registry
 	actionReg := service.NewActionRegistry()
+
+	// Git provider (needed by ci_poll and hitl_gate actions)
+	cmdRunner := pkgexec.NewRealCommandRunner()
+	gitProvider := gitadapter.NewGhCliAdapter(cmdRunner, logger)
+
+	// CI Poll action (no Docker required)
+	ciPollCfg := actionadapter.CIPollConfig{
+		DefaultPollInterval: 30 * time.Second,
+		DefaultTimeout:      15 * time.Minute,
+	}
+	ciPollAction := actionadapter.NewCIPollAction(gitProvider, eventRepo, ciPollCfg, logger)
+	actionReg.Register(ciPollAction)
+	logger.Info("ci_poll action registered")
+
+	// HITL Gate action (no Docker required)
+	hitlGateAction := actionadapter.NewHITLGateAction(hitlRepo, runRepo, gitProvider, eventRepo, storyRepo, logger)
+	actionReg.Register(hitlGateAction)
+	logger.Info("hitl_gate action registered")
 
 	// Cost tracking (for agent_run action)
 	costSvc := costService
@@ -199,6 +222,13 @@ func run() error {
 			)
 			actionReg.Register(agentRunAction)
 			logger.Info("agent_run action registered")
+
+			// Register action_type aliases so pipeline configs using
+			// implement/review/merge resolve to AgentRunAction
+			for _, alias := range []string{"implement", "review", "merge"} {
+				actionReg.RegisterAlias(alias, agentRunAction)
+			}
+			logger.Info("action aliases registered", "aliases", []string{"implement", "review", "merge"})
 
 			// Incremental retry action (delegates to agent_run)
 			incrementalRetryAction := actionadapter.NewIncrementalRetryAction(
@@ -252,7 +282,6 @@ func run() error {
 	}
 
 	// HITL service and handler
-	hitlRepo := pgadapter.NewHITLRepo(queries)
 	hitlService := service.NewHITLService(hitlRepo, runRepo, eventRepo, logger)
 	hitlHandler := handler.NewHITLHandler(hitlService)
 

--- a/backend/internal/domain/model/pipeline_config.go
+++ b/backend/internal/domain/model/pipeline_config.go
@@ -46,4 +46,6 @@ var ValidActionTypes = map[string]bool{
 	"merge":     true,
 	"test":      true,
 	"custom":    true,
+	"ci_poll":   true,
+	"hitl_gate": true,
 }

--- a/backend/internal/domain/service/action_registry.go
+++ b/backend/internal/domain/service/action_registry.go
@@ -32,6 +32,14 @@ func (r *InMemoryActionRegistry) Register(action model.Action) {
 	r.actions[action.Name()] = action
 }
 
+// RegisterAlias registers an existing action under an alias name.
+// The action is stored under the alias key; its own Name() is not affected.
+func (r *InMemoryActionRegistry) RegisterAlias(alias string, action model.Action) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.actions[alias] = action
+}
+
 // Get retrieves an action by name.
 // Returns ACTION_NOT_FOUND error if action is not registered.
 func (r *InMemoryActionRegistry) Get(name string) (model.Action, error) {

--- a/backend/internal/domain/service/action_registry_test.go
+++ b/backend/internal/domain/service/action_registry_test.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+)
+
+// stubAction is a minimal model.Action implementation for testing the registry.
+type stubAction struct {
+	name string
+}
+
+func (a *stubAction) Name() string                                         { return a.name }
+func (a *stubAction) Execute(_ context.Context, _ *model.RunContext) error { return nil }
+
+func TestInMemoryActionRegistry_RegisterAlias(t *testing.T) {
+	reg := NewActionRegistry()
+	action := &stubAction{name: "agent_run"}
+	reg.Register(action)
+
+	// Register aliases
+	for _, alias := range []string{"implement", "review", "merge"} {
+		reg.RegisterAlias(alias, action)
+	}
+
+	// Original name still resolves (AC #7)
+	got, err := reg.Get("agent_run")
+	if err != nil {
+		t.Fatalf("Get(agent_run) error: %v", err)
+	}
+	if got != action {
+		t.Fatalf("Get(agent_run) returned different instance")
+	}
+
+	// Aliases resolve to the same instance (AC #3, #4, #5)
+	for _, alias := range []string{"implement", "review", "merge"} {
+		got, err := reg.Get(alias)
+		if err != nil {
+			t.Fatalf("Get(%s) error: %v", alias, err)
+		}
+		if got != action {
+			t.Fatalf("Get(%s) returned different instance than agent_run", alias)
+		}
+	}
+
+	// Unregistered names still fail
+	_, err = reg.Get("nonexistent")
+	if err == nil {
+		t.Fatal("Get(nonexistent) should have returned an error")
+	}
+}

--- a/backend/internal/domain/service/pipeline_executor.go
+++ b/backend/internal/domain/service/pipeline_executor.go
@@ -19,6 +19,13 @@ import (
 // ErrRunPaused is returned when a run is paused mid-execution.
 var ErrRunPaused = fmt.Errorf("run paused")
 
+// actionTypeToTemplateName maps pipeline config action_type aliases to prompt template names.
+var actionTypeToTemplateName = map[string]string{
+	"implement": TemplateNameImplement,
+	"review":    TemplateNameReview,
+	"merge":     TemplateNameMerge,
+}
+
 // errStepSuspended is returned by executeStep when the step transitions
 // to waiting_approval. It is NOT a failure — it signals the executor to
 // stop processing further steps without marking the run as failed.
@@ -200,6 +207,14 @@ func (e *PipelineExecutor) executeStep(ctx context.Context, run *model.Run, step
 		ProjectID: run.ProjectID,
 		StoryID:   run.StoryID,
 		Metadata:  metadata,
+	}
+
+	// Inject template_name based on action_type alias (implement, review, merge).
+	// An explicit template_name already in metadata (e.g. from incremental retry) takes precedence.
+	if _, exists := runCtx.Metadata["template_name"]; !exists {
+		if tmplName, ok := actionTypeToTemplateName[step.Action]; ok {
+			runCtx.Metadata["template_name"] = tmplName
+		}
 	}
 
 	// Execute action

--- a/backend/internal/domain/service/template_service.go
+++ b/backend/internal/domain/service/template_service.go
@@ -15,6 +15,7 @@ const (
 	TemplateNameImplement      = "implement"
 	TemplateNameImplementRetry = "implement-retry"
 	TemplateNameReview         = "review"
+	TemplateNameMerge          = "merge"
 	TemplateNameMergeConflict  = "merge-conflict"
 )
 
@@ -126,6 +127,16 @@ Fix the issues described above while preserving the existing changes.`,
 - Verify all acceptance criteria are met
 - Check code quality and adherence to project conventions
 - Flag any issues or suggest improvements`,
+
+		TemplateNameMerge: `Merge changes for {{story_key}}: {{story_title}}
+
+## Story Context
+**Objective:** {{story_objective}}
+
+## Merge Instructions
+- Create a pull request for the feature branch
+- Ensure CI checks pass before merging
+- Use squash merge to maintain clean commit history`,
 
 		TemplateNameMergeConflict: `Resolve merge conflict for {{story_key}}: {{story_title}}
 


### PR DESCRIPTION
## Summary
- Register `ci_poll` and `hitl_gate` actions at startup so pipeline steps using these action types no longer fail with `ACTION_NOT_FOUND`
- Add `RegisterAlias` method to `InMemoryActionRegistry` and register `implement`, `review`, `merge` as aliases for `AgentRunAction`
- Inject `template_name` into `RunContext.Metadata` based on `step.Action` so `AgentRunAction` selects the correct prompt template
- Add `TemplateNameMerge` constant and default merge prompt template to `TemplateService`
- Add `ci_poll` and `hitl_gate` to `ValidActionTypes` so pipeline config validation accepts them

## Changes
| File | Change |
|------|--------|
| `backend/cmd/api/main.go` | Wire `GitProvider` (GhCliAdapter), register `ci_poll`, `hitl_gate`, and aliases `implement/review/merge` |
| `backend/internal/domain/service/action_registry.go` | Add `RegisterAlias(alias, action)` method |
| `backend/internal/domain/service/action_registry_test.go` | New test for `RegisterAlias` covering AC #3–5, #7 |
| `backend/internal/domain/service/pipeline_executor.go` | Inject `template_name` metadata from `actionTypeToTemplateName` map |
| `backend/internal/domain/service/template_service.go` | Add `TemplateNameMerge` constant and default merge template |
| `backend/internal/domain/model/pipeline_config.go` | Add `ci_poll`, `hitl_gate` to `ValidActionTypes` |

## Test plan
- [x] `golangci-lint run ./...` passes
- [x] `go test ./... -short` passes (all unit tests green)
- [x] `TestInMemoryActionRegistry_RegisterAlias` validates alias resolution
- [ ] Manual smoke: start backend and verify log lines for all action registrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)