### PR TITLE
feat(runs): add cancel run endpoint and UI

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -928,6 +928,33 @@ paths:
         "409":
           $ref: "#/components/responses/Conflict"
 
+  /projects/{projectId}/runs/{runId}/cancel:
+    post:
+      operationId: cancelRun
+      summary: Cancel a pending, running, or paused story run
+      description: >
+        Transitions the run to cancelled status. If the run has a step currently
+        executing in a container, the container is stopped. Pending steps are
+        marked as cancelled. Returns 409 if the run is already in a terminal
+        state (completed, failed, or cancelled).
+      tags: [runs]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/RunIdPath"
+      responses:
+        "200":
+          description: Run cancelled successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Run"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
   /projects/{projectId}/epics/{epicId}/runs/{runId}/pause:
     post:
       operationId: pauseEpicRun
@@ -971,6 +998,33 @@ paths:
       responses:
         "200":
           description: Epic run resumed successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Run"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /projects/{projectId}/epics/{epicId}/runs/{runId}/cancel:
+    post:
+      operationId: cancelEpicRun
+      summary: Cancel a pending, running, or paused epic run
+      description: >
+        Cancels the epic run and all active child runs. Containers for
+        running steps are stopped. Returns 409 if the run is already in a
+        terminal state.
+      tags: [runs]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/EpicIdPath"
+        - $ref: "#/components/parameters/RunIdPath"
+      responses:
+        "200":
+          description: Epic run cancelled successfully
           content:
             application/json:
               schema:

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -260,6 +260,9 @@ func run() error {
 	}
 
 	runService := service.NewRunService(runRepo, projectRepo, storyRepo, pipelineConfigRepo, jobQueue, eventRepo)
+	if containerMgr != nil {
+		runService.SetContainerManager(containerMgr)
+	}
 	runHandler := handler.NewRunHandler(runService)
 
 	// Orphan cleanup and timeout enforcement (requires Docker)

--- a/backend/internal/api/handler/gen_server.go
+++ b/backend/internal/api/handler/gen_server.go
@@ -1459,6 +1459,9 @@ type ServerInterface interface {
 	// Launch a batch run for all stories in an epic (async)
 	// (POST /projects/{projectId}/epics/{epicId}/runs)
 	LaunchEpicRun(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, epicId EpicIdPath)
+	// Cancel a pending, running, or paused epic run
+	// (POST /projects/{projectId}/epics/{epicId}/runs/{runId}/cancel)
+	CancelEpicRun(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, epicId EpicIdPath, runId RunIdPath)
 	// Pause an in-progress epic run
 	// (POST /projects/{projectId}/epics/{epicId}/runs/{runId}/pause)
 	PauseEpicRun(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, epicId EpicIdPath, runId RunIdPath)
@@ -1495,6 +1498,9 @@ type ServerInterface interface {
 	// Create a new pipeline run for a project
 	// (POST /projects/{projectId}/runs)
 	CreateRun(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath)
+	// Cancel a pending, running, or paused story run
+	// (POST /projects/{projectId}/runs/{runId}/cancel)
+	CancelRun(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, runId RunIdPath)
 	// Get total costs for a run with per-step breakdown
 	// (GET /projects/{projectId}/runs/{runId}/costs)
 	GetRunCosts(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, runId RunIdPath)
@@ -1750,6 +1756,12 @@ func (_ Unimplemented) LaunchEpicRun(w http.ResponseWriter, r *http.Request, pro
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Cancel a pending, running, or paused epic run
+// (POST /projects/{projectId}/epics/{epicId}/runs/{runId}/cancel)
+func (_ Unimplemented) CancelEpicRun(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, epicId EpicIdPath, runId RunIdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // Pause an in-progress epic run
 // (POST /projects/{projectId}/epics/{epicId}/runs/{runId}/pause)
 func (_ Unimplemented) PauseEpicRun(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, epicId EpicIdPath, runId RunIdPath) {
@@ -1819,6 +1831,12 @@ func (_ Unimplemented) ListRunsByProject(w http.ResponseWriter, r *http.Request,
 // Create a new pipeline run for a project
 // (POST /projects/{projectId}/runs)
 func (_ Unimplemented) CreateRun(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Cancel a pending, running, or paused story run
+// (POST /projects/{projectId}/runs/{runId}/cancel)
+func (_ Unimplemented) CancelRun(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, runId RunIdPath) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -2956,6 +2974,55 @@ func (siw *ServerInterfaceWrapper) LaunchEpicRun(w http.ResponseWriter, r *http.
 	handler.ServeHTTP(w, r)
 }
 
+// CancelEpicRun operation middleware
+func (siw *ServerInterfaceWrapper) CancelEpicRun(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "epicId" -------------
+	var epicId EpicIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "epicId", chi.URLParam(r, "epicId"), &epicId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "epicId", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "runId" -------------
+	var runId RunIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "runId", chi.URLParam(r, "runId"), &runId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "runId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CancelEpicRun(w, r, projectId, epicId, runId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // PauseEpicRun operation middleware
 func (siw *ServerInterfaceWrapper) PauseEpicRun(w http.ResponseWriter, r *http.Request) {
 
@@ -3401,6 +3468,46 @@ func (siw *ServerInterfaceWrapper) CreateRun(w http.ResponseWriter, r *http.Requ
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.CreateRun(w, r, projectId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CancelRun operation middleware
+func (siw *ServerInterfaceWrapper) CancelRun(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "runId" -------------
+	var runId RunIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "runId", chi.URLParam(r, "runId"), &runId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "runId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CancelRun(w, r, projectId, runId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -4543,6 +4650,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Post(options.BaseURL+"/projects/{projectId}/epics/{epicId}/runs", wrapper.LaunchEpicRun)
 	})
 	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/projects/{projectId}/epics/{epicId}/runs/{runId}/cancel", wrapper.CancelEpicRun)
+	})
+	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/projects/{projectId}/epics/{epicId}/runs/{runId}/pause", wrapper.PauseEpicRun)
 	})
 	r.Group(func(r chi.Router) {
@@ -4577,6 +4687,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/projects/{projectId}/runs", wrapper.CreateRun)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/projects/{projectId}/runs/{runId}/cancel", wrapper.CancelRun)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/projects/{projectId}/runs/{runId}/costs", wrapper.GetRunCosts)
@@ -4660,154 +4773,158 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x9i24cOZLgrxB5B4wNVEklWXJ3ezHAypLbrR3brZPs7ZvpNQqszKgqrjLJbJIpucYw",
-	"sP9w94X7JQs+8s18leoh2w0MeiyJSQYjgsF487PnsyhmFKgU3ovPXow5jkAC1z+9iol/GVxhuVQ/BSB8",
-	"TmJJGPVe6L+hDx8uL7yRR9QvYjVs5FEcgffCA/2pN/I4/JEQDoH3QvIERp7wlxBhNd+c8QhL74WXJESN",
-	"lKtYfSkkJ3Thffky0mtcJ7QVBJ7QDjD0DA+E5JfL92+u4Y8EhGyCRg1B3IxpgWhJZJjN9EComkC5BsES",
-	"7kMLGOSha79jksyJj9WSTXAUxyCf0TlZtIBESzM+ELwrvIArxcx1qNSfEE2iGfAUkD8S4KsckhgvwCuu",
-	"F8AcJ6H0XhyNvIhQEiWR/rddl1AJC+BmYeAta19KiASKgSO7hnN54NNmEI4nIy/CnywMk0k3RJz9J/iN",
-	"fGv/3EKYOJ3ggTRpOcrXraeYb+AE3zAuX64ayPIzgTBAkiHBuESzVQNh1F+n+q8Oung+BywhmGLpBkBC",
-	"3LZ9ISFuwYHQnz8UCZLxVRMQ+o+tEOiPHwjCe4jiEEtoYccolkjaYS3wyGymB4H0RX0sYkYF6EvvJQ6s",
-	"fFY/+YxKoPqfOI5DK54O/1MoYD8XlvnfHObeC+9/HeYX6qH5qzh8xTnjZqnyZl/iIL0yvC8j75zReUj8",
-	"HSyc3RC+XRI9gYPFAQoSsxQgiDAJnyqofmZ8RoIA6PbBypZCY4SDiFCEfR+EQBl5zc3zM0tosEMsUSbR",
-	"XK/5ZeR9oDiRS8bJP2EHMJRWU3+2X6gJz5eYqqtGiHvGi1wbcxYDl8RwtJ9wDlROYztQ/S4i9A3QhTqB",
-	"R7UzMfIo3DcN/9F1qvPj93t9ucp0H7MJ2EzdK4bzhbzAEl8xQh07CLAE9f/wCUdxqD49nhw/H0+Ox0cT",
-	"b5QfcT3OsR3JJA6nPhNymoigNNPk4Oj42UlxDpbMwsIsVlOo7jJdqjxz095ukijCfFXfGb5bmK/Vpa8l",
-	"7PoQjrxZEixATkMSkfpOjya95oiBExZMgQYNGP/h/WTyQv/vH1XcjyWJnASwkwqJuWwi5BrTFrAfMSqX",
-	"tT0/Ozg5ff5Dr3238MjRwfGzk9Ohs9wD3DqIefr8hx+Hs1sFugpGS1QbNTGVkzm10qINrSbxUZJHRdJp",
-	"+2vOOFISCqhMNf05YJlwEJ5WVFO5cTxRumpd0ujLvDjtBwEcnZWmrMx0ejrqEmBCYpmIsoI2w/5tyBbe",
-	"yAOq1OXfC78hdBpztuAgFNgBo1BAV4Og06A3I7Vo/Zxr46dZQi8xpRBOzUyfM/gCInwjQe9htmTsVi2X",
-	"Yyr/c23/xtrSEiYIiAIBh1elNWufZPN+9hIeKlNVyli8ODy0yxz4LDrEMTm0sIjDg4MDzfPV/QPFs9Bc",
-	"jhn2jVqWrWF+tF/OGAsBU/3pnboWp3MSSuAlvvhdmQEKhjgECVrnS+jBHBO10seRR5Rp5dyY/QXmHK/q",
-	"t1UR9RneqoA0U9maT42kxQt1F/KEahlWU3fPGZWYUODIDkGJAG2KwCfwEwlIT6CtA4GeWHQKNeAvAfNv",
-	"gf8FkTliEZESgqcF3jZ/9UbebTIDTkGCqHBPOqCGMLvKNGIBhHWYL8yf0XmIkwCQHoXYHXBOAjACoQAz",
-	"oUguiUDWivSKIPh6hjGLEzE+GT9XmkIShop5KhxShK1BGp0hof9ZWKggM47c0mdBpDr3dyQw3Fbe6Gsi",
-	"UfpXva/iRirEWBC5TGZNxDB/9fSCIVb/mBE5S/xbkGWiZAOdoEp2C3QK9M7ha8ERIDZHcgkI6B3hjEaK",
-	"CHeYE4VQtGRhQOhCD1gQifRc6IlSbdWvzI9ECgjnT0tEen35/pcPL6fvf/3bq3d9KFSX6G9X6MpFlD6C",
-	"nEPMploeVXf84fpNumFLkr8IvTP1iSDq2ivtIxVnBsVamjG+OIxW45xjOjY37AIwpmxq8DZKiDq+0gN2",
-	"qX7WVDRTDcdeaiNPC0ZKvs7fWYIwB0TSdRR/aH0Bff5s9IZbWH35ouR891KVuyubVFvnUhODwx2BezUX",
-	"cO3f8hMhWVQ+AsUPe+DfsUn7XTNlrhPaSI6YxBASqmezV2h5gBZr6h/ZjVOR+H4qnBqPRq9t2Xlcu2i9",
-	"0Qx8rs8MSUnQz1NTntN+OarhpxnL2qHUfDH6PsQSUx+mPicSOMFOnAUQAw3E1KC07y0/0q7/fnsdebew",
-	"Kp+Mm/HkqHzaTl3Xh9kxuQMnRMJn5SOh1E2joc+5ZlX1T7HEHAKHtllUYttcBxrNN2aowgPmygackxDE",
-	"MIxJIsOKJMolUMgWhKZe66oUamcehd10dhe3KDvCoRPn7lSHwXg0Pjp9fzR58WyYwfgQW6Y2GalYyD/8",
-	"MIEfTyaTMRz/NBufHAUnY/zD0fPxycnz56enJyeTyaTkrWjixr4mUd3KNvfYtArY8+ebASznx74GVA5D",
-	"PtIxrRIuPktsELKT2c/N0C8jL4mDTTNJhXmNzMsRO0rFs0VGBfxROQxQgK+J8y/OXr8KFuC4Z7Tv0eGn",
-	"Nz5Jc0/fwkopokpEAvVXZc3NSrH6wdcioj7ze/1718yyNvFx951h4M+Wa0HAOxY4EPBA4V0bGOKVS8v/",
-	"B3A2nmFldhmbS517PRYRGsCn4s4n9Qhb6Vj0Yff+YrYHZxZla4EnzVZbMH5tQx51rEOwqFwcrX7rAgc7",
-	"rhTKguGTaW7o0nLMzCMLbtNO3xDhdifjQUC5thbjBaE4vUnaZrjKRzq8yNgrzdW0k+uEnmmNyfhVKjRT",
-	"ug5PaE3y//TTtiS/2lyQhOrvJTlf+H2DqCcgjLQsgXrqjF0XcVXcZEX85lO2oO8CJCahQ9FIXUr2FnFe",
-	"Ep1Wb1ld6aeNDFFRew4rqwBr0FXJe0M8nlBq/lV0ulmHm+LZRBi9NSd+/nET5Qcdu+uE6vu+UxjUL+kU",
-	"tQVGKV3MKTgt/GKWrrHLgrMknpqbYfN3SX6Iq7Tr5EDXNdRBkFV/PrHOAIcbhpI/klQdIUpXIHMCHN0T",
-	"uVRXWeotg4PFwQipu7mPktJsfxbxn23aSUYdUq3LSvevfauCFJTum1fX03e/vp/+/OuHdxdua0JJFNHs",
-	"ZS9RKocsAiHwwqXjK6ShywuEZ/7R8bNC3Lkz6KrAz2eu46MqTDUWXGj7mfEFk51BZZ0fUN5BIoD/q/3x",
-	"wGdR8WIxw7t2YUa5oCok4HWZij0tQTKfF71iNaaeEwiQGoXsKDTnLNLuRuPe5gntcywXWEIe2MmQheOY",
-	"szsc7k7Wc9DOCkanHLBNTuiEnoNg4d0D70bj9tvMJHxd8dgsWZ1DhYR4E7eoobOJV2kCDLozh8BQkNDd",
-	"tpAZ3uG/0mM2aq4UMZvvrwh9edni8XFf5R3CYgMGQFH07NcOuIxixuWNUV2apWGTULvG9yjC/DZg9zQT",
-	"avrG+fvZ2zdI+yQjLCVwe5vPQubfih53j1mwB8hCx4KdV3J/1TCfc2XTpupUsWpqPUym0ysQmyOrASK5",
-	"xBKZ4UgyRPTknks3M39qn5XCfbhClj/TNZyzWddQ22R2SAbqk1tYIRxywMEKwScibJSxw3DK4M4XLejx",
-	"FvntxFu9ateayjt4i/0loTBWgOrYo14DWR2lyYHjykbVTqgIr9AMEESxXCEy17/0WRIGWj9Sf/kkOfbL",
-	"yMinL2hblYz9JMK0CmRxSD/Hdjr/yGDDhcg3SkxuWZVS0iNP2CsY5OAnHK7+VYij4iyF7Lw+OllhdtcG",
-	"3xocNHuVnCrv5dxE1PUSiAjEYaGYmkMwQhhxECBRSOgtWmKBZgAUiT5xwWYteOS9ZQGE50zIlxywFoUO",
-	"YNO8h7ZMBUcy2i1QMSU0TsqujWeTic4+yHBPqHx+4hQKdg6WyOokpwPmSFPFhqf/VRGpEVGasrLPKsgu",
-	"lNcTob75DKitBK8KaVWPII9qe/GvbYex9hE06pdmltN4WBypfsI2oPc6jm2XH07P7wLwqqQkVxIuqvfC",
-	"kUuqZUVRxZHHk0YBWBp3ctypJJmPRmntV7acczfGZCsWBUqINuiXaMx3kgwpK1h7IbRv4gmZo6trowyK",
-	"p83OhJZaRV1f08sm7m2KbslsbbIoW4zJDkuxTskNHJwG9nBlXNQ49Vkno1pT0Xzq3JNN0Gm6arefJVDN",
-	"j2pFloX2RkLsQlG7sD7egLAuyWkDfKfALUHdkAE2bc+Iq2TCSdDK1cCEuJGHE8mm1slUwtAch8KpGlTp",
-	"/uOPm6F7rjXb/dZ1ZvsbwSgFWf7dEpPbZHwyPi3vvYfeXU+XaUWYzkWcxiwk/qqLOa/V2Csz1Cl9Sql6",
-	"6eWeas0l0lQWdjKVTUPdag75ZjLEfcL9hMjpTBlRwKc48yKWQfttCXIJXN9X9htkv1H2ni0VC1dIchLH",
-	"xh/RycDVxbNgcpMfxVc2qZ8oEFGavqhdPjazqxiSy4qpnapFdekIO4KA75ccxJKFgU4oKy6erolmMGcc",
-	"zK6N87d4A7QVdI+2lRj3baT8bzLD/zvN39+WXhDhT1NToOjyGOqGBsj83VIio6tiqA83F+gJoWYVbcwj",
-	"RsNywtvRxOnjaNhxXrTXUbFQT/u9p1kcKv/m9HQzeHpUFQ87s5btTZqhtknMN949buE8zI62NG+t2J2t",
-	"ciHZS8N1eBwdeu5spS743pNeJ7TPlCLNYek1qU2u7Zi27RynzUTsOdaFyNs+vWV/Z+UqVn9D6m8pFJlo",
-	"0QWzpfWPD4bU+GZ+XteK+o9GJouWJU8nA726uWPYtar5a/eyR32XbSxC9spYqIBXYL2MsUf5wWk5eZuw",
-	"vq1o22+otlz7taPqhm1ZdoMq1Hbuzt1kjdteqtr2WsbQVDw3+OIssPtmTnHx/Oz3MF/bsOTWI7j1g/Zv",
-	"mAK6YDC89HPdaPCQVi+12PCouSb2Wmc/tebx5Xlp1T486vf6QrNJbNYOKvqxKxWqky7Y7WJuUAV0Z0AW",
-	"EVx1AACicI/SEeiJtejRj8hfYp2rwEXZSqNwf2Nog4U4On7WRQkbeHUvbiLnxiTk4AO5gwDNViilV8HF",
-	"8/rf/xmcH01mxzKckaNo9uxS+tG///Mf//f//LVTqBgIOlIDij60eqQdf5oqMZqeoyywU+px1+WVMZ61",
-	"qqimjGqLgo6t28UbeTi8x6uKl6s0oCOxoABuaVnnxhO6ZrHBZooLOGd8Wsi7WDvNtFzwOxUUx2LJ5OC0",
-	"56w+sG42APeBSrwA466zOEq7Xkz++7/+39Fk8nSk/5Sov2CJdHM+pLZ/4DW2RHTyy/AiCT4U+/0KK2wN",
-	"RUOFhY+pD2E4sMhiEzn9f4NV6mjAQjCfZGloK9soTufx/wtisbXmsECCRYAgWADysQCBIrxCS3wHiDLz",
-	"6UGv4sSyLrQRVadQPZClkBaKVYcoOjW7eyNB30HB1XqVR5F7HpoY3JA99Ozg6HR4/lAhOFvM77UkKJmT",
-	"HYFai/emGq6B0WkxwCUCcadHZDs4K6GnuamDxcw1u38gWopCztmfbbhBujtmdTRam6zX2K+dZwto6tX8",
-	"7zqhG7CGlCqxZxMooW2xbqd+saauk0YzLec+LmUoZItpKoIcJpdufFnIf6l0f75Ib1XGiUJ3aLr+6qAT",
-	"ETrlVXJ19f4LokkYGouHsTx0O7zqReuoDRHS35bEX9o1sZSgG+9aWJ4cmTrGp02gNCzdqJZXTTq1qJAc",
-	"S1isTMA6i79ZWJpWznwx1OfapaITt+ZJqF2LmywE2p7m16Hwjbx7TJSZO83qxAYVDTU0GrJ/ZdwGQ7sK",
-	"B+oJVlnzi2yarFFR//qc64T+RuTyJr2JcRj+Ovde/N5HCHZ3Y+qYw51o1LOH0kfbyLtLB3TdSM96BRfW",
-	"yz3f0u09JI+vwHU9vZ6NCfNHm0iYP14jYX5zWkSlyM0emzyfviWFfuS1ahQNZel922mtlZO6gxZcw5q9",
-	"7KIEvau911AvwvfaDWwrJn1D35shprwj2u3o9beuQ2VtS/v04Ph0HXlTcHHkdkthjVYUNGY7qNu/M78u",
-	"IEIS6uuSeFtQSajO7Qt07F1U8ttcLZQG4PlhiKvF78s3xnrR+LzSYL3IeoF8/YPsOW1aaJs2Vasksdj2",
-	"VB2p57aRW0efnmK1bWd3E63/dlR7VJCT99LK9efAOPfzsiX3/jdgezd0oNmp9Z3t5Vd+Q+gidBtUCacC",
-	"ZUO13RSqf/yRACcgRohxJPTnZpQecQsrFDJ2m8Q6VgI9FPEcs0od74G7j+kWbgZ2Ze+mdy4VPmhpv14n",
-	"+w+20Lpc/LtW83o7k+4n+c5qfeu2rl+/TX2Ngwxcb1dXnCldoICiiNBi7OZo1BTb7h++HrThZmj/bKD/",
-	"OCo91+qYn2/iYyOBy5VKjcTdZEFR717JFsIddvf/jnv3d8rfzbfv/06T+7+mJPyUK9Kk4vWu08f2gECz",
-	"pFnvsYAClqJ4XSS151CmS2SP8tlRu3gXoDcCv55u899o1/jupvANlPsghqVWUrgf619vKr/yJiL6Ycmh",
-	"koWFJULpFwu9kU797Mu6AviOksM3laO6rbKn1tzXwbgvb3KPOdcpHm0EQMM9zE+peGQDfgzNavt0YyjR",
-	"BH7CiVzdqBnTUBm7JXCWuN6C/bff3lvVRyhtCQuEKVK38K80XCGTyozMBOkTsdlP6SOxNkU13XVM/gYr",
-	"886m0mPSfnnYlF3bj35hMVzK3xi/Feg94MhzPNyqZTI6u7rM9KTiV6nOFGGKF8Zlrm5OxUQH/0Hf2xi7",
-	"+so6ZOxDo0od4YlcZpOqBRSAHPvy4D/UTkLig22xZcF9e/lecVHJ5GQxUDPngdJR7EfiUI3NhXZpp2dX",
-	"l97IuwMuzB4nB0cHE31fxUBxTLwX3rODycEzTWe51NQ7xIlcHs51y9hxMSE6tt5Zxa7pi94vKr1l7bO9",
-	"IORLFqw29pSqu4HtlzLLKu2s+vLv8eR4Y0BUG6K5X5cFaXufBUTEWPpLCNATk6OMuHboQYD++7/+P4q5",
-	"sa7tcCX1LF71E70nk0kTQNkODwsPGxfPovfi948jT6QBAM+OQThPXy80YrsjOMsil3ghtOxVh/ejmtOw",
-	"gw4ONTOBbob3wUjlbdC/1GyvF9knG1vbCNk6rTVMSCT6NeN5orC3BByA6Xp5A3J8bgRXTQZm4k4Jw0y6",
-	"5dDUnrPW7HDUzQ71h4UbGOINWyjbD1PTZUiZqemd2swAzMRFGjmAJTJjgRItTuooeMMWCwgQS2QBg+HK",
-	"W3+npb2peXV/CtOMomtzRkuxBnR5X69BnptJ3HvbPp+dF/aA0vbkG8DTayjhKFwV30mCoAtnaV/HZpZI",
-	"S6y2KBeqVVy9RMPR1kmm+77njS/LLL5lMTHw1lCf/NT9SfaMffs1Y3aMsC6V6mQgAX0UjFLl1tb4yFEd",
-	"tuN7pod6kUKYdxGuyc7NKQ03IC0hM6UhUZpt1sU108PrBF4SGY4toUSjbFUWUKF4UJdwYI4jkPp0/F49",
-	"ED/rMASarUpFgijLFNHWgi4hyo2FPMs7I0Lvhu41U9CN2RxmZU7BlfrR6zMYeGH8xy2yVrUXnpO1tJkH",
-	"gYkvs3kJxxu5cHQEuzQrMoElU8iY15BYflJM5OKnw9lqLCTEh5/Vfy+DL22Xd2HrL1c6flRjsg4y3ehF",
-	"rrBc7oxILgKVWP5haoD66KT7o3dM/qwfKnHrDSWAdJQJ8YTqKFMfIn5WP6a9FHvTcDD1ih0b/yRiiYi4",
-	"TMLZyrQNHUq5w0KnQvcNfmYGfKNkzC6PddWv7ZN+LSUv4xVLvgq/rMMp5nJtU/Wq/QQ2xSfbUBmrsO5Y",
-	"XxzCo5lW863yqKFGLxa1ftx2tfQqHTSUAR+gAXaPv2FcvlztQGEstm7qpSxmSN2UnojDMJ80p2P2q49f",
-	"Rg1CJHuo34bvt3H4S2vsyfmQNcVy0MeGKmxIanenvkRHg6TUhsxbL9ZJWTyWh5+J0QYDCMG02SrT90L/",
-	"PqfvsPPZrD2cNLe+M6AEe9HUzHYRbsfgqFF53jyiJrtk4f0ryWncr6ofl0VR4sB+Kd/wYQTYvAhzJkPu",
-	"WIXpQf/0davHq7iUWMZgteu01uTdoe1zOrZ9To1ztKgoO+KMwtmCW0gFwBNdRPLXyQiZVqp/1Z23nyLB",
-	"TC1P1jJbl/f4mKIZpDXaECC8wIQeoLMgInTMaLhCQIOYEWoD1g4P7bmB46UBY7ty+byyZ+OP3EAgSX30",
-	"rPujnxmfkSAA+lB2MfFiFxmNQ2UAF9l/KTPL1Gfl6q27qgQvFhwWWovTzVQDLHGWoyBi8M1zqan4Y3fa",
-	"sa8znk370ZF5aHCWltoJ48VjfDVSbDVCmAYmG/kAvSw0jxWmeSP1wySwLQLK+acBEXGIVwiHjC4ECQAl",
-	"Ai/AxXr5BXfOxDrqeoo1w32jWue1fLs2k9ogzWQzuxzOWWvWXATmhTE/BIUcZf3Ds4n6708Tp8N5B3dv",
-	"sVLQIYbPciZJGSFjlv3dyU2c6zow5jB0nZZDf4m5bHNCFvB1rsdum9X01jRYyKZibYjdtsBovbLVdLMn",
-	"LPGVukccZRw15rvAJFwVSKwvoP2pgoETHEMrTSYONABue3gMYz91Dffkvms1dNvMxxNaOOjbZL1HHVR7",
-	"WH+ntIfXXjM0ezhvMmJzdr+/48UTOg7hDmxv90yteKhkF3kdfI/Tld6FfyoSvX1hX6EGoSGwv1qfvyAm",
-	"/lhJ7sPP6p/XCe0IZL4yozbAXB0fvErB2b4Pxy5luzg6GECXTSsRY105xmqIgY9NcxeRFazsR5mkCFII",
-	"tYunAb6cL9TwTr5oDy+80iO2zgbfRjBCIat/JEIj39DQ0M83/TI2FZgw85dkhmO1Ore0hyvUHh/KDx+3",
-	"GesoNmHYcaBD46ZJsOw8xLGei2j9yGYpiqIlFaHO66qfWDJX1WWfEMsmeLLfVTXI+afJ/vCIzC7dfGkM",
-	"x1w1TuHQpjLsmwiT3RzlvYd6rCZQDfQUJHhzlGdPdNpWXGiwuN8Rj+wlHLRlUfGw+yGNODXKlp73wWGA",
-	"F122y8XZ629LFl2cvW7Lt784e210O8oCEDqeAcECxA5zoo43V7/4inPmrjBa+SEo8atzxJR+YXRZ0zgB",
-	"qE/Ulp1JwNmQFVpwHC/Rk4uz10+Nevxgjkydog0VZzih/nKnJnUzWx5v2p4+080ttAnSbFGrb4Ik1EUZ",
-	"2fjvnTUNXyCMZlj6S40nzY5hqL8lINLSR4XGJ1isqP/0gVx6+Jlr58+hfv2lOW5/pf4sij6HA3S+JGFQ",
-	"aLNp31fRdS1cB+M5oCWEwQjdL0lYLNizvfSQn0+hyEFoAkiy9NEdwugBSqO+J5OfELFdi1I2IkKvZ+wK",
-	"nAjdvkjnEbhCrnoPezl23aN35PPSbctbzqV5A2hTCQk7VCY0bRV7EjpOmxJmfFI4I1oyr3lEOIgkgtbc",
-	"liRShyRFY35UrswvCuyuzoaZMDDXs+7BRhjNDoL1BUn9ftsnWb6xWBL3PRopTZuOhQH7z3PRdi5SSn19",
-	"B8NQt86TA87EksjwMK057EzOCcM8R8s07svFvn1HQl9ryyTCFKUvShygCxBkQW1ajZ/w0Dz5gc7fXKJ7",
-	"xm/nIbsXuv9EsdrbnBFcqDTWp8lXYOgOe2n6l7pWBAC6VzcVBQgEMo2+XEdCJ9KbDbeXea7h59xWVkwN",
-	"3CbP85s08918sZFyyeHGZt0/XYIn5YtCxWVDsMtRIFHiXlpo3Noe26i3eH3UFK+D20XxIiqQb3e4D6eV",
-	"BsgFTSOVy1TsCkrUUfOoQxTNvYV3HLBw4M3BTu/qhNtPNGN9BsxjE4699OXBfiLn8HPxx17xi82zb7ei",
-	"9a4E5ICohosbHkXZiYO07QKl2Uf+qAiyLc/5A6XQ5BFIoa+15mIYq64pdw5l2tPUeXO+B5cG9IgFjwK4",
-	"jDkBdD+EvAEaIIxkFaJ1iJgaT61pf6Ve9Y/aLClD6kqESY1Fw/cJtymje2wQEjtBaq5sscPHqUrdVVe3",
-	"eeptrcrO+SjCrovt1uShbzLm6rpANsOzjRKpNcVfmXLXCRUvV+uWi+4yOXDLPsT+yX4ap5vK7NMO5SZK",
-	"W+9eu8G8Ac/vVi3k64TuySRu8AxfJ/TrtXnhvlRG28U6rYIhi45UazdrSoutK9lB9vDugga6Mqwxgfw6",
-	"q0XSQ4r52RDndSL703WYxKZoRRT6oDVBOaC+YEhk+SatBzc92LBMBJLMhisO0PtSo1cbJaML81Z5Hior",
-	"BY1HaJYoRVxzuolBYA4o1PF1NakjcNYeTkZPokRINIM0cv20McC8kyDafsNi199ApDhLQTBpGcMiYmuF",
-	"hfMIL5vn8TgtfzmLNBOGWEiUvZGmWbcHs/YL8H4nfPntRGrXYUybJ9Sqrd/YMY+8iKf6eF0U4bEA9UVR",
-	"jzYXhrkA5lmXXfu4tn2qcpTK7P6ddh21vpVbSxPnFlZq4ZCxW5TE6Am3RzV9R0MNalrVvIncvOQ2z0/9",
-	"CddeRkuahZY/3Wp4dKYxsb9IYgqXo7aJxbY1h9UsDI+UK93TQ9NlJN3YR9ger5lUenZsx4aSfV63zkfm",
-	"qHxf5U729X93vVPOb11y/JBEMeMtTvtL/fcNSfQtsWYJxj25ECswiCR0+mnMMK1DhLJWTms0CpOtx7lu",
-	"dJIXaD5Oli5x6MskvEWGo3KRqVTPCHPTsEDv+O9nb98g/bpfhKUsvYQwgHM/a6T1CndvRK72KPs1AA2I",
-	"MN3YjO2vsWLPiKCGW67JRfM4KDHZ1Z20/xaNmf5UqtsrKSTNcaS9UWtb0abh6svOWOXP8r2m8r0WQdP/",
-	"kuj2Hmsy7Mh/vFv51NGGxqrPhb4vj8hfbOQX9jkTJvWbmx5fvT3FdU6o1s5V/ABay9Y1FjZdOHNZG0dv",
-	"AJzcQZD71PLXtCshUqPI0T8SSNSEYkX93EfndLvZ3YYccLBCS/MEqGlTavpGnkwm5bFEZMMDRkGNOCmP",
-	"YLwGl/XszRUVnNnp2o+9E39ex0nYaJjtNyKXN4qGHfG2SrmMpeCfotlRSOiI8hUdNwMci+lr652PDxTe",
-	"jRffbSpAGQ+DHiOIYolyZG8qQ6A6cVuX3iiW4xyCHs8VFLb6qL1jZVD39/hBEV/uBuJFWn1nnrMKpzb5",
-	"0Bx82i27Dj+n/7zs+VLDBlm7Wz69z4Ab9tJDCV9fqbeiQvYuidTSD/ORkWyyR8nxKJ6gKEHkeIrCcd20",
-	"Pkmxf/pu8UmLde+nfXLZn64R2fKWRn+ppu6vYmJJRy7dYObfXW5GpyVXaqgqzMi9yahK/1QihQXJaR01",
-	"Oyw60qPX89aWDPA/U6MfkhrdYvImwr5q3kjDD3rE9/mmntp7f/IZXO6vjQAOQwtDTmrzc4HWh1FrfdXb",
-	"1RVncxKCt2W0OjtHmWxXvQl1g2g4NnAe0uomvzD/X0S2Qh1brZpYGUXbUomyVfakDTXR6IN9xr5Oo10p",
-	"QA/WTppZAT2hONJ9VA4ZRxBhEj7tOEyH6Uv72nPv4przJaYLRc904JY8PXqZdJFBXOMyru08yNfTurJK",
-	"d/84pQbFSb4ctc206vdIpeb7rb6Eplb4Wp0ViShlxeTysuk+2TA6dyDfDHUe6j7YJXWMMq8FctXL0OtC",
-	"eziNtnUJKsge2/2n0Py9lNc2Hng9GvyEE7nS3GI6kJ0lcum9+P2j4goB/C7lpcrzMleX6O4IzbAAFCsm",
-	"GnkJD70X3iGOyeHdkWYqu2Lt27wDmgmBBvaFsSy7XKHNkUav6RZhihcQqZvD8WWqvzc9Kdz+deE5bWf7",
-	"+/avTQdTx9rFOGb7FNZ67HKTd+6i7J1pKgBonybNhGnZULla2wVKtVC7PtkvSYTpmNCxXMI4ZCzOu6c5",
-	"JtT90uqTONqptEBV7mbhKtcQEkmO/Vvd4pcGiM3UUcAzEhK5ck1pUkW+fPzyPwEAAP//dTZnOwcSAQA=",
+	"H4sIAAAAAAAC/+x9iW4cOZLorxD1HtA2UJdkyd3txQAry26PdtxuPUnefjO9RoGVGVXFVSaZTTIl1xgG",
+	"9h/e+8L9kgWPvJlXqQ75AAY9VhWLDEYEg3Hz08BjYcQoUCkGLz4NIsxxCBK4/ut1RLwL/xLLlfrLB+Fx",
+	"EknC6OCF/g69f3/xajAcEPVBpIYNBxSHMHgxAP3TwXDA4c+YcPAHLySPYTgQ3gpCrOZbMB5iOXgxiGOi",
+	"Rsp1pH4pJCd0Ofj8eajXuIppIwg8pi1g6BkeCMlfL27eXsGfMQhZB40agrgZ0wDRisggnemBUNWBcgWC",
+	"xdyDBjDIQ9d+xyRZEA+rJevgyI9BHqMLsmwAiRZmfCB4l3gJl4qZq1CprxCNwznwBJA/Y+DrDJIIL2GQ",
+	"X8+HBY4DOXhxNByEhJIwDvW/7bqESlgCNwsDb1j7QkIoUAQc2TWcywOf1YNwPB0OQvzRwjCdtkPE2X+C",
+	"V8u39usGwkTJBA+kScNRvmo8xXwLJ/iacflyXUOWXwgEPpIMCcYlmq9rCKO+nelvHXQZeBywBH+GpRsA",
+	"CVHT9oWEqAEHQv/8oUiQjK/rgNBfNkKgf/xAEG4gjAIsoYEdw0giaYc1wCPTmR4E0mf1YxExKkBfei+x",
+	"b+Wz+stjVALV/8RRFFjxNPlPoYD9lFvmf3NYDF4M/tcku1An5lsxec0542ap4mZfYj+5Mgafh4NzRhcB",
+	"8fawcHpDeHZJ9ATGyzHyY7MUIAgxCZ4qqH5hfE58H+juwUqXQiOE/ZBQhD0PhEApec3N8wuLqb9HLFEm",
+	"0UKv+Xk4eE9xLFeMk3/CHmAorKa+tr9QE56vMFVXjRD3jOe5NuIsAi6J4Wgv5hyonEV2oPosJPQt0KU6",
+	"gUeVMzEcULivG/6T61Rnx++P6nKl6T6kE7C5ulcM5wv5Ckt8yQh17MDHEtT/w0ccRoH66fH0+Ploejw6",
+	"mg6G2RHX4xzbkUziYOYxIWex8AszTcdHx89O8nOweB7kZrGaQnmXyVLFmev2dh2HIebr6s7w3dL8Wl36",
+	"WsJuDuFwMI/9JchZQEJS3enRtNMcEXDC/BlQvwbjP95Mpy/0//5Rxv1IktBJADupkJjLOkJuMG0O+yGj",
+	"clXZ87PxyenzHzvtu4FHjsbHz05O+85yD3DrIObp8x9/6s9uJehKGC1QbVjHVE7m1EqLNrTqxEdBHuVJ",
+	"p+2vBeNISSigMtH0F4BlzEEMtKKayI3jqdJVq5JGX+b5ad8L4OisMGVpptPTYZsAExLLWBQVtDn2bgO2",
+	"HAwHQJW6/EfuE0JnEWdLDkKB7TMKOXTVCDoNej1S89bPuTZ+6iX0ClMKwczM9CmFzyfCMxL0HuYrxm7V",
+	"chmmsq8r+zfWlpYwvk8UCDi4LKxZ+Uk676dBzANlqkoZiReTiV1m7LFwgiMysbCIyXg81jxf3j9QPA/M",
+	"5Zhi36hl6RrmT/vLOWMBYKp/eqeuxdmCBBJ4gS/+UGaAgiEKQILW+WI6XmCiVvowHBBlWjk3Zj/AnON1",
+	"9bbKoz7FWxmQeipb86mWtHip7kIeUy3DKuruOaMSEwoc2SEoFqBNEfgIXiwB6Qm0dSDQE4tOoQb84DPv",
+	"FvgPiCwQC4mU4D/N8bb5djAc3MZz4BQkiBL3JAMqCLOrzELmQ1CF+ZX5Gp0HOPYB6VGI3QHnxAcjEHIw",
+	"E4rkighkrchBHgRPzzBiUSxGJ6PnSlOIg0AxT4lD8rDVSKMzJPQ/cwvlZMaRW/osiVTn/o74htuKG31D",
+	"JEq+1fvKb6REjCWRq3heRwzz7UAvGGD1jzmR89i7BVkkSjrQCapkt0BnQO8cvhYcAmILJFeAgN4Rzmio",
+	"iHCHOVEIRSsW+IQu9YAlkUjPhZ4o1VZ9ZP4kUkCweFog0puLm7++fzm7+e1vr991oVBVov+6RpcuonQR",
+	"5BwiNtPyqLzj91dvkw1bkvwg9M7UTwRR115hH4k4MyjW0ozx5SRcjzKOadlcvwvAmLKJwVsrIar4Sg7Y",
+	"hfpbU9FM1R97iY08yxkp2Tp/ZzHCHBBJ1lH8ofUF9OmT0RtuYf35s5Lz7UuV7q50Um2dS00MDncE7tVc",
+	"wLV/y4uFZGHxCOR/2AH/jk3a39VT5iqmteSISAQBoXo2e4UWB2ixpv6R3jglie8lwqn2aHTalp3HtYvG",
+	"G83A5/qZISnxu3lqinPaXw4r+KnHsnYo1V+MngeRxNSDmceJBE6wE2c+REB9MTMo7XrLD7Xrv9teh4Nb",
+	"WBdPxvVoelQ8baeu68PsmNyBEyLhseKRUOqm0dAXXLOq+qdYYQ6+Q9vMK7FNrgON5mszVOEBc2UDLkgA",
+	"oh/GJJFBSRJlEihgS0ITr3VZCjUzj8JuMruLW5Qd4dCJM3eqw2A8Gh2d3hxNXzzrZzA+xJapTEZKFvKP",
+	"P07hp5PpdATHP89HJ0f+yQj/ePR8dHLy/Pnp6cnJdDoteCvquLGrSVS1ss09NisD9vz5dgDL+LGrAZXB",
+	"kI10TKuEi8diG4RsZfZzM/TzcBBH/raZpMS8RuZliB0m4tkiowT+sBgGyMFXx/mvzt689pfguGe079Hh",
+	"pzc+SXNP38JaKaJKRAL11kXNzUqx6sHXIqI6843+3DWzrEx83H5nGPjT5RoQ8I75DgQ8UHhXBgZ47dLy",
+	"/wGcjeZYmV3G5lLnXo9FhPrwMb/zaTXCVjgWXdi9u5jtwJl52ZrjSbPVBoxf2ZBHFevgL0sXR6PfOsfB",
+	"jiuFMr//ZJob2rQcM/PQglu307dEuN3JuBdQrq1FeEkoTm6Sphkus5EOLzIeFOaq28lVTM+0xmT8KiWa",
+	"KV2Hx7Qi+X/+eVeSX23OjwP1fUHO5z6vEfUEhJGWBVBPnbHrPK7ymyyJ32zKBvS9AolJ4FA0EpeSvUWc",
+	"l0Sr1VtUV7ppI31U1I7DiirABnRV8t4Qj8eUmn/lnW7W4aZ4NhZGb82In/24jvK9jt1VTPV93yoMqpd0",
+	"gtocoxQu5gScBn4xS1fYZclZHM3MzbD9uyQ7xGXatXKg6xpqIci6O59YZ4DDDUPJn3GijhClK5AFAY7u",
+	"iVypqyzxlsF4OR4idTd3UVLq7c88/tNNO8moQ6pVWen+2LMqSE7pvn59NXv3283sl9/ev3vltiaURBH1",
+	"XvYCpTLIQhACL106vkIauniF8Nw7On6Wizu3Bl0V+NnMVXyUhanGggttvzC+ZLI1qKzzA4o7iAXwf7V/",
+	"jj0W5i8WM7xtF2aUC6pcAl6bqdjREiSLRd4rVmHqBQEfqVHIjkILzkLtbjTubR7TLsdyiSVkgZ0UWTiK",
+	"OLvDwf5kPQftrGB0xgHb5IRW6DkIFtw98G40br/tTMI3FY/1ktU5VEiItnGLGjqbeJUmQK87sw8MOQnd",
+	"bguZ4S3+Kz1mq+ZKHrPZ/vLQF5fNHx/3Vd4iLLZgAORFz2HtgIswYlxeG9WlXhrWCbUrfI9CzG99dk9T",
+	"oaZvnL+f/foWaZ9kiKUEbm/zecC8W9Hh7jELdgBZ6Fiw80rurhpmc65t2lSVKlZNrYbJdHoFYgtkNUAk",
+	"V1giMxxJhoiefODSzcxXzbNSuA/WyPJnsoZzNusaaprMDklBfXILa4QDDthfI/hIhI0ythhOKdzZojk9",
+	"3iK/mXjr181aU3EHv2JvRSiMFKA69qjXQFZHqXPguLJRtRMqxGs0BwRhJNeILPSHHosDX+tH6puPkmOv",
+	"iIxs+py2VcrYj0NMy0Dmh3RzbCfzDw02XIh8q8TkjlUpJT2yhL2cQQ5ezOHyX4U4ys+Sy87ropPlZndt",
+	"8FeDg3qvklPlvViYiLpeAhGBOCwVU3PwhwgjDgIkCgi9RSss0ByAItElLlivBQ8HvzIfgnMm5EsOWItC",
+	"B7BJ3kNTpoIjGe0WqJgRGsVF18az6VRnH6S4J1Q+P3EKBTsHi2V5ktMecySpYv3T/8qI1IgoTFnaZxlk",
+	"F8qriVBffQbUToJXubSqR5BHtbv4167DWIcIGnVLM8to3C+OVD1hW9B7Hce2zQ+n53cBeFlQkksJF+V7",
+	"4cgl1dKiqPzI42mtACyMOzluVZLMj4ZJ7Ve6nHM3xmTLFwVKCLfol6jNd5IMKStYeyG0b+IJWaDLK6MM",
+	"iqf1zoSGWkVdX9PJJu5siu7IbK2zKBuMyRZLsUrJLRycGvZwZVxUOPVZK6NaU9H81Lknm6BTd9XuPkug",
+	"nB/ViCwL7bWEyIWiZmF9vAVhXZDTBvhWgVuAuiYDbNacEVfKhJOglaueCXHDAY4lm1knUwFDCxwIp2pQ",
+	"pvtPP22H7pnWbPdb1ZntJ4JRCrL42QqT23h0Mjot7r2D3l1Nl2lEmM5FnEUsIN66jTmv1NhLM9QpfQqp",
+	"esnlnmjNBdKUFnYylU1D3WkO+XYyxD3CvZjI2VwZUcBnOPUiFkH7fQVyBVzfV/Y3yP5G2Xu2VCxYI8lJ",
+	"FBl/RCsDlxdPg8l1fhRP2aRerEBESfqidvnYzK58SC4tpnaqFuWlQ+wIAt6sOIgVC3ydUJZfPFkTzWHB",
+	"OJhdG+dv/gZoKuge7iox7utI+d9mhv83mr+/K70gxB9npkDR5THUDQ2Q+d5SIqWrYqj316/QE0LNKtqY",
+	"R4wGxYS3o6nTx1Gz46xor6VioZr2e0/TOFT2m9PT7eDpUVU87M1atjdpito6MV9797iFcz872tK8sWJ3",
+	"vs6EZCcN1+FxdOi587W64DtPehXTLlOKJIel06Q2ubZl2qZznDQTsedYFyLv+vQW/Z2lq1h9h9R3CRSp",
+	"aNEFs4X1j8d9anxTP69rRf2lkcmiYcnTaU+vbuYYdq1qvm1f9qjrsrVFyIMiFkrg5VgvZexhdnAaTt42",
+	"rG8r2g4bqi3Wfu2pumFXll2vCrW9u3O3WeN2kKq2g5Yx1BXP9b44c+y+nVOcPz+HPcxXNiy58whu9aD9",
+	"G6aAXjHoX/q5aTS4T6uXSmx4WF8Te6Wznxrz+LK8tHIfHvW5vtBsEpu1g/J+7FKF6rQNdruYG1QB7RmQ",
+	"eQSXHQCAKNyjZAR6Yi169BPyVljnKnBRtNIo3F8b2mAhjo6ftVHCBl7di5vIuTEJOXhA7sBH8zVK6JVz",
+	"8bz593/650fT+bEM5uQonD+7kF747//8x//9P39pFSoGgpbUgLwPrRppxx9nSowm5ygN7BR63LV5ZYxn",
+	"rSyqKaPaoqAj63YZDAc4uMfrkperMKAlsSAHbmFZ58ZjumGxwXaKCzhnfJbLu9g4zbRY8DsTFEdixWTv",
+	"tOe0PrBqNgD3gEq8BOOuszhKul5M//u//t/RdPp0qL+K1TdYIt2cD6ntjwe1LRGd/NK/SIL3xX63wgpb",
+	"Q1FTYeFh6kEQ9Cyy2EZO/99gnTgasBDMI2ka2to2itN5/P+CWGStOSyQYCEg8JeAPCxAoBCv0QrfAaLM",
+	"/HTcqTixqAttRdXJVQ+kKaS5YtU+ik7F7t5K0LdXcLVa5ZHnnocmBtdkDz0bH532zx/KBWfz+b2WBAVz",
+	"siVQa/FeV8PVMzoterhEIGr1iOwGZwX01Dd1sJi5YvcPREteyDn7s/U3SPfHrI5Ga9PNGvs182wOTZ2a",
+	"/13FdAvWkFIlDmwCxbQp1u3ULzbUdZJopuXcx6UMBWw5S0SQw+TSjS9z+S+l7s+vkluVcaLQHZiuvzro",
+	"RIROeZVcXb3/gmgcBMbiYSwL3favetE6ak2E9PcV8VZ2TSwl6Ma7FpYnR6aO8WkdKDVL16rlZZNOLSok",
+	"xxKWaxOwTuNvFpa6lVNfDPW4dqnoxK1FHGjX4jYLgXan+bUofMPBPSbKzJ2ldWK9ioZqGg3Zbxm3wdC2",
+	"woFqglXa/CKdJm1U1L0+5yqmvxO5uk5uYhwEvy0GL/7oIgTbuzG1zOFONOrYQ+mDbeTdpgO6bqRnnYIL",
+	"m+We7+j27pPHl+O6jl7P2oT5o20kzB9vkDC/PS2iVORmj02WT9+QQj8cNGoUNWXpXdtpbZSTuocWXP2a",
+	"veyjBL2tvVdfL8K32g1sJyZ9Td+bPqa8I9rt6PW3qUNlY0v7dHx8uom8ybk4Mrslt0YjCmqzHdTt35pf",
+	"5xMhCfV0SbwtqCRU5/b5OvYuSvltrhZKPfD8MMRV4vfFG2OzaHxWabBZZD1Hvu5B9ow2DbRNmqqVklhs",
+	"e6qW1HPbyK2lT0++2ra1u4nWf1uqPUrIyXppZfqzb5z7WdmSe/9bsL1rOtDs1fpO9/IbvyZ0GbgNqphT",
+	"gdKh2m4K1D/+jIETEEPEOBL652aUHnELaxQwdhtHOlYCHRTxDLNKHe+Auw/JFq57dmVvp3cmFd5rab9Z",
+	"J/v3ttC6WPy7UfN6O5PuJ/nOan2btq7fvE19hYMMXL+uLzlTukAORSGh+djN0bAutt09fN1rw/XQfm+g",
+	"/zgqPTfqmJ9t4kMtgYuVSrXE3WZBUedeyRbCPXb3/4Z797fK3+237/9Gk/u/pCT8hCuSpOLNrtPH9oBA",
+	"vaTZ7LGAHJbCaFMkNedQJkukj/LZUft4F6AzAr+cbvNfadf49qbwNZR7L/qlVlK4H+mPt5VfeR0S/bBk",
+	"X8nCggKh9IuFg6FO/ezKugL4npLDt5Wjuquyp8bc1964L27ygDnXCR5tBEDD3c9PqXhkC34MzWqHdGMo",
+	"0QRezIlcX6sZk1AZuyVwFrvegv2332+s6iOUtoQFwhSpW/g3GqyRSWVGZoLkidj0r+SRWJuimuw6In+D",
+	"tXlnU+kxSb88bMqu7Y/+yiK4kL8zfivQDeBw4Hi4VctkdHZ5kepJ+V8lOlOIKV4al7m6ORUTjf+D3tgY",
+	"u/qVdcjYh0aVOsJjuUonVQsoADn25Pg/1E4C4oFtsWXB/fXiRnFRweRkEVAz51jpKPZHYqLGZkK7sNOz",
+	"y4vBcHAHXJg9TsdH46m+ryKgOCKDF4Nn4+n4maazXGnqTXAsV5OFbhk7yidER9Y7q9g1edH7Ram3rH22",
+	"F4R8yfz11p5SdTew/VxkWaWdlV/+PZ4ebw2IckM09+uyIG3vM5+ICEtvBT56YnKUEdcOPfDRf//X/0cR",
+	"N9a1Ha6knsWrfqL3ZDqtAyjd4ST3sHH+LA5e/PFhOBBJAGBgxyCcpa/nGrHdEZxmkUu8FFr2qsP7Qc1p",
+	"2EEHh+qZQDfDe2+k8i7oX2i214ns062tbYRsldYaJiRi/ZrxIlbYWwH2wXS9vAY5OjeCqyIDU3GnhGEq",
+	"3TJoKs9Za3Y4ameH6sPCNQzxli2V7Yep6TKkzNTkTq1nAGbiIrUcwGKZskCBFidVFLxlyyX4iMUyh8Fg",
+	"Pdh8p4W9qXl1fwrTjKJtc0ZLsQZ0cV9vQJ6bSdx72z2fnef2gJL25FvA0xso4ChY599JAr8NZ0lfx3qW",
+	"SEqsdigXylVcnUTD0c5Jpvu+Z40viyy+YzHR89ZQP/m5/SfpM/bN14zZMcK6VKqVgQR0UTAKlVs74yNH",
+	"ddie75kO6kUCYdZFuCI7t6c0XIO0hEyVhlhptmkX11QPrxJ4RWQwsoQStbJVWUC54kFdwoE5DkHq0/FH",
+	"+UD8osMQaL4uFAmiNFNEWwu6hCgzFrIs75QInRu6V0xBN2YzmJU5BZfqz0GXwcBz4z/skLXKvfCcrKXN",
+	"PPBNfJktCjjeyoWjI9iFWZEJLJlCxqyGxPKTYiIXP03m65GQEE0+qf9e+J+bLu/c1l+udfyowmQtZLrW",
+	"i1xiudobkVwEKrD8w9QA9aOT9h+9Y/IX/VCJW28oAKSjTIjHVEeZuhDxk/oz6aXYmYa9qZfv2PidiAUi",
+	"4iIJ52vTNrQv5Sa5ToXuG/zMDPhKyZheHpuqX7sn/UZKXsorlnwlftmEU8zl2qTqlfsJbItPdqEylmHd",
+	"s77Yh0dTreZr5VFDjU4sav24zWrpZTKoLwM+QANsH3/NuHy53oPCmG/d1ElZTJG6LT0RB0E2aUbH9KMP",
+	"n4c1QiR9qN+G73dx+AtrHMj5kDbFctDHhipsSGp/p75AR4OkxIbMWi9WSZk/lpNPxGiDPgRg2mwV6ftK",
+	"f57Rt9/5rNceTupb3xlQ/INoama7CDdjcFirPG8fUdN9svDhleQk7lfWj4uiKHZgv5Bv+DACbF+EOZMh",
+	"96zCdKB/8rrV41VcCixjsNp2WivybmL7nI5sn1PjHM0ryo44o3C24BZSAfBEF5H8ZTpEppXqX3Tn7adI",
+	"MFPLk7bM1uU9HqZoDkmNNvgILzGhY3Tmh4SOGA3WCKgfMUJtwNrhoT03cLw0YOxWLp+X9mz8kVsIJKkf",
+	"PWv/0S+Mz4nvA30ou5h4sYuMxqHSg4vsv5SZZeqzMvXWXVWCl0sOS63F6WaqPpY4zVEQEXjmudRE/LE7",
+	"7djXGc+m/ejQPDQ4T0rthPHiMb4eKrYaIkx9k408Ri9zzWOFad5IvSD2bYuAYv6pT0QU4DXCAaNLQXxA",
+	"scBLcLFedsGdM7GJup5gzXDfsNJ5LduuzaQ2SDPZzC6Hc9qaNROBWWHMj34uR1n/8Wyq/vvz1Olw3sPd",
+	"m68UdIjhs4xJEkZImeVwd3Id57oOjDkMbadl4q0wl01OyBy+zvXYXbOa3poGC9lUrC2x2w4YrVO2mm72",
+	"hCW+VPeIo4yjwnyvMAnWORLrC+hwqqDvBMfQSpOJA/WB2x4e/dhPXcMdue9KDd018/GY5g76LlnvUQfV",
+	"HtbfKenhddAMzQ7Om5TYnN0f7njxmI4CuAPb2z1VKx4q2UVWB9/hdCV34XdForMv7AvUIDQE9qPN+Qsi",
+	"4o2U5J58Uv+8imlLIPO1GbUF5mr5wesEnN37cOxStoujgwF02bQSMdaVY6yGCPjINHcRacHKYZRJiiCB",
+	"ULt4auDL+EINb+WL5vDCaz1i52zwdQQjFLK6RyI08g0NDf080y9jW4EJM39BZjhWq3JLc7hC7fGh/PBh",
+	"l7GOfBOGPQc6NG7qBMveQxybuYg2j2wWoihaUhHqvK66iSVzVV10CbFsgye7XVW9nH+a7A+PyOzTzZfE",
+	"cMxV4xQOTSrDoYkw3c9RPniox2oC5UBPToLXR3kORKddxYV6i/s98chBwkE7FhUPux+SiFOtbOl4H0x8",
+	"vGyzXV6dvfm6ZNGrszdN+favzt4Y3Y4yH4SOZ4C/BLHHnKjj7dUvvuacuSuM1l4ASvzqHDGlXxhd1jRO",
+	"AOoRtWVnEnA6ZI2WHEcr9OTV2ZunRj1+MEcmTtGaijMcU2+1V5O6ni2Pt21Pn+nmFtoEqbeo1W/8ONBF",
+	"Gen4b501DV8gjOZYeiuNJ82OQaB/S0AkpY8KjU+wWFPv6QO5dPKJa+fPxLT7rg/cn+vvTeQ+dTsouaLA",
+	"M6F65K1I4OvA/Bil3aZE4pan5rE7iEwYVUgWReCPURLWPZn+jIjpgKPmJgLhgAP218ZukMBD26UeS2dI",
+	"1YB4kHPVPnpPTi3dl7zh4KVd3beVdLBHhcHQV5mQpv5pmHCVbiZpni9KeTN3LrQ03vBY6FnrT8Wl+lrk",
+	"XXFjdJ6eApOxYp8d0uVeXOeocEArCPwhul+RIF/HmpyS7CDpfguExoAkS96iIow6T016LInQ6xlzG8dC",
+	"d/WqPTZ6D99PTdOpsbz15R0ZTVvFnoSOkl6d2z4iHEQcQmPKVxyqQ1I+omN0aT7Isbs6G2ZC32itujUh",
+	"YTQ9CNZFKvWzhh9lUZFjcdT1aCQ0rTsWBuzv56LpXCSU+vIOhqFulSd7nIkVkcEkKcVtzVkLgix10ShB",
+	"mdi3z6toRWkVh5ii5KGVMXoFgiypzTbzYh6Yl3DQ+dsLdM/47SJg90K3Zck3QTBnBOcK8PVp8hQYuvFk",
+	"khWprhUBgO7VTUUBfIFM/zvXkdD1JWbDzdXPG7j/d5UsVgG3LiDzNikIMb/YShVxfx9MNWxTgCfhi1wh",
+	"ck0M2FE3VOBemutn3Bzyq3Y+ftQUr4LbRvE8KpBnd3gIX64GyAVNLZWLVGyL1VVR86gjd/Utt/ccx3Pg",
+	"zcFO76qEO0yQb3MGzEJ2jr105cFuImfyKf9np7De9tm3XdF6VwCyR7DPxQ2PohrLQdpmgVIfOnpUBNlV",
+	"QOmBUmj6CKTQl1qK1I9VN5Q7E5m0+nXenDfg0oAeseBRABcxJ4AehpDXQH3tuS1BtAkRE+OpMRu28ITD",
+	"ozZLipC68sMSY9HwfcxtJvUB++ZETpDqC77s8FGiUreVm26fejsrPnW+FbLvGtQNeeirTEVwXSDb4dla",
+	"idRY+aJMuauYipfrTauo95kzu2MfYvccWI3TbSW8aodyHaWtd6/ZYN6C53enFvJVTA9kEtd4hq9i+uXa",
+	"vHBfqC5vY51GwdA5rn7DMRX6SS+Rhr4ly8dpdRb/GF1kofEVFgib19ozJ7KNlFDTHxmlL9cPTZV2+vgT",
+	"EVno3XpHc1H5EPNb8BEWGQQbRujRk/SxryEy73zpOG0679P6GP5eIi6HjaFcfQvBeJPy0i+sUjw9rKkN",
+	"6xuQtlhRfE3sosuNa6uSrtICVz0kX/QDUVZ8eDhLgUlsKiFFrrlmHZQ9itb65GVcJ01GTGNPJUGVVDVs",
+	"OUY3he7hmeQ0IjUNNBdSLoZoHiszVt8TmcAMdNJWs5SsScZAT8JYSDSH5Og8rU3P+EYE4peeZ5FLc3ug",
+	"4OuaVJHlR7BFFs3W2gtnoWbCAAuJ0rtYs24HZu2WHvGN8OXXk+ewCWPa5NNGW/fajnnklaHlF1HDEI8E",
+	"qF/krVBzYZgLYJG2bn8C4+V4iOz7x8NEZndv3+5oIFG6tTRxbmGtFg4Yu0VxhJ5we1STx5nUoLpVzUP7",
+	"9Uvu8vxU3wXvZPInqc3Ze+CGR+caE4eLwydwOQpmWWT7PVnNwvBIsX1KcmjaXAzX9mXPx+tkKLxluWc3",
+	"g32zvcpH5qh8WzW05lzUFNFm/NYmxyckjBhvCHld6O+3JNF3xJoFGA/kgC/BIOLA6eU0w7QOEchKjwaj",
+	"UZhcV85196ys6v9xsnSBQ1/GwS0yHJWJTKV6hpibLjh6x38/+/Ut0k/GhljKwvM6PTj3k0Zap2SRrcjV",
+	"Dr0kDEA94rPXtgzoSywDNyKo5parc9E8DkpM93UnHb7vb6o/FYrBCwpJfRT2YNTaVay2v/qyN1b5XhNe",
+	"VxPeIGi6XxLt3mNNhj35j/crn1p6m1n1OddM7BH5i438wh5nwhROcNM4srOnuMoJ5YLskh9Aa9kiC2Zk",
+	"Lmvj6PWBkzvwM5+aXewHUU4wMIoc/TOGWE0o1tTLfHROt5vdrQ2krcy70ragVjcjPplOi2NzcTefUVAj",
+	"ToojGK/AZT17C0UFZ22H9mPvxZ/XchK2GqT+ncjVtaJhS7S6VGxmKfhdNDuq0x0x8rzjpodjUUIYBerk",
+	"tb1oE0byJh37rSbSFPHQ64WbMJIoQ/a28mvKEze1fg8jOcog6PAGTm6rj9o7VgT1cC/q5PHlfpUiT6tv",
+	"zHNW4tQ6H5qDT9tl1+RT8s+Ljs//bJG12+XTTQpcv+eDCvj6Qr0VJbK3SaSGJsuPjGTTA0qOR/GuUQEi",
+	"x/tGjuum8Z2jw9N3h+8kbXo/HZLLvrtGZMMDTd2lmrq/8oklLbl0vZl/f7kZrZZcoUu3MCMPJqNKTbmJ",
+	"FBYkp3VU77BoKS7YzFtbMMC/FxY8pLCgweSNhSZHAw3f6xHf5kOtau/dyWdwebgmHDgILAwZqc3fOVpP",
+	"wsbqxF/Xl5wtSACDHaPV2Y7QZLvqTagbRMOxhfOQ1AZ6ufl/EOkKVWw1amJFFO1KJUpXOZA2VEcjA53v",
+	"oNG+FKAHayf1rICeUBzqLkQTxhGEmARPWw7TJMJC3DPua8+9i2vOV5guFT2TgTvy9OhlkkV6cY3LuLbz",
+	"IE9P68oq3f+LxxoUJ/ky1NbTqtvLx5rvd/q8plrhS3VWxKKQFZPJy7r7ZMvo3IN8M9R5qPtgn9QxyrwW",
+	"yGUvQ6cL7eE02tUlqCB7bPefQvO3Upxee+D1aPBiTuRac4vp33cWy9XgxR8fFFcI4HcJL5XeLLu8QHdH",
+	"aI4FoEgx0XAQ82DwYjDBEZncHWmmsitWfpv1DzQhUN8+W5lmlyu0OdLoNd1CTPESQnVzOH6Z6O9179Q3",
+	"/zp9Org6gW5F2fxr0xbbsXY+jtk8hbUe29zkrbsoemfqCgCap0kyYRo2VOx14AKl3OagOtlf4xDTEaEj",
+	"uYJRwFiU9R50TKi7DVYncTQjaoCq2AvGVa4hJJIce7e6bzz1EZuro4DnJCBy7ZrSpIp8/vD5fwIAAP//",
+	"BnvNzlwYAQA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/backend/internal/api/handler/run_handler.go
+++ b/backend/internal/api/handler/run_handler.go
@@ -163,6 +163,28 @@ func (h *RunHandler) ResumeEpicRun(w http.ResponseWriter, r *http.Request, proje
 	writeJSON(w, http.StatusOK, toAPIRun(run))
 }
 
+// CancelRun handles POST /projects/{projectId}/runs/{runId}/cancel.
+func (h *RunHandler) CancelRun(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, runID RunIdPath) {
+	run, err := h.service.CancelRun(r.Context(), projectID, runID)
+	if err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toAPIRun(run))
+}
+
+// CancelEpicRun handles POST /projects/{projectId}/epics/{epicId}/runs/{runId}/cancel.
+func (h *RunHandler) CancelEpicRun(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, epicID EpicIdPath, runID RunIdPath) {
+	run, err := h.service.CancelEpicRun(r.Context(), projectID, epicID, runID)
+	if err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toAPIRun(run))
+}
+
 // toAPIRun converts a domain Run to the API Run type.
 func toAPIRun(r *model.Run) Run {
 	run := Run{

--- a/backend/internal/api/handler/server.go
+++ b/backend/internal/api/handler/server.go
@@ -256,6 +256,16 @@ func (s *Server) ResumeEpicRun(w http.ResponseWriter, r *http.Request, projectID
 	s.runs.ResumeEpicRun(w, r, projectID, epicID, runID)
 }
 
+// CancelRun delegates to RunHandler.
+func (s *Server) CancelRun(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, runID RunIdPath) {
+	s.runs.CancelRun(w, r, projectID, runID)
+}
+
+// CancelEpicRun delegates to RunHandler.
+func (s *Server) CancelEpicRun(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, epicID EpicIdPath, runID RunIdPath) {
+	s.runs.CancelEpicRun(w, r, projectID, epicID, runID)
+}
+
 // GetPipelineConfig delegates to PipelineConfigHandler.
 func (s *Server) GetPipelineConfig(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath) {
 	s.pipelineConfig.GetPipelineConfig(w, r, projectID)

--- a/backend/internal/domain/service/run_service.go
+++ b/backend/internal/domain/service/run_service.go
@@ -22,6 +22,7 @@ type RunService struct {
 	pipelineConfigRepo port.PipelineConfigRepository
 	jobQueue           port.JobQueue
 	eventPub           port.EventPublisher
+	containerMgr       port.ContainerManager
 }
 
 // NewRunService creates a new RunService.
@@ -44,6 +45,11 @@ func NewRunService(
 		svc.eventPub = eventPub[0]
 	}
 	return svc
+}
+
+// SetContainerManager configures the container manager for cancellation support.
+func (s *RunService) SetContainerManager(cm port.ContainerManager) {
+	s.containerMgr = cm
 }
 
 // PipelineStepConfig represents a step in a pipeline configuration.
@@ -459,6 +465,71 @@ func (s *RunService) PauseEpicRun(ctx context.Context, projectID, _ uuid.UUID, r
 // model with parent/child relationships, this method will also resume paused child runs.
 func (s *RunService) ResumeEpicRun(ctx context.Context, projectID, _ uuid.UUID, runID uuid.UUID) (*model.Run, error) {
 	return s.ResumeRun(ctx, projectID, runID)
+}
+
+// CancelRun transitions a run to cancelled status, stops any running containers,
+// and marks pending/running steps as cancelled.
+func (s *RunService) CancelRun(ctx context.Context, projectID, runID uuid.UUID) (*model.Run, error) {
+	run, err := s.runRepo.GetRun(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	if run.ProjectID != projectID {
+		return nil, errors.NewNotFound("run", runID)
+	}
+
+	if err := model.ValidateRunTransition(run.Status, model.RunStatusCancelled); err != nil {
+		return nil, err
+	}
+
+	// Fetch steps to cancel running/pending ones and stop containers
+	steps, err := s.runRepo.ListRunStepsByRun(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	cancelMsg := "cancelled by user"
+
+	// Stop running containers and cancel active steps
+	for _, step := range steps {
+		switch step.Status {
+		case model.StepStatusRunning, model.StepStatusWaitingApproval:
+			// Stop the container if one is running
+			if s.containerMgr != nil && step.ContainerID != nil && *step.ContainerID != "" {
+				_ = s.containerMgr.Stop(ctx, *step.ContainerID)
+			}
+			if _, err := s.runRepo.UpdateRunStepStatus(ctx, step.ID, model.StepStatusCancelled, nil, &now, &cancelMsg); err != nil {
+				return nil, err
+			}
+		case model.StepStatusPending:
+			if _, err := s.runRepo.UpdateRunStepStatus(ctx, step.ID, model.StepStatusCancelled, nil, &now, &cancelMsg); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Transition run to cancelled
+	updated, err := s.runRepo.UpdateRunStatus(ctx, runID, model.RunStatusCancelled, nil, &now, nil, &cancelMsg)
+	if err != nil {
+		return nil, err
+	}
+
+	s.publishRunEvent(ctx, updated.ProjectID, updated.ID, "cancelled", map[string]any{
+		"run_id":       runID.String(),
+		"status":       string(model.RunStatusCancelled),
+		"cancelled_at": now.Format(time.RFC3339),
+	})
+
+	return updated, nil
+}
+
+// CancelEpicRun cancels an epic run. This is a placeholder that operates on the run
+// identified by the epicId/runId combination. When story 7-2 implements the epic run
+// model with parent/child relationships, this method will also cancel active child runs.
+func (s *RunService) CancelEpicRun(ctx context.Context, projectID, _ uuid.UUID, runID uuid.UUID) (*model.Run, error) {
+	return s.CancelRun(ctx, projectID, runID)
 }
 
 // publishRunEvent publishes an event for a run status change.

--- a/backend/internal/domain/service/run_service_test.go
+++ b/backend/internal/domain/service/run_service_test.go
@@ -1523,3 +1523,229 @@ func TestListRunsByStory_ProgressPopulated(t *testing.T) {
 		t.Errorf("expected progress 66, got %d", result.Runs[0].Progress)
 	}
 }
+
+func TestCancelRun_RunningRun(t *testing.T) {
+	projectID := uuid.New()
+	runID := uuid.New()
+
+	containerID := "container-123"
+	runRepo := &mockRunRepo{
+		getRunFn: func(_ context.Context, id uuid.UUID) (*model.Run, error) {
+			return &model.Run{
+				ID:        id,
+				ProjectID: projectID,
+				Status:    model.RunStatusRunning,
+			}, nil
+		},
+		listRunStepsByRunFn: func(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+			return []*model.RunStep{
+				{ID: uuid.New(), Status: model.StepStatusCompleted},
+				{ID: uuid.New(), Status: model.StepStatusRunning, ContainerID: &containerID},
+				{ID: uuid.New(), Status: model.StepStatusPending},
+			}, nil
+		},
+		updateRunStepStatusFn: func(_ context.Context, id uuid.UUID, status model.StepStatus, _, _ *time.Time, _ *string) (*model.RunStep, error) {
+			return &model.RunStep{ID: id, Status: status}, nil
+		},
+		updateRunStatusFn: func(_ context.Context, id uuid.UUID, status model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
+			return &model.Run{ID: id, ProjectID: projectID, Status: status}, nil
+		},
+	}
+
+	var stoppedContainerID string
+	containerMgr := &mockContainerManager{
+		stopFn: func(_ context.Context, cid string) error {
+			stoppedContainerID = cid
+			return nil
+		},
+	}
+
+	svc := newRunServiceForTest(runRepo, newMockProjectRepoForService())
+	svc.SetContainerManager(containerMgr)
+
+	result, err := svc.CancelRun(context.Background(), projectID, runID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Status != model.RunStatusCancelled {
+		t.Errorf("expected status cancelled, got %s", result.Status)
+	}
+	if stoppedContainerID != containerID {
+		t.Errorf("expected container %s to be stopped, got %s", containerID, stoppedContainerID)
+	}
+}
+
+func TestCancelRun_PendingRun(t *testing.T) {
+	projectID := uuid.New()
+	runID := uuid.New()
+
+	stepsCancelled := 0
+	runRepo := &mockRunRepo{
+		getRunFn: func(_ context.Context, id uuid.UUID) (*model.Run, error) {
+			return &model.Run{
+				ID:        id,
+				ProjectID: projectID,
+				Status:    model.RunStatusPending,
+			}, nil
+		},
+		listRunStepsByRunFn: func(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+			return []*model.RunStep{
+				{ID: uuid.New(), Status: model.StepStatusPending},
+				{ID: uuid.New(), Status: model.StepStatusPending},
+			}, nil
+		},
+		updateRunStepStatusFn: func(_ context.Context, id uuid.UUID, status model.StepStatus, _, _ *time.Time, _ *string) (*model.RunStep, error) {
+			stepsCancelled++
+			return &model.RunStep{ID: id, Status: status}, nil
+		},
+		updateRunStatusFn: func(_ context.Context, id uuid.UUID, status model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
+			return &model.Run{ID: id, ProjectID: projectID, Status: status}, nil
+		},
+	}
+
+	svc := newRunServiceForTest(runRepo, newMockProjectRepoForService())
+
+	result, err := svc.CancelRun(context.Background(), projectID, runID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Status != model.RunStatusCancelled {
+		t.Errorf("expected status cancelled, got %s", result.Status)
+	}
+	if stepsCancelled != 2 {
+		t.Errorf("expected 2 steps cancelled, got %d", stepsCancelled)
+	}
+}
+
+func TestCancelRun_AlreadyCompleted(t *testing.T) {
+	projectID := uuid.New()
+	runID := uuid.New()
+
+	runRepo := &mockRunRepo{
+		getRunFn: func(_ context.Context, id uuid.UUID) (*model.Run, error) {
+			return &model.Run{
+				ID:        id,
+				ProjectID: projectID,
+				Status:    model.RunStatusCompleted,
+			}, nil
+		},
+	}
+
+	svc := newRunServiceForTest(runRepo, newMockProjectRepoForService())
+
+	_, err := svc.CancelRun(context.Background(), projectID, runID)
+	if err == nil {
+		t.Fatal("expected error for completed run, got nil")
+	}
+	domErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected DomainError, got %T", err)
+	}
+	if domErr.Code != errors.ErrCodeInvalidStateTransition {
+		t.Errorf("expected error code %s, got %s", errors.ErrCodeInvalidStateTransition, domErr.Code)
+	}
+}
+
+func TestCancelRun_WrongProject(t *testing.T) {
+	projectID := uuid.New()
+	otherProjectID := uuid.New()
+	runID := uuid.New()
+
+	runRepo := &mockRunRepo{
+		getRunFn: func(_ context.Context, id uuid.UUID) (*model.Run, error) {
+			return &model.Run{
+				ID:        id,
+				ProjectID: otherProjectID,
+				Status:    model.RunStatusRunning,
+			}, nil
+		},
+	}
+
+	svc := newRunServiceForTest(runRepo, newMockProjectRepoForService())
+
+	_, err := svc.CancelRun(context.Background(), projectID, runID)
+	if err == nil {
+		t.Fatal("expected error for wrong project, got nil")
+	}
+	domErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected DomainError, got %T", err)
+	}
+	if domErr.Category != errors.CategoryNotFound {
+		t.Errorf("expected category not_found, got %s", domErr.Category)
+	}
+}
+
+func TestCancelRun_PausedRun(t *testing.T) {
+	projectID := uuid.New()
+	runID := uuid.New()
+
+	runRepo := &mockRunRepo{
+		getRunFn: func(_ context.Context, id uuid.UUID) (*model.Run, error) {
+			return &model.Run{
+				ID:        id,
+				ProjectID: projectID,
+				Status:    model.RunStatusPaused,
+			}, nil
+		},
+		listRunStepsByRunFn: func(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+			return []*model.RunStep{
+				{ID: uuid.New(), Status: model.StepStatusCompleted},
+				{ID: uuid.New(), Status: model.StepStatusPending},
+			}, nil
+		},
+		updateRunStepStatusFn: func(_ context.Context, id uuid.UUID, status model.StepStatus, _, _ *time.Time, _ *string) (*model.RunStep, error) {
+			return &model.RunStep{ID: id, Status: status}, nil
+		},
+		updateRunStatusFn: func(_ context.Context, id uuid.UUID, status model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
+			return &model.Run{ID: id, ProjectID: projectID, Status: status}, nil
+		},
+	}
+
+	svc := newRunServiceForTest(runRepo, newMockProjectRepoForService())
+
+	result, err := svc.CancelRun(context.Background(), projectID, runID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Status != model.RunStatusCancelled {
+		t.Errorf("expected status cancelled, got %s", result.Status)
+	}
+}
+
+func TestCancelRun_PublishesEvent(t *testing.T) {
+	projectID := uuid.New()
+	runID := uuid.New()
+
+	runRepo := &mockRunRepo{
+		getRunFn: func(_ context.Context, id uuid.UUID) (*model.Run, error) {
+			return &model.Run{
+				ID:        id,
+				ProjectID: projectID,
+				Status:    model.RunStatusRunning,
+			}, nil
+		},
+		listRunStepsByRunFn: func(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+			return nil, nil
+		},
+		updateRunStatusFn: func(_ context.Context, id uuid.UUID, status model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
+			return &model.Run{ID: id, ProjectID: projectID, Status: status}, nil
+		},
+	}
+
+	eventPub := newMockEventPublisher()
+	svc := NewRunService(runRepo, newMockProjectRepoForService(), nil, nil, nil, eventPub)
+
+	_, err := svc.CancelRun(context.Background(), projectID, runID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	events := eventPub.getEvents()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Event.Action != "cancelled" {
+		t.Errorf("expected event action 'cancelled', got %s", events[0].Event.Action)
+	}
+}

--- a/frontend/src/features/runs/RunCancelConfirmDialog.vue
+++ b/frontend/src/features/runs/RunCancelConfirmDialog.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import Dialog from 'primevue/dialog'
+import Button from 'primevue/button'
+
+defineProps<{
+  visible: boolean
+  loading: boolean
+}>()
+
+const emit = defineEmits<{
+  confirm: []
+  cancel: []
+  'update:visible': [value: boolean]
+}>()
+
+function handleCancel() {
+  emit('cancel')
+  emit('update:visible', false)
+}
+</script>
+
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    header="Cancel Run"
+    class="w-full max-w-lg"
+    @update:visible="handleCancel"
+  >
+    <div class="flex flex-col gap-4">
+      <p>
+        Are you sure you want to cancel this run? Running containers will be stopped
+        and pending steps will be skipped. This action cannot be undone.
+      </p>
+    </div>
+
+    <template #footer>
+      <div class="flex justify-end gap-2">
+        <Button label="Keep Running" severity="secondary" text @click="handleCancel" />
+        <Button
+          label="Cancel Run"
+          severity="danger"
+          icon="pi pi-times"
+          :loading="loading"
+          :disabled="loading"
+          data-testid="confirm-cancel-run-btn"
+          @click="emit('confirm')"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>

--- a/frontend/src/stores/runs.ts
+++ b/frontend/src/stores/runs.ts
@@ -9,6 +9,7 @@ export const useRunsStore = defineStore('runs', () => {
   const isLoading = ref(false)
   const isPausing = ref(false)
   const isResuming = ref(false)
+  const isCancelling = ref(false)
 
   /**
    * Whether the circuit breaker is currently active for the viewed project.
@@ -49,6 +50,24 @@ export const useRunsStore = defineStore('runs', () => {
       return data
     } finally {
       isResuming.value = false
+    }
+  }
+
+  /** Cancel a pending, running, or paused run. */
+  async function cancelRun(projectId: string, runId: string) {
+    isCancelling.value = true
+    try {
+      const { data, error } = await apiClient.POST(
+        '/projects/{projectId}/runs/{runId}/cancel',
+        { params: { path: { projectId, runId } } },
+      )
+      if (error) throw error
+      if (data) {
+        updateRunStatus(runId, data.status)
+      }
+      return data
+    } finally {
+      isCancelling.value = false
     }
   }
 
@@ -93,9 +112,11 @@ export const useRunsStore = defineStore('runs', () => {
     isLoading,
     isPausing,
     isResuming,
+    isCancelling,
     circuitBreakerActive,
     pauseRun,
     resumeRun,
+    cancelRun,
     updateRunStatus,
     handleSSEEvent,
   }

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -12,6 +12,7 @@ import { differenceInSeconds } from 'date-fns'
 import { useRunDetail } from '@/features/runs/composables/useRunDetail'
 import { useRunsStore } from '@/stores/runs'
 import RunLogViewer from '@/features/runs/RunLogViewer.vue'
+import RunCancelConfirmDialog from '@/features/runs/RunCancelConfirmDialog.vue'
 import { runStatusSeverity } from '@/utils/runStatus'
 import type { RunStep } from '@/features/runs/composables/useRunDetail'
 
@@ -35,8 +36,13 @@ const stepSeverity: Record<string, string> = {
 
 const canPause = computed(() => run.value?.status === 'running')
 const canResume = computed(() => run.value?.status === 'paused')
+const canCancel = computed(() => {
+  const status = run.value?.status
+  return status === 'pending' || status === 'running' || status === 'paused'
+})
 
 const pauseError = ref<string | null>(null)
+const cancelDialogVisible = ref(false)
 
 async function handlePause() {
   if (!projectId.value || !runId.value) return
@@ -59,6 +65,18 @@ async function handleResume() {
   } catch (err) {
     pauseError.value = err instanceof Error ? err.message : 'Failed to resume run'
     toast.add({ severity: 'error', summary: 'Failed to resume run', detail: pauseError.value, life: 5000 })
+  }
+}
+
+async function handleCancelConfirm() {
+  if (!projectId.value || !runId.value) return
+  try {
+    await runsStore.cancelRun(projectId.value, runId.value)
+    cancelDialogVisible.value = false
+    toast.add({ severity: 'success', summary: 'Run cancelled', life: 3000 })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to cancel run'
+    toast.add({ severity: 'error', summary: 'Failed to cancel run', detail: msg, life: 5000 })
   }
 }
 
@@ -116,6 +134,15 @@ function formatDuration(step: RunStep): string | null {
           :loading="runsStore.isResuming"
           data-testid="resume-run-btn"
           @click="handleResume"
+        />
+        <Button
+          v-if="canCancel"
+          label="Cancel"
+          icon="pi pi-times"
+          severity="danger"
+          outlined
+          data-testid="cancel-run-btn"
+          @click="cancelDialogVisible = true"
         />
       </div>
     </div>
@@ -193,5 +220,14 @@ function formatDuration(step: RunStep): string | null {
         <RunLogViewer :project-id="run.project_id" :run-id="run.id" />
       </div>
     </template>
+
+    <!-- Cancel Confirmation Dialog -->
+    <RunCancelConfirmDialog
+      :visible="cancelDialogVisible"
+      :loading="runsStore.isCancelling"
+      @confirm="handleCancelConfirm"
+      @cancel="cancelDialogVisible = false"
+      @update:visible="cancelDialogVisible = $event"
+    />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Add `POST /projects/{projectId}/runs/{runId}/cancel` endpoint that transitions runs from pending/running/paused to cancelled status, stopping running containers and marking pending steps as cancelled
- Add `POST /projects/{projectId}/epics/{epicId}/runs/{runId}/cancel` endpoint for epic run cancellation
- Add Cancel button with confirmation dialog to the Run Detail view in the frontend

## Changes

### Backend
- **OpenAPI spec**: Added `cancelRun` and `cancelEpicRun` operation definitions
- **RunService**: Added `CancelRun()` and `CancelEpicRun()` methods with state machine validation, container stop support, and event publishing
- **RunService**: Added `SetContainerManager()` for optional container lifecycle management
- **RunHandler**: Added `CancelRun()` and `CancelEpicRun()` HTTP handlers
- **Server delegation**: Wired cancel handlers in `server.go`
- **main.go**: Injects container manager into RunService when available
- **Tests**: 6 unit tests covering running/pending/paused/completed/wrong-project scenarios and event publishing

### Frontend
- **Runs store**: Added `cancelRun()` action and `isCancelling` loading state
- **RunDetailView**: Added Cancel button (outlined danger style) visible for pending/running/paused runs
- **RunCancelConfirmDialog**: New confirmation dialog warning about container stop and irreversibility

## Test plan
- [x] Backend unit tests pass (6 new cancel tests + all existing)
- [x] Frontend type check passes (`vue-tsc --build`)
- [x] Frontend lint passes (`eslint`)
- [x] Frontend unit tests pass (536 tests)
- [ ] E2E: Launch a run, cancel while running, verify status transitions to cancelled
- [ ] E2E: Verify cancel button hidden for completed/failed/cancelled runs
- [ ] E2E: Verify confirmation dialog appears and can be dismissed

🤖 Generated with [Claude Code](https://claude.com/claude-code)