### PR TITLE
docs(stories): update runtime-1 status to done after merge

### DIFF
--- a/_bmad-output/implementation-artifacts/runtime-1-agent-docker-image.md
+++ b/_bmad-output/implementation-artifacts/runtime-1-agent-docker-image.md
@@ -1,6 +1,6 @@
 # Story runtime-1: Agent Docker Image and Entrypoint
 
-**Status:** ready-for-dev
+**Status:** done
 **Branch:** `feat/runtime-1-agent-docker-image`
 **Commit scope:** `agent`
 
@@ -228,3 +228,9 @@ The **runtime agent image** (`agent/Dockerfile`) is intentionally minimal:
 - `scripts/entrypoint.sh` — reference BMAD entrypoint (pipeline mode, not for runtime)
 - `backend/internal/adapter/action/agent_run.go` — how the image is launched (env vars, container opts)
 - `backend/internal/adapter/docker/` — DockerContainerManager and DockerLogStreamer implementations
+
+---
+
+## Change Log
+
+- Merged to develop via PR #134 (2026-02-22)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -188,7 +188,7 @@ development_status:
 
   # Post-MVP: Agent Runtime & E2E Pipeline
   post-mvp-agent-runtime: backlog
-  runtime-1-agent-docker-image: ready-for-dev
+  runtime-1-agent-docker-image: done
   runtime-2-action-wiring-and-action-type-mapping: ready-for-dev
   runtime-3-test-project-postgres-e2e-validation: ready-for-dev
 
@@ -839,7 +839,7 @@ parallel_waves:
     stories:
       - key: runtime-1-agent-docker-image
         domain: shared
-        status: ready-for-dev
+        status: done
       - key: runtime-2-action-wiring-and-action-type-mapping
         domain: back
         status: ready-for-dev


### PR DESCRIPTION
## Summary
- Update runtime-1 story status from ready-for-dev to done
- Update sprint-status.yaml to reflect completed merge
- Add Change Log entry for PR #134 merge

## Context
Story runtime-1 was merged via PR #134 (squash merge into develop). This PR updates the tracking files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)