### PR TITLE
fix(event): flush SSE headers immediately to avoid 30s connection delay

### DIFF
--- a/backend/internal/api/handler/sse_handler.go
+++ b/backend/internal/api/handler/sse_handler.go
@@ -106,6 +106,10 @@ func (h *SSEHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
 
+	// Flush headers immediately so the browser's EventSource transitions
+	// from CONNECTING to OPEN without waiting for the first keepalive.
+	flusher.Flush()
+
 	// Replay missed events if Last-Event-ID is present
 	lastEventID := r.Header.Get("Last-Event-ID")
 	if lastEventID != "" {


### PR DESCRIPTION
## Summary
- Add `flusher.Flush()` right after setting SSE response headers in `sse_handler.go`
- Without this, Go's `net/http` buffers headers until the first Write+Flush, leaving the browser's EventSource stuck at `readyState=0` (CONNECTING) for up to 30s

## Test plan
- [x] E2E smoke tests pass (28/28)
- [x] SSE connection opens instantly instead of waiting 30s for keepalive

🤖 Generated with [Claude Code](https://claude.com/claude-code)