### PR TITLE
feat(deploy): add .env.example and forward agent tokens in docker-compose

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,66 @@
+# =============================================================================
+# hopeitworks — environment variables
+# Copy this file to deploy/.env and fill in the values.
+# NEVER commit deploy/.env to git.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Database
+# -----------------------------------------------------------------------------
+POSTGRES_USER=hopeitworks
+POSTGRES_PASSWORD=hopeitworks_dev_password
+POSTGRES_DB=hopeitworks_dev
+# Host port for Postgres (container always listens on 5432 internally)
+POSTGRES_PORT=5432
+
+# -----------------------------------------------------------------------------
+# Auth
+# -----------------------------------------------------------------------------
+# SECURITY: Change this before deploying. The default is insecure.
+JWT_SECRET=your-jwt-secret-here
+
+# -----------------------------------------------------------------------------
+# Agent tokens (required for pipeline execution)
+# -----------------------------------------------------------------------------
+# GitHub personal access token or GitHub App installation token.
+# Needs repo read/write scope for the target repository.
+GITHUB_TOKEN=your-github-token-here
+
+# Claude Code OAuth token — obtained from https://claude.ai/
+CLAUDE_CODE_OAUTH_TOKEN=your-claude-code-oauth-token-here
+
+# -----------------------------------------------------------------------------
+# Docker / Agent runtime
+# -----------------------------------------------------------------------------
+# Docker image used for agent containers (must be built locally or pulled).
+AGENT_IMAGE=hopeitworks/agent:latest
+
+# Path to the CLAUDE.md template directory (relative to repo root inside container).
+CLAUDE_MD_PATH=agent/claude-md
+
+# Docker network for agent containers (must match the Compose-created network name).
+DOCKER_AGENT_NETWORK=deploy_hopeitworks_agent-network
+
+# -----------------------------------------------------------------------------
+# Application
+# -----------------------------------------------------------------------------
+APP_ENV=development
+LOG_LEVEL=debug
+SERVER_PORT=8080
+FRONTEND_URL=http://localhost:5173
+
+# -----------------------------------------------------------------------------
+# SMTP (optional — MailHog is used for local dev)
+# -----------------------------------------------------------------------------
+# SMTP_HOST and SMTP_PORT are set directly in docker-compose.yml for the api
+# service (pointing to the mailhog container). Override here only if using an
+# external mail server.
+# SMTP_HOST=mailhog
+# SMTP_PORT=1025
+SMTP_FROM=noreply@hopeitworks.local
+# SMTP_USERNAME=
+# SMTP_PASSWORD=
+
+# MailHog UI/SMTP host port mappings
+MAILHOG_SMTP_PORT=1025
+MAILHOG_UI_PORT=8025

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -41,20 +41,31 @@ services:
       dockerfile: Dockerfile
     container_name: hopeitworks-api
     environment:
+      # --- application ---
       APP_ENV: ${APP_ENV:-development}
       LOG_LEVEL: ${LOG_LEVEL:-debug}
       SERVER_PORT: ${SERVER_PORT:-8080}
+      # --- database ---
       DB_HOST: postgres
       DB_PORT: 5432
       DB_NAME: ${POSTGRES_DB:-hopeitworks_dev}
       DB_USER: ${POSTGRES_USER:-hopeitworks}
       DB_PASSWORD: ${POSTGRES_PASSWORD:-hopeitworks_dev_password}
       DB_SSLMODE: disable
+      # --- auth ---
+      JWT_SECRET: ${JWT_SECRET:-dev-secret-key-change-in-production}
+      # --- docker / agent runtime ---
       DOCKER_HOST: tcp://socket-proxy:2375
       DOCKER_AGENT_NETWORK: ${DOCKER_AGENT_NETWORK:-deploy_hopeitworks_agent-network}
+      AGENT_IMAGE: ${AGENT_IMAGE:-hopeitworks/agent:latest}
+      CLAUDE_MD_PATH: ${CLAUDE_MD_PATH:-agent/claude-md}
+      # --- agent tokens (required for pipeline execution) ---
+      GITHUB_TOKEN: ${GITHUB_TOKEN}
+      CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN}
+      # --- smtp ---
       SMTP_HOST: mailhog
       SMTP_PORT: 1025
-      SMTP_FROM: noreply@hopeitworks.local
+      SMTP_FROM: ${SMTP_FROM:-noreply@hopeitworks.local}
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost:5173}
     ports:
       - "${SERVER_PORT:-8080}:8080"


### PR DESCRIPTION
## Summary
- Create `deploy/.env.example` documenting all environment variables needed for pipeline execution (database, auth, agent tokens, Docker runtime, SMTP) with placeholder values and descriptions
- Update `deploy/docker-compose.yml` to forward `JWT_SECRET`, `GITHUB_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `AGENT_IMAGE`, and `CLAUDE_MD_PATH` to the api container
- Add category comments to docker-compose env vars for readability
- `deploy/.env` is already gitignored by existing `.gitignore` rules

## Test plan
- [ ] Verify `deploy/.env.example` contains all env vars referenced by backend code
- [ ] Verify `docker compose config` produces valid output when using `.env.example` as source
- [ ] Verify `git check-ignore deploy/.env` confirms the file is ignored
- [ ] Verify api container receives `JWT_SECRET`, `GITHUB_TOKEN`, and `CLAUDE_CODE_OAUTH_TOKEN` when started with `docker compose up`

Refs: runtime-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)