### PR TITLE
docs(stories): add runtime-4/5/6 stories for pipeline e2e readiness

### DIFF
--- a/_bmad-output/implementation-artifacts/runtime-4-run-context-metadata-propagation.md
+++ b/_bmad-output/implementation-artifacts/runtime-4-run-context-metadata-propagation.md
@@ -1,0 +1,139 @@
+# Story runtime-4: RunContext Metadata Propagation
+
+**Status:** ready-for-dev
+**Branch:** `feat/runtime-4-run-context-metadata`
+**Commit scope:** `pipeline`
+
+---
+
+## Story
+
+As the pipeline executor, I need `RunContext.Metadata` to be populated with `branch_name`, `template_name`, and `model` before any action executes — so that `AgentRunAction` can launch containers with a valid branch, the correct prompt template, and the per-step model configured in the pipeline YAML.
+
+Currently three critical metadata keys are either never set or not propagated:
+
+1. **`branch_name`** is read by `agent_run.go` at `runCtx.Metadata["branch_name"]` but is never written anywhere. The agent container validates `BRANCH_NAME` at startup and crashes if it is empty.
+2. **`template_name`** is injected by `pipeline_executor.go` (lines 214–218) using `actionTypeToTemplateName` — this part is already correctly implemented and must not be changed.
+3. **`model`** is present as `PipelineStep.Model` in the YAML config but is never stored on the `Run`, the `RunStep`, or the `RunContext`. `AgentRunAction.createContainer` has no per-step model env var and always falls back to the project-level default.
+
+---
+
+## Acceptance Criteria
+
+**AC #1 — branch_name is generated and available to actions**
+- Given a story with key `"runtime-4"` and a run is launched via `LaunchRun`
+- When the implement step's `AgentRunAction.Execute` is called
+- Then `runCtx.Metadata["branch_name"]` equals `"feat/runtime-4"`
+- And the container receives `BRANCH_NAME=feat/runtime-4`
+
+**AC #2 — template_name is set per step based on action_type (verify, no regression)**
+- Given a pipeline with steps implement / review / merge
+- When each step executes
+- Then the implement step has `runCtx.Metadata["template_name"] == "implement"`
+- And the review step has `runCtx.Metadata["template_name"] == "review"`
+- And the merge step has `runCtx.Metadata["template_name"] == "merge"`
+- (This is already implemented in `pipeline_executor.go` — add a test to cover it, do not change the logic)
+
+**AC #3 — model is propagated from pipeline config to the container**
+- Given a pipeline config with `model: "claude-opus-4-6"` on the implement step and `model: "claude-sonnet-4-6"` on the review step
+- When each step executes
+- Then `runCtx.Metadata["model"]` equals `"claude-opus-4-6"` for the implement step
+- And `runCtx.Metadata["model"]` equals `"claude-sonnet-4-6"` for the review step
+- And if `PipelineStep.Model` is empty, `runCtx.Metadata["model"]` is not set (the container falls back to its own default)
+
+**AC #4 — all tests pass**
+- Given the changes are applied
+- When `go test ./... -short` is run from `backend/`
+- Then all tests pass with zero failures
+- And `golangci-lint run ./...` reports zero errors
+
+---
+
+## Tasks / Subtasks
+
+- [ ] **T1.** Generate `branch_name` in `LaunchRun` and store it on `Run.Metadata` (AC: #1)
+  - [ ] T1.1 In `run_service.go` `LaunchRun`, after fetching `story`, compute `branchName := "feat/" + story.Key`
+  - [ ] T1.2 Populate `run.Metadata` with `map[string]interface{}{"branch_name": branchName}` before calling `runRepo.CreateRun`
+  - [ ] T1.3 Confirm `Run.Metadata` is a `map[string]interface{}` JSONB field — it is not currently on the `Run` struct; add it if absent (check `model/run.go` and the DB schema / sqlc queries)
+  - [ ] T1.4 Confirm `PipelineExecutor.executeStep` copies `run.Metadata` into `RunContext.Metadata` — it currently initialises `metadata := make(map[string]any)` fresh each time. Merge `run.Metadata` into this map before building `RunContext`
+
+- [ ] **T2.** Propagate `PipelineStep.Model` into `RunContext.Metadata` (AC: #3)
+  - [ ] T2.1 In `run_service.go` `LaunchRun`, when creating each `RunStep`, store `stepCfg.Model` in `RunStep.Metadata` (add `Metadata map[string]interface{}` to `RunStep` if absent, backed by JSONB)
+  - [ ] T2.2 Alternatively (simpler for MVP): store the step model in `Run.Metadata` keyed by step order or name, so the executor can look it up. Evaluate which approach requires fewer schema changes.
+  - [ ] T2.3 In `pipeline_executor.go` `executeStep`, after building `RunContext`, set `runCtx.Metadata["model"] = step.Model` when `step.Model != ""`
+  - [ ] T2.4 In `agent_run.go` `createContainer`, read `runCtx.Metadata["model"]` and add `MODEL=<value>` to the container env when present; the entrypoint can use it to override the Claude Code model flag
+
+- [ ] **T3.** Verify template_name injection (no regression) and add test (AC: #2)
+  - [ ] T3.1 Confirm the existing logic in `pipeline_executor.go` lines 213–218 is correct and untouched
+  - [ ] T3.2 Add a unit test in `pipeline_executor_test.go` (or a new file) that asserts `template_name` is set correctly for each of implement / review / merge action types
+
+- [ ] **T4.** Update `agent_run_test.go` with new metadata tests (AC: #1, #3)
+  - [ ] T4.1 Add test `TestAgentRunAction_BranchNameFromMetadata` — sets `branch_name` in `RunContext.Metadata`, verifies `BRANCH_NAME` env var is passed to the container
+  - [ ] T4.2 Add test `TestAgentRunAction_ModelFromMetadata` — sets `model` in `RunContext.Metadata`, verifies the container env contains the expected model var
+  - [ ] T4.3 Add test `TestAgentRunAction_ModelFallback` — omits `model` from metadata, verifies no model env var is injected (no regression on existing behaviour)
+
+- [ ] **T5.** Run lint and tests (AC: #4)
+  - [ ] T5.1 `cd backend && go test ./... -short`
+  - [ ] T5.2 `cd backend && golangci-lint run ./...`
+  - [ ] T5.3 Fix any lint errors before committing
+
+---
+
+## Dev Notes
+
+### Key observations from code reading
+
+**`branch_name` — root cause:**
+`LaunchRun` in `run_service.go` (line 318) creates a `model.Run` with no `Metadata` field. The `Run` struct in `model/run.go` does not currently have a `Metadata` field. The `PipelineExecutor.ExecuteRun` initialises `metadata := make(map[string]any)` at line 113 (a fresh empty map), so nothing from the Run ever flows into `RunContext.Metadata`. The fix requires:
+1. Adding `Metadata map[string]interface{}` to `model.Run` (check whether the DB column already exists as JSONB — look at migrations and sqlc-generated code before adding a migration)
+2. Setting it in `LaunchRun`
+3. Merging it into the `metadata` map in `ExecuteRun` before calling `executeStep`
+
+**`template_name` — already correct:**
+`pipeline_executor.go` lines 212–218 already inject `template_name` from `actionTypeToTemplateName`. `agent_run.go` `resolveTemplateName` reads it at line 161. No code change needed here — only a test to prevent regression.
+
+**`model` propagation — two options:**
+
+Option A (preferred, minimal schema change): Add `Metadata map[string]interface{}` to `model.RunStep` backed by JSONB. Store `model` there when creating steps in `LaunchRun`. In `executeStep`, merge step metadata into the shared `metadata` map before building `RunContext`.
+
+Option B (no schema change): Store per-step model in `Run.Metadata` keyed as `"step_<order>_model"`. Simpler but less clean. Only use if the schema change for `RunStep.Metadata` is blocked.
+
+Check `backend/migrations/` and `backend/internal/adapter/postgres/db/models.go` to determine which JSONB columns already exist on `runs` and `run_steps` before deciding.
+
+**`model` in container env:**
+The entrypoint (`agent/entrypoint.sh`) does not currently consume a `MODEL` env var. Adding it to the container env is safe — the entrypoint can ignore unknown vars. When the entrypoint is updated (separate story) to honour `MODEL`, it will already be there. For this story, just ensure the env var is passed through.
+
+### File paths
+
+| File | Action |
+|------|--------|
+| `backend/internal/domain/model/run.go` | ADD `Metadata map[string]interface{}` field to `Run` struct |
+| `backend/internal/domain/model/run.go` | ADD `Metadata map[string]interface{}` field to `RunStep` struct (if option A) |
+| `backend/internal/domain/service/run_service.go` | MODIFY `LaunchRun` — compute `branch_name`, populate `run.Metadata` and step metadata |
+| `backend/internal/domain/service/pipeline_executor.go` | MODIFY `ExecuteRun` — merge `run.Metadata` into the shared `metadata` map |
+| `backend/internal/domain/service/pipeline_executor.go` | MODIFY `executeStep` — inject `model` from step metadata into `RunContext.Metadata` |
+| `backend/internal/adapter/action/agent_run.go` | MODIFY `createContainer` — add `MODEL` env var when `runCtx.Metadata["model"]` is set |
+| `backend/internal/adapter/action/agent_run_test.go` | ADD tests for branch_name and model propagation |
+| `backend/internal/domain/service/pipeline_executor_test.go` | ADD test for template_name injection per action_type |
+| `backend/migrations/` | ADD migration if `Metadata` JSONB column is missing on `runs` or `run_steps` |
+| `backend/queries/` | ADD sqlc queries if new columns require them; regenerate with `make generate` |
+
+### Branch naming convention
+
+The convention `feat/{story-key}` (lowercase) matches what `agent/entrypoint.sh` expects. Story keys are already lowercase in the system (e.g., `"runtime-4"` not `"RUNTIME-4"`). Confirm with the `Story.Key` value from the test fixtures before hardcoding the format.
+
+### No changes to `actionTypeToTemplateName`
+
+The map at `pipeline_executor.go` lines 23–27 is correct and complete. Do not touch it.
+
+### Testing approach
+
+- Use the existing `agentRunFixture` helper in `agent_run_test.go` — it already supports `Metadata` on `RunContext`
+- For `pipeline_executor` tests, hand-write a minimal mock `RunRepository` and `ActionRegistry` — follow the patterns in `pipeline_executor_test.go` if it exists, or create one matching the style of `agent_run_test.go`
+- All tests must be `-short` compatible (no containers, no network, no filesystem except temp dirs)
+
+---
+
+## Change Log
+
+- Created 2026-02-22

--- a/_bmad-output/implementation-artifacts/runtime-5-env-vars-dotenv-setup.md
+++ b/_bmad-output/implementation-artifacts/runtime-5-env-vars-dotenv-setup.md
@@ -1,0 +1,185 @@
+# Story runtime-5: Environment Variables and .env Setup
+
+**Status:** ready-for-dev
+**Branch:** `feat/runtime-5-env-vars-dotenv`
+**Commit scope:** `deploy`
+
+---
+
+## Story
+
+As a developer setting up hopeitworks for the first time, I need a documented `.env.example` file and a properly configured Docker Compose stack that forwards all required environment variables — so that agent pipeline execution works out of the box without hunting through source code for undocumented secrets.
+
+---
+
+## Acceptance Criteria
+
+**AC #1 — .env.example exists with all required variables documented**
+- Given a new developer clones the repo
+- When they look at `deploy/.env.example`
+- Then all env vars needed for full pipeline execution are listed with descriptions
+- And sensitive vars have placeholder values (e.g., `your-github-token-here`)
+- And non-sensitive vars have sensible defaults
+
+**AC #2 — docker-compose forwards agent-critical env vars**
+- Given `deploy/.env` contains `GITHUB_TOKEN=xxx` and `CLAUDE_CODE_OAUTH_TOKEN=yyy`
+- When `docker compose up` starts the api container
+- Then the api container has `GITHUB_TOKEN=xxx` and `CLAUDE_CODE_OAUTH_TOKEN=yyy` in its environment
+- And when the api spawns an agent container, those tokens are passed through
+
+**AC #3 — .env is gitignored**
+- Given `deploy/.env` exists locally
+- When `git status` is run
+- Then `.env` does not appear as untracked
+
+**AC #4 — JWT_SECRET is configurable**
+- Given `JWT_SECRET=my-secure-secret` in `.env`
+- When the api container starts
+- Then it uses `my-secure-secret` instead of the hardcoded default
+
+---
+
+## Tasks / Subtasks
+
+- [ ] **T1.** Audit all env var reads in the backend (AC: #1)
+  - [ ] T1.1 Read `backend/cmd/api/main.go` — list all `getEnvOrDefault` and `os.Getenv` calls
+  - [ ] T1.2 Read `backend/internal/adapter/action/agent_run.go` lines 191-192 — confirm token var names
+  - [ ] T1.3 Read `backend/internal/config/loader.go` — check for additional env overrides
+  - [ ] T1.4 Read `deploy/docker-compose.yml` — list all currently declared env vars
+
+- [ ] **T2.** Create `deploy/.env.example` (AC: #1, #4)
+  - [ ] T2.1 Group vars by category: Database, Auth, Docker, Agent, SMTP
+  - [ ] T2.2 Add `GITHUB_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN` with placeholder values
+  - [ ] T2.3 Add `JWT_SECRET` with placeholder and a comment warning about the insecure default
+  - [ ] T2.4 Add `AGENT_IMAGE` with default `hopeitworks/agent:latest`
+  - [ ] T2.5 Add `CLAUDE_MD_PATH` with default `agent/claude-md`
+  - [ ] T2.6 Carry over all existing vars already in `docker-compose.yml` (Postgres, SMTP, etc.)
+
+- [ ] **T3.** Update `deploy/docker-compose.yml` (AC: #2, #4)
+  - [ ] T3.1 Add `GITHUB_TOKEN: ${GITHUB_TOKEN}` to the `api` service `environment:` section
+  - [ ] T3.2 Add `CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN}` to the `api` service
+  - [ ] T3.3 Add `JWT_SECRET: ${JWT_SECRET:-dev-secret-key-change-in-production}` to the `api` service
+  - [ ] T3.4 Keep all existing env vars unchanged
+  - [ ] T3.5 Add comments grouping env vars by category for readability
+
+- [ ] **T4.** Update `.gitignore` (AC: #3)
+  - [ ] T4.1 Check if `deploy/.env` or `*.env` is already gitignored
+  - [ ] T4.2 If not, add `deploy/.env` entry to `.gitignore`
+
+---
+
+## Dev Notes
+
+### Dependencies
+
+- No code changes — deploy/config only
+- `GITHUB_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN` must be set in the host environment (or `deploy/.env`) before running `docker compose up`
+
+### File Paths
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `deploy/.env.example` | CREATE | Documents all env vars with placeholders and descriptions |
+| `deploy/docker-compose.yml` | MODIFY | Forward `GITHUB_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `JWT_SECRET` to api container |
+| `.gitignore` | MODIFY (if needed) | Ensure `deploy/.env` is not committed |
+
+### Technical Specifications
+
+**deploy/.env.example structure:**
+
+```dotenv
+# =============================================================================
+# hopeitworks — environment variables
+# Copy this file to deploy/.env and fill in the values.
+# NEVER commit deploy/.env to git.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Database
+# -----------------------------------------------------------------------------
+POSTGRES_USER=hopeitworks
+POSTGRES_PASSWORD=hopeitworks
+POSTGRES_DB=hopeitworks
+
+# -----------------------------------------------------------------------------
+# Auth
+# -----------------------------------------------------------------------------
+# SECURITY: Change this before deploying. The default is insecure.
+JWT_SECRET=your-jwt-secret-here
+
+# -----------------------------------------------------------------------------
+# Agent tokens (required for pipeline execution)
+# -----------------------------------------------------------------------------
+# GitHub personal access token or GitHub App installation token.
+# Needs repo read/write scope for the target repository.
+GITHUB_TOKEN=your-github-token-here
+
+# Claude Code OAuth token — obtained from https://claude.ai/
+CLAUDE_CODE_OAUTH_TOKEN=your-claude-code-oauth-token-here
+
+# -----------------------------------------------------------------------------
+# Docker / Agent runtime
+# -----------------------------------------------------------------------------
+# Docker image used for agent containers (must be built locally or pulled).
+AGENT_IMAGE=hopeitworks/agent:latest
+
+# Path to the CLAUDE.md template directory (relative to repo root inside container).
+CLAUDE_MD_PATH=agent/claude-md
+
+# -----------------------------------------------------------------------------
+# SMTP (optional — for email notifications)
+# -----------------------------------------------------------------------------
+SMTP_HOST=mailhog
+SMTP_PORT=1025
+SMTP_FROM=noreply@hopeitworks.local
+```
+
+**docker-compose.yml api service environment additions:**
+
+```yaml
+environment:
+  # --- existing vars (unchanged) ---
+  DATABASE_URL: postgres://...
+  # ...
+
+  # --- auth ---
+  JWT_SECRET: ${JWT_SECRET:-dev-secret-key-change-in-production}
+
+  # --- agent tokens ---
+  GITHUB_TOKEN: ${GITHUB_TOKEN}
+  CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN}
+```
+
+**Why `${VAR}` vs `${VAR:-default}`:**
+
+- `GITHUB_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN`: no default — if missing, `docker compose` will warn and the var will be empty, causing agent runs to fail at runtime (intentional — fail fast rather than silently skip auth)
+- `JWT_SECRET`: use `${JWT_SECRET:-dev-secret-key-change-in-production}` to keep the existing behavior (insecure default for local dev) while allowing override
+
+### Source Code References
+
+| File | Line(s) | What it reads |
+|------|---------|---------------|
+| `backend/cmd/api/main.go` | ~97 | `JWT_SECRET` via `getEnvOrDefault` |
+| `backend/cmd/api/main.go` | ~211 | `AGENT_IMAGE` via `getEnvOrDefault` |
+| `backend/cmd/api/main.go` | ~216 | `CLAUDE_MD_PATH` via `getEnvOrDefault` |
+| `backend/internal/adapter/action/agent_run.go` | 191 | `GITHUB_TOKEN` via `os.Getenv` |
+| `backend/internal/adapter/action/agent_run.go` | 192 | `CLAUDE_CODE_OAUTH_TOKEN` via `os.Getenv` |
+
+### Testing Requirements
+
+- Run `docker compose --env-file deploy/.env.example config` and verify no warnings about missing required vars (after filling in dummy values)
+- Verify `deploy/.env` appears in `.gitignore` output: `git check-ignore -v deploy/.env`
+- Verify `docker compose up api` picks up `JWT_SECRET` by checking the api startup log for no "insecure default" warning (if such a log exists)
+
+### References
+
+- `backend/cmd/api/main.go` — all `getEnvOrDefault` calls
+- `backend/internal/adapter/action/agent_run.go` — agent token reads
+- `deploy/docker-compose.yml` — current state of env var forwarding
+- `backend/internal/config/loader.go` — env override logic
+
+---
+
+## Change Log
+
+- Created 2026-02-22

--- a/_bmad-output/implementation-artifacts/runtime-6-default-pipeline-steps-and-templates.md
+++ b/_bmad-output/implementation-artifacts/runtime-6-default-pipeline-steps-and-templates.md
@@ -1,0 +1,133 @@
+# Story runtime-6: Default Pipeline Steps and Prompt Templates
+
+**Status:** ready-for-dev
+**Branch:** `feat/runtime-6-default-steps-templates`
+**Commit scope:** `pipeline`
+
+---
+
+## Story
+
+As the hopeitworks platform maintainer, I need the default pipeline configuration to use current model names and the prompt template DB seeds to be complete and consistent with the hardcoded fallbacks — so that new projects are seeded with correct, up-to-date defaults and existing projects are not missing the `merge` template in their DB.
+
+---
+
+## Acceptance Criteria
+
+**AC #1 — Model names are current**
+- Given `DefaultPipelineConfigYAML` is read
+- When the YAML is parsed
+- Then all model references use current model IDs (`claude-opus-4-6`, `claude-sonnet-4-6`)
+- And no reference to `claude-sonnet-4-5` remains in the codebase
+
+**AC #2 — All default templates are seeded in DB**
+- Given migration 000024 is applied
+- When all templates are queried for any project
+- Then `implement`, `implement-retry`, `review`, `merge`, and `merge-conflict` templates all exist in DB
+- And the migration is idempotent (re-running does not create duplicates)
+
+**AC #3 — Template content is consistent**
+- Given `getDefaultTemplate` returns hardcoded fallbacks
+- When compared with DB-seeded templates (migration 000012 + migration 000024)
+- Then the content is identical for each template name
+- Specifically: `implement-retry` DB seed must include `{{log_tail}}` (currently missing from 000012)
+
+**AC #4 — Templates provide quality prompts**
+- Given the `implement` template is rendered with story data
+- When an agent reads the prompt
+- Then the prompt includes: story key, title, objective, acceptance criteria, file paths to modify, branch name, and clear instructions
+- And the `review` template includes: what to check (ACs, lint, tests), how to report findings
+- And the `merge` template includes: CI check, rebase strategy, squash merge instructions
+
+**AC #5 — All tests pass**
+- Given the changes are applied
+- When `go test ./... -short` runs
+- Then all tests pass
+- And `golangci-lint run ./...` reports zero errors
+
+---
+
+## Tasks / Subtasks
+
+- [ ] **T1.** Fix model names in `DefaultPipelineConfigYAML` (AC: #1)
+  - [ ] T1.1 In `pipeline_config_service.go`, change `review` step model from `claude-sonnet-4-5` to `claude-sonnet-4-6`
+  - [ ] T1.2 In `pipeline_config_service.go`, change `merge` step model from `claude-sonnet-4-5` to `claude-sonnet-4-6`
+
+- [ ] **T2.** Create migration 000024 to seed the `merge` template (AC: #2)
+  - [ ] T2.1 Check `ls backend/migrations/` to confirm 000024 is the correct next number
+  - [ ] T2.2 Create `backend/migrations/000024_seed_merge_template.up.sql` — INSERT merge template for all projects where it does not already exist
+  - [ ] T2.3 Create `backend/migrations/000024_seed_merge_template.down.sql` — DELETE the merge template for all projects
+
+- [ ] **T3.** Sync `implement-retry` template content (AC: #3)
+  - [ ] T3.1 Update migration 000012 `implement-retry` seed to add `## Log Tail\n{{log_tail}}` section between `## Previous Error` and `## Existing Changes` (to match the hardcoded fallback in `template_service.go`)
+  - [ ] T3.2 Verify the hardcoded fallback in `getDefaultTemplate` exactly matches the 000012 seed for all other templates (implement, review, merge-conflict)
+
+- [ ] **T4.** Review and improve template content (AC: #4)
+  - [ ] T4.1 Improve `implement` hardcoded fallback and 000012 seed: add explicit instruction line ("Implement the story according to the acceptance criteria") and a `## Dev Notes` section using `{{dev_notes}}` if the variable exists in `TemplateContext`
+  - [ ] T4.2 Improve `review` hardcoded fallback and 000012 seed: add explicit check items (ACs met, `golangci-lint` passes, tests added, no secrets, no `console.log`)
+  - [ ] T4.3 Improve `merge` hardcoded fallback and 000024 seed: add explicit steps (check CI on feature branch, rebase on `develop`, create PR with `gh pr create`, squash merge with `gh pr merge --squash`, verify post-merge CI on `develop`)
+
+- [ ] **T5.** Run lint and tests (AC: #5)
+  - [ ] T5.1 `cd backend && golangci-lint run ./...` — must report zero errors
+  - [ ] T5.2 `cd backend && go test ./... -short` — must pass
+
+---
+
+## Dev Notes
+
+### Migration number
+
+Verify with `ls backend/migrations/` before creating files. At time of story writing, the last migration was 000023 (two separate 000023 files exist — `create_password_reset_tokens` and `create_revoked_tokens`). Use 000024 unless a higher number already exists.
+
+### Template variables available in `TemplateContext`
+
+Check `backend/internal/domain/model/` for the `TemplateContext` struct to know which Handlebars variables are valid. Do not reference variables that do not exist on the struct.
+
+### Down migration for 000024
+
+The down migration must only delete templates that were seeded by the up migration — do not delete templates that were manually created by users. Use a `WHERE template_content = '...'` guard or, safer, just DELETE by name since these are the platform defaults:
+
+```sql
+DELETE FROM prompt_templates WHERE name = 'merge';
+```
+
+### Hardcoded fallback vs DB seed — when each is used
+
+- DB seeds (000012, 000024): used for existing projects after migration runs. New projects are seeded by `SeedDefaultTemplates` service call at project creation time.
+- Hardcoded fallbacks in `getDefaultTemplate`: safety net when DB lookup returns not-found (e.g., template deleted by user, new template name added before next migration).
+- Both must stay in sync — the DB is the primary source, the hardcoded fallback is the emergency backup.
+
+### Do NOT remove hardcoded fallbacks
+
+The `getDefaultTemplate` function in `template_service.go` must retain all fallbacks even after adding the DB seed migration.
+
+### Template syntax
+
+Templates use Handlebars syntax. Variables: `{{variable_name}}`. Loops: `{{#each list}}- {{this}}{{/each}}`. The renderer is registered in `TemplateRenderer` port.
+
+### Merge template content guidance
+
+The merge step agent must:
+1. Check that the feature branch CI is green (use `gh pr checks` or `gh run list`)
+2. Rebase the feature branch on `develop` (or base branch)
+3. Open a PR with `gh pr create --title "..." --body "..."` following conventional commit format
+4. Squash merge with `gh pr merge --squash --auto` or after CI green
+5. Confirm the merge and verify `develop` CI passes
+
+---
+
+## File Paths
+
+| Action | Path |
+|--------|------|
+| MODIFY | `backend/internal/domain/service/pipeline_config_service.go` |
+| MODIFY | `backend/internal/domain/service/template_service.go` |
+| MODIFY | `backend/migrations/000012_seed_default_prompt_templates.up.sql` |
+| CREATE | `backend/migrations/000024_seed_merge_template.up.sql` |
+| CREATE | `backend/migrations/000024_seed_merge_template.down.sql` |
+
+---
+
+## Change Log
+
+- Story created (2026-02-22)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -187,10 +187,13 @@ development_status:
   1-22-auto-migrate-on-startup: ready-for-dev
 
   # Post-MVP: Agent Runtime & E2E Pipeline
-  post-mvp-agent-runtime: backlog
+  post-mvp-agent-runtime: in-progress
   runtime-1-agent-docker-image: done
-  runtime-2-action-wiring-and-action-type-mapping: ready-for-dev
+  runtime-2-action-wiring-and-action-type-mapping: done
   runtime-3-test-project-postgres-e2e-validation: done
+  runtime-4-run-context-metadata-propagation: ready-for-dev
+  runtime-5-env-vars-dotenv-setup: ready-for-dev
+  runtime-6-default-pipeline-steps-and-templates: ready-for-dev
 
   # Post-MVP: E2E Usability Fixes
   post-mvp-e2e-usability: done
@@ -857,3 +860,22 @@ parallel_waves:
     container_count: 1
     depends_on: [wave-27]
     notes: "Fix test-project + validate real end-to-end pipeline run"
+
+  wave-29:
+    phase: 9-agent-runtime
+    stories:
+      - key: runtime-4-run-context-metadata-propagation
+        domain: back
+        status: ready-for-dev
+        cross_epic_deps: []
+      - key: runtime-5-env-vars-dotenv-setup
+        domain: shared
+        status: ready-for-dev
+        cross_epic_deps: []
+      - key: runtime-6-default-pipeline-steps-and-templates
+        domain: back
+        status: ready-for-dev
+        cross_epic_deps: []
+    container_count: 3
+    depends_on: [wave-28]
+    notes: "RunContext metadata + env vars + default pipeline config/templates"


### PR DESCRIPTION
## Summary
- runtime-4: RunContext metadata propagation (branch_name, template_name, model) — BLOQUANT
- runtime-5: Environment variables and .env.example setup
- runtime-6: Default pipeline steps and prompt templates
- Sprint status updated with wave-29

## Test plan
- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)