### PR TITLE
fix(pipeline): configure River default queue for job execution

### DIFF
--- a/backend/internal/adapter/river/job_queue.go
+++ b/backend/internal/adapter/river/job_queue.go
@@ -25,6 +25,9 @@ type JobQueue struct {
 // workers must have all job types registered before calling NewClient.
 func NewJobQueue(pool *pgxpool.Pool, workers *river.Workers) (*JobQueue, error) {
 	client, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: 10},
+		},
 		Workers: workers,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `Queues` config to River client initialization
- Without it, `river.Client.Start()` fails and no jobs are processed
- Sets `MaxWorkers: 10` on the default queue

## Test plan
- [x] `go build ./...` passes
- [x] Backend starts without River error in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)