### PR TITLE
docs(stories): update runtime-3 status to done after merge (#137)

### DIFF
--- a/_bmad-output/implementation-artifacts/runtime-3-test-project-postgres-e2e-validation.md
+++ b/_bmad-output/implementation-artifacts/runtime-3-test-project-postgres-e2e-validation.md
@@ -1,6 +1,6 @@
 # Story runtime-3: Fix test-project and End-to-End Validation
 
-**Status:** ready-for-dev
+**Status:** done
 **Branch:** `feat/runtime-3-test-project-e2e-validation`
 **Commit scope:** `test-project`
 
@@ -293,3 +293,9 @@ For now: the Docker path is authoritative. `src/` is legacy.
 - `test-project/stories/todo-stories.md` — pipeline validation stories
 - `deploy/docker-compose.yml` — reference for postgres service pattern in this project
 - `backend/internal/integration/` — pipeline integration tests that reference test-project stories
+
+---
+
+## Change Log
+
+- Merged to develop via PR #137 (squash merge, 2026-02-22)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -190,7 +190,7 @@ development_status:
   post-mvp-agent-runtime: backlog
   runtime-1-agent-docker-image: done
   runtime-2-action-wiring-and-action-type-mapping: ready-for-dev
-  runtime-3-test-project-postgres-e2e-validation: ready-for-dev
+  runtime-3-test-project-postgres-e2e-validation: done
 
   # Post-MVP: E2E Usability Fixes
   post-mvp-e2e-usability: done
@@ -852,7 +852,7 @@ parallel_waves:
     stories:
       - key: runtime-3-test-project-postgres-e2e-validation
         domain: shared
-        status: ready-for-dev
+        status: done
         explicit_deps: [runtime-1-agent-docker-image, runtime-2-action-wiring-and-action-type-mapping]
     container_count: 1
     depends_on: [wave-27]


### PR DESCRIPTION
## Summary
- Update sprint-status.yaml: runtime-3 → done
- Update story file status to done with merge changelog entry

Post-merge housekeeping for story runtime-3 (PR #137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)