### PR TITLE
feat(api-spec): add Agent entity schema and CRUD endpoints to OpenAPI spec

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -39,6 +39,8 @@ tags:
     description: Human-in-the-loop approval endpoints
   - name: notifications
     description: Notification configuration endpoints
+  - name: agents
+    description: Agent management endpoints
   - name: costs
     description: Cost tracking and observability endpoints
 
@@ -1068,6 +1070,7 @@ paths:
     get:
       operationId: listPromptTemplates
       summary: List prompt templates for a project
+      deprecated: true
       tags: [prompt-templates]
       parameters:
         - $ref: "#/components/parameters/ProjectIdPath"
@@ -1086,6 +1089,7 @@ paths:
     post:
       operationId: createPromptTemplate
       summary: Create a new prompt template in a project
+      deprecated: true
       tags: [prompt-templates]
       parameters:
         - $ref: "#/components/parameters/ProjectIdPath"
@@ -1115,6 +1119,7 @@ paths:
     get:
       operationId: getPromptTemplate
       summary: Get a prompt template by ID
+      deprecated: true
       tags: [prompt-templates]
       parameters:
         - $ref: "#/components/parameters/ProjectIdPath"
@@ -1134,6 +1139,7 @@ paths:
     put:
       operationId: updatePromptTemplate
       summary: Update a prompt template
+      deprecated: true
       tags: [prompt-templates]
       parameters:
         - $ref: "#/components/parameters/ProjectIdPath"
@@ -1165,6 +1171,7 @@ paths:
     delete:
       operationId: deletePromptTemplate
       summary: Delete a prompt template
+      deprecated: true
       tags: [prompt-templates]
       parameters:
         - $ref: "#/components/parameters/ProjectIdPath"
@@ -1176,6 +1183,142 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ── Agents ───────────────────────────────────────────────────────────
+  /agents:
+    get:
+      operationId: listGlobalAgents
+      summary: List all global agents (scope = global)
+      tags: [agents]
+      parameters:
+        - $ref: "#/components/parameters/PageParam"
+        - $ref: "#/components/parameters/PerPageParam"
+      responses:
+        "200":
+          description: List of global agents
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Agent"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /projects/{projectId}/agents:
+    get:
+      operationId: listProjectAgents
+      summary: List agents available for a project (project-scoped + global)
+      tags: [agents]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/PageParam"
+        - $ref: "#/components/parameters/PerPageParam"
+      responses:
+        "200":
+          description: List of agents
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Agent"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+    post:
+      operationId: createAgent
+      summary: Create a new project-scoped agent
+      tags: [agents]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAgentRequest"
+      responses:
+        "201":
+          description: Agent created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Agent"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+
+  /projects/{projectId}/agents/{agentId}:
+    get:
+      operationId: getAgent
+      summary: Get a single agent by ID
+      tags: [agents]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/AgentIdPath"
+      responses:
+        "200":
+          description: Agent found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Agent"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    put:
+      operationId: updateAgent
+      summary: Update an agent
+      tags: [agents]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/AgentIdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAgentRequest"
+      responses:
+        "200":
+          description: Agent updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Agent"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    delete:
+      operationId: deleteAgent
+      summary: Delete an agent
+      tags: [agents]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+        - $ref: "#/components/parameters/AgentIdPath"
+      responses:
+        "204":
+          description: Agent deleted
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
 
@@ -1705,6 +1848,15 @@ components:
         type: string
         format: uuid
       description: Prompt template UUID
+
+    AgentIdPath:
+      name: agentId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: Agent UUID
 
     RunIdPath:
       name: runId
@@ -2620,6 +2772,92 @@ components:
         pagination:
           $ref: "#/components/schemas/Pagination"
 
+    # ── Agent ────────────────────────────────────────────────────────
+    Agent:
+      type: object
+      required:
+        - id
+        - name
+        - model
+        - image
+        - template_content
+        - scope
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        model:
+          type: string
+          description: LLM model identifier (e.g. "claude-opus-4-6", "claude-sonnet-4-6")
+        image:
+          type: string
+          description: Docker image reference for the agent runtime container
+        template_content:
+          type: string
+          description: Handlebars prompt template content
+        scope:
+          type: string
+          enum:
+            - global
+            - project
+          description: >
+            "global" agents are available across all projects;
+            "project" agents are scoped to a single project.
+        project_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Required when scope is "project"; null for global agents
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    CreateAgentRequest:
+      type: object
+      required:
+        - name
+        - model
+        - image
+        - template_content
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        model:
+          type: string
+        image:
+          type: string
+        template_content:
+          type: string
+        scope:
+          type: string
+          enum: [global, project]
+          default: project
+
+    UpdateAgentRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        model:
+          type: string
+        image:
+          type: string
+        template_content:
+          type: string
+
     # ── Pipeline Config ──────────────────────────────────────────────
     PipelineStep:
       type: object
@@ -3426,6 +3664,12 @@ components:
             $ref: "#/components/schemas/Error"
     Forbidden:
       description: Forbidden - admin access required
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    UnprocessableEntity:
+      description: Validation error
       content:
         application/json:
           schema:

--- a/backend/internal/api/handler/gen_server.go
+++ b/backend/internal/api/handler/gen_server.go
@@ -26,6 +26,18 @@ const (
 	CookieAuthScopes = "cookieAuth.Scopes"
 )
 
+// Defines values for AgentScope.
+const (
+	AgentScopeGlobal  AgentScope = "global"
+	AgentScopeProject AgentScope = "project"
+)
+
+// Defines values for CreateAgentRequestScope.
+const (
+	CreateAgentRequestScopeGlobal  CreateAgentRequestScope = "global"
+	CreateAgentRequestScopeProject CreateAgentRequestScope = "project"
+)
+
 // Defines values for CreateEpicRequestStatus.
 const (
 	CreateEpicRequestStatusBacklog    CreateEpicRequestStatus = "backlog"
@@ -285,6 +297,32 @@ const (
 	GetProjectCostSummaryParamsPeriodN90d GetProjectCostSummaryParamsPeriod = "90d"
 )
 
+// Agent defines model for Agent.
+type Agent struct {
+	CreatedAt time.Time          `json:"created_at"`
+	Id        openapi_types.UUID `json:"id"`
+
+	// Image Docker image reference for the agent runtime container
+	Image string `json:"image"`
+
+	// Model LLM model identifier (e.g. "claude-opus-4-6", "claude-sonnet-4-6")
+	Model string `json:"model"`
+	Name  string `json:"name"`
+
+	// ProjectId Required when scope is "project"; null for global agents
+	ProjectId *openapi_types.UUID `json:"project_id"`
+
+	// Scope "global" agents are available across all projects; "project" agents are scoped to a single project.
+	Scope AgentScope `json:"scope"`
+
+	// TemplateContent Handlebars prompt template content
+	TemplateContent string    `json:"template_content"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+// AgentScope "global" agents are available across all projects; "project" agents are scoped to a single project.
+type AgentScope string
+
 // ChangePasswordRequest defines model for ChangePasswordRequest.
 type ChangePasswordRequest struct {
 	CurrentPassword string `json:"current_password"`
@@ -307,6 +345,18 @@ type CostSummary struct {
 	TotalCostUsd       float64   `json:"total_cost_usd"`
 	TotalCostWeekUsd   *float64  `json:"total_cost_week_usd,omitempty"`
 }
+
+// CreateAgentRequest defines model for CreateAgentRequest.
+type CreateAgentRequest struct {
+	Image           string                   `json:"image"`
+	Model           string                   `json:"model"`
+	Name            string                   `json:"name"`
+	Scope           *CreateAgentRequestScope `json:"scope,omitempty"`
+	TemplateContent string                   `json:"template_content"`
+}
+
+// CreateAgentRequestScope defines model for CreateAgentRequest.Scope.
+type CreateAgentRequestScope string
 
 // CreateEpicRequest defines model for CreateEpicRequest.
 type CreateEpicRequest struct {
@@ -941,6 +991,14 @@ type StoryListOrSingle struct {
 // StoryStatus defines model for StoryStatus.
 type StoryStatus string
 
+// UpdateAgentRequest defines model for UpdateAgentRequest.
+type UpdateAgentRequest struct {
+	Image           *string `json:"image,omitempty"`
+	Model           *string `json:"model,omitempty"`
+	Name            *string `json:"name,omitempty"`
+	TemplateContent *string `json:"template_content,omitempty"`
+}
+
 // UpdateEpicRequest defines model for UpdateEpicRequest.
 type UpdateEpicRequest struct {
 	Description *string                  `json:"description,omitempty"`
@@ -1056,6 +1114,9 @@ type UserList struct {
 	Pagination Pagination `json:"pagination"`
 }
 
+// AgentIdPath defines model for AgentIdPath.
+type AgentIdPath = openapi_types.UUID
+
 // EpicIdPath defines model for EpicIdPath.
 type EpicIdPath = openapi_types.UUID
 
@@ -1110,6 +1171,18 @@ type NotFound = Error
 // Unauthorized defines model for Unauthorized.
 type Unauthorized = Error
 
+// UnprocessableEntity defines model for UnprocessableEntity.
+type UnprocessableEntity = Error
+
+// ListGlobalAgentsParams defines parameters for ListGlobalAgents.
+type ListGlobalAgentsParams struct {
+	// Page Page number
+	Page *PageParam `form:"page,omitempty" json:"page,omitempty"`
+
+	// PerPage Items per page
+	PerPage *PerPageParam `form:"per_page,omitempty" json:"per_page,omitempty"`
+}
+
 // ListHITLRequestsParams defines parameters for ListHITLRequests.
 type ListHITLRequestsParams struct {
 	// Status Filter by HITL request status
@@ -1135,6 +1208,15 @@ type ListProjectsParams struct {
 
 	// SortBy Field to sort by
 	SortBy *SortByParam `form:"sort_by,omitempty" json:"sort_by,omitempty"`
+}
+
+// ListProjectAgentsParams defines parameters for ListProjectAgents.
+type ListProjectAgentsParams struct {
+	// Page Page number
+	Page *PageParam `form:"page,omitempty" json:"page,omitempty"`
+
+	// PerPage Items per page
+	PerPage *PerPageParam `form:"per_page,omitempty" json:"per_page,omitempty"`
 }
 
 // GetProjectCostsParams defines parameters for GetProjectCosts.
@@ -1266,6 +1348,12 @@ type CreateProjectJSONRequestBody = CreateProjectRequest
 // UpdateProjectJSONRequestBody defines body for UpdateProject for application/json ContentType.
 type UpdateProjectJSONRequestBody = UpdateProjectRequest
 
+// CreateAgentJSONRequestBody defines body for CreateAgent for application/json ContentType.
+type CreateAgentJSONRequestBody = CreateAgentRequest
+
+// UpdateAgentJSONRequestBody defines body for UpdateAgent for application/json ContentType.
+type UpdateAgentJSONRequestBody = UpdateAgentRequest
+
 // CreateEpicJSONRequestBody defines body for CreateEpic for application/json ContentType.
 type CreateEpicJSONRequestBody = CreateEpicRequest
 
@@ -1372,6 +1460,9 @@ func (t *StoryListOrSingle) UnmarshalJSON(b []byte) error {
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// List all global agents (scope = global)
+	// (GET /agents)
+	ListGlobalAgents(w http.ResponseWriter, r *http.Request, params ListGlobalAgentsParams)
 	// Request a password reset link via email
 	// (POST /auth/forgot-password)
 	ForgotPassword(w http.ResponseWriter, r *http.Request)
@@ -1423,6 +1514,21 @@ type ServerInterface interface {
 	// Reset the circuit breaker for a project
 	// (POST /projects/{id}/circuit-breaker/reset)
 	ResetCircuitBreaker(w http.ResponseWriter, r *http.Request, id IdPath)
+	// List agents available for a project (project-scoped + global)
+	// (GET /projects/{projectId}/agents)
+	ListProjectAgents(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, params ListProjectAgentsParams)
+	// Create a new project-scoped agent
+	// (POST /projects/{projectId}/agents)
+	CreateAgent(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath)
+	// Delete an agent
+	// (DELETE /projects/{projectId}/agents/{agentId})
+	DeleteAgent(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, agentId AgentIdPath)
+	// Get a single agent by ID
+	// (GET /projects/{projectId}/agents/{agentId})
+	GetAgent(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, agentId AgentIdPath)
+	// Update an agent
+	// (PUT /projects/{projectId}/agents/{agentId})
+	UpdateAgent(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, agentId AgentIdPath)
 	// Get aggregated cost data for a project
 	// (GET /projects/{projectId}/costs)
 	GetProjectCosts(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, params GetProjectCostsParams)
@@ -1585,6 +1691,12 @@ type ServerInterface interface {
 
 type Unimplemented struct{}
 
+// List all global agents (scope = global)
+// (GET /agents)
+func (_ Unimplemented) ListGlobalAgents(w http.ResponseWriter, r *http.Request, params ListGlobalAgentsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // Request a password reset link via email
 // (POST /auth/forgot-password)
 func (_ Unimplemented) ForgotPassword(w http.ResponseWriter, r *http.Request) {
@@ -1684,6 +1796,36 @@ func (_ Unimplemented) UpdateProject(w http.ResponseWriter, r *http.Request, id 
 // Reset the circuit breaker for a project
 // (POST /projects/{id}/circuit-breaker/reset)
 func (_ Unimplemented) ResetCircuitBreaker(w http.ResponseWriter, r *http.Request, id IdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List agents available for a project (project-scoped + global)
+// (GET /projects/{projectId}/agents)
+func (_ Unimplemented) ListProjectAgents(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, params ListProjectAgentsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Create a new project-scoped agent
+// (POST /projects/{projectId}/agents)
+func (_ Unimplemented) CreateAgent(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Delete an agent
+// (DELETE /projects/{projectId}/agents/{agentId})
+func (_ Unimplemented) DeleteAgent(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, agentId AgentIdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get a single agent by ID
+// (GET /projects/{projectId}/agents/{agentId})
+func (_ Unimplemented) GetAgent(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, agentId AgentIdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Update an agent
+// (PUT /projects/{projectId}/agents/{agentId})
+func (_ Unimplemented) UpdateAgent(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, agentId AgentIdPath) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -2007,6 +2149,47 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(http.Handler) http.Handler
+
+// ListGlobalAgents operation middleware
+func (siw *ServerInterfaceWrapper) ListGlobalAgents(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListGlobalAgentsParams
+
+	// ------------- Optional query parameter "page" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "page", r.URL.Query(), &params.Page)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "page", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "per_page" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "per_page", r.URL.Query(), &params.PerPage)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "per_page", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListGlobalAgents(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
 
 // ForgotPassword operation middleware
 func (siw *ServerInterfaceWrapper) ForgotPassword(w http.ResponseWriter, r *http.Request) {
@@ -2461,6 +2644,207 @@ func (siw *ServerInterfaceWrapper) ResetCircuitBreaker(w http.ResponseWriter, r 
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ResetCircuitBreaker(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListProjectAgents operation middleware
+func (siw *ServerInterfaceWrapper) ListProjectAgents(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListProjectAgentsParams
+
+	// ------------- Optional query parameter "page" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "page", r.URL.Query(), &params.Page)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "page", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "per_page" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "per_page", r.URL.Query(), &params.PerPage)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "per_page", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListProjectAgents(w, r, projectId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateAgent operation middleware
+func (siw *ServerInterfaceWrapper) CreateAgent(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateAgent(w, r, projectId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteAgent operation middleware
+func (siw *ServerInterfaceWrapper) DeleteAgent(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "agentId" -------------
+	var agentId AgentIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "agentId", chi.URLParam(r, "agentId"), &agentId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "agentId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteAgent(w, r, projectId, agentId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetAgent operation middleware
+func (siw *ServerInterfaceWrapper) GetAgent(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "agentId" -------------
+	var agentId AgentIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "agentId", chi.URLParam(r, "agentId"), &agentId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "agentId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAgent(w, r, projectId, agentId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateAgent operation middleware
+func (siw *ServerInterfaceWrapper) UpdateAgent(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "agentId" -------------
+	var agentId AgentIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "agentId", chi.URLParam(r, "agentId"), &agentId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "agentId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateAgent(w, r, projectId, agentId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -4612,6 +4996,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	}
 
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/agents", wrapper.ListGlobalAgents)
+	})
+	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/auth/forgot-password", wrapper.ForgotPassword)
 	})
 	r.Group(func(r chi.Router) {
@@ -4661,6 +5048,21 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/projects/{id}/circuit-breaker/reset", wrapper.ResetCircuitBreaker)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/projects/{projectId}/agents", wrapper.ListProjectAgents)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/projects/{projectId}/agents", wrapper.CreateAgent)
+	})
+	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/projects/{projectId}/agents/{agentId}", wrapper.DeleteAgent)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/projects/{projectId}/agents/{agentId}", wrapper.GetAgent)
+	})
+	r.Group(func(r chi.Router) {
+		r.Put(options.BaseURL+"/projects/{projectId}/agents/{agentId}", wrapper.UpdateAgent)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/projects/{projectId}/costs", wrapper.GetProjectCosts)
@@ -4825,161 +5227,170 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x9iW4cOZLorxD1HtA2UJdkyd3txQAry26PdtxuPUnefjO9RoGVGVXFVSaZTTIl1xgG",
-	"9h/e+8L9kgWPvJlXqQ75ABazbRWTDEYEg3Hz08BjYcQoUCkGLz4NIsxxCBK4/tfriHgX/iWWK/UvH4TH",
-	"SSQJo4MX+jf0/v3Fq8FwQNQfIjVsOKA4hMGLAehPB8MBhz9jwsEfvJA8huFAeCsIsZpvwXiI5eDFII6J",
-	"GinXkfpSSE7ocvD581CvcRXTRhB4TFvA0DM8EJK/Xty8vYI/YxCyDho1BHEzpgGiFZFBOtMDoaoD5QoE",
-	"i7kHDWCQh679jkmyIB5WS9bBkR+DPEYXZNkAEi3M+EDwLvESLhUzV6FSPyEah3PgCSB/xsDXGSQRXsIg",
-	"v54PCxwHcvDiaDgICSVhHOr/tusSKmEJ3CwMvGHtCwmhQBFwZNdwLg98Vg/C8XQ4CPFHC8N02g4RZ/8J",
-	"Xi3f2p8bCBMlEzyQJg1H+arxFPMtnOBrxuXLdQ1ZfiEQ+EgyJBiXaL6uIYz6daZ/ddBl4HHAEvwZlm4A",
-	"JERN2xcSogYcCP35Q5EgGV/XAaF/bIRAf/xAEG4gjAIsoYEdw0giaYc1wCPTmR4E0mf1sYgYFaAvvZfY",
-	"t/JZ/ctjVALV/4mjKLDiafKfQgH7KbfM/+awGLwY/K9JdqFOzK9i8ppzxs1Sxc2+xH5yZQw+DwfnjC4C",
-	"4u1h4fSG8OyS6AmMl2Pkx2YpQBBiEjxVUP3C+Jz4PtDdg5UuhUYI+yGhCHseCIFS8pqb5xcWU3+PWKJM",
-	"ooVe8/Nw8J7iWK4YJ/+EPcBQWE39bL9QE56vMFVXjRD3jOe5NuIsAi6J4Wgv5hyonEV2oPpbSOhboEt1",
-	"Ao8qZ2I4oHBfN/wn16nOjt8f1eVK031IJ2Bzda8YzhfyFZb4khHq2IGPJaj/Dx9xGAXq0+Pp8fPR9Hh0",
-	"NB0MsyOuxzm2I5nEwcxjQs5i4Rdmmo6Pjp+d5Odg8TzIzWI1hfIuk6WKM9ft7ToOQ8zX1Z3hu6X5Wl36",
-	"WsJuDuFwMI/9JchZQEJS3enRtNMcEXDC/BlQvwbjP95Mpy/0//2jjPuRJKGTAHZSITGXdYTcYNoc9kNG",
-	"5aqy52fjk9PnP3badwOPHI2Pn52c9p3lHuDWQczT5z/+1J/dStCVMFqg2rCOqZzMqZUWbWjViY+CPMqT",
-	"TttfC8aRklBAZaLpLwDLmIMYaEU1kRvHU6WrViWNvszz074XwNFZYcrSTKenwzYBJiSWsSgqaHPs3QZs",
-	"ORgOgCp1+Y/cXwidRZwtOQgFts8o5NBVI+g06PVIzVs/59r4qZfQK0wpBDMz06cUPp8Iz0jQe5ivGLtV",
-	"y2WYyn6u7N9YW1rC+D5RIODgsrBm5ZN03k+DmAfKVJUyEi8mE7vM2GPhBEdkYmERk/F4rHm+vH+geB6Y",
-	"yzHFvlHL0jXMP+2Xc8YCwFR/eqeuxdmCBBJ4gS/+UGaAgiEKQILW+WI6XmCiVvowHBBlWjk3Zv+AOcfr",
-	"6m2VR32KtzIg9VS25lMtafFS3YU8plqGVdTdc0YlJhQ4skNQLECbIvARvFgC0hNo60CgJxadQg34wWfe",
-	"LfAfEFkgFhIpwX+a423z62A4uI3nwClIECXuSQZUEGZXmYXMh6AK8yvzMzoPcOwD0qMQuwPOiQ9GIORg",
-	"JhTJFRHIWpGDPAienmHEoliMTkbPlaYQB4FinhKH5GGrkUZnSOj/zC2UkxlHbumzJFKd+zviG24rbvQN",
-	"kSj5Ve8rv5ESMZZEruJ5HTHMrwO9YIDVf8yJnMfeLcgiUdKBTlAluwU6A3rn8LXgEBBbILkCBPSOcEZD",
-	"RYQ7zIlCKFqxwCd0qQcsiUR6LvREqbbqT+afRAoIFk8LRHpzcfPX9y9nN7/97fW7LhSqSvRf1+jSRZQu",
-	"gpxDxGZaHpV3/P7qbbJhS5IfhN6Z+kQQde0V9pGIM4NiLc0YX07C9SjjmJbN9bsAjCmbGLy1EqKKr+SA",
-	"Xah/ayqaqfpjL7GRZzkjJVvn7yxGmAMiyTqKP7S+gD59MnrDLaw/f1Zyvn2p0t2VTqqtc6mJweGOwL2a",
-	"C7j2b3mxkCwsHoH8hx3w79ik/a6eMlcxrSVHRCIICNWz2Su0OECLNfUf6Y1TkvheIpxqj0anbdl5XLto",
-	"vNEMfK7PDEmJ381TU5zTfjms4Kcey9qhVH8xeh5EElMPZh4nEjjBTpz5EAH1xcygtOstP9Su/257HQ5u",
-	"YV08Gdej6VHxtJ26rg+zY3IHToiEx4pHQqmbRkNfcM2q6j/FCnPwHdpmXoltch1oNF+boQoPmCsbcEEC",
-	"EP0wJokMSpIok0ABWxKaeK3LUqiZeRR2k9ld3KLsCIdOnLlTHQbj0ejo9OZo+uJZP4PxIbZMZTJSspB/",
-	"/HEKP51MpyM4/nk+OjnyT0b4x6Pno5OT589PT09OptNpwVtRx41dTaKqlW3usVkZsOfPtwNYxo9dDagM",
-	"hmykY1olXDwW2yBkK7Ofm6Gfh4M48rfNJCXmNTIvQ+wwEc8WGSXwh8UwQA6+Os5/dfbmtb8Exz2jfY8O",
-	"P73xSZp7+hbWShFVIhKoty5qblaKVQ++FhHVmW/0310zy8rEx+13hoE/Xa4BAe+Y70DAA4V3ZWCA1y4t",
-	"/x/A2WiOldllbC517vVYRKgPH/M7n1YjbIVj0YXdu4vZDpyZl605njRbbcD4lQ15VLEO/rJ0cTT6rXMc",
-	"7LhSKPP7T6a5oU3LMTMPLbh1O31LhNudjHsB5dpahJeE4uQmaZrhMhvp8CLjQWGuup1cxfRMa0zGr1Ki",
-	"mdJ1eEwrkv/nn3cl+dXm/DhQvxfkfO7vNaKegDDSsgDqqTN2ncdVfpMl8ZtN2YC+VyAxCRyKRuJSsreI",
-	"85JotXqL6ko3baSPitpxWFEF2ICuSt4b4vGYUvNfeaebdbgpno2F0Vsz4mcf11G+17G7iqm+71uFQfWS",
-	"TlCbY5TCxZyA08AvZukKuyw5i6OZuRm2f5dkh7hMu1YOdF1DLQRZd+cT6wxwuGEo+TNO1BGidAWyIMDR",
-	"PZErdZUl3jIYL8dDpO7mLkpKvf2Zx3+6aScZdUi1Kivdf/asCpJTuq9fX83e/XYz++W39+9eua0JJVFE",
-	"vZe9QKkMshCEwEuXjq+Qhi5eITz3jo6f5eLOrUFXBX42cxUfZWGqseBC2y+ML5lsDSrr/IDiDmIB/F/t",
-	"P8ceC/MXixnetgszygVVLgGvzVTsaAmSxSLvFasw9YKAj9QoZEehBWehdjca9zaPaZdjucQSssBOiiwc",
-	"RZzd4WB/sp6DdlYwOuOAbXJCK/QcBAvuHng3Grffdibhm4rHesnqHCokRNu4RQ2dTbxKE6DXndkHhpyE",
-	"breFzPAW/5Ues1VzJY/ZbH956IvL5o+P+ypvERZbMADyouewdsBFGDEur43qUi8N64TaFb5HIea3Prun",
-	"qVDTN87fz359i7RPMsRSAre3+Txg3q3ocPeYBTuALHQs2Hkld1cNsznXNm2qShWrplbDZDq9ArEFshog",
-	"kisskRmOJENETz5w6Wbmp+ZZKdwHa2T5M1nDOZt1DTVNZoekoD65hTXCAQfsrxF8JMJGGVsMpxTubNGc",
-	"Hm+R30y89etmram4g1+xtyIURgpQHXvUayCro9Q5cFzZqNoJFeI1mgOCMJJrRBb6jx6LA1/rR+qXj5Jj",
-	"r4iMbPqctlXK2I9DTMtA5od0c2wn8w8NNlyIfKvE5I5VKSU9soS9nEEOXszh8l+FOMrPksvO66KT5WZ3",
-	"bfBXg4N6r5JT5b1YmIi6XgIRgTgsFVNz8IcIIw4CJAoIvUUrLNAcgCLRJS5YrwUPB78yH4JzJuRLDliL",
-	"QgewSd5DU6aCIxntFqiYERrFRdfGs+lUZx+kuCdUPj9xCgU7B4tleZLTHnMkqWL90//KiNSIKExZ2mcZ",
-	"ZBfKq4lQX30G1E6CV7m0qkeQR7W7+Neuw1iHCBp1SzPLaNwvjlQ9YVvQex3Hts0Pp+d3AXhZUJJLCRfl",
-	"e+HIJdXSoqj8yONprQAsjDs5blWSzEfDpPYrXc65G2Oy5YsCJYRb9EvU5jtJhpQVrL0Q2jfxhCzQ5ZVR",
-	"BsXTemdCQ62irq/pZBN3NkV3ZLbWWZQNxmSLpVil5BYOTg17uDIuKpz6rJVRraloPnXuySbo1F21u88S",
-	"KOdHNSLLQnstIXKhqFlYH29BWBfktAG+VeAWoK7JAJs1Z8SVMuEkaOWqZ0LccIBjyWbWyVTA0AIHwqka",
-	"lOn+00/boXumNdv9VnVm+xfBKAVZ/NsKk9t4dDI6Le69g95dTZdpRJjORZxFLCDeuo05r9TYSzPUKX0K",
-	"qXrJ5Z5ozQXSlBZ2MpVNQ91pDvl2MsQ9wr2YyNlcGVHAZzj1IhZB+30FcgVc31f2G2S/UfaeLRUL1khy",
-	"EkXGH9HKwOXF02BynR/FUzapFysQUZK+qF0+NrMrH5JLi6mdqkV56RA7goA3Kw5ixQJfJ5TlF0/WRHNY",
-	"MA5m18b5m78Bmgq6h7tKjPs6Uv63meH/jebv70ovCPHHmSlQdHkMdUMDZH63lEjpqhjq/fUr9IRQs4o2",
-	"5hGjQTHh7Wjq9HHU7Dgr2mupWKim/d7TNA6VfXN6uh08PaqKh71Zy/YmTVFbJ+Zr7x63cO5nR1uaN1bs",
-	"zteZkOyk4To8jg49d75WF3znSa9i2mVKkeSwdJrUJte2TNt0jpNmIvYc60LkXZ/eor+zdBWr35D6LYEi",
-	"FS26YLaw/vG4T41v6ud1rah/NDJZNCx5Ou3p1c0cw65Vza/tyx51Xba2CHlQxEIJvBzrpYw9zA5Ow8nb",
-	"hvVtRdthQ7XF2q89VTfsyrLrVaG2d3fuNmvcDlLVdtAyhrriud4XZ47dt3OK8+fnsIf5yoYldx7BrR60",
-	"f8MU0CsG/Us/N40G92n1UokND+trYq909lNjHl+Wl1buw6P+ri80m8Rm7aC8H7tUoTptg90u5gZVQHsG",
-	"ZB7BZQcAIAr3KBmBnliLHv2EvBXWuQpcFK00CvfXhjZYiKPjZ22UsIFX9+Imcm5MQg4ekDvw0XyNEnrl",
-	"XDxv/v2f/vnRdH4sgzk5CufPLqQX/vs///F//89fWoWKgaAlNSDvQ6tG2vHHmRKjyTlKAzuFHndtXhnj",
-	"WSuLasqotijoyLpdBsMBDu7xuuTlKgxoSSzIgVtY1rnxmG5YbLCd4gLOGZ/l8i42TjMtFvzOBMWRWDHZ",
-	"O+05rQ+smg3APaASL8G46yyOkq4X0//+r/93NJ0+HeqfYvULlkg350Nq++NBbUtEJ7/0L5LgfbHfrbDC",
-	"1lDUVFh4mHoQBD2LLLaR0/83WCeOBiwE80iahra2jeJ0Hv+/IBZZaw4LJFgICPwlIA8LECjEa7TCd4Ao",
-	"M5+OOxUnFnWhrag6ueqBNIU0V6zaR9Gp2N1bCfr2Cq5Wqzzy3PPQxOCa7KFn46PT/vlDueBsPr/XkqBg",
-	"TrYEai3e62q4ekanRQ+XCEStHpHd4KyAnvqmDhYzV+z+gWjJCzlnf7b+Bun+mNXRaG26WWO/Zp7NoalT",
-	"87+rmG7BGlKqxIFNoJg2xbqd+sWGuk4SzbSc+7iUoYAtZ4kIcphcuvFlLv+l1P35VXKrMk4UugPT9VcH",
-	"nYjQKa+Sq6v3XxCNg8BYPIxlodv+VS9aR62JkP6+It7KromlBN1418Ly5MjUMT6tA6Vm6Vq1vGzSqUWF",
-	"5FjCcm0C1mn8zcJSt3Lqi6Ee1y4Vnbi1iAPtWtxmIdDuNL8WhW84uMdEmbmztE6sV9FQTaMh+yvjNhja",
-	"VjhQTbBKm1+k06SNirrX51zF9HciV9fJTYyD4LfF4MUfXYRgezemljnciUYdeyh9sI2823RA1430rFNw",
-	"YbPc8x3d3n3y+HJc19HrWZswf7SNhPnjDRLmt6dFlIrc7LHJ8ukbUuiHg0aNoqYsvWs7rY1yUvfQgqtf",
-	"s5d9lKC3tffq60X4VruB7cSkr+l708eUd0S7Hb3+NnWobGxpn46PTzeRNzkXR2a35NZoREFttoO6/Vvz",
-	"63wiJKGeLom3BZWE6tw+X8feRSm/zdVCqQeeH4a4Svy+eGNsFo3PKg02i6znyNc9yJ7RpoG2SVO1UhKL",
-	"bU/VknpuG7m19OnJV9u2djfR+m9LtUcJOVkvrUx/9o1zPytbcu9/C7Z3TQeavVrf6V5+49eELgO3QRVz",
-	"KlA6VNtNgfqPP2PgBMQQMY6E/tyM0iNuYY0Cxm7jSMdKoIMinmFWqeMdcPch2cJ1z67s7fTOpMJ7Le03",
-	"62T/3hZaF4t/N2peb2fS/STfWa1v09b1m7epr3CQgevX9SVnShfIoSgkNB+7ORrWxba7h697bbge2u8N",
-	"9B9HpedGHfOzTXyoJXCxUqmWuNssKOrcK9lCuMfu/t9w7/5W+bv99v3faHL/l5SEn3BFklS82XX62B4Q",
-	"qJc0mz0WkMNSGG2KpOYcymSJ9FE+O2of7wJ0RuCX023+K+0a394UvoZy70W/1EoK9yP9523lV16HRD8s",
-	"2VeysKBAKP1i4WCoUz+7sq4Avqfk8G3lqO6q7Kkx97U37oubPGDOdYJHGwHQcPfzUyoe2YIfQ7PaId0Y",
-	"SjSBF3Mi19dqxiRUxm4JnMWut2D/7fcbq/oIpS1hgTBF6hb+jQZrZFKZkZkgeSI2/VfySKxNUU12HZG/",
-	"wdq8s6n0mKRfHjZl1/ajv7IILuTvjN8KdAM4HDgebtUyGZ1dXqR6Uv6rRGcKMcVL4zJXN6diovF/0Bsb",
-	"Y1dfWYeMfWhUqSM8lqt0UrWAApBjT47/Q+0kIB7YFlsW3F8vbhQXFUxOFgE1c46VjmI/EhM1NhPahZ2e",
-	"XV4MhoM74MLscTo+Gk/1fRUBxREZvBg8G0/HzzSd5UpTb4JjuZosdMvYUT4hOrLeWcWuyYveL0q9Ze2z",
-	"vSDkS+avt/aUqruB7eciyyrtrPzy7/H0eGtAlBuiuV+XBWl7n/lERFh6K/DRE5OjjLh26IGP/vu//j+K",
-	"uLGu7XAl9Sxe9RO9J9NpHUDpDie5h43zZ3Hw4o8Pw4FIAgADOwbhLH0914jtjuA0i1zipdCyVx3eD2pO",
-	"ww46OFTPBLoZ3nsjlXdB/0KzvU5kn25tbSNkq7TWMCER69eMF7HC3gqwD6br5TXI0bkRXBUZmIo7JQxT",
-	"6ZZBU3nOWrPDUTs7VB8WrmGIt2ypbD9MTZchZaYmd2o9AzATF6nlABbLlAUKtDipouAtWy7BRyyWOQwG",
-	"68HmOy3sTc2r+1OYZhRtmzNaijWgi/t6A/LcTOLe2+757Dy3B5S0J98Cnt5AAUfBOv9OEvhtOEv6Otaz",
-	"RFJitUO5UK7i6iQajnZOMt33PWt8WWTxHYuJnreG+uTn9k/SZ+ybrxmzY4R1qVQrAwnoomAUKrd2xkeO",
-	"6rA93zMd1IsEwqyLcEV2bk9puAZpCZkqDbHSbNMurqkeXiXwishgZAklamWrsoByxYO6hANzHILUp+OP",
-	"8oH4RYch0HxdKBJEaaaIthZ0CVFmLGRZ3ikROjd0r5iCbsxmMCtzCi7VPwddBgPPjf+wQ9Yq98JzspY2",
-	"88A38WW2KOB4KxeOjmAXZkUmsGQKGbMaEstPiolc/DSZr0dCQjT5pP73wv/cdHnntv5yreNHFSZrIdO1",
-	"XuQSy9XeiOQiUIHlH6YGqI9O2j96x+Qv+qESt95QAEhHmRCPqY4ydSHiJ/XPpJdiZxr2pl6+Y+N3IhaI",
-	"iIsknK9N29C+lJvkOhW6b/AzM+ArJWN6eWyqfu2e9BspeSmvWPKV+GUTTjGXa5OqV+4nsC0+2YXKWIZ1",
-	"z/piHx5NtZqvlUcNNTqxqPXjNqull8mgvgz4AA2wffw14/Lleg8KY751UydlMUXqtvREHATZpBkd0z99",
-	"+DysESLpQ/02fL+Lw19Y40DOh7QploM+NlRhQ1L7O/UFOhokJTZk1nqxSsr8sZx8IkYb9CEA02arSN9X",
-	"+u8Zffudz3rt4aS+9Z0BxT+Ipma2i3AzBoe1yvP2ETXdJwsfXklO4n5l/bgoimIH9gv5hg8jwPZFmDMZ",
-	"cs8qTAf6J69bPV7FpcAyBqttp7Ui7ya2z+nI9jk1ztG8ouyIMwpnC24hFQBPdBHJX6ZDZFqp/kV33n6K",
-	"BDO1PGnLbF3e42GK5pDUaIOP8BITOkZnfkjoiNFgjYD6ESPUBqwdHtpzA8dLA8Zu5fJ5ac/GH7mFQJL6",
-	"6Fn7R78wPie+D/Sh7GLixS4yGodKDy6y/6XMLFOflam37qoSvFxyWGotTjdT9bHEaY6CiMAzz6Um4o/d",
-	"ace+zng27UeH5qHBeVJqJ4wXj/H1ULHVEGHqm2zkMXqZax4rTPNG6gWxb1sEFPNPfSKiAK8RDhhdCuID",
-	"igVegov1sgvunIlN1PUEa4b7hpXOa9l2bSa1QZrJZnY5nNPWrJkIzApjfvRzOcr6H8+m6n9/njodznu4",
-	"e/OVgg4xfJYxScIIKbMc7k6u41zXgTGHoe20TLwV5rLJCZnD17keu2tW01vTYCGbirUldtsBo3XKVtPN",
-	"nrDEl+oecZRxVJjvFSbBOkdifQEdThX0neAYWmkycaA+cNvDox/7qWu4I/ddqaG7Zj4e09xB3yXrPeqg",
-	"2sP6OyU9vA6aodnBeZMSm7P7wx0vHtNRAHdge7unasVDJbvI6uA7nK7kLvyuSHT2hX2BGoSGwP5pc/6C",
-	"iHgjJbknn9R/XsW0JZD52ozaAnO1fPA6AWf3Phy7lO3i6GAAXTatRIx15RirIQI+Ms1dRFqwchhlkiJI",
-	"INQunhr4Mr5Qw1v5ojm88FqP2DkbfB3BCIWs7pEIjXxDQ0M/z/TL2FZgwsxfkBmO1arc0hyuUHt8KD98",
-	"2GWsI9+EYc+BDo2bOsGy9xDHZi6izSObhSiKllSEOq+rbmLJXFUXXUIs2+DJbldVL+efJvvDIzL7dPMl",
-	"MRxz1TiFQ5PKcGgiTPdzlA8e6rGaQDnQk5Pg9VGeA9FpV3Gh3uJ+TzxykHDQjkXFw+6HJOJUK1s63gcT",
-	"Hy/bbJdXZ2++Lln06uxNU779q7M3RrejzAeh4xngL0HsMSfqeHv1i685Z+4Ko7UXgBK/OkdM6RdGlzWN",
-	"E4B6RG3ZmQScDlmjJcfRCj15dfbmqVGPH8yRiVO0puIMx9Rb7dWkrmfL423b02e6uYU2QeotavWNHwe6",
-	"KCMd/62zpuELhNEcS2+l8aTZMQj0twREUvqo0PgEizX1nj6QSyefuHb+TEy77/rA/bn+3UTuU7eDkisK",
-	"PBOqR96KBL4OzI9R2m1KJG55ah67g8iEUYVkUQT+GCVh3ZPpz4iYDjhqbiIQDjhgf23sBgk8tF3qsXSG",
-	"VA2IBzlX7aP35NTSfckbDl7a1X1bSQd7VBgMfZUJaeqfhglX6WaS5vmilDdz50JL4w2PhZ61/lRcqp9F",
-	"3hU3RufpKTAZK/bZIV3uxXWOCge0gsAfovsVCfJ1rMkpyQ6S7rdAaAxIsuQtKsKo89Skx5IIvZ4xt3Es",
-	"dFev2mOj9/D91DSdGstbX96R0bRV7EnoKOnVue0jwkHEITSmfMWhOiTlIzpGl+YPOXZXZ8NM6ButVbcm",
-	"JIymB8G6SKV+1vCjLCpyLI66Ho2EpnXHwoD9/Vw0nYuEUl/ewTDUrfJkjzOxIjKYJKW4rTlrQZClLhol",
-	"KBP79nkVrSit4hBTlDy0MkavQJAltdlmXswD8xIOOn97ge4Zv10E7F7otiz5JgjmjOBcAb4+TZ4CQzee",
-	"TLIi1bUiANC9uqkogC+Q6X/nOhK6vsRsuLn6eQP3/66SxSrg1gVk3iYFIeaLrVQR9/fBVMM2BXgSvsgV",
-	"ItfEgB11QwXupbl+xs0hv2rn40dN8Sq4bRTPowJ5doeH8OVqgFzQ1FK5SMW2WF0VNY86clffcnvPcTwH",
-	"3hzs9K5KuMME+TZnwCxk59hLVx7sJnImn/L/7BTW2z77tita7wpA9gj2ubjhUVRjOUjbLFDqQ0ePiiC7",
-	"Cig9UApNH4EU+lJLkfqx6oZyZyKTVr/Om/MGXBrQIxY8CuAi5gTQwxDyGqivPbcliDYhYmI8NWbDFp5w",
-	"eNRmSRFSV35YYiwavo+5zaQ+YN+cyAlSfcGXHT5KVOq2ctPtU29nxafOt0L2XYO6IQ99lakIrgtkOzxb",
-	"K5EaK1+UKXcVU/FyvWkV9T5zZnfsQ+yeA6txuq2EV+1QrqO09e41G8xb8Pzu1EK+iumBTOIaz/BVTL9c",
-	"mxfuC9XlbazTKBg6x9VvOKZCP+kl0tC3ZPk4rc7iH6OLLDS+wgJh81p75kS2kRJq+iOj9OX6oanSTh9/",
-	"IiILvVvvaC4qH2J+Cz7CIoNgwwg9epI+9jVE5p0vHadN531aH8PfS8TlsDGUq28hGG9SXvqFVYqnhzW1",
-	"YX0D0hYriq+JXXS5cW1V0lVa4KqH5It+IMqKDw9nKTCJTSWkyDXXrIOyR9Fan7yM66TJiGnsqSSokqqG",
-	"LcfoptA9PJOcRqSmgeZCysUQzWNlxup7IhOYgU7aapaSNckY6EkYC4nmkBydp7XpGd+IQPzS8yxyaW4P",
-	"FHxdkyqy/Ai2yKLZWnvhLNRMGGAhUXoXa9btwKzd0iO+Eb78evIcNmFMm3zaaOte2zGPvDK0/CJqGOKR",
-	"APVF3go1F4a5ABZp6/YnMF6Oh8i+fzxMZHb39u2OBhKlW0sT5xbWauGAsVsUR+gJt0c1eZxJDapb1Ty0",
-	"X7/kLs9P9V3wTiZ/ktqcvQdueHSuMXG4OHwCl6NglkW235PVLAyPFNunJIemzcVwbV/2fLxOhsJblnt2",
-	"M9g326t8ZI7Kt1VDa85FTRFtxm9tcnxCwojxhpDXhf59SxJ9R6xZgPFADvgSDCIOnF5OM0zrEIGs9Ggw",
-	"GoXJdeVcd8/Kqv4fJ0sXOPRlHNwiw1GZyFSqZ4i56YKjd/z3s1/fIv1kbIilLDyv04NzP2mkdUoW2Ypc",
-	"7dBLwgDUIz57bcuAvsQycCOCam65OhfN46DEdF930uH7/qb6U6EYvKCQ1EdhD0atXcVq+6sve2OV7zXh",
-	"dTXhDYKm+yXR7j3WZNiT/3i/8qmlt5lVn3PNxB6Rv9jIL+xxJkzhBDeNIzt7iqucUC7ILvkBtJYtsmBG",
-	"5rI2jl4fOLkDP/Op2cV+EOUEA6PI0T9jiNWEYk29zEfndLvZ3dpA2sq8K20LanUz4pPptDg2F3fzGQU1",
-	"4qQ4gvEKXNazt1BUcNZ2aD/2Xvx5LSdhq0Hq34lcXSsatkSrS8VmloLfRbOjOt0RI887bno4FiWEUaBO",
-	"XtuLNmEkb9Kx32oiTREPvV64CSOJMmRvK7+mPHFT6/cwkqMMgg5v4OS2+qi9Y0VQD/eiTh5f7lcp8rT6",
-	"xjxnJU6t86E5+LRddk0+Jf950fH5ny2ydrt8ukmB6/d8UAFfX6i3okT2NonU0GT5kZFsekDJ8SjeNSpA",
-	"5HjfyHHdNL5zdHj67vCdpE3vp0Ny2XfXiGx4oKm7VFP3Vz6xpCWXrjfz7y83o9WSK3TpFmbkwWRUqSk3",
-	"kcKC5LSOCqk/elz6RPiEgzRvANTlD5PlErjQj9tLZfsvELb5tumz1mOUuTiUPmRG6mw3nUpsGrAw40Kw",
-	"35pf894M9SOhHocQqNQ9CKT206QVFTlHx02WUCTTDGfwdfYEkixNlCILRCS6x7q1WboyllDjK4Eol6OU",
-	"H48YRyH+qIEiOjHKA/DBd+cuSb7+RX+80cPqOaYfPppX2FuPiKYWoUQSrHOyk7wSK2pLPq8vJb1Js2CZ",
-	"392nrN4t2FLCs1lMpODm+l6+85DynQbHUiw0ORpo+F6P+DafQ1Z7704+g8vDtbrBQWBhyEht/p2j9SRs",
-	"rAH+dX3J2YIEMNgxWp1NP01Oud6E0tM0HFs4D0kFrpeb/weRrlDFVqO9U0TRrgyPdJUD2Rx1NHpvr7sq",
-	"jfZlZjzYBqhnBfSE4lD3+poofSzEJHjacpgmERbinnFf65gurjlfYbpU9EwG7sifqpdJFunFNS4Xlp0H",
-	"eXpaV+72/t8V16A4yZehtp5W3d4X13y/00ds1QpfqkswFoXcs0xe1t0nW0bnHuSboc5DnXT7pI4xmbVA",
-	"LvvyOl1oD6fRri5BBdlju/8Umr+VFhC1B16PBi/mRK41t5gumWexXA1e/PFBcYUAfpfwUullwMsLdHeE",
-	"5lgAihQTDQcxDwYvBhMckcndkWYqu2Ll26xLp0k08O3jsGkNh0Kbo1hF0y3EFC+1/8X1ZaK/f6p5kr75",
-	"6/SB7uoEuuFr89em+bxj7Xy2QPMU1npsC0a17qLoA60rs2meJsk3a9hQsaOIC5RyM5HqZH+NQ0xHhI7k",
-	"CkYBY1HW4dMxoe7pWZ3E0fKrAapixyVXUZSQSHLs3erXGaiP2FwdBTwnAZFr15QmIevzh8//EwAA///K",
-	"ugLRwhsBAA==",
+	"H4sIAAAAAAAC/+x9i27cOLbgrxDaBdrBlqvKjpPuzsUA13HSGd9J0l7bmd6Z7qDAklhVvJZINUnZqTEC",
+	"3H/Y/cL7JQs+JFES9SqrqpwHMJiOSxJ5eM7h4Xnz3vNpFFOCiODei3svhgxGSCCm/jpdIiLOgwsoVvLP",
+	"AHGf4VhgSrwX+iH48OH8lTfysPwllu+NPAIj5L3woP7YG3kM/ZlghgLvhWAJGnncX6EIyhEXlEVQeC+8",
+	"JMHyTbGO5adcMEyW3ufPI+91jP06COSzBgCQ+nSA+S8T0ggCS0gLGGqEB0Ly1/Prt5fozwTxWpLIVwDT",
+	"7zRAtMIizEZ6IFR1oFwiThPmowYw8EPnfk8FXmAfyinr4LDfAT4lC7xsAIkURnwgeBdwiS7kfqpCJR8B",
+	"kkRzxFJA/kwQW+eQxHCJPHu+AC1gEgrvxdHIizDBURKpf5t5MRFoiZieGLGGuc8FijiIEQNmDuf0iM3q",
+	"QTiejrwIfjIwTKftEDH6n8iv5VvzuIEwcTrAA2nSsJUvG3cxG2AHX1EmXq5ryPILRmEABAWcMgHm6xrC",
+	"yKcz9dRBF89nCAoUzKBwAyBQ3LR8LlDcgAOuPn8oEgRl6zog1MNGCNTHDwThGkVxCAVqYMcoFkCY1xrg",
+	"EdlIDwLps/yYx5RwpM7dlzAw8ln+5VMiEFH/hHEcGvE0+U8ugb23pvmfDC28F97/mORn+kQ/5ZPXjFGm",
+	"pyou9iUM0iPD+zzyzihZhNjfwcTZCeGbKcEBGi/HIEj0VAigCOLwiYTqF8rmOAgQ2T5Y2VTgEMAgwgRA",
+	"30ecg4y8+uT5hSYk2CGWCBVgoeb8PPI+EJiIFWX4X2gHMBRmU7PHjEqcwHmIXhOBxXr7QPwdhjjQxzgy",
+	"76RbLNdVlQrLaIyYwHorWRLR3ogBFOhQ4AhVd+NIKibtm3bk4UgekBXp8Yr6N4gB9RQwtEAMER+BBWVA",
+	"rBBQarFUGeXskvcFxESpAZUJIhqgsDrB27fvgHoEcICIVFgQM3vnD88PYRKgQxon/PDk8Pkf3ij/kVNC",
+	"kNA/P3FNqKXavTzb3yKylLLx+Nkzdbqnfx85PjOH80zjrcy/eteAuxUigPs0RgBz8Ef60R/evwGShKHC",
+	"zzKkcxhqFHFvVCGBfFHyXCphK5Co8atA/OHpkf/wzNgAMgTgLcRqOAB9RjkHMAyBAYv/mw2i/ZWaQh3U",
+	"EHBMliFKvxn/QbyRh4hUg343M3oZdryPDnjT82Nm7Z2SSg9JEKI5ZFxOUziW0m8c4yZx0JPrP9vn1+9a",
+	"N1fskLJhyu8OoFO8j4r6hwVEvnY6V8iQJ80KEqmkcn5HmX3elTZwwhgiYhabFxV/NvMjQXd1r//UtvDK",
+	"dKXhnCuhXLyCAl5Q7BJBEgvyv+gTjGLJvN7x9Pj54fT48GhqM7l6z8UkVMBw5lMuZgkPCiNNx0fHT0/s",
+	"MWgi90c2irExyqtMpyqOXLe2qySKIFtXVwZvl/praS4o3WxzCEfePAmWSMxCHOHqSo+mncaIEcM0mCES",
+	"1GD8x+vp9IX63z/LuK89D8ygXEAm6gi5wbAW9iNKxKqy5qfjk2fPf+y07gYeORofPz151neUO4RuHMR8",
+	"9vzHn/qzWwm6EkYLVBvVMZWTOZW4USd/rfzITun643Woc9A6fVKDLBX+A5wLzXKrq6yuR6PydNVhsXAo",
+	"2TtAOcDk2S1VRKmNGFfLAkGRMCRPcRuL0+m0Qe/Ih/3AEQOnhSFLI3Whh4Ai4UWCzKF/E9KlRZD8F0xm",
+	"MaNLhrgEO6AEOYjjwns9Um3305nyPtUfdCtICApneqT7DL4Ac18fRHdovqL0Rk6XYyp/XFm/dncpQR0E",
+	"WIIAw4vCnJVPsnHvvYSF3gtvJUTMX0wmZpqxT6MJjPHEwMIn4/FYcWx5/YhI1SooYF9rbdkcBSVuTmmI",
+	"IFGf3kpta7bAoUCswBe/eywhEoY4RAIpozsh4wXEcqaPIw8LFLkXZn6AjMF19dC3UZ/hrQxIPZWN/6qW",
+	"tEp9nBmdv6rjnaVGQGYWJFyrmOgT8hORGg1coJiDA4NOLl/4IVDWxg8ALwCNsBAoeGLxtn7qjbybZI4Y",
+	"QQLxEvekL1QQZmaZ1Rghr/RjcKZMC2OP0FvEGA60sWPDjAkQK8yBJQ4zEEoWSxc1v1YanQKu/mlNZMmM",
+	"I7f0WWIh9/0tDjS3FRf6BguQPjVGXL6QEjGWWKySeR0x9FNPTRhC+Y85FvPEv0GiSJTsRSeogt4gMkPk",
+	"1uHshhECdKHsTERuMaMkkkS4hQwrQ2dFwwCTpXphiQVQY4EDQoX6Sf+JBUfh4kmBSG/Or//64eXs+te/",
+	"vX7fhUJVif5uDS5cROkiyBmK6UzJo/KKP1y+TRdsSPIDVyuTn3AstYfCOlJxplGspBlly0m0Psw5pmVx",
+	"/Q4A7UtMPY61EqKKr3SDncu/FRX1UP2x51Im8nn+QRNl1+J0HskfSu0C9/da/bpB68+fpZxvn6p0dmWD",
+	"KveoUMRg6BajOzkWYkpH8RMuaFTcAvaHnRQfh1GqvqunzGVCaskR4xiFmKjRzBFafEGJNaVepidOSeL7",
+	"qXCq3RqdlmXGca2i8UTT8Lk+0yTt5OKqjGm+HFXwU49l5dGvPxh9H8UCEh/NfIYFYhg6cRagGJGAzzRK",
+	"u57yIxV7nXV0592gdXFnXB1Oj4q77Znr+NArxrduIyOzCWx1Uxs6C6ZYVf6TryBDgdMUyJXYJrepQvOV",
+	"flXiATJpSi9wiHg/jAkswpIkyiVQSJeYpGHDshRqZh6J3XR0F7dIO6LNe1u2u48Oj55dH01fPO1ndz/E",
+	"lqnxFedj/PjjFP10Mp0eouOf54cnR8HJIfzx6Pnhycnz58+enZxMp9Opw7O5sUnU4ozNP3/+fBjAcn7s",
+	"akDlMORvOoaVwsWniUlEaWX2M/1qxdk5CJO4vKEWYjPXqEFGCfx+flDJda9O37wOtJuidM6o4I8jUKqD",
+	"QvqcvkFrqYhKEYmIvy5qbkaKVTe+EhHVka/V766RRWXg4/YzQ8OfTdeAgPc0cCDggcK78mII1y4t/5+I",
+	"0cM5lGaXtrnkvlfvAkwC9Mle+bSa4lDYFl3YvbuY7cCZtmy1eFIvtQHjlybmXMU6Cpalg6MxZmdxsONI",
+	"ITToP5jihjYtR488MuDWrfQt5m6vPOwFlGtpMVxiAtOTpGmEi/xNhzMeeoWx6lZymZBTpTFpv0qJZlLX",
+	"YQmpSP6ff96W5JeLC5JQPi/Ieev3GlGPEdfSsgDqM2fykI0re5El8ZsP2YC+V0hAHDoUjdSl1BQya7V6",
+	"Nwk291FRO75WVAE2oKuU95p4LCFE/8t2uhmHm+TZhGu9NSd+/nEd5Xttu8uEqPO+VRhUD+kUtRajFA7m",
+	"FJwGftFTV9hlyWgSz/TJMPxZkm/i/gFwxzHUQpB1dz4xzgCHG4bgP5NUHbGyEu6wWMmjLPWWofFyPALy",
+	"bO6ipNTbnzb+s0U7yahSRaqy0v2zb1QQS+m+en05e//r9eyXXz+8f+W2JqRE4fVe9gKlcsgixLmJTJV0",
+	"fIk0cP4KwLl/dPzUSvxpjV1L8PORq/goC1OFBRfafqFsSUVrbF4laBVXkHDE/t38OfZpZB8s+vW2Vei3",
+	"XFBZGdDDJPoEeLGoT734QCQTB0C+lSZbgAWjUTGPp8u2XEKB8sBOhiwYx4zewnB3sp4h5aygZMYQNIlZ",
+	"rdAzxGl4+8CzUbv9hhmEbSoe6yWr81UuUDzEKarprONVigC9zsw+MFgSut0W0q+3+K/UO4OaKzZm8/XZ",
+	"0BentbeP+yhvERYDGAC26NmvHXAexZSJK6261EvDOqF2Ce9ABNlNQO9IJtTUifOP03dvgfJJRlAIxMxp",
+	"Pg+pf8M7nD31+QUlkLmKBTuP5O6qYT7m2qSMVqli1NRqmExlqQC6AEYDBGIFBdCvA0EBVoN7Lt1MP2oe",
+	"laC7cA0Mf6ZzOEczrqGmwcwrGagHN2gNYMgQDNYAfcLcRBlbDKcM7nxSS483yG8m3vp1s9ZUXME76K8w",
+	"QYcSUBV7VHMAo6PUOXBc5QDKCRXBNZgjgKJYrAFeqB99moSB0o/kk0+CQb+IDCvXJ9e2SvmVSQRJGUj7",
+	"lW6O7XT8kcaGC5FvpZjcsiolpUee92gZ5MhPGLr4d86P7FGsJMcuOpk1umuB7zQO6r1KTpX3fKEj6moK",
+	"gDlgaCmZmqFgBCBgiCMBQkxuwApyMEeIAN4lLlivBY+8dzRA4Rnl4iVDUIlCB7Bp3kNTpoIjp+8GET7D",
+	"JE6Kro2n06nKPshwj4l4fuIUCmYMmojyIM96jJFm3PXPoiwj0qSUWUOW1lkG2YXyaiLUV58BtZXglZVW",
+	"9QjyqLYX/9p2GGsfQaNuaWY5jfvFkao7bAC917Ft2/xwanwXgBcFJbmUcFE+F45cUi2rSrXfPJ7WCsDC",
+	"eyfHrUqS/miUFt9m0zlXo002uypboGhAv0RtvpOgQFrByguhfBMHeAEuLrUyyJ/UOxMaisVVgWMnm7iz",
+	"Kbols7XOomwwJlssxSolB9g4NezhyriocOrTVkY1pqL+1Lkmk6BTd9RuP0ugnB/ViCwD7ZVAsQtFzcL6",
+	"eABhXZDTGvhWgVuAuiYDbNacEVfKhBNIKVc9E+JGHkwEnRknUwFDCxhyp2pQpvtPPw1D91xrNuut6syV",
+	"YsT8txXEN8nhyeGz4to76N3VdJlGhKlcxFlMQ+yv25jzUr57oV9tKpOzCZ4XYhRIU5rYyVQmDXWrOeTD",
+	"ZIj7mPkJFrO5NKIQm8HMi1gE7bcVEiukq1/NN8B8I+09U3EXroFgOI61P6KVgcuTZ8HkOj+KL21SP5Eg",
+	"gjR9Ubl8TGaXHZLLulk4VYvy1BF0BAGvVwzxFQ0DlVBmT57OCeZoQRnSq9bOX/sEaOqoMdpWYtzXkfI/",
+	"ZIb/N5q/vy29IIKfZrrO0+UxVB1lgH6eFcynwWNMwIerV+AAEz2LMuYBJWEx4e1o6vRx1Kw4r31sqVio",
+	"pv3ekSwOlX/z7NkweHpUFQ87s5bNSZqhtk7M1549buHcz442NG8sfJ6vcyHZScN1eBwdeu58LQ/4zoNe",
+	"JqTLkDzNYek0qEmubRm2aR+n3ZzMPlb13NvevUV/Z+kols+AfJZCkYkWVXdcmP943KdUOvPzumZUD7VM",
+	"5g1TPpv29OrmjmHXrPpp+7RHXaetreX2ilgogWexXsbYo3zjNOy8IaxvI9r2G6ot1n7tqLphW5Zdrwq1",
+	"nbtzh6xx20tV217LGOqK53ofnBa7D7OL7f2z3818acKSW4/gVjfaf0CCwCuK+pd+bhoN7tMxpxIbHtXX",
+	"xF6q7KfGPL48L63cSEr+rg40k8Rm7CDbj12qUJ22wW4mc4PKUXsGpI3gsgMAAYLuQPoGODAWPfgJ+Cuo",
+	"chUYL1ppBN1dadpAzo+On7ZRwgRe3ZPryLk2CRnyEb5FAZivQUovy8Xz5u//Cs6OpvNjEc7xUTR/ei78",
+	"6O//+uf/+d9/aRUqGoKW1ADbh1aNtMNPMylG032UBXYKTUbbvDLas1YW1YQSZVGQQ+N28UYeDO/guuTl",
+	"KrzQklhggVuY1rnwhGxYbDBMcQFjlM2svIuN00yLBb8zTmDMV1T0TnvO6gOrZgNiPiICLpF21xkcpV0v",
+	"pv/9X//3aDp9MlKPEvkECqC6owK5/LFX25PWyS/9iyRYX+x3K6wwNRQ1FRY+JD4Kw55FFkPk9P8NrVNH",
+	"A+Sc+jhLQ1ubboMqj//fAI2NNQc54DRCAAVLBHzIEQcRXIMVvEWAUP3puFNx4jD960pBnax6IEshtYpV",
+	"+yg6Fbt7kKBvr+BqtcrD5p6HJgbXZA89HR89658/ZAVn7fxeQ4KCOdkSqDV4r6vh6hmd5j1cIihu9Yhs",
+	"B2cF9NQ3dTCYuaR3D0SLLeScbe76G6S7Y1ZHv7rpZv0Rm3nWQlOnHoqXCRnAGpKqxJ5NoIQ0xbqd+sWG",
+	"uk4azTSc+7iUoZAuZ6kIcphcqn+olf9Sar//Kj1VKcMS3aFuu66CTpirlFfB5NFrNcZllOah2/5VL0pH",
+	"rYmQ/rbC/srMCYVAqsWsgeXgSNcxPqkDpWbqWrW8bNLJSblgUKDlWgess/ibgaVu5swXQ3ymXCoqcWuR",
+	"hMq1OGQh0PY0vxaFb+TdQSzN3FlWJ9araKim0ZB5SpkJhrYVDlQTrLLmF9kwWaOi7vU5lwn5DYvVVXoS",
+	"wzD8deG9+L2LEGzvxtQyhjvRqGMPpY/mJoU2HdB1Ij3tFFzYLPd8S6d3nzw+i+s6ej1rE+aPhkiYP94g",
+	"YX44LaJU5FZq0dqYQj/yGjWKmrL0ru20NspJ3UELrn7NXnZRgt7W3quvF+Fb7Qa2FZO+pu9NH1PeEe12",
+	"9Prb1KGysaX9bHz8bBN5Y7k4crvFmqMRBbXZDvL0b82vCzAXmPiqJN4UVGKicvsCFXvnpfw2VwulHnh+",
+	"GOIq8fviibFZND6vNNgssm6Rr3uQPadNA23TpmqlJBbTnqol9dw0cmvp02NX27Z2N1H6b0u1Rwk5eS+t",
+	"XH8OtHM/L1tyr38A27umA81Ore9sLb+yK3XviNOgShjhIHtV2U2h/MefCWIY8RGgLL22RFfXyjdu0BqE",
+	"lN4ksYqVoA6KeI5ZqY53wN3HdAlXPbuyt9M7lwoflLR/NBcCdGvjX6G0XsVm/fg/mHLxYgnzRi34zUiq",
+	"K+Z7o7tu2oB/82b7Ndh5t75gVGo0FooiTOwI1NGoLkLfPQjfa8H10H6/BuBx1Ktu1Pc/X8THWgIX661q",
+	"iTtkWVTnjs8Gwh3eUfAN30DQKn+Hv4TgGy1R+JJKCVKuSFOjNztOH9s1CPWSZrMrDywsRfGmSGrOBE2n",
+	"KF+it4vbDToj8Mvpmf+V9r5vb21fQ7kPvF+CKEF3h+rnobJEryKs7ifuK1loWCCUuvjWG6kE1q6syxHb",
+	"UYr7UJm22yreaszg7Y374iL3mDme4tHEMRTc/bytkkcG8MYoVtunM0aKJuQnDIv1lRwxDfjRG4xOE9eV",
+	"4v/x27VRfbjUliAHkAB5Cv9KwjXQCdlAD5DeNJ79ld41bhJt01XH+G9orW9KlnpM2vUP6uJx89FfaYzO",
+	"xW+U3XBwjWDkOe7/VjIZnF6cZ3qS/VWqM0WQwKV2/MuTUzLR+A9ybTIF5FfGrWTuq5bqCEvEKhtUTiAB",
+	"ZDC9KjfEPjKNwgy4786vJRcVTE4aI6LHHEsdxXzEJ/LdXGgXVnp6ce6NvFvEuF7jdHw0nqrzKkYExth7",
+	"4T0dT8dPFZ3FSlFvYm4dfnHvGZVS8qfigPPAe+FJvn2j7m48Ta8njiGDERKI8Vp3Wf6K5Dmk7/6v85jZ",
+	"LyNmvf+xdD/88XTa68LtB+w1fa32kJutvJcqHKkcl3RRug3688g7mR7VzZWhZ1K8rFzu1DSsoQeGYVgc",
+	"GRzoW6n/Yn5WDXTgkitZrOf+KMeZyHEnC9UZ+dDO+49NEKLIL8UWyp4WMoiLlzQY7rZ0d5/mz0WZJtX3",
+	"zxUOOh4MiHLfP/ct9kiYFn8B5jEU/goF4ECn4gOm/NYoAP/9X/8PxEy7X8zr8lg0eH2imWDazgQvoYWM",
+	"XFh7L37/aDOEeQfAvErD6jd4i2FWLJExhJTuFjuoGGg9E6iejx/0sb0N+hd6SnYi+3SwufUp7Ni+KizM",
+	"E99HnC8Sib0VggHSzV2vkDg80ydb5ZDMzkN5WmbHXw5NWUf5vLlMqGGIt3QJMJFns2qmhckSpEpXPQNQ",
+	"Hf6r5QCaiIwFCrQ4cdztT5dLFACaCAuD4XoQ6UeXalzVhkX3XGlbnFZjncfhGyTO9CDutW2fz86sNYC0",
+	"C/8AeHqDCjgK1/Z1YChow1navrSeJdJKwi3KhXKxYifRcLR1kqnrDfL+rkUW37KY6HlqyE9+bv/kjJJF",
+	"iP22Y0avGEBVEdjKQBx1UTAKBYpb4yNHEeSOz5kO6kUKYd4suyI7h1MarpAwhMyUhkSaPlmz4sxQqxJ4",
+	"hUV4aAjVbGpYNbIOU6O4/F9UnArM14VaWJAlRClzUlXK5dZkXsyQEaHzvQUVX8Fjtn06dvXXqQwu1lLG",
+	"Cwp0GgVdFHA8nFlSGBXoyKOu181LpQw/SSZy8dNkvj7kAsWTe/n/58HnpsPbWvrLtQow9rVnr9QkF1Cs",
+	"dkYkF4EKLP8wNUB+dNL+0XsqflH38bj1hgJAKgwJWEJUGLILEe/ln2nL0M407E09uzHpdyIWiAiLJJyv",
+	"dXfcvpSbWA053Sf4qX7hKyVjdnhsqn5tn/QbKXkZrxjylfhlE07Rh2uTqldumzEUn2xDZSzDumN9sQ+P",
+	"ZlrN18qjmhqdWNQ4+pvV0ov0pR16v9vfv6JMvFzvQGG0O5R1UhYzpA7pvo5zIqR0zH76+HlUI0T0ffx5",
+	"R8ttbP7CHHtyPmS93xz0MbEsE7Pc3a4v0FEjKbUh8w6jVVLa23Jyj7U2GKAQ6W5yRfq+Ur/n9O23P+u1",
+	"h5P6Do8alGAvmppeLoDNGBzVKs/DI2q6Sxbev5KcBobL+nFRFCUO7BcSUh9GgOFFmDNbdscqTAf6p5e4",
+	"PV7FpcAyGqttu7Ui7yamne+haeernaO2ouyIM3Jnp3kuJAAHqlbqL9MR0B2D/6IazD8BnOqStawzvKpi",
+	"8yEBc5S2IkABgEuIyRicBhEmh5SEa4BIEFNMTEaDw0N7puF4qcHYrlw+K61Z+yMHCCTJj562f/QLZXMc",
+	"BIg8lF10vNhFRu1Q6cFF5l/KIG/P8DDba9MUj3QuTbPR95yQoXNChk4G0Rkg8BZiletcZC9wYP5xqDJE",
+	"AvC/mlJEmvVujbMHMtTHbWrthaq5HevshqOqdFcPivr6JsLr+LjLRzGjUlBKRnhNBBbrDop7yhrQ0NeZ",
+	"OdQgjSb36r/nXXT7QXioXc6caoB6nDuaSo/BGiD1hKg3BR4HXqe72k2L3LG0F8PB5Inq6qyy9WCL03rb",
+	"YW8U25a90V/47oxdCpbGnswGsoF81U0ncmXPXSoPl0uGlspnp26IkIpQlrLMY+TjBUZBphHQW5XGoQog",
+	"9Z0KI317+jztH8J1zJay9UgaESMASaCLE8fgpXUjBtcd6YkfJoHpe1YsRwswj0O4BjCkZMlxgEDC4RK5",
+	"DI3cnXFG+SB6a6mddL5cU1ipkaaLG13pBdl9EzkL5tX+PwZWyaL64+lU/v/PU2d6wQ48LXb7E+dGyJgk",
+	"ZYSMWfYnSOs412Ue6c3Qtlsm/goy0RRytvB1pt7dNquppSmwgKnMGIjdtsBonYwn1cEWCnhBscuIqjLf",
+	"K4jDtUVi5W7Yn+MvcIKjaaXIxBAJEDONCfuxH0sI78h9l/LVbTMfS4i10bfJel+rq8BqTLzXgq0OobqM",
+	"2Ize7W97sYQchugWmQurMrXioZKd5829Ouyu9Cz8rkh09qF8gRqEgsD8tDl/oRj7h1JyT+7lPy8T0pK2",
+	"9lq/tX3z7XUKzvZNbjOVaU3vYADVRUmKGBO401ZDjNih7ljJs/r1/SiTBKAUQmWS18CX84V8vZUvmp3t",
+	"r9Ubj9nJ/ohSTySyuuedKORrGmr6+boJ4FCOcz1+0Vtena3KLc1OcrnGR+0jt3uy7dhFrnBTJ1h2ntCy",
+	"WUBw8zy2gutdSSpMnMdVN7Gkj6pOTvcheLLbUdXL5a7I/nCP+y6DurmPHmmcVoVDk8qwbyJMd7OV957Y",
+	"YzSBsmPekuD1fvk90WlbXvne4n5HPLKX5J8ti4qHnQ95oKBGtnQ8DyYBXLbZLq9O33xdsujV6Zum6spX",
+	"p2+0bkdogLiKZ6BgifgOM+CPh+tW8Zox6q4nX/shkuJXVQRI/ULrsrqPGiI+lkt2lnxlr6zBksF4BQ5e",
+	"nb55otXjB3Nk6hSt6S8AE+KvdmpS17Pl8dD29KnqdadMkHqLWn4TJKEqwc3e/9ZZU/MFgGAOhb9SeFLs",
+	"GIbqW4x42uhCovEA8jXxnzyQSyf3TDl/JvoOo/o0zTP1XOdpZm4HKVckeDoxE/grHAYqDXMMsuazPHXL",
+	"E32DN4p1GJULGscoGIM0rHsy/Rlg3RBTjo05gCFDMFhru0EgFpmrt6BwhlQ1iHvZV+1v78ippS5bath4",
+	"2VVVQ6WY7lBh0PSVJqSudh+lXKU65Os7WTPetPaFksYbbgs1av2uuJCPue2KG4OzbBfo/GRzl6oq7mcq",
+	"I5khsEJhMAJ3KxzaXUvSXZJvJNV+DZMEAUHTC3YxJc5dk21LzNV82tyGicqOq982ag3fd03TrjG89eVt",
+	"GUVbyZ6YHKat+4feIgzxJEKNCf5JJDdJeYuOwYX+wWJ3uTf0gIHWWlWnckxJthGMi1Sou9o/iaIiR5O4",
+	"69ZIaVq3LTTY3/dF075IKfXlbQxN3SpP9tgTKyzCSdp4pTVnLQzzQhWtBOVi39wZqRSlVRJBAtLbI8fg",
+	"FeJ4SUy2mZ+wUF/vCc7enoM7ym4WIb3jqgmf3fJK7xFotVtSu8mXYKg+9GkNjDxWOELgTp5UBKGAA90O",
+	"27UlVLWFXnBzr5sN3P/bShargFsXkEnLFQxFB+kZ098HUw3bFOBJ+cJqO1MTA3ZUiRe4l1jXmzSH/KoX",
+	"oTxqilfBbaO4jQrgmxXuw5erAHJBU0vlIhXbYnVV1DzqyF39DTw7juM58OZgp/dVwu0nyLc5A+YhO8da",
+	"uvJgN5Ezubf/7BTWG5592xWt9wUgewT7XNzwKGrvHaRtFij1oaNHRZBtBZQeKIWmj0AKfamF5/1YdUO5",
+	"MxHpzR/Ok/MauTSgRyx4JMBFzHFT+rtzQl4hEijPbQmiTYiYGk+N2bCFG90etVlShNSVH5Yai5rvE2Yy",
+	"qffYJTF2glRf3m9eP0xV6rbmIsNTb2utRpxXB+6648iGPPRVpiK4DpBheLZWIjVWvkhT7jIh/OV60545",
+	"X1JjihYfYvccWIXToRJelUO5jtLGu9dsMA/g+d2qhXyZkD2ZxDWe4cuEfLk2L7or9BJqY51GwdA5rn7N",
+	"IOHqhl+ehb4FteO0Kot/DM7z0PgKcgCVF9lyIptICdG3YahwiYq/j3RPnuwuWMzz0LvxjlpR+QiyGxQA",
+	"yHMINozQg4Ps7t8R0Nf+qjhtNu6T+hj+TiIu+42hXH4LwXid8tIvrFLcPbSp6f4bJEyxIv+a2EWVG9dW",
+	"JV1mBa7qFbvoB8V58eH+LAUqoK6E5FYr9TooexSt9cnLuEpbyuk27lKCSqmq2XIMrgt3xeSSU4vULNBc",
+	"SLkYgXkizVh1TuQCM1RJW81SsiYZAxxECRdgjtKt86Q2PeMbEYhfep6Fleb2QMHXNakiz4+gizyarbQX",
+	"RiPFhCHkAmRnsWLdDszaLT3iG+HLryfPYRPGNMmnjbbulXnnkVeGlnJaaRTBQ47kF7YVqg8MfQAssot6",
+	"DtB4OR6BOfRvQrocpTK7+2U9jgYSpVNLEecGreXEIaU3IInBATNbNb2rVb5UN+sNWjdOuc39o6CXvPAr",
+	"u1KgdjP509RmygorlBiXq9lbHD6Fy1EwS2PT78loFppHiu1T0k3T5mK4Mhf9P14nQ+Fq+x27GTR2HHyk",
+	"t8q3VUOr90VNEW3Ob21yfIKjmLKGkNe5ej6QRN8SaxZg3JMDvgQDT0Knl1O/pnSIUFR6NGiNQue6Mqa6",
+	"Z+VV/4+TpQsc+jIJb4DmqFxkStUzgkx3wVEr/sfpu7fydyIiKEThMsUenHuvkNYpWWQQudqhl4QGqEd8",
+	"9sqUAX2JZeBaBNWccnUumsdBiemuzqT93/KQ6U+FYvCCQlIfhd0btbYVq+2vvuyMVb7XhNfVhDcImu6H",
+	"RLv3WJFhR/7j3cqnlt5mRn22mok9In+xll/QZ5TrwgmmG0d29hRXOaFckF3yAygtm+fBjNxlrR29AWL4",
+	"FgW5T81M9gMvJxhoRY78maBEDsjXxM99dE63m1mtCaSp0B5JC2pVM+KT6bT4rhV3CyhB8o2T4huUVeAy",
+	"nj3VSNxZ26H82Dvx57XshEGD1L9hsbqSNGyJVpeKzQwFv4tmR3W6I0ZuO256OBYFiuJQ7rxC+VTMkLq1",
+	"Xx/PI/eNL1EsrrOvv9XUmiIeet1wGMUC5OgfKuOmPHDT1T9RLA5zCGw3WRsLZDcWWot/1B60Iqj7u2PR",
+	"xpf7njKbet+Yd63Eu3V+Ngfntsu3yX36z4rvoo3ZsysiB2T2dhl2nYHb74rJAga/UB9HiRHapFbHc0s3",
+	"a35kRJzuUbo8itswCxA5bsV0HFJJJ3JnV1Lun+JbvG9z01Ntn3z33ekiGi767C755Klnp6y0ZOn1Zv7d",
+	"ZX202oiF/t9cv7k3qVVq940FNyA57a5CUpF6b3Iv/6NzjIS+XaAuMxkvl4hxOad8U2cY6Uxek1eH4jHI",
+	"nSdSi9Jvqjw6laSsW7tQ7Zww3+qntp9EPsTEZyhCRKjuBkJ5gLJaDcuFcp2nKoksdxoFKi8DCJqlYOEF",
+	"wALcQdU0LZsZClTjhUGxlf1kvw8oAxH8pIDCKuXKRyhAgTsrSrD1L+pjyVEPYfoufhRJx0ewRRS1MMEC",
+	"Q5XtnWasGFFb8qZ9KYlTigXL/O7eZfUOx5bioM2iLQUH2vfCoIcUBjW4rBKuyNFAww/qjd5a3Vdxt4Fc",
+	"e3fyaVzur4kODEMDQ05q/bdF60nUWF38bn3B6AKHUi/aKlqd7UR1trpahNTTFBwD7Ie0tte3xv+BZzNU",
+	"sdUYPC6iaFuGRzbLnmyOOhp9MMddlUa7MjMebAPUswI4IDBSXcQmUh+LIC5cqe3aTJMYcn5HWaB0TBfX",
+	"nK0gWUp6pi9uyQurpkkn6cU1LjeXGQf4alhXVvgu6F30ZCpQnOTLUVtPq3vcJaVK8X3f066XB1HO8KW6",
+	"DRNeyGrL5WXdeTIwOncg3zR1Huq22yV1tMmsBHLZu9fpQHs4jbZ1CErIHtv5J9H8rTSXqN3w6m3kJwyL",
+	"teIW3X/zNBEr78XvHyVXcMRuU14q3Tl4cQ5uj8AccgRiyUQjL2Gh98KbwBhPbo8UU5kZK9/m/T91CkNg",
+	"rp3NqkMk2hxlMIpuESRwqfwvri9T/d0R8lFlEc1fp8ExxwCqlWzz17qtvWNuOw+heQhjPbYFrFpXUfSB",
+	"1hXwNA+TZrI1LKjYq8QFSrlNSXWwvyYRJIeYHIoVOgwpjfPeoY4BVbfQ6iCOZmINUBV7OVVH03fTN2PH",
+	"3BHvqtXiAggG/Rt1aQQJAJ3LfQTnOMRi7RpL54l9/vj5/wcAAP//UrVeZTIvAQA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file


### PR DESCRIPTION
## Summary

- Add `Agent`, `CreateAgentRequest`, `UpdateAgentRequest` schemas and `AgentIdPath` parameter to `api/openapi.yaml`
- Define project-scoped CRUD endpoints: `listProjectAgents`, `createAgent`, `getAgent`, `updateAgent`, `deleteAgent` under `/projects/{projectId}/agents`
- Define global endpoint: `listGlobalAgents` at `/agents`
- Mark all existing `/projects/{projectId}/templates` operations as `deprecated: true`
- Add `UnprocessableEntity` (422) response to components
- Regenerate backend server interface (`gen_server.go`) — new methods satisfied by `Unimplemented` stubs
- Frontend type generation verified (schema.d.ts is gitignored but regenerates cleanly)

## Acceptance Criteria

- [x] Agent schema present with all required fields (id, name, model, image, template_content, scope, project_id, created_at, updated_at)
- [x] Project-scoped CRUD endpoints defined (GET list, POST create, GET one, PUT update, DELETE)
- [x] Global agent list endpoint defined (GET /api/v1/agents)
- [x] Existing template endpoints preserved but marked deprecated
- [x] Backend code generation succeeds (`make generate` exits 0)
- [x] Frontend code generation succeeds (`npm run generate-api` exits 0)

## Verification

- `cd backend && make generate` — exits 0
- `cd backend && go build ./...` — compiles
- `cd backend && golangci-lint run ./...` — passes
- `cd backend && go test ./... -short` — all tests pass
- `cd frontend && npm run generate-api` — exits 0
- `cd frontend && npm run lint` — passes
- `cd frontend && npm run type-check` — passes

## Test plan

- [x] Verify OpenAPI spec validates and contains all new schemas/endpoints
- [x] Verify backend code generation produces correct interface methods
- [x] Verify frontend type generation includes Agent types and endpoint paths
- [x] Verify existing template endpoints still exist but are deprecated
- [x] Verify all lint and test suites pass

Refs: R-1-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)