### PR TITLE
fix(ui): fix DAG visualization not rendering due to broken CSS height chain

### DIFF
--- a/frontend/src/features/dag/DagGraph.vue
+++ b/frontend/src/features/dag/DagGraph.vue
@@ -32,7 +32,7 @@ const nodeTypes: Record<string, any> = {
 </script>
 
 <template>
-  <div class="dag-graph-container h-full">
+  <div class="dag-graph-container flex h-full flex-col">
     <div v-if="isLoading" class="flex items-center justify-center h-full">
       <Skeleton width="100%" height="100%" />
     </div>
@@ -50,7 +50,7 @@ const nodeTypes: Record<string, any> = {
       :edges="edges"
       :node-types="nodeTypes"
       fit-view-on-init
-      class="h-full"
+      class="flex-1"
     >
       <Controls />
       <MiniMap />
@@ -61,5 +61,6 @@ const nodeTypes: Record<string, any> = {
 <style scoped>
 .dag-graph-container {
   min-height: 400px;
+  height: 100%;
 }
 </style>

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -76,7 +76,7 @@ watch(
 </script>
 
 <template>
-  <div class="flex flex-col">
+  <div class="flex h-full flex-col">
     <!-- Header -->
     <div class="flex items-center gap-3 border-b border-surface-200 px-6 py-4">
       <Button


### PR DESCRIPTION
## Summary
- Vue Flow requires a concrete height on its container
- `ProjectDetailView` root div was missing `h-full`, breaking the flex height chain
- `DagGraph.vue` container needed `flex-col` + `flex-1` on VueFlow

## Test plan
- [x] DAG renders with nodes and edges visible
- [x] Controls (zoom, fit, lock) and minimap visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)