### PR TITLE
feat(ui): display token counts in cost dashboard and run detail

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3169,6 +3169,16 @@ components:
           type: number
           format: double
           example: 3.4567
+        total_tokens_input:
+          type: integer
+          format: int64
+          description: Total input tokens consumed in the period
+          example: 500000
+        total_tokens_output:
+          type: integer
+          format: int64
+          description: Total output tokens consumed in the period
+          example: 80000
         avg_cost_per_story_usd:
           type: number
           format: double
@@ -3227,6 +3237,16 @@ components:
           type: number
           format: double
           example: 0.01234
+        tokens_input:
+          type: integer
+          format: int64
+          description: Total input tokens for this run
+          example: 100000
+        tokens_output:
+          type: integer
+          format: int64
+          description: Total output tokens for this run
+          example: 20000
 
     RunCostBreakdown:
       type: object
@@ -3321,6 +3341,16 @@ components:
           type: number
           format: double
           example: 3.15
+        total_tokens_input:
+          type: integer
+          format: int64
+          description: Total input tokens across all steps
+          example: 300000
+        total_tokens_output:
+          type: integer
+          format: int64
+          description: Total output tokens across all steps
+          example: 50000
         steps:
           type: array
           items:

--- a/frontend/src/features/costs/CostSummaryCard.vue
+++ b/frontend/src/features/costs/CostSummaryCard.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import Skeleton from 'primevue/skeleton'
+import { formatTokenCount } from '@/utils/formatCost'
 
-defineProps<{
+const props = defineProps<{
   label: string
   value: string
   isLoading: boolean
+  tokensInput?: number
+  tokensOutput?: number
 }>()
 </script>
 
@@ -12,6 +15,15 @@ defineProps<{
   <div class="rounded-lg border border-surface-200 bg-surface-0 p-4">
     <p class="mb-1 text-sm text-surface-500">{{ label }}</p>
     <Skeleton v-if="isLoading" width="6rem" height="1.75rem" />
-    <p v-else class="text-2xl font-bold">{{ value }}</p>
+    <template v-else>
+      <p class="text-2xl font-bold">{{ value }}</p>
+      <div
+        v-if="props.tokensInput !== undefined || props.tokensOutput !== undefined"
+        class="mt-1 text-sm text-surface-500"
+      >
+        <span>In: {{ formatTokenCount(props.tokensInput ?? 0) }}</span>
+        <span class="ml-2">Out: {{ formatTokenCount(props.tokensOutput ?? 0) }}</span>
+      </div>
+    </template>
   </div>
 </template>

--- a/frontend/src/features/costs/RunCostTable.vue
+++ b/frontend/src/features/costs/RunCostTable.vue
@@ -4,7 +4,7 @@ import Column from 'primevue/column'
 import Tag from 'primevue/tag'
 import Skeleton from 'primevue/skeleton'
 import { useRelativeTime } from '@/composables/useRelativeTime'
-import { formatCostUSD } from '@/utils/formatCost'
+import { formatCostUSD, formatTokenCount } from '@/utils/formatCost'
 import { statusSeverity } from '@/utils/runStatus'
 import type { components } from '@/api/schema'
 
@@ -64,6 +64,16 @@ const skeletonRows = [1, 2, 3]
       <Column field="started_at" header="Started">
         <template #body="{ data: row }">
           <RelativeCell :date="row.started_at" />
+        </template>
+      </Column>
+      <Column field="tokens_input" header="Tokens In">
+        <template #body="{ data: row }">
+          {{ formatTokenCount(row.tokens_input ?? 0) }}
+        </template>
+      </Column>
+      <Column field="tokens_output" header="Tokens Out">
+        <template #body="{ data: row }">
+          {{ formatTokenCount(row.tokens_output ?? 0) }}
         </template>
       </Column>
       <Column field="total_cost_usd" header="Cost">

--- a/frontend/src/views/CostDashboardView.vue
+++ b/frontend/src/views/CostDashboardView.vue
@@ -66,6 +66,8 @@ function budgetPercent(total: number, limit: number): number {
         <CostSummaryCard
           label="Total cost this week"
           :value="summary ? formatCostUSD(summary.total_cost_week_usd ?? 0) : '$0.00'"
+          :tokens-input="summary?.total_tokens_input"
+          :tokens-output="summary?.total_tokens_output"
           :is-loading="isLoading"
           data-testid="card-week"
         />

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -14,7 +14,7 @@ import RunLogViewer from '@/features/runs/RunLogViewer.vue'
 import RunTimeline from '@/features/runs/RunTimeline.vue'
 import RunCancelConfirmDialog from '@/features/runs/RunCancelConfirmDialog.vue'
 import { runStatusSeverity } from '@/utils/runStatus'
-import { formatCostUSD } from '@/utils/formatCost'
+import { formatCostUSD, formatTokenCount } from '@/utils/formatCost'
 
 const route = useRoute()
 const runId = computed(() => route.params.id as string)
@@ -140,6 +140,11 @@ const progress = computed(() => {
           data-testid="run-total-cost"
         >
           {{ totalCostDisplay }}
+          <template v-if="costDetail.value?.total_tokens_input !== undefined || costDetail.value?.total_tokens_output !== undefined">
+            <span class="mx-1 text-surface-400">|</span>
+            <span class="text-surface-500">In: {{ formatTokenCount(costDetail.value?.total_tokens_input ?? 0) }}</span>
+            <span class="ml-1 text-surface-500">Out: {{ formatTokenCount(costDetail.value?.total_tokens_output ?? 0) }}</span>
+          </template>
         </span>
         <Button
           v-if="canPause"
@@ -197,6 +202,33 @@ const progress = computed(() => {
           :retry-loading="runsStore.isRetrying"
           @retry-step="handleRetryStep"
         />
+      </div>
+
+      <!-- Step Cost Breakdown -->
+      <div v-if="costDetail.value?.steps && costDetail.value.steps.length > 0">
+        <h2 class="text-lg font-semibold mb-3">Step Costs</h2>
+        <div class="rounded-lg border border-surface-200 bg-surface-0 overflow-hidden">
+          <table class="w-full text-sm">
+            <thead class="bg-surface-50 text-surface-600">
+              <tr>
+                <th class="px-4 py-2 text-left font-medium">Step</th>
+                <th class="px-4 py-2 text-left font-medium">Model</th>
+                <th class="px-4 py-2 text-right font-medium">Tokens In</th>
+                <th class="px-4 py-2 text-right font-medium">Tokens Out</th>
+                <th class="px-4 py-2 text-right font-medium">Cost</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-surface-100">
+              <tr v-for="step in costDetail.value.steps" :key="step.step_id">
+                <td class="px-4 py-2 font-medium">{{ step.step_name }}</td>
+                <td class="px-4 py-2 text-surface-500">{{ step.model }}</td>
+                <td class="px-4 py-2 text-right">{{ formatTokenCount(step.tokens_input) }}</td>
+                <td class="px-4 py-2 text-right">{{ formatTokenCount(step.tokens_output) }}</td>
+                <td class="px-4 py-2 text-right">{{ formatCostUSD(step.cost_usd) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
 
       <!-- Live Log Viewer -->


### PR DESCRIPTION
## Summary
- Add `tokens_input` and `tokens_output` fields to `CostSummary`, `RunCostRow`, and `RunCostDetail` OpenAPI schemas
- Update `CostSummaryCard.vue` to display token counts (In/Out) below the USD amount using `formatTokenCount`
- Add "Tokens In" and "Tokens Out" columns to `RunCostTable.vue` next to the Cost column
- Add per-step cost breakdown table in `RunDetailView.vue` showing step name, model, tokens in/out, and cost
- Display total token counts in the run detail header alongside total cost

## Test plan
- [ ] Verify `CostSummaryCard` shows token counts when `tokensInput`/`tokensOutput` props are provided
- [ ] Verify `CostSummaryCard` does not show token line when props are not provided
- [ ] Verify `RunCostTable` renders "Tokens In" and "Tokens Out" columns with formatted values
- [ ] Verify step cost breakdown table appears in run detail view with token counts per step
- [ ] Verify all token values use `formatTokenCount` (thousands separator formatting)
- [ ] Verify `npm run lint` passes
- [ ] Verify `npm run type-check` passes

Refs: R-5-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)