### PR TITLE
feat(runs): add slide-in log panel for run steps

### DIFF
--- a/frontend/src/features/runs/RunStepLogPanel.vue
+++ b/frontend/src/features/runs/RunStepLogPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, toRef } from 'vue'
+import { computed } from 'vue'
 import Drawer from 'primevue/drawer'
 import Tag from 'primevue/tag'
 import Message from 'primevue/message'
@@ -24,8 +24,7 @@ const emit = defineEmits<{
 }>()
 
 const stepId = computed(() => props.step?.id ?? null)
-const stepIdRef = toRef(stepId)
-const { lines, sseStatus, clearLogs } = useStepLogs(props.projectId, props.runId, stepIdRef)
+const { lines, sseStatus, clearLogs } = useStepLogs(props.projectId, props.runId, stepId)
 
 /** Format an ISO timestamp to HH:mm:ss. */
 function formatTime(iso?: string | null): string {

--- a/frontend/src/features/runs/RunStepLogPanel.vue
+++ b/frontend/src/features/runs/RunStepLogPanel.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import { computed, toRef } from 'vue'
+import Drawer from 'primevue/drawer'
+import Tag from 'primevue/tag'
+import Message from 'primevue/message'
+import LogViewer from '@/ui/composed/LogViewer.vue'
+import { useStepLogs } from './composables/useStepLogs'
+import { statusSeverity } from '@/utils/runStatus'
+import { format, parseISO, differenceInSeconds } from 'date-fns'
+import type { components } from '@/api/schema'
+
+type RunStep = components['schemas']['RunStep']
+
+const props = defineProps<{
+  step: RunStep | null
+  runId: string
+  projectId: string
+  visible: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+  'update:visible': [value: boolean]
+}>()
+
+const stepId = computed(() => props.step?.id ?? null)
+const stepIdRef = toRef(stepId)
+const { lines, sseStatus, clearLogs } = useStepLogs(props.projectId, props.runId, stepIdRef)
+
+/** Format an ISO timestamp to HH:mm:ss. */
+function formatTime(iso?: string | null): string {
+  if (!iso) return ''
+  try {
+    return format(parseISO(iso), 'HH:mm:ss')
+  } catch {
+    return ''
+  }
+}
+
+/** Compute human-readable duration between two ISO timestamps. */
+const duration = computed(() => {
+  if (!props.step?.started_at) return null
+  const start = parseISO(props.step.started_at)
+  const end = props.step.completed_at ? parseISO(props.step.completed_at) : new Date()
+  const totalSeconds = differenceInSeconds(end, start)
+  if (totalSeconds < 60) return `${totalSeconds}s`
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes < 60) return `${minutes}m ${seconds}s`
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return `${hours}h ${remainingMinutes}m`
+})
+
+const isRunning = computed(() => props.step?.status === 'running')
+
+function handleVisibleUpdate(value: boolean) {
+  emit('update:visible', value)
+  if (!value) {
+    emit('close')
+  }
+}
+</script>
+
+<template>
+  <Drawer
+    :visible="visible"
+    position="right"
+    :modal="true"
+    :dismissable="true"
+    :close-on-escape="true"
+    :pt="{
+      root: 'w-full md:w-1/2',
+      content: 'flex flex-col flex-1 overflow-hidden p-0',
+    }"
+    data-testid="step-log-panel"
+    @update:visible="handleVisibleUpdate"
+  >
+    <template #header>
+      <div v-if="step" class="flex flex-col gap-2 w-full">
+        <div class="flex items-center gap-3 flex-wrap">
+          <h3 class="text-lg font-semibold m-0" data-testid="step-name">
+            {{ step.step_name }}
+          </h3>
+          <Tag
+            :value="step.status"
+            :severity="statusSeverity(step.status)"
+            data-testid="step-status"
+          />
+        </div>
+        <div class="flex items-center gap-4 text-sm text-surface-500">
+          <span v-if="step.started_at" data-testid="step-started-at">
+            Started: {{ formatTime(step.started_at) }}
+          </span>
+          <span v-if="step.completed_at" data-testid="step-completed-at">
+            Completed: {{ formatTime(step.completed_at) }}
+          </span>
+          <span v-else-if="isRunning" data-testid="step-running-indicator">
+            Running...
+          </span>
+          <span v-if="duration" data-testid="step-duration">
+            Duration: {{ duration }}
+          </span>
+        </div>
+      </div>
+    </template>
+
+    <div v-if="step" class="flex flex-col flex-1 overflow-hidden p-4 gap-4">
+      <!-- Error message -->
+      <Message
+        v-if="step.error_message"
+        severity="error"
+        :closable="false"
+        data-testid="step-error-message"
+      >
+        {{ step.error_message }}
+      </Message>
+
+      <!-- Log viewer -->
+      <div class="flex-1 overflow-hidden">
+        <LogViewer :lines="lines" :status="sseStatus" @clear="clearLogs" />
+      </div>
+    </div>
+  </Drawer>
+</template>

--- a/frontend/src/features/runs/RunTimeline.vue
+++ b/frontend/src/features/runs/RunTimeline.vue
@@ -16,6 +16,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   retryStep: [stepId: string]
+  selectStep: [step: RunStep]
 }>()
 
 const stepsRef = computed(() => props.steps)
@@ -45,7 +46,11 @@ function canRetry(group: { root: RunStep; retries: RunStep[] }): boolean {
       data-testid="step-group"
     >
       <!-- Root step header -->
-      <div class="flex items-center gap-3" data-testid="root-step">
+      <div
+        class="flex items-center gap-3 cursor-pointer hover:bg-surface-50 dark:hover:bg-surface-800 -mx-2 px-2 py-1 rounded transition-colors"
+        data-testid="root-step"
+        @click="emit('selectStep', lastStep(group))"
+      >
         <span class="font-semibold text-surface-800">{{ group.root.step_name }}</span>
         <Tag
           :severity="statusSeverity(group.root.status)"

--- a/frontend/src/features/runs/__tests__/RunStepLogPanel.spec.ts
+++ b/frontend/src/features/runs/__tests__/RunStepLogPanel.spec.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { ref } from 'vue'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import RunStepLogPanel from '../RunStepLogPanel.vue'
+import type { components } from '@/api/schema'
+import { useStepLogs } from '../composables/useStepLogs'
+
+type RunStep = components['schemas']['RunStep']
+
+const mockLines = ref<unknown[]>([])
+const mockSseStatus = ref('open')
+const mockClearLogs = vi.fn()
+
+vi.mock('../composables/useStepLogs', () => ({
+  useStepLogs: vi.fn(() => ({
+    lines: mockLines,
+    sseStatus: mockSseStatus,
+    clearLogs: mockClearLogs,
+  })),
+}))
+
+const mockedUseStepLogs = vi.mocked(useStepLogs)
+
+vi.mock('@/ui/composed/LogViewer.vue', () => ({
+  default: {
+    name: 'LogViewer',
+    template: '<div data-testid="log-viewer" />',
+    props: ['lines', 'status'],
+  },
+}))
+
+vi.mock('primevue/drawer', () => ({
+  default: {
+    name: 'Drawer',
+    template: `
+      <div v-if="visible" data-testid="step-log-panel">
+        <slot name="header" />
+        <slot />
+      </div>
+    `,
+    props: ['visible', 'position', 'modal', 'dismissable', 'closeOnEscape', 'pt'],
+    emits: ['update:visible'],
+  },
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function makeStep(overrides?: Partial<RunStep>): RunStep {
+  return {
+    id: 'step-1',
+    run_id: 'run-1',
+    step_name: 'dev-story',
+    step_order: 1,
+    action: 'agent_run',
+    status: 'running',
+    started_at: '2026-02-17T10:30:00Z',
+    created_at: '2026-02-17T10:00:00Z',
+    parent_step_id: null,
+    retry_count: null,
+    retry_type: null,
+    ...overrides,
+  }
+}
+
+function mountPanel(props: {
+  step: RunStep | null
+  visible: boolean
+  runId?: string
+  projectId?: string
+}) {
+  wrapper = mount(RunStepLogPanel, {
+    props: {
+      runId: props.runId ?? 'run-1',
+      projectId: props.projectId ?? 'proj-1',
+      step: props.step,
+      visible: props.visible,
+    },
+    global: {
+      plugins: [PrimeVue],
+    },
+  })
+  return wrapper
+}
+
+describe('RunStepLogPanel', () => {
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('renders the panel when visible is true with a step', () => {
+    mountPanel({ step: makeStep(), visible: true })
+    expect(wrapper.find('[data-testid="step-log-panel"]').exists()).toBe(true)
+  })
+
+  it('does not render panel content when visible is false', () => {
+    mountPanel({ step: makeStep(), visible: false })
+    expect(wrapper.find('[data-testid="step-log-panel"]').exists()).toBe(false)
+  })
+
+  it('displays step name in the header', () => {
+    mountPanel({ step: makeStep({ step_name: 'code-review' }), visible: true })
+    const stepName = wrapper.find('[data-testid="step-name"]')
+    expect(stepName.exists()).toBe(true)
+    expect(stepName.text()).toBe('code-review')
+  })
+
+  it('displays step status tag', () => {
+    mountPanel({ step: makeStep({ status: 'failed' }), visible: true })
+    const statusTag = wrapper.find('[data-testid="step-status"]')
+    expect(statusTag.exists()).toBe(true)
+    expect(statusTag.text()).toBe('failed')
+  })
+
+  it('displays started_at timestamp', () => {
+    mountPanel({
+      step: makeStep({ started_at: '2026-02-17T10:30:00Z' }),
+      visible: true,
+    })
+    const startedAt = wrapper.find('[data-testid="step-started-at"]')
+    expect(startedAt.exists()).toBe(true)
+    expect(startedAt.text()).toContain('Started:')
+  })
+
+  it('displays completed_at when present', () => {
+    mountPanel({
+      step: makeStep({
+        started_at: '2026-02-17T10:30:00Z',
+        completed_at: '2026-02-17T10:35:00Z',
+        status: 'completed',
+      }),
+      visible: true,
+    })
+    const completedAt = wrapper.find('[data-testid="step-completed-at"]')
+    expect(completedAt.exists()).toBe(true)
+    expect(completedAt.text()).toContain('Completed:')
+  })
+
+  it('shows "Running..." when step is running and has no completed_at', () => {
+    mountPanel({
+      step: makeStep({ status: 'running', completed_at: undefined }),
+      visible: true,
+    })
+    const runningIndicator = wrapper.find('[data-testid="step-running-indicator"]')
+    expect(runningIndicator.exists()).toBe(true)
+    expect(runningIndicator.text()).toBe('Running...')
+  })
+
+  it('displays duration', () => {
+    mountPanel({
+      step: makeStep({
+        started_at: '2026-02-17T10:30:00Z',
+        completed_at: '2026-02-17T10:35:30Z',
+        status: 'completed',
+      }),
+      visible: true,
+    })
+    const duration = wrapper.find('[data-testid="step-duration"]')
+    expect(duration.exists()).toBe(true)
+    expect(duration.text()).toContain('Duration:')
+    expect(duration.text()).toContain('5m 30s')
+  })
+
+  it('displays error message when step has error_message', () => {
+    mountPanel({
+      step: makeStep({
+        status: 'failed',
+        error_message: 'Container exited with code 1',
+      }),
+      visible: true,
+    })
+    const errorMsg = wrapper.find('[data-testid="step-error-message"]')
+    expect(errorMsg.exists()).toBe(true)
+    expect(errorMsg.text()).toContain('Container exited with code 1')
+  })
+
+  it('does not display error message when step has no error_message', () => {
+    mountPanel({
+      step: makeStep({ error_message: undefined }),
+      visible: true,
+    })
+    expect(wrapper.find('[data-testid="step-error-message"]').exists()).toBe(false)
+  })
+
+  it('renders LogViewer component', () => {
+    mountPanel({ step: makeStep(), visible: true })
+    expect(wrapper.find('[data-testid="log-viewer"]').exists()).toBe(true)
+  })
+
+  it('emits close and update:visible when drawer closes', async () => {
+    mountPanel({ step: makeStep(), visible: true })
+    const drawer = wrapper.findComponent({ name: 'Drawer' })
+    expect(drawer.exists()).toBe(true)
+    await drawer.vm.$emit('update:visible', false)
+    expect(wrapper.emitted('update:visible')?.[0]).toEqual([false])
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('calls useStepLogs with correct arguments', () => {
+    mountPanel({ step: makeStep({ id: 'step-42' }), visible: true, projectId: 'proj-X', runId: 'run-X' })
+    expect(mockedUseStepLogs).toHaveBeenCalledWith('proj-X', 'run-X', expect.any(Object))
+  })
+})

--- a/frontend/src/features/runs/__tests__/useStepLogs.spec.ts
+++ b/frontend/src/features/runs/__tests__/useStepLogs.spec.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, nextTick } from 'vue'
+
+let capturedOnEvent: (eventName: string, data: unknown) => void
+const mockStatus = ref('open')
+const mockClose = vi.fn()
+
+vi.mock('@/composables/useSSE', () => ({
+  useSSE: vi.fn((_projectId: string, onEvent: (eventName: string, data: unknown) => void) => {
+    capturedOnEvent = onEvent
+    return { status: mockStatus, close: mockClose }
+  }),
+}))
+
+/** Helper to build an SSE event envelope matching the backend model.Event shape. */
+function makeLogEvent(overrides: {
+  run_id: string
+  step_id?: string
+  message: string
+  timestamp: string
+  raw_line?: string
+}) {
+  return {
+    id: 'evt-1',
+    project_id: 'proj-1',
+    entity_type: 'log',
+    entity_id: 'step-1',
+    action: 'emitted',
+    payload: {
+      run_id: overrides.run_id,
+      step_id: overrides.step_id,
+      message: overrides.message,
+      raw_line: overrides.raw_line ?? overrides.message,
+      timestamp: overrides.timestamp,
+    },
+    created_at: overrides.timestamp,
+  }
+}
+
+describe('useStepLogs', () => {
+  let useStepLogs: typeof import('../composables/useStepLogs').useStepLogs
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockStatus.value = 'open'
+    const mod = await import('../composables/useStepLogs')
+    useStepLogs = mod.useStepLogs
+  })
+
+  it('appends log line when log.emitted event matches runId and stepId', () => {
+    const stepId = ref<string | null>('step-1')
+    const { lines } = useStepLogs('proj-1', 'run-1', stepId)
+
+    capturedOnEvent(
+      'log.emitted',
+      makeLogEvent({
+        run_id: 'run-1',
+        step_id: 'step-1',
+        message: 'hello world',
+        timestamp: '2026-02-17T10:30:00Z',
+      }),
+    )
+
+    expect(lines.value).toHaveLength(1)
+    expect(lines.value[0]!.text).toBe('hello world')
+    expect(lines.value[0]!.timestamp).toBeInstanceOf(Date)
+  })
+
+  it('ignores log events with different stepId', () => {
+    const stepId = ref<string | null>('step-1')
+    const { lines } = useStepLogs('proj-1', 'run-1', stepId)
+
+    capturedOnEvent(
+      'log.emitted',
+      makeLogEvent({
+        run_id: 'run-1',
+        step_id: 'step-OTHER',
+        message: 'should be ignored',
+        timestamp: '2026-02-17T10:30:00Z',
+      }),
+    )
+
+    expect(lines.value).toHaveLength(0)
+  })
+
+  it('ignores log events with different runId', () => {
+    const stepId = ref<string | null>('step-1')
+    const { lines } = useStepLogs('proj-1', 'run-1', stepId)
+
+    capturedOnEvent(
+      'log.emitted',
+      makeLogEvent({
+        run_id: 'run-OTHER',
+        step_id: 'step-1',
+        message: 'should be ignored',
+        timestamp: '2026-02-17T10:30:00Z',
+      }),
+    )
+
+    expect(lines.value).toHaveLength(0)
+  })
+
+  it('ignores non log.emitted events', () => {
+    const stepId = ref<string | null>('step-1')
+    const { lines } = useStepLogs('proj-1', 'run-1', stepId)
+
+    capturedOnEvent('run.started', { payload: { run_id: 'run-1' } })
+    capturedOnEvent('step.completed', { payload: { run_id: 'run-1' } })
+
+    expect(lines.value).toHaveLength(0)
+  })
+
+  it('clears logs when stepId changes', async () => {
+    const stepId = ref<string | null>('step-1')
+    const { lines } = useStepLogs('proj-1', 'run-1', stepId)
+
+    capturedOnEvent(
+      'log.emitted',
+      makeLogEvent({
+        run_id: 'run-1',
+        step_id: 'step-1',
+        message: 'line for step 1',
+        timestamp: '2026-02-17T10:30:00Z',
+      }),
+    )
+
+    expect(lines.value).toHaveLength(1)
+
+    stepId.value = 'step-2'
+    await nextTick()
+
+    expect(lines.value).toHaveLength(0)
+  })
+
+  it('clearLogs resets lines to empty', () => {
+    const stepId = ref<string | null>('step-1')
+    const { lines, clearLogs } = useStepLogs('proj-1', 'run-1', stepId)
+
+    capturedOnEvent(
+      'log.emitted',
+      makeLogEvent({
+        run_id: 'run-1',
+        step_id: 'step-1',
+        message: 'line 1',
+        timestamp: '2026-02-17T10:30:00Z',
+      }),
+    )
+
+    expect(lines.value).toHaveLength(1)
+
+    clearLogs()
+    expect(lines.value).toHaveLength(0)
+  })
+
+  it('does not connect when stepId is null', () => {
+    const stepId = ref<string | null>(null)
+    const { sseStatus } = useStepLogs('proj-1', 'run-1', stepId)
+
+    expect(sseStatus.value).toBe('closed')
+  })
+
+  it('prefers raw_line over message', () => {
+    const stepId = ref<string | null>('step-1')
+    const { lines } = useStepLogs('proj-1', 'run-1', stepId)
+
+    capturedOnEvent(
+      'log.emitted',
+      makeLogEvent({
+        run_id: 'run-1',
+        step_id: 'step-1',
+        message: 'parsed',
+        raw_line: '{"raw":"data"}',
+        timestamp: '2026-02-17T10:30:00Z',
+      }),
+    )
+
+    expect(lines.value[0]!.text).toBe('{"raw":"data"}')
+  })
+})

--- a/frontend/src/features/runs/composables/useStepLogs.ts
+++ b/frontend/src/features/runs/composables/useStepLogs.ts
@@ -1,0 +1,91 @@
+import { ref, watch, type Ref, onBeforeUnmount } from 'vue'
+import { useSSE, type SSEStatus } from '@/composables/useSSE'
+import type { LogLine } from '@/ui/composed/LogViewer.vue'
+
+/** Shape of the SSE data for log events (full model.Event from backend). */
+interface SSEEventData {
+  id: string
+  project_id: string
+  entity_type: string
+  entity_id: string
+  action: string
+  payload: {
+    run_id: string
+    step_id?: string
+    message: string
+    raw_line?: string
+    timestamp: string
+    level?: string
+    is_json?: boolean
+  }
+  created_at: string
+}
+
+/**
+ * Composable that connects to SSE and collects log lines for a specific step.
+ * Filters `log.emitted` events matching both the given runId and stepId.
+ * Reactively watches stepId — when it changes, clears logs and filters for
+ * the new step. Cleans up the SSE connection on unmount.
+ */
+export function useStepLogs(
+  projectId: string,
+  runId: string,
+  stepId: Ref<string | null>,
+) {
+  const lines = ref<LogLine[]>([])
+  const sseStatus = ref<SSEStatus>('connecting')
+
+  let closeFn: (() => void) | null = null
+
+  function connect() {
+    if (closeFn) {
+      closeFn()
+      closeFn = null
+    }
+
+    lines.value = []
+
+    if (!stepId.value) {
+      sseStatus.value = 'closed'
+      return
+    }
+
+    const currentStepId = stepId.value
+
+    const { status, close } = useSSE(projectId, (eventName, data) => {
+      if (eventName !== 'log.emitted') return
+      const event = data as SSEEventData
+      const logPayload = event.payload
+      if (!logPayload || logPayload.run_id !== runId) return
+      if (logPayload.step_id !== currentStepId) return
+      lines.value.push({
+        text: logPayload.raw_line || logPayload.message,
+        timestamp: new Date(logPayload.timestamp),
+      })
+    })
+
+    closeFn = close
+    sseStatus.value = status.value
+
+    watch(status, (val) => {
+      sseStatus.value = val
+    })
+  }
+
+  watch(stepId, () => {
+    connect()
+  }, { immediate: true })
+
+  onBeforeUnmount(() => {
+    if (closeFn) {
+      closeFn()
+      closeFn = null
+    }
+  })
+
+  function clearLogs() {
+    lines.value = []
+  }
+
+  return { lines, sseStatus, clearLogs }
+}

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -13,8 +13,12 @@ import { useRunsStore } from '@/stores/runs'
 import RunLogViewer from '@/features/runs/RunLogViewer.vue'
 import RunTimeline from '@/features/runs/RunTimeline.vue'
 import RunCancelConfirmDialog from '@/features/runs/RunCancelConfirmDialog.vue'
+import RunStepLogPanel from '@/features/runs/RunStepLogPanel.vue'
 import { runStatusSeverity } from '@/utils/runStatus'
 import { formatCostUSD, formatTokenCount } from '@/utils/formatCost'
+import type { components } from '@/api/schema'
+
+type RunStep = components['schemas']['RunStep']
 
 const route = useRoute()
 const runId = computed(() => route.params.id as string)
@@ -49,6 +53,17 @@ const canCancel = computed(() => {
 
 const pauseError = ref<string | null>(null)
 const cancelDialogVisible = ref(false)
+const selectedStep = ref<RunStep | null>(null)
+const stepPanelVisible = ref(false)
+
+function handleSelectStep(step: RunStep) {
+  selectedStep.value = step
+  stepPanelVisible.value = true
+}
+
+function handleCloseStepPanel() {
+  stepPanelVisible.value = false
+}
 
 async function handlePause() {
   if (!projectId.value || !runId.value) return
@@ -201,6 +216,7 @@ const progress = computed(() => {
           :steps="run.steps"
           :retry-loading="runsStore.isRetrying"
           @retry-step="handleRetryStep"
+          @select-step="handleSelectStep"
         />
       </div>
 
@@ -245,6 +261,17 @@ const progress = computed(() => {
       @confirm="handleCancelConfirm"
       @cancel="cancelDialogVisible = false"
       @update:visible="cancelDialogVisible = $event"
+    />
+
+    <!-- Step Log Panel -->
+    <RunStepLogPanel
+      v-if="run"
+      :step="selectedStep"
+      :run-id="run.id"
+      :project-id="run.project_id"
+      :visible="stepPanelVisible"
+      @close="handleCloseStepPanel"
+      @update:visible="stepPanelVisible = $event"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Add `RunStepLogPanel.vue` component using PrimeVue `Drawer` that slides in from the right when a step is clicked in the pipeline timeline
- Create `useStepLogs` composable that filters SSE `log.emitted` events by both `runId` and `stepId`, with reactive step switching support
- Add `selectStep` emit to `RunTimeline.vue` making step rows clickable with hover state
- Wire the panel into `RunDetailView.vue` with step selection state management
- Panel displays step metadata (name, status tag, started/completed timestamps, duration), error messages for failed steps, and per-step live log streaming

## Acceptance Criteria Coverage
- AC1: Panel slides in from right via PrimeVue Drawer with `position="right"`
- AC2: Header shows step name, status Tag, timestamps, and computed duration
- AC3: LogViewer renders logs with ANSI color support, auto-scroll
- AC4: Error message displayed in PrimeVue Message with `severity="error"` above logs
- AC5: Close button (built-in Drawer close) slides panel out
- AC6: Escape key closes panel (`closeOnEscape` prop)
- AC7: Mobile full-width via `w-full md:w-1/2` responsive classes + modal backdrop
- AC8: Desktop 50% width via Tailwind responsive class
- AC9: SSE log streaming via `useStepLogs` composable filtering by step
- AC10: Step switching clears logs and re-subscribes to new step's SSE stream

## Test plan
- [x] `npm run lint` passes
- [x] `npm run type-check` passes (tsc --noEmit)
- [x] `npm run test:unit` passes — 66 test files, 569 tests
- [x] New unit tests for `useStepLogs` composable (8 tests: filtering, step switching, cleanup)
- [x] New unit tests for `RunStepLogPanel` component (12 tests: visibility, metadata display, error messages, emit behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)