### PR TITLE
fix(pipeline): auto-migrate River internal tables on startup

### DIFF
--- a/backend/internal/adapter/river/job_queue.go
+++ b/backend/internal/adapter/river/job_queue.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivermigrate"
 
 	"github.com/zakari/hopeitworks/backend/internal/domain/port"
 )
@@ -23,7 +24,16 @@ type JobQueue struct {
 
 // NewJobQueue creates a new JobQueue.
 // workers must have all job types registered before calling NewClient.
+// River tables are auto-migrated on creation.
 func NewJobQueue(pool *pgxpool.Pool, workers *river.Workers) (*JobQueue, error) {
+	migrator, err := rivermigrate.New(riverpgxv5.New(pool), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create river migrator: %w", err)
+	}
+	if _, err := migrator.Migrate(context.Background(), rivermigrate.DirectionUp, nil); err != nil {
+		return nil, fmt.Errorf("run river migrations: %w", err)
+	}
+
 	client, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},


### PR DESCRIPTION
## Summary
- Add `rivermigrate.Migrate()` call in `NewJobQueue` to auto-create River's internal tables
- Without this, River's `Start()` fails with "relation river_queue does not exist"
- Combined with previous fix (#145) for queue config, River now starts correctly

## Test plan
- [x] `go build ./...` passes
- [x] Backend starts without any River errors
- [x] `river_queue` table created in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)