### PR TITLE
fix(pipeline): runtime fixes and SSE live update wiring

### DIFF
--- a/backend/internal/adapter/river/execute_run_job.go
+++ b/backend/internal/adapter/river/execute_run_job.go
@@ -2,6 +2,7 @@ package river
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/riverqueue/river"
@@ -26,6 +27,12 @@ type ExecuteRunWorker struct {
 // NewExecuteRunWorker creates a new ExecuteRunWorker.
 func NewExecuteRunWorker(executor *service.PipelineExecutor) *ExecuteRunWorker {
 	return &ExecuteRunWorker{executor: executor}
+}
+
+// Timeout returns the maximum duration for a pipeline run job.
+// Agent containers can take 30+ minutes for complex stories.
+func (w *ExecuteRunWorker) Timeout(_ *river.Job[ExecuteRunArgs]) time.Duration {
+	return 45 * time.Minute
 }
 
 // Work executes the pipeline run identified by the job payload.

--- a/backend/internal/integration/pipeline_validation_test.go
+++ b/backend/internal/integration/pipeline_validation_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/zakari/hopeitworks/backend/internal/testutil"
 )
 
-// testProjectStoriesPath returns the path to test-project/stories/todo-stories.md.
+// testProjectStoriesPath returns the path to testdata/todo-stories.md.
 func testProjectStoriesPath() string {
 	_, filename, _, _ := runtime.Caller(0)
-	return filepath.Join(filepath.Dir(filename), "..", "..", "..", "test-project", "stories", "todo-stories.md")
+	return filepath.Join(filepath.Dir(filename), "..", "..", "testdata", "todo-stories.md")
 }
 
 const (

--- a/backend/testdata/todo-stories.md
+++ b/backend/testdata/todo-stories.md
@@ -1,0 +1,69 @@
+---
+key: TODO-1
+epic: E-1
+scope: backend
+status: backlog
+---
+# Add create todo endpoint
+
+## Acceptance Criteria
+- POST /todos creates a new todo item
+- Returns 201 with the created todo
+- Validates required fields
+
+---
+key: TODO-2
+epic: E-1
+scope: backend
+status: backlog
+---
+# Add list todos endpoint
+
+## Acceptance Criteria
+- GET /todos returns all todo items
+- Supports pagination
+- Returns 200 with list
+
+---
+key: TODO-3
+epic: E-1
+depends_on:
+  - TODO-1
+scope: backend
+status: backlog
+---
+# Add update todo endpoint
+
+## Acceptance Criteria
+- PUT /todos/{id} updates an existing todo
+- Returns 200 with updated todo
+- Returns 404 if todo not found
+
+---
+key: TODO-4
+epic: E-1
+scope: backend
+status: backlog
+---
+# Add delete todo endpoint
+
+## Acceptance Criteria
+- DELETE /todos/{id} deletes a todo
+- Returns 204 on success
+- Returns 404 if todo not found
+
+---
+key: TODO-5
+epic: E-1
+depends_on:
+  - TODO-2
+  - TODO-3
+scope: frontend
+status: backlog
+---
+# Add todo list UI
+
+## Acceptance Criteria
+- Displays list of todos fetched from API
+- Supports creating, updating, and deleting todos
+- Shows loading and error states

--- a/frontend/src/features/runs/__tests__/useRecentRuns.spec.ts
+++ b/frontend/src/features/runs/__tests__/useRecentRuns.spec.ts
@@ -10,6 +10,10 @@ vi.mock('@/api/client', () => ({
   },
 }))
 
+vi.mock('@/composables/useSSE', () => ({
+  useSSE: vi.fn(),
+}))
+
 /** Wraps composable that calls onMounted in a simulated lifecycle */
 function withSetup<T>(composable: () => T): T {
   let result!: T

--- a/frontend/src/features/runs/__tests__/useRunDetail.spec.ts
+++ b/frontend/src/features/runs/__tests__/useRunDetail.spec.ts
@@ -10,6 +10,10 @@ vi.mock('@/api/client', () => ({
   },
 }))
 
+vi.mock('@/composables/useSSE', () => ({
+  useSSE: vi.fn(),
+}))
+
 /** Wraps composable that calls onMounted in a simulated lifecycle */
 function withSetup<T>(composable: () => T): T {
   let result!: T
@@ -64,7 +68,7 @@ describe('useRunDetail', () => {
   it('fetches run on mount and populates run.value', async () => {
     mockGet.mockResolvedValue({ data: mockRun, error: undefined })
 
-    const { run, isLoading } = withSetup(() => useRunDetail('run-1'))
+    const { run, isLoading } = withSetup(() => useRunDetail('run-1', ''))
     await flushPromises()
 
     expect(run.value).toEqual(mockRun)
@@ -78,7 +82,7 @@ describe('useRunDetail', () => {
       error: { error: { code: 'NOT_FOUND', message: 'Run not found' } },
     })
 
-    const { run, error } = withSetup(() => useRunDetail('run-1'))
+    const { run, error } = withSetup(() => useRunDetail('run-1', ''))
     await flushPromises()
 
     expect(run.value).toBeNull()
@@ -89,7 +93,7 @@ describe('useRunDetail', () => {
   it('retry() re-calls the API', async () => {
     mockGet.mockResolvedValue({ data: mockRun, error: undefined })
 
-    const { retry } = withSetup(() => useRunDetail('run-1'))
+    const { retry } = withSetup(() => useRunDetail('run-1', ''))
     await flushPromises()
 
     expect(mockGet).toHaveBeenCalledTimes(1)
@@ -109,7 +113,7 @@ describe('useRunDetail', () => {
       }),
     )
 
-    const { isLoading } = withSetup(() => useRunDetail('run-1'))
+    const { isLoading } = withSetup(() => useRunDetail('run-1', ''))
 
     expect(isLoading.value).toBe(true)
 

--- a/frontend/src/features/runs/composables/useRecentRuns.ts
+++ b/frontend/src/features/runs/composables/useRecentRuns.ts
@@ -1,5 +1,6 @@
 import { ref, onMounted } from 'vue'
 import { apiClient } from '@/api/client'
+import { useSSE } from '@/composables/useSSE'
 
 /** Lightweight run shape for list views (matches OpenAPI Run schema fields). */
 export interface RunSummary {
@@ -101,6 +102,16 @@ export function useRecentRuns(options?: { projectId?: string; limit?: number }) 
     }
     allRuns.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
     runs.value = allRuns.slice(0, limit)
+  }
+
+  // When scoped to a single project, subscribe to SSE so the list stays live
+  // without polling. The global (no-projectId) list only updates on manual refresh.
+  if (projectId) {
+    useSSE(projectId, (eventName) => {
+      if (eventName === 'run.started' || eventName === 'run.completed' || eventName === 'run.failed') {
+        fetchRuns()
+      }
+    })
   }
 
   onMounted(fetchRuns)

--- a/frontend/src/features/runs/composables/useRunDetail.ts
+++ b/frontend/src/features/runs/composables/useRunDetail.ts
@@ -1,5 +1,6 @@
 import { onMounted } from 'vue'
 import { useAsyncAction } from '@/composables/useAsyncAction'
+import { useSSE } from '@/composables/useSSE'
 import { apiClient } from '@/api/client'
 
 /** Run with steps shape matching the API RunWithSteps schema. */
@@ -33,11 +34,23 @@ export interface RunStep {
   created_at: string
 }
 
+/** SSE event types that should trigger a run data refetch. */
+const RUN_REFRESH_EVENTS = new Set([
+  'run.started',
+  'run.completed',
+  'run.failed',
+  'step.started',
+  'step.completed',
+  'step.failed',
+])
+
 /**
  * Composable for fetching a single run by ID with its steps.
  * Uses useAsyncAction to wrap the API call with loading/error state.
+ * Subscribes to SSE events for the given project and refetches whenever
+ * a run or step event matches the current run ID.
  */
-export function useRunDetail(runId: string) {
+export function useRunDetail(runId: string, projectId: string) {
   const {
     data: run,
     isLoading,
@@ -53,6 +66,19 @@ export function useRunDetail(runId: string) {
 
   async function fetchRun() {
     await execute()
+  }
+
+  // Subscribe to SSE events if a projectId is available so run/step status
+  // changes are reflected immediately without polling.
+  if (projectId) {
+    useSSE(projectId, (eventName, data) => {
+      if (!RUN_REFRESH_EVENTS.has(eventName)) return
+      const payload = data as { run_id?: string; step?: { run_id?: string } }
+      // Events carry run_id at the top level or nested inside a step object.
+      const eventRunId = payload.run_id ?? payload.step?.run_id
+      if (eventRunId && eventRunId !== runId) return
+      fetchRun()
+    })
   }
 
   onMounted(fetchRun)

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -22,7 +22,7 @@ const projectId = computed(() => route.query.projectId as string ?? '')
 const runsStore = useRunsStore()
 const toast = useToast()
 
-const { run: runRef, isLoading, error, retry } = useRunDetail(runId.value)
+const { run: runRef, isLoading, error, retry } = useRunDetail(runId.value, projectId.value)
 const run = computed(() => runRef.value)
 
 const stepSeverity: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Increase River job timeout from 1min to 45min (agents need time to code)
- Wire SSE events to RunDetailView for live run/step status updates
- Wire SSE events to runs list for auto-refresh on status changes
- Fix tests for SSE mock

## Test plan
- [x] 536/536 frontend tests passing
- [x] Go builds clean
- [x] Agent container confirmed running >1min before timeout fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)