### PR TITLE
docs(stories): add pipeline UX stories 3-15 to 3-18 and update sprint status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,14 +378,14 @@ Both sides generate types and clients from the same OpenAPI spec. Never manually
 | Epic | Description | Status |
 |------|-------------|--------|
 | Epic 1 | Project scaffolding & foundation | IN PROGRESS |
-| Epic 2 | Story board & management | NOT STARTED |
-| Epic 3 | Pipeline execution engine | NOT STARTED |
-| Epic 4 | Agent runtime & container management | NOT STARTED |
+| Epic 2 | Story board & management | IN PROGRESS |
+| Epic 3 | Pipeline execution engine | IN PROGRESS |
+| Epic 4 | Agent runtime & container management | IN PROGRESS |
 | Epic 5 | DAG scheduler & epic runs | NOT STARTED |
 | Epic 6 | HITL gates & approval workflow | NOT STARTED |
 | Epic 7 | Pipeline configuration & templates | NOT STARTED |
-| Epic 8 | Real-time monitoring & SSE | NOT STARTED |
-| Epic 9 | Cost tracking & observability | NOT STARTED |
+| Epic 8 | Real-time monitoring & SSE | IN PROGRESS |
+| Epic 9 | Cost tracking & observability | IN PROGRESS |
 | Epic 10 | Reference project & validation | NOT STARTED |
 
 ### Completed
@@ -394,6 +394,18 @@ Both sides generate types and clients from the same OpenAPI spec. Never manually
 - Story 1-2: OpenAPI 3.0 spec + code generation pipeline
 - Story 1-7: Vue 3 scaffolding + PrimeVue 4 + Tailwind CSS v4
 - Story 1-14: CLAUDE.md files for agent scoping
+- Story 2-1: Epic CRUD API and board view
+- Story 2-2: Stories CRUD API with status filtering
+- Story 3-10: Run launch API endpoint (single story)
+- Story 3-11: Pipeline executor with step sequencing
+- Story 4-1: Docker agent runtime with container lifecycle
+- Story 4-2: Agent entrypoint with Claude Code integration
+- Story 8-1: SSE event infrastructure (Postgres NOTIFY + SSE handler)
+- Story 8-2: Run/step status SSE events and frontend wiring
+- Auth: Login, logout, forgot/reset password, user profile
+- Admin: User management CRUD
+- Pipeline runtime fixes: River timeout, OAuth auth, healthcheck, template mount
+- Pipeline wiring: story_key in Run API, story status transitions on run complete
 
 ## Known Constraints
 

--- a/_bmad-output/implementation-artifacts/3-15-fix-live-log-streaming-sse.md
+++ b/_bmad-output/implementation-artifacts/3-15-fix-live-log-streaming-sse.md
@@ -1,0 +1,370 @@
+# Story 3-15: Fix live log streaming from agent container to browser via SSE
+
+Status: ready-for-dev
+
+## Story
+
+As a **developer monitoring a running pipeline**,
+I want **live log output from the agent container to stream in real time to the RunDetailView log viewer**,
+so that **I can observe what the agent is doing without waiting for the run to complete or manually inspecting Docker logs**.
+
+## Problem Statement
+
+The live logs in `RunDetailView` permanently display "No log output yet" even while an agent container is actively running and producing NDJSON output. The infrastructure is partially built on both sides but two critical issues break the end-to-end flow:
+
+1. **Payload shape mismatch**: The backend publishes the full `model.LogEvent` struct as the SSE event payload, but the frontend expects a flattened payload with fields `{ run_id, step_id, line, timestamp }`. The frontend also reads properties directly off the SSE `data` object instead of the nested `payload` field inside the `model.Event` wrapper.
+2. **No throttling/batching**: Claude Code agents emit NDJSON at very high frequency (dozens of lines per second). Each line triggers a Postgres INSERT (via `EventPublisher.Publish`) + NOTIFY. This will overwhelm the event bus and the SSE connection under real load.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Log lines appear in real time in the browser**
+- **Given** a run is in `running` status with an active agent container producing NDJSON output
+- **When** the user opens `RunDetailView` for that run
+- **Then** log lines appear incrementally in the `LogViewer` component within 2 seconds of being emitted by the container
+- **And** the "No log output yet" placeholder disappears as soon as the first log line arrives
+
+**AC2: SSE event payload matches frontend expectations**
+- **Given** the backend publishes a `log.emitted` SSE event
+- **When** the frontend receives it via `useSSE`
+- **Then** the `useRunLogs` composable can extract `run_id`, `step_id`, `line`, and `timestamp` from the event data
+- **And** events with a different `run_id` are correctly ignored
+
+**AC3: High-frequency log output does not overwhelm SSE**
+- **Given** the agent emits more than 50 log lines per second
+- **When** those lines are processed by the log streamer
+- **Then** they are batched into groups and published as bulk SSE events (max one publish per 200ms)
+- **And** no log lines are dropped (all are delivered, just with slight batching delay)
+
+**AC4: Cost events are accumulated and recorded correctly**
+- **Given** the agent emits NDJSON lines with `"type": "cost"` containing `input_tokens`, `output_tokens`, and `model`
+- **When** the container exits
+- **Then** all cost events are aggregated and a single `cost_records` row is inserted via `CostService.RecordStepCost`
+- **And** cost lines are NOT forwarded to the SSE event bus (existing behavior preserved)
+
+**AC5: Non-JSON log lines are handled gracefully**
+- **Given** the agent container emits a plain text line (not valid JSON)
+- **When** the line is parsed by `parseNDJSONLine`
+- **Then** it is published as a `log.emitted` event with the raw text in the `line` field
+- **And** `is_json` is set to `false` in the payload
+
+**AC6: Log streaming stops cleanly on container exit**
+- **Given** the agent container exits (code 0 or non-zero)
+- **When** the log stream EOF is reached
+- **Then** the log consumer goroutine finishes, any pending batch is flushed, and no further events are published
+- **And** on non-zero exit, the last N lines are persisted as `log_tail` on the run step (existing behavior preserved)
+
+## Technical Notes
+
+### Root Cause Analysis
+
+The end-to-end log flow is:
+
+```
+Container stdout (NDJSON)
+  -> LogStreamer.StreamLogs (docker/log_streamer.go)
+    -> parseNDJSONLine (docker/ndjson_parser.go)
+      -> logCh (chan model.LogEvent)
+        -> agent_run.go streamAndWait goroutine
+          -> publishLogEvent
+            -> EventPublisher.Publish (INSERT + NOTIFY)
+              -> SSEHandler.writeSSEEvent
+                -> EventSource in browser
+                  -> useSSE -> useRunLogs -> LogViewer
+```
+
+**Issue 1 -- Payload shape mismatch (backend -> frontend)**
+
+`publishLogEvent` in `agent_run.go` (line 331-350) marshals the entire `model.LogEvent` struct as the event payload:
+
+```go
+payload, err := json.Marshal(logEvent)  // full LogEvent with run_id, step_id, message, raw_line, is_json, data, type, ...
+event := model.Event{
+    Payload: payload,
+}
+```
+
+The SSE handler then marshals the full `model.Event` wrapper:
+
+```go
+payload, _ := json.Marshal(event)  // { id, project_id, entity_type, entity_id, action, payload: {LogEvent...}, created_at }
+fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event.EventName(), payload)
+```
+
+The frontend `useRunLogs.ts` (line 14) expects:
+```typescript
+const payload = data as { run_id: string; line: string; timestamp: string }
+```
+
+But receives the full `Event` object, and `line` does not exist in `LogEvent` (it has `message` and `raw_line`).
+
+**Issue 2 -- Frontend reads wrong nesting level**
+
+`useRunLogs.ts` reads `data.run_id` directly, but the actual SSE data has `data.payload.run_id`. The `useSSE` composable passes the parsed JSON to `onEvent` callback, and `useRunLogs` treats it as the flat payload.
+
+**Fix approach**: Two things need to happen:
+
+1. **Backend**: Create a slim SSE-specific payload struct in `publishLogEvent` that matches frontend expectations: `{ run_id, step_id, line, timestamp }`. Use `raw_line` as `line` (or `message` for non-JSON lines).
+
+2. **Frontend**: Fix `useRunLogs.ts` to correctly extract the payload from the SSE event data. The SSE event data is the full `model.Event` object, so the frontend needs to read `data.payload.run_id`, `data.payload.line`, etc.
+
+### Key Files
+
+| File | Role | Change |
+|------|------|--------|
+| `backend/internal/adapter/action/agent_run.go` | Consumes logCh, publishes events | Restructure `publishLogEvent` payload; add batching to `streamAndWait` goroutine |
+| `backend/internal/adapter/docker/ndjson_parser.go` | Parses NDJSON lines | No changes needed |
+| `backend/internal/adapter/docker/log_streamer.go` | Streams Docker container logs | No changes needed |
+| `backend/internal/domain/model/log_event.go` | LogEvent struct | No changes needed |
+| `backend/internal/domain/model/event.go` | Event struct (SSE wrapper) | No changes needed |
+| `backend/internal/domain/port/event_publisher.go` | EventPublisher interface | No changes needed |
+| `backend/internal/api/handler/sse_handler.go` | Writes SSE frames | No changes needed |
+| `frontend/src/features/runs/composables/useRunLogs.ts` | Filters log.emitted SSE events | Fix payload extraction path |
+| `frontend/src/features/runs/RunLogViewer.vue` | Renders LogViewer | No changes needed |
+| `frontend/src/ui/composed/LogViewer.vue` | Pure display component | No changes needed |
+| `frontend/src/composables/useSSE.ts` | SSE connection manager | No changes needed |
+| `backend/internal/adapter/action/agent_run_test.go` | Tests for agent_run | Update test assertions for new payload shape and batching |
+
+### Payload Contract (SSE data for `log.emitted`)
+
+The SSE frame sent by `writeSSEEvent` looks like:
+```
+event: log.emitted
+data: {"id":"<event-uuid>","project_id":"<uuid>","entity_type":"log","entity_id":"<step-uuid>","action":"emitted","payload":<inner-json>,"created_at":"..."}
+id: <event-uuid>
+```
+
+The `payload` field (inner JSON) must match this shape for frontend consumption:
+
+```json
+{
+  "run_id": "uuid-string",
+  "step_id": "uuid-string",
+  "line": "raw log text or message",
+  "timestamp": "2026-02-22T10:30:00Z",
+  "level": "info",
+  "is_json": true
+}
+```
+
+The frontend `useRunLogs.ts` must extract from the outer Event object:
+```typescript
+const event = data as { payload: { run_id: string; step_id: string; line: string; timestamp: string } }
+const payload = event.payload
+```
+
+### Batching Strategy
+
+To avoid overwhelming Postgres and SSE with per-line INSERTs and NOTIFYs at high frequency:
+
+1. In the `streamAndWait` log consumption goroutine, replace the per-event `publishLogEvent` call with a batch accumulator
+2. Use a ticker (200ms interval) to flush accumulated log events as a single bulk publish
+3. On channel close (container exit), flush remaining batch immediately
+4. Each batch publish creates ONE `model.Event` with a `payload` containing an array of log entries
+5. Alternatively (simpler): keep individual events but use a rate-limited publisher that coalesces events within a 200ms window into a single Postgres INSERT + NOTIFY
+
+**Recommended approach (simpler, less change)**: Batch log events in the goroutine, publish a single event containing an array of log lines every 200ms. The frontend then unpacks the array.
+
+Updated payload contract for batched events:
+```json
+{
+  "run_id": "uuid-string",
+  "step_id": "uuid-string",
+  "lines": [
+    { "line": "...", "timestamp": "...", "level": "info", "is_json": true },
+    { "line": "...", "timestamp": "...", "level": "info", "is_json": false }
+  ]
+}
+```
+
+Frontend `useRunLogs.ts` then loops over `payload.lines` and pushes each entry to the `lines` ref.
+
+### Implementation Details
+
+#### Backend: `publishLogEvent` replacement in `agent_run.go`
+
+Define a slim payload struct for SSE:
+
+```go
+// logSSELine is the per-line shape sent inside a log.emitted SSE event.
+type logSSELine struct {
+    Line      string    `json:"line"`
+    Timestamp time.Time `json:"timestamp"`
+    Level     string    `json:"level"`
+    IsJSON    bool      `json:"is_json"`
+}
+
+// logSSEPayload is the payload for a batched log.emitted SSE event.
+type logSSEPayload struct {
+    RunID  string       `json:"run_id"`
+    StepID string       `json:"step_id"`
+    Lines  []logSSELine `json:"lines"`
+}
+```
+
+In `streamAndWait`, replace the direct `publishLogEvent` call with:
+
+```go
+const logFlushInterval = 200 * time.Millisecond
+
+var logBatch []logSSELine
+flushTicker := time.NewTicker(logFlushInterval)
+defer flushTicker.Stop()
+
+flushLogs := func() {
+    if len(logBatch) == 0 {
+        return
+    }
+    a.publishLogBatch(ctx, runCtx, logBatch)
+    logBatch = logBatch[:0]
+}
+
+// In the goroutine consuming logCh:
+for {
+    select {
+    case logEvent, ok := <-logCh:
+        if !ok {
+            flushLogs() // flush remaining on channel close
+            return
+        }
+        if logEvent.Type == "cost" {
+            costEvents = append(costEvents, model.CostEvent{...})
+            continue
+        }
+        line := logEvent.Message
+        if line == "" {
+            line = logEvent.RawLine
+        }
+        logBatch = append(logBatch, logSSELine{
+            Line:      line,
+            Timestamp: logEvent.Timestamp,
+            Level:     logEvent.Level,
+            IsJSON:    logEvent.IsJSON,
+        })
+        // Also maintain ring buffer for log tail
+        if len(logTail) >= tailSize {
+            logTail = logTail[1:]
+        }
+        logTail = append(logTail, logEvent.Message)
+    case <-flushTicker.C:
+        flushLogs()
+    }
+}
+```
+
+New `publishLogBatch` method:
+
+```go
+func (a *AgentRunAction) publishLogBatch(ctx context.Context, runCtx *model.RunContext, lines []logSSELine) {
+    payload := logSSEPayload{
+        RunID:  runCtx.Run.ID.String(),
+        StepID: runCtx.RunStep.ID.String(),
+        Lines:  lines,
+    }
+    payloadJSON, err := json.Marshal(payload)
+    if err != nil {
+        a.logger.Error("failed to marshal log batch", "error", err)
+        return
+    }
+    event := model.Event{
+        ID:         uuid.New(),
+        ProjectID:  runCtx.ProjectID,
+        EntityType: "log",
+        EntityID:   runCtx.RunStep.ID,
+        Action:     "emitted",
+        Payload:    payloadJSON,
+    }
+    if err := a.eventPub.Publish(ctx, event); err != nil {
+        a.logger.Warn("failed to publish log batch", "error", err, "line_count", len(lines))
+    }
+}
+```
+
+Remove the old `publishLogEvent` method entirely.
+
+#### Frontend: `useRunLogs.ts` fix
+
+```typescript
+export function useRunLogs(projectId: string, runId: string) {
+  const lines = ref<LogLine[]>([])
+
+  const { status: sseStatus } = useSSE(projectId, (eventName, data) => {
+    if (eventName !== 'log.emitted') return
+
+    // SSE data is the full Event object; extract nested payload
+    const event = data as {
+      payload: {
+        run_id: string
+        step_id: string
+        lines: Array<{ line: string; timestamp: string; level: string; is_json: boolean }>
+      }
+    }
+
+    // payload is a JSON string inside the Event — parse if needed
+    let payload = event.payload
+    if (typeof payload === 'string') {
+      try { payload = JSON.parse(payload) } catch { return }
+    }
+
+    if (payload.run_id !== runId) return
+
+    for (const entry of payload.lines) {
+      lines.value.push({
+        text: entry.line,
+        timestamp: new Date(entry.timestamp),
+      })
+    }
+  })
+
+  function clearLogs() {
+    lines.value = []
+  }
+
+  return { lines, sseStatus, clearLogs }
+}
+```
+
+**Note on `payload` field type**: In the SSE frame, `writeSSEEvent` does `json.Marshal(event)` which marshals `Payload json.RawMessage` as raw JSON embedded in the outer object. Since `json.RawMessage` is `[]byte`, when marshaled it appears as the raw JSON inline (not double-encoded). So the frontend receives `event.payload` as a parsed object, not a string. The `typeof === 'string'` guard is defensive.
+
+## Tasks / Subtasks
+
+- [ ] [BACK] Task 1: Refactor `publishLogEvent` into batched `publishLogBatch` in `agent_run.go`
+  - [ ] Define `logSSELine` and `logSSEPayload` structs with correct JSON tags
+  - [ ] Replace single-event publishing in `streamAndWait` goroutine with batch accumulator + 200ms flush ticker
+  - [ ] Implement `publishLogBatch` method that marshals `logSSEPayload` and publishes one `model.Event`
+  - [ ] Use `logEvent.Message` as `line` (fall back to `logEvent.RawLine` if message is empty)
+  - [ ] Flush remaining batch on `logCh` close (before goroutine returns)
+  - [ ] Remove old `publishLogEvent` method
+  - [ ] Preserve existing ring buffer (`logTail`) and cost event accumulation behavior
+
+- [ ] [BACK] Task 2: Update `agent_run_test.go` for new batched payload
+  - [ ] Update `TestAgentRunAction_Execute` assertions to expect batched payload shape (`lines` array inside payload)
+  - [ ] Verify payload contains `run_id`, `step_id`, and `lines` array
+  - [ ] Verify cost events are still excluded from published events
+  - [ ] Add test case for high-frequency log emission to verify batching behavior (multiple log lines result in fewer events)
+  - [ ] Verify flush on channel close delivers remaining lines
+
+- [ ] [FRONT] Task 3: Fix `useRunLogs.ts` payload extraction
+  - [ ] Update type assertion to match actual SSE Event wrapper shape (extract `data.payload`)
+  - [ ] Handle batched `lines` array: iterate and push each entry to `lines` ref
+  - [ ] Handle `payload` being either an object or a JSON string (defensive parsing)
+  - [ ] Keep `run_id` filtering on `payload.run_id`
+
+- [ ] [FRONT] Task 4: Update `useRunLogs.spec.ts` for new payload shape
+  - [ ] Update mock SSE event data to use the full `Event` wrapper with nested `payload`
+  - [ ] Update payload to use `lines` array instead of single `line` field
+  - [ ] Test that multiple lines in a single batch event all get appended
+  - [ ] Test that `run_id` filtering still works on the nested payload
+  - [ ] Test that non-`log.emitted` events are still ignored
+
+- [ ] [BACK] Task 5: Verify end-to-end SSE flow with integration test
+  - [ ] Add or update integration test that publishes a `log.emitted` event and verifies it arrives via the SSE handler with correct payload shape
+  - [ ] Verify `entity_type="log"`, `action="emitted"`, `EventName()="log.emitted"`
+  - [ ] Verify the SSE `event:` field matches `log.emitted` so the frontend `addEventListener('log.emitted', ...)` triggers
+
+## Out of Scope
+
+- Log persistence to database (logs are ephemeral, only `log_tail` on failure is persisted)
+- Log search/filtering in the frontend (future story)
+- WebSocket upgrade from SSE (MVP uses SSE)
+- Log level filtering in the UI (future enhancement)
+- Backpressure handling if frontend cannot keep up (future story)

--- a/_bmad-output/implementation-artifacts/3-16-cancel-run-endpoint-and-ui.md
+++ b/_bmad-output/implementation-artifacts/3-16-cancel-run-endpoint-and-ui.md
@@ -1,0 +1,504 @@
+# Story 3-16: Cancel Run endpoint and UI
+
+Status: ready-for-dev
+
+## Story
+
+As a project operator,
+I want to cancel a running (or paused/pending) pipeline run,
+so that I can stop wasted compute when a run is no longer needed and free the story for a new attempt.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Cancel a running run**
+- **Given** a run exists with status `running` and one step is currently executing in a Docker container
+- **When** I POST to `/api/v1/projects/{projectId}/runs/{runId}/cancel`
+- **Then** HTTP 200 is returned with the updated run object (status = `cancelled`)
+- **And** the active agent container is stopped via `ContainerManager.Stop`
+- **And** the currently running step is marked `cancelled` with `completed_at = now`
+- **And** all remaining `pending` steps are marked `cancelled` with `completed_at = now`
+- **And** the run is marked `cancelled` with `completed_at = now`
+- **And** the associated story status is set back to `backlog`
+- **And** SSE events are published: `step.cancelled` (for each affected step), `run.cancelled`, `story.status_updated`
+
+**AC2: Cancel a paused run**
+- **Given** a run exists with status `paused`
+- **When** I POST to `/api/v1/projects/{projectId}/runs/{runId}/cancel`
+- **Then** HTTP 200 is returned with the updated run object (status = `cancelled`)
+- **And** all `pending` steps are marked `cancelled`
+- **And** the run is marked `cancelled`
+- **And** the associated story status is set back to `backlog`
+- **And** SSE events are published for all state changes
+
+**AC3: Cancel a pending run**
+- **Given** a run exists with status `pending` (not yet picked up by the executor)
+- **When** I POST to `/api/v1/projects/{projectId}/runs/{runId}/cancel`
+- **Then** HTTP 200 is returned with the updated run object (status = `cancelled`)
+- **And** all `pending` steps are marked `cancelled`
+- **And** the run is marked `cancelled`
+
+**AC4: Conflict - run already in terminal state**
+- **Given** a run exists with status `completed`, `failed`, or `cancelled`
+- **When** I POST to `/api/v1/projects/{projectId}/runs/{runId}/cancel`
+- **Then** HTTP 409 is returned with error code `INVALID_STATE_TRANSITION`
+
+**AC5: Not found - run does not exist or wrong project**
+- **Given** the `runId` does not exist or does not belong to `projectId`
+- **When** I POST to `/api/v1/projects/{projectId}/runs/{runId}/cancel`
+- **Then** HTTP 404 is returned
+
+**AC6: Cancel button in frontend**
+- **Given** I am viewing the RunDetailView for a run with status `running`, `paused`, or `pending`
+- **When** I click the "Cancel" button
+- **Then** a confirmation dialog is shown
+- **And** upon confirmation, the cancel API is called
+- **And** a success toast is shown on success
+- **And** the run status and step statuses are updated reactively in the UI
+
+**AC7: Cancel button visibility**
+- **Given** I am viewing the RunDetailView
+- **When** the run is in a terminal state (`completed`, `failed`, `cancelled`)
+- **Then** the "Cancel" button is NOT displayed
+
+**AC8: Cancel an epic run**
+- **Given** an epic run exists with status `running` or `paused`
+- **When** I POST to `/api/v1/projects/{projectId}/epics/{epicId}/runs/{runId}/cancel`
+- **Then** HTTP 200 is returned with the updated run (status = `cancelled`)
+- **And** the same cancellation logic applies as AC1/AC2
+
+## Technical Notes
+
+### State Machine
+
+The `cancelled` status and transitions are already defined in `backend/internal/domain/model/run.go`:
+
+```go
+// Valid run transitions (already exist):
+RunStatusPending  -> RunStatusCancelled  // AC3
+RunStatusRunning  -> RunStatusCancelled  // AC1
+RunStatusPaused   -> RunStatusCancelled  // AC2
+
+// Valid step transitions (already exist):
+StepStatusPending -> StepStatusCancelled
+StepStatusRunning -> StepStatusCancelled
+```
+
+No changes to the state machine model are needed.
+
+### Cancel vs Pause Semantics
+
+- **Pause** is soft: the current step completes, no new steps start, run can be resumed.
+- **Cancel** is hard: the active container is killed, the current step is marked cancelled immediately, all pending steps are cancelled, story resets to `backlog`. The run cannot be resumed.
+
+### Container Cleanup
+
+When the run status is `running`, the service must find the currently executing step's `container_id` (stored on the `RunStep` record by the `agent_run` action) and call `ContainerManager.Stop(ctx, containerID)`. If the container is already gone (e.g., race condition), the error should be logged but not propagated to the caller.
+
+### Executor Awareness
+
+The `PipelineExecutor.ExecuteRun` loop already checks for `ctx.Done()` and for `paused` status between steps. For cancel, the approach is:
+1. `CancelRun` updates the run status to `cancelled` in the DB.
+2. The executor's next pause-check iteration (between steps) will see the cancelled status and stop.
+3. For the currently executing step, the container is stopped externally by `CancelRun`, which causes the action to return an error, which the executor handles.
+
+Since the executor uses a River job with its own context, and cancel operates via direct DB status update + container stop, no context cancellation propagation is needed. The executor naturally terminates when:
+- The container it is waiting on is killed (returns non-zero exit code / error)
+- The next DB status check sees `cancelled`
+
+### Story Status Reset
+
+On cancel, the story status should be set back to `backlog` to allow re-running. This differs from `failed` (which sets story to `failed`). The rationale: cancellation is a deliberate user action, not a failure, so the story should be immediately launchable again.
+
+### File Paths (exact)
+
+| File | Action |
+|------|--------|
+| `api/openapi.yaml` | Add `POST /projects/{projectId}/runs/{runId}/cancel` and `POST /projects/{projectId}/epics/{epicId}/runs/{runId}/cancel` endpoints |
+| `backend/internal/api/handler/gen_server.go` | Regenerated by oapi-codegen -- do not edit manually |
+| `backend/internal/domain/service/run_service.go` | Add `CancelRun` and `CancelEpicRun` methods |
+| `backend/internal/domain/service/run_service_test.go` | Add `CancelRun` unit tests |
+| `backend/internal/api/handler/run_handler.go` | Add `CancelRun` and `CancelEpicRun` handler methods |
+| `backend/internal/api/handler/run_handler_test.go` | Add `CancelRun` handler tests |
+| `backend/internal/api/handler/server.go` | Add `CancelRun` and `CancelEpicRun` delegation methods |
+| `backend/cmd/api/wire.go` | Update `RunService` constructor if new deps added |
+| `backend/cmd/api/wire_gen.go` | Regenerated by wire -- do not edit manually |
+| `frontend/src/api/generated/schema.d.ts` | Regenerated by openapi-typescript -- do not edit manually |
+| `frontend/src/stores/runs.ts` | Add `cancelRun` action and `isCancelling` state |
+| `frontend/src/views/RunDetailView.vue` | Add Cancel button with confirmation dialog |
+
+## Tasks / Subtasks
+
+- [ ] [BACK] Task 1: Add cancel endpoints to OpenAPI spec
+  - [ ] Add `POST /projects/{projectId}/runs/{runId}/cancel` to `api/openapi.yaml` (copy pause endpoint pattern, change operationId to `cancelRun`, summary to "Cancel a pipeline run", description to explain hard cancellation semantics)
+  - [ ] Add `POST /projects/{projectId}/epics/{epicId}/runs/{runId}/cancel` to `api/openapi.yaml` (operationId `cancelEpicRun`)
+  - [ ] Run `cd backend && make generate` to regenerate `internal/api/handler/gen_server.go`
+  - [ ] Run `cd frontend && npm run generate-api` to regenerate TypeScript types
+
+- [ ] [BACK] Task 2: Implement `CancelRun` in `RunService`
+  - [ ] Add `containerMgr port.ContainerManager` to `RunService` struct and `NewRunService` constructor (needed to stop the active container)
+  - [ ] Implement `CancelRun(ctx context.Context, projectID, runID uuid.UUID) (*model.Run, error)` in `backend/internal/domain/service/run_service.go`:
+    1. Fetch run by ID, verify `run.ProjectID == projectID` (return 404 if mismatch)
+    2. Validate transition to `cancelled` via `model.ValidateRunTransition` (returns 409 if invalid)
+    3. Fetch all steps via `runRepo.ListRunStepsByRun`
+    4. Find the currently running step (if any) and stop its container via `containerMgr.Stop(ctx, *step.ContainerID)` -- log and continue on error
+    5. Mark the running step as `cancelled` via `runRepo.UpdateRunStepStatus`
+    6. Mark all `pending` steps as `cancelled` via `runRepo.UpdateRunStepStatus` in a loop
+    7. Mark the run as `cancelled` via `runRepo.UpdateRunStatus` with `completedAt = now`
+    8. Transition the story status to `backlog` via `storyRepo.Update` (best-effort, log errors)
+    9. Publish SSE events: `step.cancelled` for each cancelled step, `run.cancelled`, `story.status_updated`
+    10. Return the updated run
+  - [ ] Implement `CancelEpicRun(ctx context.Context, projectID, epicID, runID uuid.UUID) (*model.Run, error)` as a thin wrapper that delegates to `CancelRun(ctx, projectID, runID)` (same pattern as `PauseEpicRun`)
+
+- [ ] [BACK] Task 3: Add `CancelRun` and `CancelEpicRun` handler methods
+  - [ ] Implement `CancelRun(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, runID RunIdPath)` in `backend/internal/api/handler/run_handler.go` (copy PauseRun pattern)
+  - [ ] Implement `CancelEpicRun(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, epicID EpicIdPath, runID RunIdPath)` in `backend/internal/api/handler/run_handler.go`
+  - [ ] Add `CancelRun` and `CancelEpicRun` delegation methods to `backend/internal/api/handler/server.go`
+
+- [ ] [BACK] Task 4: Update DI wiring
+  - [ ] Update `backend/cmd/api/wire.go` to inject `port.ContainerManager` into `NewRunService`
+  - [ ] Run `cd backend && wire ./cmd/api/` to regenerate `wire_gen.go`
+
+- [ ] [BACK] Task 5: Write unit tests for `CancelRun`
+  - [ ] Add `containerMgr` mock to test file (or extend existing mocks):
+    ```go
+    type mockContainerManager struct {
+        stopFn func(ctx context.Context, containerID string) error
+    }
+    func (m *mockContainerManager) Stop(ctx context.Context, containerID string) error {
+        if m.stopFn != nil { return m.stopFn(ctx, containerID) }
+        return nil
+    }
+    // Implement remaining interface methods with no-op stubs
+    ```
+  - [ ] Add table-driven tests in `backend/internal/domain/service/run_service_test.go`:
+
+    | Test | Scenario | Expected |
+    |------|----------|----------|
+    | `TestCancelRun_RunningWithContainer` | Run is `running`, step has `container_id` | Container stopped, step cancelled, pending steps cancelled, run cancelled, story reset to backlog |
+    | `TestCancelRun_RunningNoContainer` | Run is `running`, step has no `container_id` | Step cancelled, run cancelled (no container stop attempted) |
+    | `TestCancelRun_Paused` | Run is `paused` | Pending steps cancelled, run cancelled, story reset to backlog |
+    | `TestCancelRun_Pending` | Run is `pending`, all steps `pending` | All steps cancelled, run cancelled |
+    | `TestCancelRun_AlreadyCompleted` | Run is `completed` | Returns `INVALID_STATE_TRANSITION` error |
+    | `TestCancelRun_AlreadyFailed` | Run is `failed` | Returns `INVALID_STATE_TRANSITION` error |
+    | `TestCancelRun_AlreadyCancelled` | Run is `cancelled` | Returns `INVALID_STATE_TRANSITION` error |
+    | `TestCancelRun_NotFound` | Run does not exist | Returns `NOT_FOUND` error |
+    | `TestCancelRun_WrongProject` | Run exists but `projectID` mismatch | Returns `NOT_FOUND` error |
+    | `TestCancelRun_ContainerStopError` | Container stop fails | Run is still cancelled (error logged, not propagated) |
+
+  - [ ] Add handler tests in `backend/internal/api/handler/run_handler_test.go`:
+
+    | Test | Scenario | Expected HTTP |
+    |------|----------|--------------|
+    | `TestCancelRun_Success` | Service returns cancelled run | 200 + Run JSON |
+    | `TestCancelRun_NotFound` | Service returns not_found | 404 |
+    | `TestCancelRun_Conflict` | Service returns invalid_state_transition | 409 |
+
+- [ ] [BACK] Task 6: Lint and test
+  - [ ] Run `cd backend && golangci-lint run ./...` -- must pass
+  - [ ] Run `cd backend && go test ./... -short` -- must pass
+
+- [ ] [FRONT] Task 7: Add `cancelRun` action to runs store
+  - [ ] Add `isCancelling` ref to `frontend/src/stores/runs.ts`
+  - [ ] Add `cancelRun(projectId: string, runId: string)` async function following the `pauseRun` pattern:
+    ```typescript
+    async function cancelRun(projectId: string, runId: string) {
+      isCancelling.value = true
+      try {
+        const { data, error } = await apiClient.POST(
+          '/projects/{projectId}/runs/{runId}/cancel',
+          { params: { path: { projectId, runId } } },
+        )
+        if (error) throw error
+        if (data) {
+          updateRunStatus(runId, data.status)
+        }
+        return data
+      } finally {
+        isCancelling.value = false
+      }
+    }
+    ```
+  - [ ] Export `isCancelling` and `cancelRun` from the store
+
+- [ ] [FRONT] Task 8: Add Cancel button with confirmation dialog to RunDetailView
+  - [ ] Add `canCancel` computed: `run.value?.status === 'running' || run.value?.status === 'paused' || run.value?.status === 'pending'`
+  - [ ] Import `ConfirmDialog` from PrimeVue and `useConfirm` composable
+  - [ ] Add Cancel button next to existing Pause/Resume buttons:
+    ```vue
+    <Button
+      v-if="canCancel"
+      label="Cancel"
+      icon="pi pi-times-circle"
+      severity="danger"
+      :loading="runsStore.isCancelling"
+      data-testid="cancel-run-btn"
+      @click="confirmCancel"
+    />
+    ```
+  - [ ] Implement `confirmCancel()` function that shows a PrimeVue `ConfirmDialog` with:
+    - Header: "Cancel Run"
+    - Message: "Are you sure you want to cancel this run? This action cannot be undone. The active container will be stopped and all pending steps will be cancelled."
+    - Accept label: "Cancel Run" (severity danger)
+    - Reject label: "Keep Running"
+  - [ ] On accept, call `handleCancel()` which calls `runsStore.cancelRun(projectId, runId)` and shows toast on success/error
+  - [ ] Add `<ConfirmDialog />` component to the template if not already present
+
+- [ ] [FRONT] Task 9: Frontend lint and type check
+  - [ ] Run `cd frontend && npm run lint` -- must pass
+  - [ ] Run `cd frontend && npm run type-check` -- must pass
+
+## Dev Notes
+
+### Dependencies
+
+- Story 3-1 (DONE): `RunRepository` port and DB tables exist; state machine transitions are defined
+- Story 3-4 (DONE): `ContainerManager` port and Docker adapter exist with `Stop` method
+- Story 3-7 (DONE): `PipelineExecutor` exists with `handleCancellation` method
+- Story 3-10 (DONE): `LaunchRun` and Pause/Resume patterns established
+- Story 3-11 (DONE): `RunDetailView` with Pause/Resume buttons exists
+
+### Architecture Requirements
+
+- `CancelRun` is a **synchronous** operation from the API perspective -- it updates DB records and stops the container, then returns. The executor's River job will terminate naturally when the container it is waiting on is killed.
+- Container stop is **best-effort**: if the container is already gone (race condition with executor finishing), the error is logged but the cancellation still proceeds.
+- Story status reset to `backlog` is **best-effort**: if the story update fails, the cancellation still succeeds. This mirrors the `updateStoryStatus` pattern in `PipelineExecutor`.
+- No new sqlc queries are needed -- existing `UpdateRunStatus`, `UpdateRunStepStatus`, and `ListRunStepsByRun` cover all DB operations.
+- No new DB migrations are needed -- `cancelled` status already exists in the enum.
+
+### Technical Specifications
+
+#### OpenAPI spec -- `api/openapi.yaml`
+
+Add after the existing `/projects/{projectId}/runs/{runId}/resume` block:
+
+```yaml
+  /projects/{projectId}/runs/{runId}/cancel:
+    post:
+      operationId: cancelRun
+      summary: Cancel a pipeline run
+      description: >
+        Hard-cancels a run. If the run is currently executing, the active agent
+        container is stopped (SIGTERM + 10s timeout + SIGKILL). The currently
+        running step and all pending steps are marked as cancelled. The
+        associated story is reset to backlog status. Returns 409 if the run is
+        already in a terminal state (completed, failed, or cancelled).
+      tags: [runs]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/RunIdPath"
+      responses:
+        "200":
+          description: Run cancelled successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Run"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+```
+
+Add after the existing `/projects/{projectId}/epics/{epicId}/runs/{runId}/resume` block:
+
+```yaml
+  /projects/{projectId}/epics/{epicId}/runs/{runId}/cancel:
+    post:
+      operationId: cancelEpicRun
+      summary: Cancel an in-progress epic run
+      description: >
+        Cancels an epic run. When story 7-2 implements the epic run model with
+        parent/child relationships, this method will also cancel pending child runs.
+      tags: [epic-runs]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/EpicIdPath"
+        - $ref: "#/components/parameters/RunIdPath"
+      responses:
+        "200":
+          description: Epic run cancelled successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Run"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+```
+
+#### `CancelRun` service method -- `backend/internal/domain/service/run_service.go`
+
+```go
+// CancelRun hard-cancels a run: stops the active container, marks running/pending steps
+// as cancelled, transitions the run to cancelled, and resets the story to backlog.
+func (s *RunService) CancelRun(ctx context.Context, projectID, runID uuid.UUID) (*model.Run, error) {
+    run, err := s.runRepo.GetRun(ctx, runID)
+    if err != nil {
+        return nil, err
+    }
+
+    if run.ProjectID != projectID {
+        return nil, errors.NewNotFound("run", runID)
+    }
+
+    if err := model.ValidateRunTransition(run.Status, model.RunStatusCancelled); err != nil {
+        return nil, err
+    }
+
+    // Fetch all steps
+    steps, err := s.runRepo.ListRunStepsByRun(ctx, runID)
+    if err != nil {
+        return nil, err
+    }
+
+    now := time.Now()
+    cancelMsg := "cancelled by user"
+
+    // Stop active container (if any running step has a container_id)
+    for _, step := range steps {
+        if step.Status == model.StepStatusRunning && step.ContainerID != nil && *step.ContainerID != "" {
+            if s.containerMgr != nil {
+                if stopErr := s.containerMgr.Stop(ctx, *step.ContainerID); stopErr != nil {
+                    // Log but do not fail -- container may already be gone
+                    // (use structured logging in real implementation)
+                }
+            }
+        }
+    }
+
+    // Cancel running and pending steps
+    for _, step := range steps {
+        if step.Status == model.StepStatusRunning || step.Status == model.StepStatusPending ||
+           step.Status == model.StepStatusWaitingApproval {
+            if _, err := s.runRepo.UpdateRunStepStatus(ctx, step.ID, model.StepStatusCancelled, nil, &now, &cancelMsg); err != nil {
+                return nil, err
+            }
+
+            s.publishRunEvent(ctx, run.ProjectID, step.ID, "cancelled", map[string]any{
+                "run_id":    runID.String(),
+                "step_id":   step.ID.String(),
+                "step_name": step.StepName,
+                "status":    string(model.StepStatusCancelled),
+            })
+        }
+    }
+
+    // Cancel the run
+    updated, err := s.runRepo.UpdateRunStatus(ctx, runID, model.RunStatusCancelled, nil, &now, nil, &cancelMsg)
+    if err != nil {
+        return nil, err
+    }
+
+    s.publishRunEvent(ctx, updated.ProjectID, updated.ID, "cancelled", map[string]any{
+        "run_id":       runID.String(),
+        "status":       string(model.RunStatusCancelled),
+        "cancelled_at": now.Format(time.RFC3339),
+    })
+
+    // Reset story to backlog (best-effort)
+    s.resetStoryToBacklog(ctx, run)
+
+    return updated, nil
+}
+
+// CancelEpicRun cancels an epic run. Placeholder that delegates to CancelRun.
+// When story 7-2 implements parent/child relationships, this will also cancel child runs.
+func (s *RunService) CancelEpicRun(ctx context.Context, projectID, _ uuid.UUID, runID uuid.UUID) (*model.Run, error) {
+    return s.CancelRun(ctx, projectID, runID)
+}
+
+// resetStoryToBacklog resets the story associated with a run back to backlog status.
+// Errors are logged without propagating -- this is best-effort.
+func (s *RunService) resetStoryToBacklog(ctx context.Context, run *model.Run) {
+    if run.StoryID == uuid.Nil {
+        return
+    }
+
+    story, err := s.storyRepo.GetByID(ctx, run.StoryID)
+    if err != nil {
+        return
+    }
+
+    story.Status = model.StoryStatusBacklog
+    if _, err := s.storyRepo.Update(ctx, story); err != nil {
+        return
+    }
+
+    s.publishRunEvent(ctx, run.ProjectID, run.StoryID, "status_updated", map[string]any{
+        "story_id": run.StoryID.String(),
+        "run_id":   run.ID.String(),
+        "status":   model.StoryStatusBacklog,
+    })
+}
+```
+
+> **Note:** The `publishRunEvent` helper currently publishes with `entityType = "run"`. For step events, the implementation should use a dedicated `publishStepEvent` helper or generalize the `publishRunEvent` to accept `entityType`. See the `PipelineExecutor.publishEvent` method for the generalized pattern. The actual implementation should use the same event publishing pattern as `PipelineExecutor`.
+
+#### `CancelRun` handler -- `backend/internal/api/handler/run_handler.go`
+
+```go
+// CancelRun handles POST /projects/{projectId}/runs/{runId}/cancel.
+func (h *RunHandler) CancelRun(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, runID RunIdPath) {
+    run, err := h.service.CancelRun(r.Context(), projectID, runID)
+    if err != nil {
+        writeErrorResponse(w, err)
+        return
+    }
+
+    writeJSON(w, http.StatusOK, toAPIRun(run))
+}
+
+// CancelEpicRun handles POST /projects/{projectId}/epics/{epicId}/runs/{runId}/cancel.
+func (h *RunHandler) CancelEpicRun(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, epicID EpicIdPath, runID RunIdPath) {
+    run, err := h.service.CancelEpicRun(r.Context(), projectID, epicID, runID)
+    if err != nil {
+        writeErrorResponse(w, err)
+        return
+    }
+
+    writeJSON(w, http.StatusOK, toAPIRun(run))
+}
+```
+
+Add to `server.go`:
+
+```go
+// CancelRun delegates to RunHandler.
+func (s *Server) CancelRun(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, runID RunIdPath) {
+    s.runs.CancelRun(w, r, projectID, runID)
+}
+
+// CancelEpicRun delegates to RunHandler.
+func (s *Server) CancelEpicRun(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, epicID EpicIdPath, runID RunIdPath) {
+    s.runs.CancelEpicRun(w, r, projectID, epicID, runID)
+}
+```
+
+### References
+
+- `backend/internal/domain/model/run.go` -- state machine transitions (cancel already valid)
+- `backend/internal/domain/service/run_service.go` -- `PauseRun`/`ResumeRun` as pattern reference
+- `backend/internal/domain/service/pipeline_executor.go` -- `handleCancellation` method shows the executor-side cancel pattern
+- `backend/internal/api/handler/run_handler.go` -- existing handler patterns
+- `backend/internal/api/handler/server.go` -- delegation pattern
+- `backend/internal/domain/port/container_manager.go` -- `ContainerManager.Stop` interface
+- `backend/internal/adapter/docker/container_manager.go` -- Docker `Stop` implementation (SIGTERM + 10s + SIGKILL)
+- `backend/internal/domain/port/run_repository.go` -- `UpdateRunStatus`, `UpdateRunStepStatus`, `ListRunStepsByRun`
+- `frontend/src/views/RunDetailView.vue` -- existing Pause/Resume button area
+- `frontend/src/stores/runs.ts` -- existing `pauseRun`/`resumeRun` store actions
+- `api/openapi.yaml` -- existing pause/resume endpoint definitions as template
+
+## Dev Agent Record
+
+_To be filled in during implementation._
+
+## Change Log
+
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2026-02-22 | 1.0 | Initial story creation | Arch |

--- a/_bmad-output/implementation-artifacts/3-17-display-step-costs-in-run-detail.md
+++ b/_bmad-output/implementation-artifacts/3-17-display-step-costs-in-run-detail.md
@@ -1,0 +1,152 @@
+# Story 3-17: Display Step Costs in Run Detail Page
+
+Status: ready-for-dev
+
+## Story
+
+As a developer reviewing a completed run,
+I want to see the cost breakdown per step directly in the Run Detail page,
+so that I can understand AI spending without navigating to the separate Cost Dashboard.
+
+## Acceptance Criteria (BDD)
+
+**Scenario: Run has cost data**
+
+Given I am on the Run Detail page for a completed run that incurred costs,
+When the page finishes loading,
+Then I see a cost summary card showing the run's total cost in USD,
+And I see each step in the timeline annotated with its individual cost,
+And each step annotation shows the model name, token counts (input / output), and cost in USD.
+
+**Scenario: Run has no cost data**
+
+Given I am on the Run Detail page for a run with no recorded costs (e.g., pending or very new run),
+When the page finishes loading,
+Then the cost summary card shows "$0.00",
+And no cost annotations are shown on individual steps.
+
+**Scenario: Cost fetch fails**
+
+Given the `GET /projects/{projectId}/runs/{runId}/costs` endpoint returns an error,
+When the page finishes loading,
+Then the step timeline renders normally without cost annotations,
+And no error is surfaced to the user for the cost fetch (fail silently — costs are supplementary data).
+
+**Scenario: Loading state**
+
+Given the run detail page is loading,
+When cost data is still being fetched,
+Then a Skeleton placeholder is displayed where the cost summary card will appear.
+
+## Technical Notes
+
+### Endpoint
+
+`GET /projects/{projectId}/runs/{runId}/costs` — already implemented in backend.
+
+Response schema (`RunCostDetail`):
+```json
+{
+  "run_id": "uuid",
+  "total_cost": 3.15,
+  "steps": [
+    {
+      "step_id": "uuid",
+      "step_name": "implement",
+      "model": "claude-opus-4-6",
+      "tokens_input": 100000,
+      "tokens_output": 20000,
+      "cost_usd": 3.00
+    }
+  ]
+}
+```
+
+Note: `StepCostBreakdown.step_id` maps to `RunStep.id` in the timeline. Use this to join cost data to the corresponding timeline entry by `step_id`.
+
+### What to build
+
+#### 1. Composable: `frontend/src/features/runs/composables/useRunCosts.ts`
+
+A new composable wrapping the API call, following the `useAsyncAction` pattern:
+
+```typescript
+import { useAsyncAction } from '@/composables/useAsyncAction'
+import { apiClient } from '@/api/client'
+import type { components } from '@/api/schema'
+
+type RunCostDetail = components['schemas']['RunCostDetail']
+type StepCostBreakdown = components['schemas']['StepCostBreakdown']
+
+export function useRunCosts(projectId: string, runId: string) {
+  const { execute, isLoading, data } = useAsyncAction(async () => {
+    const { data } = await apiClient.GET(
+      '/api/v1/projects/{projectId}/runs/{runId}/costs',
+      { params: { path: { projectId, runId } } }
+    )
+    return data ?? null
+  })
+
+  // Return a Map<step_id, StepCostBreakdown> for O(1) lookup in the template
+  const costByStepId = computed((): Map<string, StepCostBreakdown> => {
+    if (!data.value) return new Map()
+    return new Map(data.value.steps.map((s) => [s.step_id, s]))
+  })
+
+  return { execute, isLoading, runCost: data, costByStepId }
+}
+```
+
+Errors are intentionally swallowed — cost data is supplementary, failures must not break the primary run view.
+
+#### 2. Updates to `frontend/src/views/RunDetailView.vue`
+
+- Import and call `useRunCosts(projectId.value, runId.value)` after the run data is available
+- Call `execute()` once on mount (or when `run` becomes defined)
+- Add a cost summary card **above the step timeline**, below the `<ProgressBar>`:
+  - Reuse the existing `CostSummaryCard.vue` component with props:
+    - `label="Total Run Cost"`
+    - `:value="formatCostUSD(runCost?.total_cost ?? 0)"`
+    - `:isLoading="isCostLoading"`
+- In the `#content` slot of each `<Timeline>` item, join by `costByStepId.get((item as RunStep).id)` and render cost chip inline under the step name:
+  - Show: model name, `↑ {tokens_input.toLocaleString()}` tokens in, `↓ {tokens_output.toLocaleString()}` tokens out, cost in USD
+  - Render only when `costByStepId.has(step.id)` — no empty placeholder per step
+  - Use `formatCostUSD` from `@/utils/formatCost`
+
+#### 3. No new store needed
+
+Cost data for a single run is view-local (not shared across views). Use the composable directly in the view — no Pinia store required.
+
+#### 4. No new components
+
+- `CostSummaryCard.vue` already accepts `{ label, value, isLoading }` — use as-is.
+- The per-step annotation is simple enough to be inline markup in `RunDetailView.vue`.
+
+### Constraints
+
+- No changes to `api/openapi.yaml` — the endpoint and schemas already exist.
+- No backend changes required.
+- Do NOT modify `CostSummaryCard.vue`, `CostChart.vue`, or `RunCostTable.vue`.
+- The cost fetch must not block rendering of the run timeline or logs.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1** — Create `frontend/src/features/runs/composables/useRunCosts.ts`
+  - Wraps `GET /projects/{projectId}/runs/{runId}/costs` via `apiClient`
+  - Returns `{ execute, isLoading, runCost, costByStepId }` (Map keyed by `step_id`)
+  - Errors caught and ignored (fail silently)
+
+- [ ] **Task 2** — Update `frontend/src/views/RunDetailView.vue`
+  - Import and initialize `useRunCosts`
+  - Call `execute()` once after `projectId` and `runId` are resolved (on mount, guarded by `run` being defined)
+  - Add `CostSummaryCard` between `<ProgressBar>` and the Steps section
+  - Add per-step cost chip inside the `#content` timeline slot, rendered conditionally when `costByStepId.has(step.id)`
+
+- [ ] **Task 3** — Unit tests: `frontend/src/features/runs/__tests__/useRunCosts.spec.ts`
+  - Test: returns `costByStepId` map keyed by `step_id`
+  - Test: `runCost` is `null` when API returns empty / 404
+  - Test: errors are swallowed (no thrown exception from `execute`)
+
+- [ ] **Task 4** — Lint + type-check
+  - `npm run lint`
+  - `npm run type-check`

--- a/_bmad-output/implementation-artifacts/3-18-retry-failed-step-endpoint-and-ui.md
+++ b/_bmad-output/implementation-artifacts/3-18-retry-failed-step-endpoint-and-ui.md
@@ -1,0 +1,344 @@
+# Story 3-18: Retry failed step endpoint and UI button
+
+Status: ready-for-dev
+
+## Story
+
+As a **platform user monitoring pipeline runs**,
+I want to **manually retry a failed step from the run detail page**,
+so that **I can recover a failed run without relaunching the entire pipeline from scratch**.
+
+## Context
+
+The domain model already supports retries (`RunStep.ParentStepID`, `RetryCount`, `RetryType`), and the `IncrementalRetryAction` (in `backend/internal/adapter/action/incremental_retry.go`) implements the full retry logic with tests. The `PipelineExecutor.handleStepFailure()` handles auto-retries based on `RetryPolicy`. However, there is no REST endpoint to trigger a manual retry, and the frontend `RetryStepEntry.vue` component displays retry history but cannot trigger new retries.
+
+This story adds the missing manual retry path: API endpoint, backend service method, job enqueuing, and a frontend "Retry" button on failed steps.
+
+## Acceptance Criteria (BDD)
+
+### Scenario 1: Successfully retry a failed step
+
+```gherkin
+Given a run in "failed" status
+  And the run has a step in "failed" status
+  And the step has not exceeded max retries
+When I POST /projects/{projectId}/runs/{runId}/steps/{stepId}/retry
+Then the response status is 202 Accepted
+  And the response body contains the new retry RunStep with:
+    | field         | value                        |
+    | status        | pending                      |
+    | parent_step_id| {original stepId}            |
+    | retry_count   | {previous retry_count + 1}   |
+    | retry_type    | incremental or full           |
+  And the run status transitions back to "running"
+  And the run is re-enqueued in the River job queue
+  And a "step.retried" SSE event is published
+```
+
+### Scenario 2: Retry blocked — step is not in failed status
+
+```gherkin
+Given a run with a step in "completed" status
+When I POST /projects/{projectId}/runs/{runId}/steps/{stepId}/retry
+Then the response status is 409 Conflict
+  And the error code is "STEP_NOT_RETRYABLE"
+  And the error message indicates the step must be in failed status
+```
+
+### Scenario 3: Retry blocked — max retries exceeded
+
+```gherkin
+Given a run with a failed step
+  And the step's retry_count equals the pipeline config max_retries
+When I POST /projects/{projectId}/runs/{runId}/steps/{stepId}/retry
+Then the response status is 409 Conflict
+  And the error code is "RETRY_MAX_EXCEEDED"
+  And the error message includes the max retry count
+```
+
+### Scenario 4: Retry blocked — run has an active retry already in progress
+
+```gherkin
+Given a run in "running" status (retry already in progress)
+When I POST /projects/{projectId}/runs/{runId}/steps/{stepId}/retry
+Then the response status is 409 Conflict
+  And the error code is "RUN_ALREADY_ACTIVE"
+```
+
+### Scenario 5: Step or run not found
+
+```gherkin
+Given a non-existent stepId
+When I POST /projects/{projectId}/runs/{runId}/steps/{stepId}/retry
+Then the response status is 404 Not Found
+```
+
+### Scenario 6: Frontend retry button visibility
+
+```gherkin
+Given I am on the run detail page
+  And the run has a step with status "failed"
+Then I see a "Retry" button next to the failed step
+  And the button is not visible for steps with other statuses
+```
+
+### Scenario 7: Frontend retry button interaction
+
+```gherkin
+Given I am on the run detail page with a failed step
+When I click the "Retry" button on the failed step
+Then a confirmation dialog appears
+When I confirm the retry
+Then the API is called
+  And a success toast appears: "Step retry queued"
+  And the run detail refreshes (via SSE or refetch)
+  And the retry button becomes disabled while the run is active
+```
+
+### Scenario 8: Frontend retry button — max retries reached
+
+```gherkin
+Given a failed step that has reached max retries
+Then the "Retry" button is disabled
+  And a tooltip says "Max retries reached"
+```
+
+## Technical Notes
+
+### API Endpoint
+
+Add to `api/openapi.yaml`:
+
+```yaml
+/projects/{projectId}/runs/{runId}/steps/{stepId}/retry:
+  post:
+    operationId: retryFailedStep
+    summary: Retry a failed pipeline step
+    description: >
+      Creates a new retry step linked to the original failed step via parent_step_id.
+      Transitions the run back to running and re-enqueues it for execution.
+      Returns 409 if the step is not failed, max retries are exceeded, or the run is already active.
+    tags: [runs]
+    parameters:
+      - $ref: "#/components/parameters/ProjectIdPath"
+      - $ref: "#/components/parameters/RunIdPath"
+      - $ref: "#/components/parameters/StepIdPath"
+    responses:
+      "202":
+        description: Retry step created and run re-enqueued
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RunStep"
+      "401":
+        $ref: "#/components/responses/Unauthorized"
+      "404":
+        $ref: "#/components/responses/NotFound"
+      "409":
+        $ref: "#/components/responses/Conflict"
+```
+
+### Backend Service — `RunService.RetryFailedStep()`
+
+New method on `RunService` in `backend/internal/domain/service/run_service.go`:
+
+```go
+func (s *RunService) RetryFailedStep(ctx context.Context, projectID, runID, stepID uuid.UUID) (*model.RunStep, error)
+```
+
+Logic:
+1. **Fetch run** via `runRepo.GetRun(ctx, runID)`. Verify `run.ProjectID == projectID`.
+2. **Guard: run must be "failed"**. If `run.Status` is `running` or `pending`, return `RUN_ALREADY_ACTIVE` conflict. If `completed` or `cancelled`, return `RUN_NOT_RETRYABLE`.
+3. **Fetch step** via `runRepo.GetRunStep(ctx, stepID)`. Verify `step.RunID == runID`.
+4. **Guard: step must be "failed"**. Return `STEP_NOT_RETRYABLE` if not.
+5. **Resolve retry policy** from `run.PipelineConfigSnapshot`. Parse the snapshot JSON, find the matching step by `step_order`, extract `retry_policy.max_retries` (default 3) and `retry_policy.max_incremental` (default 2, implied from `RetryPolicy.RetryType`).
+6. **Guard: max retries**. If `step.RetryCount >= maxRetries`, return `RETRY_MAX_EXCEEDED`.
+7. **Determine retry type**: if `step.RetryCount >= maxIncremental` then `"full"`, else `"incremental"`.
+8. **Create new RunStep** via `runRepo.CreateRetryRunStep()`:
+   - `ID`: new UUID
+   - `RunID`: same run
+   - `StepName`, `StepOrder`, `Action`: copied from original step
+   - `Status`: `pending`
+   - `RetryCount`: `step.RetryCount + 1`
+   - `RetryType`: computed above
+   - `ParentStepID`: original `stepID`
+9. **Transition run to "running"**: Update via `runRepo.UpdateRunStatus()` with `startedAt = now`.
+10. **Enqueue River job**: `jobQueue.EnqueueExecuteRun(ctx, runID)`.
+11. **Publish event**: `step.retried` with `{run_id, step_id, retry_step_id, retry_count, retry_type}`.
+12. Return the new retry step.
+
+**Important**: The `PipelineExecutor.ExecuteRun()` already skips completed steps and handles retry steps naturally since the new step will be `pending` and the executor iterates by `step_order`. However, the executor needs to handle the case where multiple steps exist with the same `step_order` (original + retries). The executor should pick the latest pending step for each `step_order`, skipping failed ones. This may require a minor adjustment to `ExecuteRun()` step filtering (see Task 2.3).
+
+### Backend Handler
+
+Add `RetryFailedStep` handler method to `RunHandler` in `backend/internal/api/handler/run_handler.go`:
+
+```go
+func (h *RunHandler) RetryFailedStep(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, runID RunIdPath, stepID StepIdPath) {
+    step, err := h.service.RetryFailedStep(r.Context(), projectID, runID, stepID)
+    if err != nil {
+        writeErrorResponse(w, err)
+        return
+    }
+    writeJSON(w, http.StatusAccepted, toAPIRunStep(step))
+}
+```
+
+### Executor Adjustment
+
+When the run is re-enqueued after a retry, `PipelineExecutor.ExecuteRun()` fetches all steps via `ListRunStepsByRun()`. The list will now contain the original failed step AND the new pending retry step (both at the same `step_order`). The executor must:
+
+- Skip steps with status `failed` or `cancelled` (already done for `completed`, extend to failed/cancelled).
+- Process the new `pending` retry step.
+- Continue with subsequent steps after the retry step completes.
+
+Check that `ListRunStepsByRun` returns steps ordered by `(step_order, created_at)` so the retry step comes after the original. The current query orders by `step_order ASC` only; add `created_at ASC` as a tiebreaker.
+
+### Frontend Changes
+
+#### 1. Store — `stores/runs.ts`
+
+Add `retryStep` action and `isRetrying` ref:
+
+```typescript
+const isRetrying = ref(false)
+
+async function retryStep(projectId: string, runId: string, stepId: string) {
+  isRetrying.value = true
+  try {
+    const { data, error } = await apiClient.POST(
+      '/projects/{projectId}/runs/{runId}/steps/{stepId}/retry',
+      { params: { path: { projectId, runId, stepId } } },
+    )
+    if (error) throw error
+    return data
+  } finally {
+    isRetrying.value = false
+  }
+}
+```
+
+#### 2. Run Detail View — `views/RunDetailView.vue`
+
+Add a "Retry" button inside the step timeline `#content` slot for failed steps:
+
+```vue
+<Button
+  v-if="(item as RunStep).status === 'failed'"
+  label="Retry"
+  icon="pi pi-refresh"
+  severity="warn"
+  size="small"
+  :loading="runsStore.isRetrying"
+  :disabled="isRetryDisabled(item as RunStep)"
+  v-tooltip="retryTooltip(item as RunStep)"
+  data-testid="retry-step-btn"
+  @click="handleRetryStep(item as RunStep)"
+/>
+```
+
+Helper functions:
+- `isRetryDisabled(step)`: returns true if `run.status === 'running'` or if the step has reached max retries (derive from pipeline config snapshot).
+- `retryTooltip(step)`: returns `"Max retries reached"` or `"Run is already active"` accordingly.
+- `handleRetryStep(step)`: shows a confirm dialog, then calls `runsStore.retryStep()`, shows toast on success/error.
+
+#### 3. SSE Event Handling
+
+Add `step.retried` to the `RUN_REFRESH_EVENTS` set in `useRunDetail.ts` so the view auto-refetches when a retry step is created.
+
+#### 4. RetryStepEntry Integration
+
+The existing `RetryStepEntry.vue` component already displays retry history (retry label, error context, log tail). After the retry endpoint is wired, the step timeline should render `RetryStepEntry` sub-entries for steps that have `parent_step_id` set. Group retry steps under their parent in the timeline rendering.
+
+### Database
+
+No migration needed. The `run_steps` table already has `retry_count`, `retry_type`, and `parent_step_id` columns. The `CreateRetryRunStep` sqlc query already exists.
+
+### SQL Query Update
+
+Update `ListRunStepsByRun` in `backend/queries/run_steps.sql` to add `created_at` as tiebreaker:
+
+```sql
+-- name: ListRunStepsByRun :many
+SELECT * FROM run_steps
+WHERE run_id = $1
+ORDER BY step_order ASC, created_at ASC;
+```
+
+### Error Codes
+
+| Code | HTTP | When |
+|------|------|------|
+| `STEP_NOT_RETRYABLE` | 409 | Step is not in `failed` status |
+| `RETRY_MAX_EXCEEDED` | 409 | Step retry count >= max_retries from pipeline config |
+| `RUN_ALREADY_ACTIVE` | 409 | Run is in `running` or `pending` status |
+| `RUN_NOT_RETRYABLE` | 409 | Run is in `completed` or `cancelled` status |
+
+### Events
+
+Publish `step.retried` event via `EventPublisher`:
+
+```json
+{
+  "run_id": "...",
+  "step_id": "...",
+  "retry_step_id": "...",
+  "retry_count": 2,
+  "retry_type": "incremental"
+}
+```
+
+## Tasks / Subtasks
+
+### 1. API Contract
+
+- [ ] **1.1** Add `POST /projects/{projectId}/runs/{runId}/steps/{stepId}/retry` endpoint to `api/openapi.yaml`
+- [ ] **1.2** Run `cd backend && make generate` to regenerate Go server interface
+- [ ] **1.3** Run `cd frontend && npm run generate-api` to regenerate TypeScript types
+
+### 2. Backend — Service Layer
+
+- [ ] **2.1** Add `RetryFailedStep(ctx, projectID, runID, stepID)` method to `RunService` in `backend/internal/domain/service/run_service.go`
+- [ ] **2.2** Implement validation guards: run status, step status, step ownership, max retries
+- [ ] **2.3** Update `PipelineExecutor.ExecuteRun()` to skip `failed`/`cancelled` steps when iterating (so retry resumes from the new pending step)
+- [ ] **2.4** Update `ListRunStepsByRun` SQL query to order by `(step_order ASC, created_at ASC)` for deterministic retry step ordering
+
+### 3. Backend — Handler
+
+- [ ] **3.1** Add `RetryFailedStep` handler method to `RunHandler` in `backend/internal/api/handler/run_handler.go`
+- [ ] **3.2** Wire handler to the generated server interface in `wire.go` / router registration
+
+### 4. Backend — Tests
+
+- [ ] **4.1** Unit tests for `RunService.RetryFailedStep()`: happy path, step not failed, max retries exceeded, run already active, run not found, step not found, step not belonging to run
+- [ ] **4.2** Unit test for updated `PipelineExecutor` skip-failed-steps behavior
+- [ ] **4.3** Integration test: full retry flow (create run -> fail step -> retry -> verify new step created and run re-enqueued)
+
+### 5. Frontend — Store
+
+- [ ] **5.1** Add `retryStep()` action and `isRetrying` ref to `stores/runs.ts`
+
+### 6. Frontend — Run Detail View
+
+- [ ] **6.1** Add "Retry" button to failed steps in `RunDetailView.vue` step timeline
+- [ ] **6.2** Add confirmation dialog before triggering retry
+- [ ] **6.3** Add `isRetryDisabled()` and `retryTooltip()` helper functions
+- [ ] **6.4** Add toast notifications for success/error
+- [ ] **6.5** Add `step.retried` to SSE refresh events in `useRunDetail.ts`
+
+### 7. Frontend — Retry History Display
+
+- [ ] **7.1** Group retry steps under their parent step in the timeline (render `RetryStepEntry.vue` as sub-items for steps with `parent_step_id`)
+
+### 8. Frontend — Tests
+
+- [ ] **8.1** Unit test for `retryStep()` store action
+- [ ] **8.2** Unit test for retry button visibility logic (only on failed steps, disabled when max retries reached)
+- [ ] **8.3** E2E test: click retry on failed step, verify toast and run status change
+
+### 9. Lint & Verify
+
+- [ ] **9.1** `cd backend && golangci-lint run ./...`
+- [ ] **9.2** `cd frontend && npm run lint && npm run type-check`
+- [ ] **9.3** `cd backend && go test ./... -short`
+- [ ] **9.4** `cd frontend && npm run test:unit`

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -183,17 +183,24 @@ development_status:
   fix-monaco-native-editor: done
 
   # Post-MVP: DX Improvements
-  post-mvp-dx: backlog
-  1-22-auto-migrate-on-startup: ready-for-dev
+  post-mvp-dx: done
+  1-22-auto-migrate-on-startup: done
 
   # Post-MVP: Agent Runtime & E2E Pipeline
-  post-mvp-agent-runtime: in-progress
+  post-mvp-agent-runtime: done
   runtime-1-agent-docker-image: done
   runtime-2-action-wiring-and-action-type-mapping: done
   runtime-3-test-project-postgres-e2e-validation: done
-  runtime-4-run-context-metadata-propagation: ready-for-dev
-  runtime-5-env-vars-dotenv-setup: ready-for-dev
-  runtime-6-default-pipeline-steps-and-templates: ready-for-dev
+  runtime-4-run-context-metadata-propagation: done
+  runtime-5-env-vars-dotenv-setup: done
+  runtime-6-default-pipeline-steps-and-templates: done
+
+  # Post-MVP: Pipeline UX Improvements
+  post-mvp-pipeline-ux: backlog
+  3-15-fix-live-log-streaming-sse: ready-for-dev
+  3-16-cancel-run-endpoint-and-ui: ready-for-dev
+  3-17-display-step-costs-in-run-detail: ready-for-dev
+  3-18-retry-failed-step-endpoint-and-ui: ready-for-dev
 
   # Post-MVP: E2E Usability Fixes
   post-mvp-e2e-usability: done
@@ -222,6 +229,9 @@ development_status:
 #   Phase 5 (Waves 16-19): Post-MVP Bug Fixes
 #   Phase 6 (Waves 20-21): Auth Enhancements
 #   Phase 7 (Waves 22-23): E2E Usability Fixes
+#   Phase 8 (Waves 24-26): Runner Abstraction Refactoring
+#   Phase 9 (Waves 27-29): Agent Runtime
+#   Phase 10 (Wave 30):    Pipeline UX Improvements
 #
 # Launch a single story in a container:
 #   ./scripts/bmad-dev.sh -p "/bmad-bmm-dev-story"
@@ -845,7 +855,7 @@ parallel_waves:
         status: done
       - key: runtime-2-action-wiring-and-action-type-mapping
         domain: back
-        status: ready-for-dev
+        status: done
     container_count: 2
     depends_on: [wave-26]
     notes: "Agent Docker image + action wiring — parallel, independent"
@@ -866,16 +876,43 @@ parallel_waves:
     stories:
       - key: runtime-4-run-context-metadata-propagation
         domain: back
-        status: ready-for-dev
+        status: done
         cross_epic_deps: []
       - key: runtime-5-env-vars-dotenv-setup
         domain: shared
-        status: ready-for-dev
+        status: done
         cross_epic_deps: []
       - key: runtime-6-default-pipeline-steps-and-templates
         domain: back
-        status: ready-for-dev
+        status: done
         cross_epic_deps: []
     container_count: 3
     depends_on: [wave-28]
-    notes: "RunContext metadata + env vars + default pipeline config/templates"
+    notes: "RunContext metadata + env vars + default pipeline config/templates — Phase 9 COMPLETE"
+
+  # =====================================================
+  # PHASE 10: PIPELINE UX IMPROVEMENTS
+  # =====================================================
+
+  wave-30:
+    phase: 10-pipeline-ux
+    stories:
+      - key: 3-15-fix-live-log-streaming-sse
+        domain: back
+        status: ready-for-dev
+        cross_epic_deps: [4-1-sse-streaming-endpoint, 3-5-ndjson-log-streaming-from-container]
+      - key: 3-16-cancel-run-endpoint-and-ui
+        domain: shared
+        status: ready-for-dev
+        cross_epic_deps: [3-7-pipeline-executor-sequential-step-runner]
+      - key: 3-17-display-step-costs-in-run-detail
+        domain: front
+        status: ready-for-dev
+        cross_epic_deps: [9-2-cost-aggregation-api, 4-4-run-progress-timeline-display]
+      - key: 3-18-retry-failed-step-endpoint-and-ui
+        domain: shared
+        status: ready-for-dev
+        cross_epic_deps: [8-2-incremental-retry-action, 4-4-run-progress-timeline-display]
+    container_count: 4
+    depends_on: [wave-29]
+    notes: "Pipeline UX: live logs fix, cancel run, cost display per step, retry failed step — all parallel"


### PR DESCRIPTION
## Summary
- Add 4 new user stories for Pipeline UX improvements (wave-30)
- Update sprint-status.yaml: mark runtime-4/5/6, 1-22 as done
- Add Phase 10 (Pipeline UX) with wave-30

## Stories
- 3-15: Fix live log streaming SSE
- 3-16: Cancel run endpoint and UI
- 3-17: Display step costs in run detail
- 3-18: Retry failed step endpoint and UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)