### PR TITLE
feat(ui): rename "Users" to "Administration" in sidebar

### DIFF
--- a/frontend/src/ui/layout/AppSidebar.vue
+++ b/frontend/src/ui/layout/AppSidebar.vue
@@ -38,7 +38,7 @@ const navItems = [
 ]
 
 const adminNavItems = [
-  { label: 'Users', icon: 'pi pi-users', route: '/admin/users' },
+  { label: 'Administration', icon: 'pi pi-shield', route: '/admin/users' },
 ]
 
 const sidebarWidth = computed(() => (props.collapsed ? 'w-12' : 'w-60'))


### PR DESCRIPTION
## Summary
- Rename admin sidebar item from "Users" to "Administration"
- Change icon from `pi pi-users` to `pi pi-shield`
- Route path (`/admin/users`) and RBAC visibility unchanged

## Changes
- `frontend/src/ui/layout/AppSidebar.vue`: Updated `adminNavItems` label and icon

## Test plan
- [ ] Verify admin user sees "Administration" with shield icon in sidebar
- [ ] Verify non-admin user does not see the item
- [ ] Verify clicking "Administration" navigates to `/admin/users`

Refs: R-0-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)