### PR TITLE
feat(ui): add horizontal pipeline view for runs (GitLab CI style)

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -3,3 +3,17 @@
 @import 'tailwindcss/preflight.css' layer(tailwind-base);
 @import 'tailwindcss/theme.css' layer(tailwind-base);
 @import 'tailwindcss/utilities.css' layer(tailwind-utilities);
+
+/* Running step pulse animation for pipeline view */
+@keyframes pulse-run {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+.running-indicator {
+  animation: pulse-run 1.2s ease-in-out infinite;
+}

--- a/frontend/src/features/runs/RunJobRow.vue
+++ b/frontend/src/features/runs/RunJobRow.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import Tag from 'primevue/tag'
+import { statusSeverity } from '@/utils/runStatus'
+import { formatDuration } from '@/utils/formatDuration'
+import type { RunStep } from './composables/useRunDetail'
+
+const STATUS_ICONS: Record<string, string> = {
+  pending: 'pi pi-clock',
+  running: 'pi pi-spin pi-spinner',
+  completed: 'pi pi-check-circle',
+  failed: 'pi pi-times-circle',
+  cancelled: 'pi pi-minus-circle',
+  skipped: 'pi pi-forward',
+  waiting_approval: 'pi pi-pause-circle',
+}
+
+const props = defineProps<{
+  step: RunStep
+  selected: boolean
+}>()
+
+const emit = defineEmits<{
+  click: [step: RunStep]
+}>()
+
+const icon = computed(() => STATUS_ICONS[props.step.status] ?? 'pi pi-question-circle')
+const isRunning = computed(() => props.step.status === 'running')
+const duration = computed(() =>
+  formatDuration(props.step.started_at, props.step.completed_at),
+)
+</script>
+
+<template>
+  <div
+    class="flex items-center gap-2 px-3 py-2 rounded cursor-pointer transition-colors hover:bg-surface-100 dark:hover:bg-surface-700"
+    :class="{
+      'bg-primary-50 dark:bg-primary-900/20 border border-primary-200 dark:border-primary-700': selected,
+      'border border-transparent': !selected,
+    }"
+    data-testid="job-row"
+    @click="emit('click', step)"
+  >
+    <i
+      :class="[icon, { 'running-indicator': isRunning }]"
+      data-testid="status-icon"
+    />
+    <span class="flex-1 text-sm truncate" data-testid="step-name">{{ step.step_name }}</span>
+    <Tag
+      :severity="statusSeverity(step.status)"
+      :value="step.status"
+      class="text-xs"
+      data-testid="status-tag"
+    />
+    <span class="text-xs text-surface-400 tabular-nums min-w-[3rem] text-right" data-testid="duration">
+      {{ duration }}
+    </span>
+  </div>
+</template>

--- a/frontend/src/features/runs/RunPipelineView.vue
+++ b/frontend/src/features/runs/RunPipelineView.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import Skeleton from 'primevue/skeleton'
+import RunStageColumn from './RunStageColumn.vue'
+import { groupStepsByStage } from '@/utils/pipelineStageUtils'
+import type { RunWithSteps, RunStep } from './composables/useRunDetail'
+
+interface SnapshotGroup {
+  id: string
+  name: string
+  steps: unknown[]
+}
+
+const props = defineProps<{
+  run: RunWithSteps | null
+  steps: RunStep[]
+}>()
+
+const emit = defineEmits<{
+  'step-selected': [step: RunStep]
+}>()
+
+const selectedStepId = ref<string | null>(null)
+
+/** Derive stage definitions from the run's pipeline_config_snapshot. */
+const stages = computed(() => {
+  const snapshot = props.run?.pipeline_config_snapshot as
+    | { groups?: SnapshotGroup[] }
+    | undefined
+  const groups = snapshot?.groups
+
+  if (!groups || groups.length === 0) {
+    return [{ id: 'default', name: 'Pipeline', steps: [] as unknown[] }]
+  }
+
+  return groups
+})
+
+/** Map live steps into their respective stages. */
+const stepsByStage = computed(() => {
+  const snapshot = props.run?.pipeline_config_snapshot as
+    | { groups?: SnapshotGroup[] }
+    | undefined
+  const groups = snapshot?.groups
+  return groupStepsByStage(groups, props.steps)
+})
+
+function handleStepSelected(step: RunStep) {
+  selectedStepId.value = step.id
+  emit('step-selected', step)
+}
+</script>
+
+<template>
+  <!-- Loading skeleton -->
+  <div v-if="!run" class="flex flex-row gap-4 p-4" data-testid="pipeline-loading">
+    <div v-for="n in 3" :key="n" class="flex flex-col gap-2 min-w-52">
+      <Skeleton width="6rem" height="1.25rem" />
+      <Skeleton width="100%" height="2.5rem" />
+      <Skeleton width="100%" height="2.5rem" />
+    </div>
+  </div>
+
+  <!-- Pipeline columns -->
+  <div v-else class="flex flex-row overflow-x-auto gap-0 min-h-0 p-2" data-testid="pipeline-view">
+    <RunStageColumn
+      v-for="(stage, idx) in stages"
+      :key="stage.id"
+      :stage-name="stage.name"
+      :steps="stepsByStage.get(stage.id) ?? []"
+      :selected-step-id="selectedStepId"
+      :is-last="idx === stages.length - 1"
+      @step-selected="handleStepSelected"
+    />
+  </div>
+</template>

--- a/frontend/src/features/runs/RunStageColumn.vue
+++ b/frontend/src/features/runs/RunStageColumn.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import RunJobRow from './RunJobRow.vue'
+import type { RunStep } from './composables/useRunDetail'
+
+defineProps<{
+  stageName: string
+  steps: RunStep[]
+  selectedStepId: string | null
+  isLast: boolean
+}>()
+
+const emit = defineEmits<{
+  'step-selected': [step: RunStep]
+}>()
+</script>
+
+<template>
+  <div
+    class="flex flex-col min-w-52 relative"
+    :class="{ 'border-r border-surface-200 dark:border-surface-600 pr-2 mr-2': !isLast }"
+    data-testid="stage-column"
+  >
+    <!-- Stage header -->
+    <div class="px-3 py-2 text-sm font-semibold text-surface-600 dark:text-surface-300 uppercase tracking-wider" data-testid="stage-header">
+      {{ stageName }}
+    </div>
+
+    <!-- Connector arrow on right edge (except last column) -->
+    <div
+      v-if="!isLast"
+      class="absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/2 z-10"
+      data-testid="stage-connector"
+    >
+      <i class="pi pi-chevron-right text-surface-300 dark:text-surface-500 text-xs" />
+    </div>
+
+    <!-- Step rows -->
+    <div class="flex flex-col gap-1">
+      <RunJobRow
+        v-for="step in steps"
+        :key="step.id"
+        :step="step"
+        :selected="step.id === selectedStepId"
+        @click="emit('step-selected', $event)"
+      />
+      <div
+        v-if="steps.length === 0"
+        class="px-3 py-2 text-xs text-surface-400 italic"
+        data-testid="empty-stage"
+      >
+        No steps
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/features/runs/__tests__/RunJobRow.spec.ts
+++ b/frontend/src/features/runs/__tests__/RunJobRow.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import RunJobRow from '../RunJobRow.vue'
+import type { RunStep } from '../composables/useRunDetail'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function makeStep(overrides?: Partial<RunStep>): RunStep {
+  return {
+    id: 'step-1',
+    run_id: 'run-1',
+    step_name: 'dev-story',
+    step_order: 0,
+    action: 'agent_run',
+    status: 'completed',
+    created_at: '2026-02-17T10:00:00Z',
+    ...overrides,
+  }
+}
+
+function mountRow(step: RunStep, selected = false) {
+  wrapper = mount(RunJobRow, {
+    props: { step, selected },
+    global: {
+      plugins: [PrimeVue],
+    },
+  })
+  return wrapper
+}
+
+describe('RunJobRow', () => {
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('renders step name', () => {
+    mountRow(makeStep({ step_name: 'code-review' }))
+    expect(wrapper.find('[data-testid="step-name"]').text()).toBe('code-review')
+  })
+
+  it('renders status tag', () => {
+    mountRow(makeStep({ status: 'failed' }))
+    const tag = wrapper.find('[data-testid="status-tag"]')
+    expect(tag.exists()).toBe(true)
+    expect(tag.text()).toBe('failed')
+  })
+
+  it('renders duration as "--" for pending steps', () => {
+    mountRow(makeStep({ status: 'pending', started_at: undefined }))
+    expect(wrapper.find('[data-testid="duration"]').text()).toBe('--')
+  })
+
+  it('renders formatted duration for completed steps', () => {
+    mountRow(
+      makeStep({
+        status: 'completed',
+        started_at: '2026-01-01T10:00:00Z',
+        completed_at: '2026-01-01T10:01:30Z',
+      }),
+    )
+    expect(wrapper.find('[data-testid="duration"]').text()).toBe('01:30')
+  })
+
+  it('emits click event when clicked', async () => {
+    const step = makeStep()
+    mountRow(step)
+    await wrapper.find('[data-testid="job-row"]').trigger('click')
+    expect(wrapper.emitted('click')).toBeTruthy()
+    expect(wrapper.emitted('click')![0]).toEqual([step])
+  })
+
+  it('applies selected styling when selected is true', () => {
+    mountRow(makeStep(), true)
+    const row = wrapper.find('[data-testid="job-row"]')
+    expect(row.classes()).toContain('bg-primary-50')
+  })
+
+  it('does not apply selected styling when selected is false', () => {
+    mountRow(makeStep(), false)
+    const row = wrapper.find('[data-testid="job-row"]')
+    expect(row.classes()).not.toContain('bg-primary-50')
+  })
+
+  it('applies running-indicator class for running status', () => {
+    mountRow(makeStep({ status: 'running' }))
+    const icon = wrapper.find('[data-testid="status-icon"]')
+    expect(icon.classes()).toContain('running-indicator')
+  })
+
+  it('does not apply running-indicator class for non-running status', () => {
+    mountRow(makeStep({ status: 'completed' }))
+    const icon = wrapper.find('[data-testid="status-icon"]')
+    expect(icon.classes()).not.toContain('running-indicator')
+  })
+
+  it('renders correct icon for each status', () => {
+    const statuses = [
+      { status: 'pending', icon: 'pi-clock' },
+      { status: 'running', icon: 'pi-spinner' },
+      { status: 'completed', icon: 'pi-check-circle' },
+      { status: 'failed', icon: 'pi-times-circle' },
+      { status: 'cancelled', icon: 'pi-minus-circle' },
+    ] as const
+
+    for (const { status, icon } of statuses) {
+      mountRow(makeStep({ status }))
+      const iconEl = wrapper.find('[data-testid="status-icon"]')
+      expect(iconEl.classes().join(' ')).toContain(icon)
+      wrapper.unmount()
+    }
+  })
+})

--- a/frontend/src/features/runs/__tests__/RunPipelineView.spec.ts
+++ b/frontend/src/features/runs/__tests__/RunPipelineView.spec.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import RunPipelineView from '../RunPipelineView.vue'
+import type { RunWithSteps, RunStep } from '../composables/useRunDetail'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function makeStep(overrides?: Partial<RunStep>): RunStep {
+  return {
+    id: 'step-0',
+    run_id: 'run-1',
+    step_name: 'dev-story',
+    step_order: 0,
+    action: 'agent_run',
+    status: 'completed',
+    created_at: '2026-02-17T10:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeRun(overrides?: Partial<RunWithSteps>): RunWithSteps {
+  return {
+    id: 'run-1',
+    project_id: 'proj-1',
+    story_id: 'story-1',
+    status: 'running',
+    created_at: '2026-02-17T10:00:00Z',
+    updated_at: '2026-02-17T10:00:00Z',
+    steps: [],
+    ...overrides,
+  }
+}
+
+function mountView(props: { run: RunWithSteps | null; steps: RunStep[] }) {
+  wrapper = mount(RunPipelineView, {
+    props,
+    global: {
+      plugins: [PrimeVue],
+    },
+  })
+  return wrapper
+}
+
+describe('RunPipelineView', () => {
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('shows loading skeleton when run is null', () => {
+    mountView({ run: null, steps: [] })
+    expect(wrapper.find('[data-testid="pipeline-loading"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="pipeline-view"]').exists()).toBe(false)
+  })
+
+  it('renders pipeline view when run is provided', () => {
+    mountView({ run: makeRun(), steps: [] })
+    expect(wrapper.find('[data-testid="pipeline-view"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="pipeline-loading"]').exists()).toBe(false)
+  })
+
+  it('renders one column labeled "Pipeline" when no groups in snapshot', () => {
+    mountView({ run: makeRun(), steps: [makeStep()] })
+    const columns = wrapper.findAll('[data-testid="stage-column"]')
+    expect(columns).toHaveLength(1)
+    expect(wrapper.find('[data-testid="stage-header"]').text()).toBe('Pipeline')
+  })
+
+  it('renders three columns when snapshot has three groups', () => {
+    const run = makeRun({
+      pipeline_config_snapshot: {
+        groups: [
+          { id: 'setup', name: 'Setup', steps: [{ id: 's1' }] },
+          { id: 'dev', name: 'Development', steps: [{ id: 's2' }, { id: 's3' }] },
+          { id: 'review', name: 'Review', steps: [{ id: 's4' }] },
+        ],
+      },
+    })
+    const steps = [
+      makeStep({ id: 'step-0', step_order: 0 }),
+      makeStep({ id: 'step-1', step_order: 1 }),
+      makeStep({ id: 'step-2', step_order: 2 }),
+      makeStep({ id: 'step-3', step_order: 3 }),
+    ]
+    mountView({ run, steps })
+    const columns = wrapper.findAll('[data-testid="stage-column"]')
+    expect(columns).toHaveLength(3)
+    const headers = wrapper.findAll('[data-testid="stage-header"]')
+    expect(headers[0]!.text()).toBe('Setup')
+    expect(headers[1]!.text()).toBe('Development')
+    expect(headers[2]!.text()).toBe('Review')
+  })
+
+  it('distributes steps to correct columns', () => {
+    const run = makeRun({
+      pipeline_config_snapshot: {
+        groups: [
+          { id: 'a', name: 'A', steps: [{ id: 's1' }] },
+          { id: 'b', name: 'B', steps: [{ id: 's2' }] },
+        ],
+      },
+    })
+    const steps = [
+      makeStep({ id: 'step-0', step_order: 0, step_name: 'first' }),
+      makeStep({ id: 'step-1', step_order: 1, step_name: 'second' }),
+    ]
+    mountView({ run, steps })
+    const rows = wrapper.findAll('[data-testid="job-row"]')
+    expect(rows).toHaveLength(2)
+  })
+
+  it('emits step-selected when a step is clicked', async () => {
+    const step = makeStep({ id: 'step-0', step_order: 0 })
+    mountView({ run: makeRun(), steps: [step] })
+    await wrapper.find('[data-testid="job-row"]').trigger('click')
+    expect(wrapper.emitted('step-selected')).toBeTruthy()
+    expect(wrapper.emitted('step-selected')![0]).toEqual([step])
+  })
+
+  it('renders fallback single column when pipeline_config_snapshot is undefined', () => {
+    const run = makeRun({ pipeline_config_snapshot: undefined })
+    mountView({ run, steps: [makeStep()] })
+    const columns = wrapper.findAll('[data-testid="stage-column"]')
+    expect(columns).toHaveLength(1)
+    expect(wrapper.find('[data-testid="stage-header"]').text()).toBe('Pipeline')
+  })
+
+  it('renders fallback single column when groups is empty array', () => {
+    const run = makeRun({
+      pipeline_config_snapshot: { groups: [] },
+    })
+    mountView({ run, steps: [makeStep()] })
+    const columns = wrapper.findAll('[data-testid="stage-column"]')
+    expect(columns).toHaveLength(1)
+    expect(wrapper.find('[data-testid="stage-header"]').text()).toBe('Pipeline')
+  })
+})

--- a/frontend/src/features/runs/__tests__/RunStageColumn.spec.ts
+++ b/frontend/src/features/runs/__tests__/RunStageColumn.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import RunStageColumn from '../RunStageColumn.vue'
+import type { RunStep } from '../composables/useRunDetail'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function makeStep(overrides?: Partial<RunStep>): RunStep {
+  return {
+    id: 'step-1',
+    run_id: 'run-1',
+    step_name: 'dev-story',
+    step_order: 0,
+    action: 'agent_run',
+    status: 'completed',
+    created_at: '2026-02-17T10:00:00Z',
+    ...overrides,
+  }
+}
+
+function mountColumn(props: {
+  stageName: string
+  steps: RunStep[]
+  selectedStepId?: string | null
+  isLast?: boolean
+}) {
+  wrapper = mount(RunStageColumn, {
+    props: {
+      stageName: props.stageName,
+      steps: props.steps,
+      selectedStepId: props.selectedStepId ?? null,
+      isLast: props.isLast ?? false,
+    },
+    global: {
+      plugins: [PrimeVue],
+    },
+  })
+  return wrapper
+}
+
+describe('RunStageColumn', () => {
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('renders stage name in header', () => {
+    mountColumn({ stageName: 'Development', steps: [] })
+    expect(wrapper.find('[data-testid="stage-header"]').text()).toBe('Development')
+  })
+
+  it('renders correct number of job rows', () => {
+    const steps = [
+      makeStep({ id: 'step-1', step_name: 'dev-story' }),
+      makeStep({ id: 'step-2', step_name: 'code-review' }),
+      makeStep({ id: 'step-3', step_name: 'merge' }),
+    ]
+    mountColumn({ stageName: 'Dev', steps })
+    const rows = wrapper.findAll('[data-testid="job-row"]')
+    expect(rows).toHaveLength(3)
+  })
+
+  it('shows empty stage message when no steps', () => {
+    mountColumn({ stageName: 'Empty', steps: [] })
+    expect(wrapper.find('[data-testid="empty-stage"]').exists()).toBe(true)
+  })
+
+  it('emits step-selected when a job row is clicked', async () => {
+    const step = makeStep({ id: 'step-1' })
+    mountColumn({ stageName: 'Dev', steps: [step] })
+    await wrapper.find('[data-testid="job-row"]').trigger('click')
+    expect(wrapper.emitted('step-selected')).toBeTruthy()
+    expect(wrapper.emitted('step-selected')![0]).toEqual([step])
+  })
+
+  it('shows connector arrow when not the last column', () => {
+    mountColumn({ stageName: 'Dev', steps: [], isLast: false })
+    expect(wrapper.find('[data-testid="stage-connector"]').exists()).toBe(true)
+  })
+
+  it('hides connector arrow for the last column', () => {
+    mountColumn({ stageName: 'Dev', steps: [], isLast: true })
+    expect(wrapper.find('[data-testid="stage-connector"]').exists()).toBe(false)
+  })
+
+  it('applies border-r class when not last column', () => {
+    mountColumn({ stageName: 'Dev', steps: [], isLast: false })
+    const col = wrapper.find('[data-testid="stage-column"]')
+    expect(col.classes()).toContain('border-r')
+  })
+
+  it('does not apply border-r class on last column', () => {
+    mountColumn({ stageName: 'Dev', steps: [], isLast: true })
+    const col = wrapper.find('[data-testid="stage-column"]')
+    expect(col.classes()).not.toContain('border-r')
+  })
+})

--- a/frontend/src/utils/__tests__/formatDuration.spec.ts
+++ b/frontend/src/utils/__tests__/formatDuration.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { formatDuration } from '../formatDuration'
+
+describe('formatDuration', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns "--" when startedAt is not provided', () => {
+    expect(formatDuration()).toBe('--')
+    expect(formatDuration(null)).toBe('--')
+    expect(formatDuration(undefined)).toBe('--')
+  })
+
+  it('formats completed duration as mm:ss', () => {
+    expect(
+      formatDuration('2026-01-01T10:00:00Z', '2026-01-01T10:01:30Z'),
+    ).toBe('01:30')
+  })
+
+  it('formats zero duration', () => {
+    expect(
+      formatDuration('2026-01-01T10:00:00Z', '2026-01-01T10:00:00Z'),
+    ).toBe('00:00')
+  })
+
+  it('formats longer durations correctly', () => {
+    expect(
+      formatDuration('2026-01-01T10:00:00Z', '2026-01-01T10:12:45Z'),
+    ).toBe('12:45')
+  })
+
+  it('uses Date.now() for running steps (no completedAt)', () => {
+    const now = new Date('2026-01-01T10:02:00Z').getTime()
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+    expect(formatDuration('2026-01-01T10:00:00Z')).toBe('02:00')
+  })
+
+  it('returns "--" when startedAt is null and completedAt is provided', () => {
+    expect(formatDuration(null, '2026-01-01T10:01:30Z')).toBe('--')
+  })
+})

--- a/frontend/src/utils/__tests__/pipelineStageUtils.spec.ts
+++ b/frontend/src/utils/__tests__/pipelineStageUtils.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { groupStepsByStage, type StageGroup } from '../pipelineStageUtils'
+
+function makeGroup(id: string, name: string, stepCount: number): StageGroup {
+  return {
+    id,
+    name,
+    steps: Array.from({ length: stepCount }, (_, i) => ({ id: `${id}-step-${i}` })),
+  }
+}
+
+function makeStep(order: number): { step_order: number; id: string; step_name: string } {
+  return { step_order: order, id: `step-${order}`, step_name: `Step ${order}` }
+}
+
+describe('groupStepsByStage', () => {
+  it('groups steps into multiple stages by cumulative step count', () => {
+    const groups = [
+      makeGroup('setup', 'Setup', 2),
+      makeGroup('dev', 'Development', 2),
+      makeGroup('review', 'Review', 2),
+    ]
+    const steps = [
+      makeStep(0),
+      makeStep(1),
+      makeStep(2),
+      makeStep(3),
+      makeStep(4),
+      makeStep(5),
+    ]
+
+    const result = groupStepsByStage(groups, steps)
+
+    expect(result.size).toBe(3)
+    expect(result.get('setup')).toHaveLength(2)
+    expect(result.get('dev')).toHaveLength(2)
+    expect(result.get('review')).toHaveLength(2)
+    expect(result.get('setup')![0]!.step_order).toBe(0)
+    expect(result.get('setup')![1]!.step_order).toBe(1)
+    expect(result.get('dev')![0]!.step_order).toBe(2)
+    expect(result.get('dev')![1]!.step_order).toBe(3)
+    expect(result.get('review')![0]!.step_order).toBe(4)
+    expect(result.get('review')![1]!.step_order).toBe(5)
+  })
+
+  it('returns all steps under "default" when groups is empty', () => {
+    const steps = [makeStep(0), makeStep(1)]
+    const result = groupStepsByStage([], steps)
+
+    expect(result.size).toBe(1)
+    expect(result.get('default')).toHaveLength(2)
+  })
+
+  it('returns all steps under "default" when groups is undefined', () => {
+    const steps = [makeStep(0)]
+    const result = groupStepsByStage(undefined, steps)
+
+    expect(result.size).toBe(1)
+    expect(result.get('default')).toHaveLength(1)
+  })
+
+  it('handles empty steps array', () => {
+    const groups = [makeGroup('setup', 'Setup', 2)]
+    const result = groupStepsByStage(groups, [])
+
+    expect(result.size).toBe(1)
+    expect(result.get('setup')).toHaveLength(0)
+  })
+
+  it('handles groups with zero steps', () => {
+    const groups = [
+      makeGroup('empty', 'Empty', 0),
+      makeGroup('dev', 'Development', 2),
+    ]
+    const steps = [makeStep(0), makeStep(1)]
+    const result = groupStepsByStage(groups, steps)
+
+    expect(result.get('empty')).toHaveLength(0)
+    expect(result.get('dev')).toHaveLength(2)
+  })
+
+  it('handles fewer live steps than config expects', () => {
+    const groups = [
+      makeGroup('setup', 'Setup', 2),
+      makeGroup('dev', 'Development', 3),
+    ]
+    const steps = [makeStep(0), makeStep(1), makeStep(2)]
+    const result = groupStepsByStage(groups, steps)
+
+    expect(result.get('setup')).toHaveLength(2)
+    expect(result.get('dev')).toHaveLength(1)
+  })
+})

--- a/frontend/src/utils/formatDuration.ts
+++ b/frontend/src/utils/formatDuration.ts
@@ -1,0 +1,19 @@
+/**
+ * Formats the duration between two ISO 8601 timestamps as mm:ss.
+ * Returns '--' if startedAt is not provided (pending step).
+ * Uses Date.now() as the end time for running steps (no completedAt).
+ */
+export function formatDuration(
+  startedAt?: string | null,
+  completedAt?: string | null,
+): string {
+  if (!startedAt) return '--'
+  const start = new Date(startedAt).getTime()
+  const end = completedAt ? new Date(completedAt).getTime() : Date.now()
+  const secs = Math.floor((end - start) / 1000)
+  const m = Math.floor(secs / 60)
+    .toString()
+    .padStart(2, '0')
+  const s = (secs % 60).toString().padStart(2, '0')
+  return `${m}:${s}`
+}

--- a/frontend/src/utils/pipelineStageUtils.ts
+++ b/frontend/src/utils/pipelineStageUtils.ts
@@ -1,0 +1,43 @@
+/**
+ * Pipeline stage grouping utilities.
+ * Maps live RunStep objects to their respective pipeline groups (stages)
+ * using the cumulative step count from the pipeline config snapshot.
+ */
+
+/** Minimal shape of a pipeline group from the config snapshot. */
+export interface StageGroup {
+  id: string
+  name: string
+  steps: unknown[]
+}
+
+/**
+ * Groups run steps into their respective pipeline stages based on the
+ * cumulative step count in each group from the config snapshot.
+ *
+ * If groups is empty or undefined, all steps are placed under a single
+ * 'default' stage labeled "Pipeline".
+ */
+export function groupStepsByStage<T extends { step_order: number }>(
+  groups: StageGroup[] | undefined,
+  steps: T[],
+): Map<string, T[]> {
+  const result = new Map<string, T[]>()
+
+  if (!groups || groups.length === 0) {
+    result.set('default', [...steps])
+    return result
+  }
+
+  let offset = 0
+  for (const group of groups) {
+    const groupStepCount = group.steps.length
+    const stageSteps = steps.filter(
+      (s) => s.step_order >= offset && s.step_order < offset + groupStepCount,
+    )
+    result.set(group.id, stageSteps)
+    offset += groupStepCount
+  }
+
+  return result
+}


### PR DESCRIPTION
## Summary

- Add `RunPipelineView.vue` orchestrator component that derives horizontal stage columns from `run.pipeline_config_snapshot.groups` with fallback to a single "Pipeline" column for legacy configs
- Add `RunStageColumn.vue` presentational component rendering stage header, connector arrows between columns, and delegating step rows to `RunJobRow`
- Add `RunJobRow.vue` presentational component displaying step name, status icon (with severity mapping), PrimeVue Tag, formatted duration, and click-to-select with visual highlight
- Add `formatDuration` utility (`mm:ss` format, handles pending/running/completed states)
- Add `groupStepsByStage` utility mapping live `RunStep[]` to stages via cumulative step count from config snapshot
- Add `pulse-run` CSS animation for running step indicators
- 38 unit tests across 5 test files (all passing)

Refs: R-4-1

## Test plan

- [x] `npm run lint` passes
- [x] `npm run type-check` has no new errors (pre-existing schema.d.ts errors only)
- [x] `npm run test:unit` — all 607 tests pass (38 new)
- [ ] Visual verification in browser once integrated into `RunDetailView` (R-4-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)