### PR TITLE
fix(pipeline): update story status on run start/complete/fail

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -240,7 +240,7 @@ func run() error {
 	}
 
 	// Pipeline executor: wired with the real action registry and event publisher
-	pipelineExecutor := service.NewPipelineExecutor(runRepo, actionReg, eventRepo, logger)
+	pipelineExecutor := service.NewPipelineExecutor(runRepo, storyRepo, actionReg, eventRepo, logger)
 	pipelineExecutor.SetCircuitBreaker(circuitBreakerService)
 
 	// River job queue for async pipeline execution

--- a/backend/internal/domain/service/epic_run_service_test.go
+++ b/backend/internal/domain/service/epic_run_service_test.go
@@ -200,7 +200,7 @@ func TestLaunchEpicRun_HappyPath(t *testing.T) {
 	}
 	runSvc := NewRunService(runRepo, pRepo, sRepo, mockPCR, &mockJobQueue{})
 	actionReg := newMockActionRegistry()
-	pipeExec := NewPipelineExecutor(runRepo, actionReg, eventPub, logger)
+	pipeExec := NewPipelineExecutor(runRepo, sRepo, actionReg, eventPub, logger)
 	stubExecutor := NewParallelGroupExecutor(epicRunRepo, runSvc, pipeExec, eventPub, logger)
 
 	svc := NewEpicRunService(epicRunRepo, storyRepo, epicRepo, scheduler, stubExecutor, eventPub, logger)

--- a/backend/internal/domain/service/parallel_group_executor_test.go
+++ b/backend/internal/domain/service/parallel_group_executor_test.go
@@ -83,7 +83,7 @@ func TestParallelGroupExecutor_Execute_HappyPath(t *testing.T) {
 
 	runSvc := NewRunService(runRepo, projectRepo, storyRepo, mockPCR, &mockJobQueue{})
 	actionReg := newMockActionRegistry()
-	pipeExec := NewPipelineExecutor(runRepo, actionReg, eventPub, logger)
+	pipeExec := NewPipelineExecutor(runRepo, storyRepo, actionReg, eventPub, logger)
 	executor := NewParallelGroupExecutor(epicRunRepo, runSvc, pipeExec, eventPub, logger)
 
 	err := executor.Execute(context.Background(), epicRun, dag)
@@ -178,7 +178,7 @@ func TestParallelGroupExecutor_Execute_FailFast(t *testing.T) {
 
 	runSvc := NewRunService(runRepo, projectRepo, storyRepo, mockPCR, &mockJobQueue{})
 	actionReg := newMockActionRegistry()
-	pipeExec := NewPipelineExecutor(runRepo, actionReg, eventPub, logger)
+	pipeExec := NewPipelineExecutor(runRepo, storyRepo, actionReg, eventPub, logger)
 	executor := NewParallelGroupExecutor(epicRunRepo, runSvc, pipeExec, eventPub, logger)
 
 	err := executor.Execute(context.Background(), epicRun, dag)

--- a/backend/internal/domain/service/pipeline_executor.go
+++ b/backend/internal/domain/service/pipeline_executor.go
@@ -34,6 +34,7 @@ var errStepSuspended = errors.New("step suspended for approval")
 // PipelineExecutor orchestrates sequential execution of pipeline steps.
 type PipelineExecutor struct {
 	runRepo        port.RunRepository
+	storyRepo      port.StoryRepository
 	actionReg      port.ActionRegistry
 	eventPub       port.EventPublisher
 	circuitBreaker *CircuitBreakerService
@@ -43,12 +44,14 @@ type PipelineExecutor struct {
 // NewPipelineExecutor creates a new pipeline executor.
 func NewPipelineExecutor(
 	runRepo port.RunRepository,
+	storyRepo port.StoryRepository,
 	actionReg port.ActionRegistry,
 	eventPub port.EventPublisher,
 	logger *slog.Logger,
 ) *PipelineExecutor {
 	return &PipelineExecutor{
 		runRepo:   runRepo,
+		storyRepo: storyRepo,
 		actionReg: actionReg,
 		eventPub:  eventPub,
 		logger:    logger,
@@ -108,6 +111,9 @@ func (e *PipelineExecutor) ExecuteRun(ctx context.Context, runID uuid.UUID) erro
 		"status":     string(model.RunStatusRunning),
 		"started_at": now.Format(time.RFC3339),
 	})
+
+	// Transition story to "running"
+	e.updateStoryStatus(ctx, run, model.StoryStatusRunning)
 
 	// 4. Merge persisted run metadata into the shared metadata map.
 	// This carries branch_name and per-step model keys set by LaunchRun.
@@ -169,6 +175,9 @@ func (e *PipelineExecutor) ExecuteRun(ctx context.Context, runID uuid.UUID) erro
 		"status":       string(model.RunStatusCompleted),
 		"completed_at": completedAt.Format(time.RFC3339),
 	})
+
+	// Transition story to "done"
+	e.updateStoryStatus(ctx, run, model.StoryStatusDone)
 
 	// Reset circuit breaker count on success
 	if e.circuitBreaker != nil {
@@ -291,6 +300,9 @@ func (e *PipelineExecutor) handleStepFailure(ctx context.Context, run *model.Run
 		"status":        string(model.RunStatusFailed),
 		"error_message": errMsg,
 	})
+
+	// Transition story to "failed"
+	e.updateStoryStatus(ctx, run, model.StoryStatusFailed)
 }
 
 // handleCancellation marks step and run as cancelled, publishes events.
@@ -322,6 +334,48 @@ func (e *PipelineExecutor) handleCancellation(run *model.Run, step *model.RunSte
 	e.publishEvent(bgCtx, run.ProjectID, "run", run.ID, "cancelled", map[string]any{
 		"run_id": run.ID.String(),
 		"status": string(model.RunStatusCancelled),
+	})
+}
+
+// updateStoryStatus fetches the story linked to the run and updates its status.
+// Errors are logged without failing the run execution — story status is best-effort.
+func (e *PipelineExecutor) updateStoryStatus(ctx context.Context, run *model.Run, status string) {
+	if run.StoryID == uuid.Nil {
+		return
+	}
+
+	story, err := e.storyRepo.GetByID(ctx, run.StoryID)
+	if err != nil {
+		e.logger.Error("failed to fetch story for status update",
+			"story_id", run.StoryID,
+			"run_id", run.ID,
+			"target_status", status,
+			"error", err,
+		)
+		return
+	}
+
+	story.Status = status
+	if _, err := e.storyRepo.Update(ctx, story); err != nil {
+		e.logger.Error("failed to update story status",
+			"story_id", run.StoryID,
+			"run_id", run.ID,
+			"target_status", status,
+			"error", err,
+		)
+		return
+	}
+
+	e.logger.Info("story status updated",
+		"story_id", run.StoryID,
+		"run_id", run.ID,
+		"status", status,
+	)
+
+	e.publishEvent(ctx, run.ProjectID, "story", run.StoryID, "status_updated", map[string]any{
+		"story_id": run.StoryID.String(),
+		"run_id":   run.ID.String(),
+		"status":   status,
 	})
 }
 

--- a/backend/internal/domain/service/pipeline_executor_test.go
+++ b/backend/internal/domain/service/pipeline_executor_test.go
@@ -103,6 +103,49 @@ type stepStatusCall struct {
 	ErrorMsg    *string
 }
 
+// mockStoryRepoForExecutor implements port.StoryRepository for PipelineExecutor testing.
+type mockStoryRepoForExecutor struct {
+	getByIDFn func(ctx context.Context, id uuid.UUID) (*model.Story, error)
+	updateFn  func(ctx context.Context, story *model.Story) (*model.Story, error)
+}
+
+func (m *mockStoryRepoForExecutor) Create(_ context.Context, story *model.Story) (*model.Story, error) {
+	return story, nil
+}
+func (m *mockStoryRepoForExecutor) GetByID(ctx context.Context, id uuid.UUID) (*model.Story, error) {
+	if m.getByIDFn != nil {
+		return m.getByIDFn(ctx, id)
+	}
+	return nil, nil
+}
+func (m *mockStoryRepoForExecutor) GetByKey(_ context.Context, _ uuid.UUID, _ string) (*model.Story, error) {
+	return nil, nil
+}
+func (m *mockStoryRepoForExecutor) ListByProject(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Story, error) {
+	return nil, nil
+}
+func (m *mockStoryRepoForExecutor) ListByStatus(_ context.Context, _ uuid.UUID, _ []string, _, _ int32) ([]*model.Story, error) {
+	return nil, nil
+}
+func (m *mockStoryRepoForExecutor) ListByEpic(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Story, error) {
+	return nil, nil
+}
+func (m *mockStoryRepoForExecutor) CountByProject(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+func (m *mockStoryRepoForExecutor) CountByStatus(_ context.Context, _ uuid.UUID, _ []string) (int64, error) {
+	return 0, nil
+}
+func (m *mockStoryRepoForExecutor) Update(ctx context.Context, story *model.Story) (*model.Story, error) {
+	if m.updateFn != nil {
+		return m.updateFn(ctx, story)
+	}
+	return story, nil
+}
+func (m *mockStoryRepoForExecutor) Delete(_ context.Context, _ uuid.UUID) error {
+	return nil
+}
+
 // executorTestFixture provides shared test setup for PipelineExecutor tests.
 type executorTestFixture struct {
 	runID     uuid.UUID
@@ -112,6 +155,7 @@ type executorTestFixture struct {
 	run       *model.Run
 
 	runRepo   *mockRunRepo
+	storyRepo *mockStoryRepoForExecutor
 	actionReg *mockActionRegistry
 	eventPub  *mockEventPublisher
 	executor  *PipelineExecutor
@@ -128,6 +172,17 @@ func newExecutorTestFixture(stepCount int) *executorTestFixture {
 		storyID:   uuid.New(),
 		actionReg: newMockActionRegistry(),
 		eventPub:  newMockEventPublisher(),
+	}
+
+	// storyRepo returns a basic story by default so updateStoryStatus doesn't panic.
+	f.storyRepo = &mockStoryRepoForExecutor{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			return &model.Story{
+				ID:        id,
+				ProjectID: f.projectID,
+				Status:    model.StoryStatusBacklog,
+			}, nil
+		},
 	}
 
 	f.run = &model.Run{
@@ -220,7 +275,7 @@ func newExecutorTestFixture(stepCount int) *executorTestFixture {
 		},
 	}
 
-	f.executor = NewPipelineExecutor(f.runRepo, f.actionReg, f.eventPub, testLogger())
+	f.executor = NewPipelineExecutor(f.runRepo, f.storyRepo, f.actionReg, f.eventPub, testLogger())
 
 	return f
 }
@@ -316,14 +371,18 @@ func TestExecuteRun_EventsPublishedInOrder(t *testing.T) {
 	events := f.eventPub.getEvents()
 
 	// Expected event order:
-	// run.started, step.started(0), step.completed(0), step.started(1), step.completed(1), run.completed
+	// run.started, story.status_updated(running),
+	// step.started(0), step.completed(0), step.started(1), step.completed(1),
+	// run.completed, story.status_updated(done)
 	expectedEvents := []string{
 		"run.started",
+		"story.status_updated",
 		"step.started",
 		"step.completed",
 		"step.started",
 		"step.completed",
 		"run.completed",
+		"story.status_updated",
 	}
 
 	if len(events) != len(expectedEvents) {
@@ -349,9 +408,9 @@ func TestExecuteRun_EventsPublishedInOrder(t *testing.T) {
 		t.Errorf("run.started payload: expected status running, got %v", startedPayload["status"])
 	}
 
-	// Verify step events include step_id and step_name
+	// Verify step events include step_id and step_name (now at index 2, after story.status_updated)
 	var stepPayload map[string]any
-	if err := json.Unmarshal(events[1].Event.Payload, &stepPayload); err != nil {
+	if err := json.Unmarshal(events[2].Event.Payload, &stepPayload); err != nil {
 		t.Fatalf("failed to unmarshal step.started payload: %v", err)
 	}
 	if _, ok := stepPayload["step_id"]; !ok {
@@ -361,9 +420,9 @@ func TestExecuteRun_EventsPublishedInOrder(t *testing.T) {
 		t.Error("step.started payload: missing step_name")
 	}
 
-	// Verify run.completed event payload
+	// Verify run.completed event payload (at index 6, before final story.status_updated)
 	var completedPayload map[string]any
-	if err := json.Unmarshal(events[len(events)-1].Event.Payload, &completedPayload); err != nil {
+	if err := json.Unmarshal(events[6].Event.Payload, &completedPayload); err != nil {
 		t.Fatalf("failed to unmarshal run.completed payload: %v", err)
 	}
 	if completedPayload["run_id"] != f.runID.String() {
@@ -706,14 +765,18 @@ func TestExecuteRun_FailureEventOrder(t *testing.T) {
 	events := f.eventPub.getEvents()
 
 	// Expected event order:
-	// run.started, step.started(0), step.completed(0), step.started(1), step.failed(1), run.failed
+	// run.started, story.status_updated(running),
+	// step.started(0), step.completed(0), step.started(1), step.failed(1),
+	// run.failed, story.status_updated(failed)
 	expectedEvents := []string{
 		"run.started",
+		"story.status_updated",
 		"step.started",
 		"step.completed",
 		"step.started",
 		"step.failed",
 		"run.failed",
+		"story.status_updated",
 	}
 
 	if len(events) != len(expectedEvents) {

--- a/backend/internal/integration/pipeline_validation_test.go
+++ b/backend/internal/integration/pipeline_validation_test.go
@@ -399,7 +399,7 @@ func TestIntegration_PipelineValidation_Execution(t *testing.T) {
 	eventRepo := postgres.NewEventRepo(queries)
 
 	// Create pipeline executor
-	executor := service.NewPipelineExecutor(runRepo, actionReg, eventRepo, logger)
+	executor := service.NewPipelineExecutor(runRepo, storyRepo, actionReg, eventRepo, logger)
 
 	// Execute the pipeline
 	err = executor.ExecuteRun(ctx, run.ID)
@@ -590,7 +590,7 @@ func TestIntegration_PipelineValidation_FullFlow(t *testing.T) {
 	actionReg.Register(&noopAction{name: "review"})
 
 	eventRepo := postgres.NewEventRepo(queries)
-	executor := service.NewPipelineExecutor(runRepo, actionReg, eventRepo, logger)
+	executor := service.NewPipelineExecutor(runRepo, storyRepo, actionReg, eventRepo, logger)
 
 	err = executor.ExecuteRun(ctx, run.ID)
 	if err != nil {

--- a/backend/internal/integration/pipeline_validation_test.go
+++ b/backend/internal/integration/pipeline_validation_test.go
@@ -452,21 +452,27 @@ func TestIntegration_PipelineValidation_Execution(t *testing.T) {
 		}
 
 		// Events are returned in created_at DESC order.
-		// Expected events (8 total):
-		// run.started, 3x(step.started + step.completed), run.completed
+		// Expected events (10 total):
+		// story.status_updated(running), run.started, 3x(step.started + step.completed), run.completed, story.status_updated(done)
 		if len(events) < 8 {
 			t.Fatalf("expected at least 8 events, got %d", len(events))
 		}
 
-		// Verify most recent event (index 0, DESC order) is run.completed
-		if events[0].EntityType != "run" || events[0].Action != "completed" {
-			t.Errorf("most recent event: expected run.completed, got %s.%s", events[0].EntityType, events[0].Action)
+		// Find run.completed and run.started events (story.status_updated may be before/after)
+		var foundRunCompleted, foundRunStarted bool
+		for _, e := range events {
+			if e.EntityType == "run" && e.Action == "completed" {
+				foundRunCompleted = true
+			}
+			if e.EntityType == "run" && e.Action == "started" {
+				foundRunStarted = true
+			}
 		}
-
-		// Verify oldest event (last index, DESC order) is run.started
-		last := events[len(events)-1]
-		if last.EntityType != "run" || last.Action != "started" {
-			t.Errorf("oldest event: expected run.started, got %s.%s", last.EntityType, last.Action)
+		if !foundRunCompleted {
+			t.Error("expected run.completed event, not found")
+		}
+		if !foundRunStarted {
+			t.Error("expected run.started event, not found")
 		}
 
 		// Count step events


### PR DESCRIPTION
## Summary
- Inject `StoryRepository` into `PipelineExecutor`
- Transition story: backlog → running → done/failed as the pipeline progresses
- Publish `story.status_updated` SSE events for frontend reactivity
- Best-effort: errors logged but don't block pipeline execution

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -short` passes (updated 5 test files)
- [x] `golangci-lint run ./...` passes
- [ ] Launch a run and verify story transitions from backlog → running → done

🤖 Generated with [Claude Code](https://claude.com/claude-code)