### PR TITLE
fix(test): update TestLaunchRun_ModelInMetadata to expect claude-sonnet-4-6

### DIFF
--- a/backend/internal/domain/service/run_service_test.go
+++ b/backend/internal/domain/service/run_service_test.go
@@ -739,8 +739,8 @@ func TestLaunchRun_ModelInMetadata(t *testing.T) {
 	if !ok {
 		t.Fatal("expected step_1_model in metadata")
 	}
-	if step1Model != "claude-sonnet-4-5" {
-		t.Errorf("expected step_1_model %q, got %q", "claude-sonnet-4-5", step1Model)
+	if step1Model != "claude-sonnet-4-6" {
+		t.Errorf("expected step_1_model %q, got %q", "claude-sonnet-4-6", step1Model)
 	}
 }
 


### PR DESCRIPTION
Post-merge fix after runtime-6 model name updates.

PR #142 (runtime-4) was merged with a test expecting the old model name `claude-sonnet-4-5`, which conflicts with runtime-6's update to `claude-sonnet-4-6`.

This fix updates the test assertion to expect the current model name.

Fixes the failing CI on develop after runtime-6 merge.