### PR TITLE
feat(runs): display step costs in run detail view

### DIFF
--- a/frontend/src/features/runs/__tests__/useRunCosts.spec.ts
+++ b/frontend/src/features/runs/__tests__/useRunCosts.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { useRunCosts } from '../composables/useRunCosts'
+
+const mockGet = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+  },
+}))
+
+/** Wraps composable that calls onMounted in a simulated lifecycle */
+function withSetup<T>(composable: () => T): T {
+  let result!: T
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { createApp, defineComponent } = require('vue')
+  const app = createApp(
+    defineComponent({
+      setup() {
+        result = composable()
+        return () => null
+      },
+    }),
+  )
+  app.mount(document.createElement('div'))
+  return result
+}
+
+const mockCostDetail = {
+  run_id: 'run-1',
+  total_cost: 4.52,
+  steps: [
+    {
+      step_id: 'step-1',
+      step_name: 'dev-story',
+      model: 'claude-opus-4-6',
+      tokens_input: 150000,
+      tokens_output: 30000,
+      cost_usd: 4.5,
+    },
+    {
+      step_id: 'step-2',
+      step_name: 'code-review',
+      model: 'claude-sonnet-4-6',
+      tokens_input: 5000,
+      tokens_output: 1000,
+      cost_usd: 0.02,
+    },
+  ],
+}
+
+describe('useRunCosts', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+  })
+
+  it('fetches cost detail on mount', async () => {
+    mockGet.mockResolvedValue({ data: mockCostDetail, error: undefined })
+
+    const { costDetail, isLoading } = withSetup(() => useRunCosts('proj-1', 'run-1'))
+    await flushPromises()
+
+    expect(costDetail.value).toEqual(mockCostDetail)
+    expect(isLoading.value).toBe(false)
+    expect(mockGet).toHaveBeenCalledWith('/projects/{projectId}/runs/{runId}/costs', {
+      params: { path: { projectId: 'proj-1', runId: 'run-1' } },
+    })
+  })
+
+  it('sets error when API returns error', async () => {
+    mockGet.mockResolvedValue({
+      data: undefined,
+      error: { error: { code: 'NOT_FOUND', message: 'Run not found' } },
+    })
+
+    const { costDetail, error } = withSetup(() => useRunCosts('proj-1', 'run-1'))
+    await flushPromises()
+
+    expect(costDetail.value).toBeNull()
+    expect(error.value).toBeInstanceOf(Error)
+    expect(error.value?.message).toBe('Failed to load run costs')
+  })
+
+  it('retry() re-calls the API', async () => {
+    mockGet.mockResolvedValue({ data: mockCostDetail, error: undefined })
+
+    const { retry } = withSetup(() => useRunCosts('proj-1', 'run-1'))
+    await flushPromises()
+
+    expect(mockGet).toHaveBeenCalledTimes(1)
+
+    mockGet.mockClear()
+    mockGet.mockResolvedValue({ data: mockCostDetail, error: undefined })
+
+    await retry()
+    expect(mockGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes isLoading as true during fetch', async () => {
+    let resolvePromise: (value: unknown) => void
+    mockGet.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePromise = resolve
+      }),
+    )
+
+    const { isLoading } = withSetup(() => useRunCosts('proj-1', 'run-1'))
+
+    expect(isLoading.value).toBe(true)
+
+    resolvePromise!({ data: mockCostDetail, error: undefined })
+    await flushPromises()
+
+    expect(isLoading.value).toBe(false)
+  })
+})

--- a/frontend/src/features/runs/composables/useRunCosts.ts
+++ b/frontend/src/features/runs/composables/useRunCosts.ts
@@ -38,11 +38,15 @@ export function useRunCosts(
 
   // Refetch costs when run status changes (costs finalize on step completion)
   if (runStatus) {
-    watch(runStatus, (newStatus, oldStatus) => {
-      if (newStatus !== oldStatus) {
-        fetchCosts()
-      }
-    })
+    watch(
+      runStatus,
+      (newStatus, oldStatus) => {
+        if (newStatus !== oldStatus && oldStatus !== undefined) {
+          fetchCosts()
+        }
+      },
+      { flush: 'post' },
+    )
   }
 
   onMounted(fetchCosts)

--- a/frontend/src/features/runs/composables/useRunCosts.ts
+++ b/frontend/src/features/runs/composables/useRunCosts.ts
@@ -1,0 +1,51 @@
+import { onMounted, watch, type Ref } from 'vue'
+import { useAsyncAction } from '@/composables/useAsyncAction'
+import { apiClient } from '@/api/client'
+import type { components } from '@/api/schema'
+
+export type RunCostDetail = components['schemas']['RunCostDetail']
+export type StepCostBreakdown = components['schemas']['StepCostBreakdown']
+
+/**
+ * Composable for fetching cost detail for a specific run.
+ * Returns total cost and per-step cost breakdown.
+ * Refetches when the run status changes to completed or failed.
+ */
+export function useRunCosts(
+  projectId: string,
+  runId: string,
+  runStatus?: Ref<string | undefined>,
+) {
+  const {
+    data: costDetail,
+    isLoading,
+    error,
+    execute,
+  } = useAsyncAction(async () => {
+    const { data, error: apiError } = await apiClient.GET(
+      '/projects/{projectId}/runs/{runId}/costs',
+      {
+        params: { path: { projectId, runId } },
+      },
+    )
+    if (apiError) throw new Error('Failed to load run costs')
+    return data as RunCostDetail
+  })
+
+  async function fetchCosts() {
+    await execute()
+  }
+
+  // Refetch costs when run status changes (costs finalize on step completion)
+  if (runStatus) {
+    watch(runStatus, (newStatus, oldStatus) => {
+      if (newStatus !== oldStatus) {
+        fetchCosts()
+      }
+    })
+  }
+
+  onMounted(fetchCosts)
+
+  return { costDetail, isLoading, error, retry: fetchCosts }
+}

--- a/frontend/src/utils/__tests__/formatCost.spec.ts
+++ b/frontend/src/utils/__tests__/formatCost.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { formatCostUSD, formatTokenCount } from '../formatCost'
+
+describe('formatCostUSD', () => {
+  it('formats zero as $0.00', () => {
+    expect(formatCostUSD(0)).toBe('$0.00')
+  })
+
+  it('formats small costs with up to 5 decimal places', () => {
+    const result = formatCostUSD(0.00123)
+    expect(result).toBe('$0.00123')
+  })
+
+  it('formats larger costs with 2 decimal places', () => {
+    expect(formatCostUSD(4.5)).toBe('$4.50')
+  })
+})
+
+describe('formatTokenCount', () => {
+  it('formats small numbers without separators', () => {
+    expect(formatTokenCount(500)).toBe('500')
+  })
+
+  it('formats thousands with comma separators', () => {
+    expect(formatTokenCount(150000)).toBe('150,000')
+  })
+
+  it('formats millions with comma separators', () => {
+    expect(formatTokenCount(1500000)).toBe('1,500,000')
+  })
+
+  it('formats zero', () => {
+    expect(formatTokenCount(0)).toBe('0')
+  })
+})

--- a/frontend/src/utils/formatCost.ts
+++ b/frontend/src/utils/formatCost.ts
@@ -10,3 +10,8 @@ export function formatCostUSD(value: number): string {
     maximumFractionDigits: 5,
   }).format(value)
 }
+
+/** Formats a token count with thousands separators (e.g., 100,000). */
+export function formatTokenCount(count: number): string {
+  return new Intl.NumberFormat('en-US').format(count)
+}

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -10,9 +10,12 @@ import Button from 'primevue/button'
 import { useToast } from 'primevue/usetoast'
 import { differenceInSeconds } from 'date-fns'
 import { useRunDetail } from '@/features/runs/composables/useRunDetail'
+import { useRunCosts } from '@/features/runs/composables/useRunCosts'
+import type { StepCostBreakdown } from '@/features/runs/composables/useRunCosts'
 import { useRunsStore } from '@/stores/runs'
 import RunLogViewer from '@/features/runs/RunLogViewer.vue'
 import { runStatusSeverity } from '@/utils/runStatus'
+import { formatCostUSD, formatTokenCount } from '@/utils/formatCost'
 import type { RunStep } from '@/features/runs/composables/useRunDetail'
 
 const route = useRoute()
@@ -24,6 +27,29 @@ const toast = useToast()
 
 const { run: runRef, isLoading, error, retry } = useRunDetail(runId.value, projectId.value)
 const run = computed(() => runRef.value)
+
+const runStatus = computed(() => run.value?.status)
+const { costDetail, isLoading: isCostLoading } = useRunCosts(
+  projectId.value,
+  runId.value,
+  runStatus,
+)
+
+/** Map of step_id → StepCostBreakdown for quick lookups in the timeline. */
+const stepCostMap = computed(() => {
+  const map = new Map<string, StepCostBreakdown>()
+  if (!costDetail.value?.steps) return map
+  for (const step of costDetail.value.steps) {
+    map.set(step.step_id, step)
+  }
+  return map
+})
+
+/** Total run cost formatted for display. */
+const totalCostDisplay = computed(() => {
+  if (!costDetail.value) return null
+  return formatCostUSD(costDetail.value.total_cost)
+})
 
 const stepSeverity: Record<string, string> = {
   completed: 'success',
@@ -99,6 +125,13 @@ function formatDuration(step: RunStep): string | null {
       </div>
       <div class="flex items-center gap-3">
         <Tag v-if="run" :value="run.status" :severity="runStatusSeverity[run.status]" />
+        <span
+          v-if="totalCostDisplay && !isCostLoading"
+          class="text-sm font-medium text-surface-600 bg-surface-100 dark:bg-surface-800 px-2 py-1 rounded"
+          data-testid="run-total-cost"
+        >
+          {{ totalCostDisplay }}
+        </span>
         <Button
           v-if="canPause"
           label="Pause"
@@ -174,6 +207,24 @@ function formatDuration(step: RunStep): string | null {
                 <span>{{ (item as RunStep).action }}</span>
                 <span v-if="formatDuration(item as RunStep)" class="text-surface-400">
                   {{ formatDuration(item as RunStep) }}
+                </span>
+              </div>
+              <!-- Per-step cost breakdown -->
+              <div
+                v-if="stepCostMap.get((item as RunStep).id)"
+                class="flex items-center gap-3 text-xs text-surface-500 mt-1"
+                data-testid="step-cost"
+              >
+                <span class="font-mono bg-surface-100 dark:bg-surface-800 px-1.5 py-0.5 rounded">
+                  {{ stepCostMap.get((item as RunStep).id)!.model }}
+                </span>
+                <span>
+                  {{ formatTokenCount(stepCostMap.get((item as RunStep).id)!.tokens_input) }} in
+                  /
+                  {{ formatTokenCount(stepCostMap.get((item as RunStep).id)!.tokens_output) }} out
+                </span>
+                <span class="font-medium text-surface-700 dark:text-surface-300">
+                  {{ formatCostUSD(stepCostMap.get((item as RunStep).id)!.cost_usd) }}
                 </span>
               </div>
               <div

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -51,6 +51,11 @@ const totalCostDisplay = computed(() => {
   return formatCostUSD(costDetail.value.total_cost)
 })
 
+/** Helper to get step cost breakdown by step ID. */
+function getStepCost(stepId: string): StepCostBreakdown | undefined {
+  return stepCostMap.value.get(stepId)
+}
+
 const stepSeverity: Record<string, string> = {
   completed: 'success',
   running: 'info',
@@ -211,20 +216,20 @@ function formatDuration(step: RunStep): string | null {
               </div>
               <!-- Per-step cost breakdown -->
               <div
-                v-if="stepCostMap.get((item as RunStep).id)"
+                v-if="getStepCost((item as RunStep).id)"
                 class="flex items-center gap-3 text-xs text-surface-500 mt-1"
                 data-testid="step-cost"
               >
                 <span class="font-mono bg-surface-100 dark:bg-surface-800 px-1.5 py-0.5 rounded">
-                  {{ stepCostMap.get((item as RunStep).id)!.model }}
+                  {{ getStepCost((item as RunStep).id)!.model }}
                 </span>
                 <span>
-                  {{ formatTokenCount(stepCostMap.get((item as RunStep).id)!.tokens_input) }} in
+                  {{ formatTokenCount(getStepCost((item as RunStep).id)!.tokens_input) }} in
                   /
-                  {{ formatTokenCount(stepCostMap.get((item as RunStep).id)!.tokens_output) }} out
+                  {{ formatTokenCount(getStepCost((item as RunStep).id)!.tokens_output) }} out
                 </span>
                 <span class="font-medium text-surface-700 dark:text-surface-300">
-                  {{ formatCostUSD(stepCostMap.get((item as RunStep).id)!.cost_usd) }}
+                  {{ formatCostUSD(getStepCost((item as RunStep).id)!.cost_usd) }}
                 </span>
               </div>
               <div


### PR DESCRIPTION
## Summary
- Add `useRunCosts` composable to fetch per-run cost detail from `GET /projects/{projectId}/runs/{runId}/costs`
- Display total run cost in the run detail header next to the status tag
- Show per-step cost breakdown (model, input/output tokens, USD cost) inline in the step timeline
- Add `formatTokenCount` utility for thousands-separated token count formatting
- Composable refetches costs on run status changes so data updates as steps complete
- Add unit tests for `useRunCosts` composable and `formatCost` utilities (11 new tests)

## Test plan
- [x] `npx vue-tsc --build` passes with no type errors
- [x] `npx eslint . --cache` passes with no lint errors
- [x] All 547 unit tests pass (64 test files)
- [ ] Verify run detail page shows total cost in header when cost data exists
- [ ] Verify per-step cost (model, tokens in/out, USD) appears below each step in timeline
- [ ] Verify cost data gracefully hides when no cost records exist for a run
- [ ] Verify cost data refreshes when run status changes (step completes)

Refs: S-3-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)