### PR TITLE
fix(deploy): fix agent runtime startup issues

### DIFF
--- a/agent/entrypoint.sh
+++ b/agent/entrypoint.sh
@@ -53,7 +53,8 @@ if [[ -n "${GITHUB_TOKEN:-}" ]]; then
 fi
 
 # --- Configure Claude Code authentication ---
-export ANTHROPIC_API_KEY="$CLAUDE_CODE_OAUTH_TOKEN"
+# CLAUDE_CODE_OAUTH_TOKEN is natively recognized by Claude Code (authMethod: oauth_token).
+# Do NOT remap it to ANTHROPIC_API_KEY — that expects a direct API key, not an OAuth token.
 
 # --- Clone repository ---
 emit_log "Cloning repository: $REPO_URL (branch: $BRANCH_NAME)"
@@ -108,7 +109,7 @@ emit_log "Prompt written to /tmp/prompt.md"
 emit_log "Starting Claude Code agent"
 
 EXIT_CODE=0
-claude --dangerously-skip-permissions --print --output-format stream-json < /tmp/prompt.md || EXIT_CODE=$?
+claude --dangerously-skip-permissions --print --verbose --output-format stream-json < /tmp/prompt.md || EXIT_CODE=$?
 
 # --- Emit cost event ---
 # Claude Code with --output-format stream-json emits result messages that may

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-hopeitworks}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-hopeitworks} -d ${POSTGRES_DB:-hopeitworks_dev}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -67,6 +67,8 @@ services:
       SMTP_PORT: 1025
       SMTP_FROM: ${SMTP_FROM:-noreply@hopeitworks.local}
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost:5173}
+    volumes:
+      - ../agent/claude-md:/app/agent/claude-md:ro
     ports:
       - "${SERVER_PORT:-8080}:8080"
     depends_on:


### PR DESCRIPTION
## Summary
- Fix pg_isready healthcheck to specify correct DB name (stops FATAL log spam in Postgres)
- Mount `agent/claude-md/` templates into API container (fixes "no such file" error)
- Fix Claude Code auth: use native `CLAUDE_CODE_OAUTH_TOKEN` env var instead of remapping to `ANTHROPIC_API_KEY`
- Add `--verbose` flag required by `--output-format stream-json`

## Test plan
- [x] Verified agent container starts and stays running
- [x] Verified Claude Code authenticates with OAuth token
- [x] Verified Postgres logs are clean (no more FATAL spam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)