### PR TITLE
feat(editor): add step type editors for new pipeline action types

### DIFF
--- a/frontend/src/features/pipeline/AddStepDialog.vue
+++ b/frontend/src/features/pipeline/AddStepDialog.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, reactive, watch } from 'vue'
 import Dialog from 'primevue/dialog'
 import InputText from 'primevue/inputtext'
+import Textarea from 'primevue/textarea'
 import Select from 'primevue/select'
 import Checkbox from 'primevue/checkbox'
+import ToggleSwitch from 'primevue/toggleswitch'
 import InputNumber from 'primevue/inputnumber'
 import Button from 'primevue/button'
 import Message from 'primevue/message'
@@ -17,11 +19,11 @@ const modelOptions = [
 
 const actionTypeOptions = [
   { label: 'Agent Run', value: 'agent_run' },
-  { label: 'Git Branch', value: 'git_branch' },
-  { label: 'Git PR', value: 'git_pr' },
-  { label: 'Notification', value: 'notification' },
-  { label: 'Human', value: 'human' },
-  { label: 'CI Poll', value: 'ci_poll' },
+  { label: 'Create Git Branch', value: 'git_branch' },
+  { label: 'Create Pull Request', value: 'git_pr' },
+  { label: 'Send Notification', value: 'notification' },
+  { label: 'Human Task', value: 'human' },
+  { label: 'Poll CI Status', value: 'ci_poll' },
   { label: 'HITL Gate', value: 'hitl_gate' },
 ]
 
@@ -48,6 +50,8 @@ const autoApprove = ref(false)
 const maxRetries = ref(2)
 const retryType = ref<PipelineStep['retry_policy']['retry_type']>('on-failure')
 const validationError = ref<string | null>(null)
+const config = reactive<Record<string, string>>({})
+const configDraft = ref(false)
 
 function resetForm() {
   name.value = ''
@@ -57,6 +61,12 @@ function resetForm() {
   maxRetries.value = 2
   retryType.value = 'on-failure'
   validationError.value = null
+  resetConfig()
+}
+
+function resetConfig() {
+  Object.keys(config).forEach((key) => delete config[key])
+  configDraft.value = false
 }
 
 watch(
@@ -64,6 +74,18 @@ watch(
   (isVisible) => {
     if (isVisible) {
       resetForm()
+    }
+  },
+)
+
+watch(
+  () => actionType.value,
+  () => {
+    resetConfig()
+    if (actionType.value !== 'agent_run') {
+      model.value = undefined as unknown as PipelineStep['model']
+    } else {
+      model.value = 'claude-sonnet-4-6'
     }
   },
 )
@@ -84,6 +106,9 @@ function handleAdd() {
       max_retries: maxRetries.value,
       retry_type: retryType.value,
     },
+    config: Object.keys(config).length > 0 || (actionType.value === 'git_pr' && configDraft.value)
+      ? { ...config, ...(actionType.value === 'git_pr' ? { draft: String(configDraft.value) } : {}) }
+      : undefined,
   }
 
   emit('add', step)
@@ -131,7 +156,8 @@ function close() {
         />
       </div>
 
-      <div class="flex flex-col gap-2">
+      <!-- Model selector: only visible for agent_run -->
+      <div v-if="actionType === 'agent_run'" class="flex flex-col gap-2">
         <label for="model-select" class="text-sm font-medium">Model</label>
         <Select
           id="model-select"
@@ -143,6 +169,103 @@ function close() {
           data-testid="model-select"
         />
       </div>
+
+      <!-- git_branch config fields -->
+      <template v-if="actionType === 'git_branch'">
+        <div class="flex flex-col gap-2">
+          <label for="branch-pattern" class="text-sm font-medium">Branch Pattern</label>
+          <InputText
+            id="branch-pattern"
+            v-model="config.branch_pattern"
+            class="w-full"
+            placeholder="e.g., feat/{story_key}-{slug}"
+            data-testid="branch-pattern-input"
+          />
+        </div>
+      </template>
+
+      <!-- git_pr config fields -->
+      <template v-if="actionType === 'git_pr'">
+        <div class="flex flex-col gap-2">
+          <label for="title-template" class="text-sm font-medium">PR Title Template</label>
+          <InputText
+            id="title-template"
+            v-model="config.title_template"
+            class="w-full"
+            placeholder="e.g., feat({scope}): {summary}"
+            data-testid="title-template-input"
+          />
+        </div>
+        <div class="flex flex-col gap-2">
+          <label for="target-branch" class="text-sm font-medium">Target Branch</label>
+          <InputText
+            id="target-branch"
+            v-model="config.target_branch"
+            class="w-full"
+            placeholder="e.g., develop"
+            data-testid="target-branch-input"
+          />
+        </div>
+        <div class="flex items-center gap-2">
+          <ToggleSwitch
+            v-model="configDraft"
+            input-id="draft-toggle"
+            data-testid="draft-toggle"
+          />
+          <label for="draft-toggle" class="text-sm font-medium">Draft PR</label>
+        </div>
+      </template>
+
+      <!-- notification config fields -->
+      <template v-if="actionType === 'notification'">
+        <div class="flex flex-col gap-2">
+          <label for="notification-message" class="text-sm font-medium">Message</label>
+          <Textarea
+            id="notification-message"
+            v-model="config.message"
+            class="w-full"
+            rows="3"
+            placeholder="Notification message"
+            data-testid="notification-message-input"
+          />
+        </div>
+      </template>
+
+      <!-- human config fields -->
+      <template v-if="actionType === 'human'">
+        <div class="flex flex-col gap-2">
+          <label for="human-message" class="text-sm font-medium">Message</label>
+          <Textarea
+            id="human-message"
+            v-model="config.message"
+            class="w-full"
+            rows="3"
+            placeholder="What to display to the human reviewer"
+            data-testid="human-message-input"
+          />
+        </div>
+        <div class="flex flex-col gap-2">
+          <label for="human-instructions" class="text-sm font-medium">Instructions</label>
+          <Textarea
+            id="human-instructions"
+            v-model="config.instructions"
+            class="w-full"
+            rows="3"
+            placeholder="Optional detailed instructions"
+            data-testid="human-instructions-input"
+          />
+        </div>
+      </template>
+
+      <!-- ci_poll: no config fields -->
+      <Message v-if="actionType === 'ci_poll'" severity="info" :closable="false" data-testid="ci-poll-info">
+        No additional configuration required
+      </Message>
+
+      <!-- hitl_gate: no config fields -->
+      <Message v-if="actionType === 'hitl_gate'" severity="info" :closable="false" data-testid="hitl-gate-info">
+        No additional configuration required
+      </Message>
 
       <div class="flex items-center gap-2">
         <Checkbox

--- a/frontend/src/features/pipeline/PipelineStepCard.vue
+++ b/frontend/src/features/pipeline/PipelineStepCard.vue
@@ -8,6 +8,16 @@ import Checkbox from 'primevue/checkbox'
 import InputNumber from 'primevue/inputnumber'
 import type { PipelineStep } from '@/stores/pipelineConfig'
 
+const ACTION_TYPE_ICONS: Record<string, string> = {
+  agent_run: 'pi pi-android',
+  git_branch: 'pi pi-code-branch',
+  git_pr: 'pi pi-arrow-right-arrow-left',
+  notification: 'pi pi-bell',
+  human: 'pi pi-user',
+  ci_poll: 'pi pi-sync',
+  hitl_gate: 'pi pi-shield',
+}
+
 const modelOptions = [
   { label: 'Claude Opus 4.6', value: 'claude-opus-4-6' },
   { label: 'Claude Sonnet 4.6', value: 'claude-sonnet-4-6' },
@@ -36,6 +46,10 @@ const emit = defineEmits<{
   moveUp: []
   moveDown: []
 }>()
+
+const actionTypeIcon = computed(() => {
+  return ACTION_TYPE_ICONS[props.step.action_type] ?? 'pi pi-cog'
+})
 
 const modelLabel = computed(() => {
   return modelOptions.find((o) => o.value === props.step.model)?.label ?? props.step.model
@@ -76,8 +90,8 @@ function onRetryTypeChange(value: PipelineStep['retry_policy']['retry_type']) {
         <div class="flex items-center gap-3">
           <span class="font-mono text-sm opacity-60">{{ index + 1 }}.</span>
           <span class="font-semibold">{{ step.name }}</span>
-          <Tag :value="step.action_type" severity="info" />
-          <span class="text-sm opacity-70">{{ modelLabel }}</span>
+          <Tag :value="step.action_type" severity="info" :icon="actionTypeIcon" data-testid="action-type-tag" />
+          <span v-if="step.model" class="text-sm opacity-70">{{ modelLabel }}</span>
           <Tag
             :value="step.auto_approve ? 'Auto' : 'Manual'"
             :severity="autoApproveSeverity"

--- a/frontend/src/features/pipeline/__tests__/AddStepDialog.spec.ts
+++ b/frontend/src/features/pipeline/__tests__/AddStepDialog.spec.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, afterEach, vi, beforeAll } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { h, defineComponent, nextTick } from 'vue'
+import PrimeVue from 'primevue/config'
+import AddStepDialog from '../AddStepDialog.vue'
+
+beforeAll(() => {
+  // PrimeVue Select uses matchMedia which is not available in jsdom
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+/** Stub Dialog to render inline instead of teleporting. */
+const DialogStub = defineComponent({
+  name: 'DialogStub',
+  props: ['visible', 'modal', 'header'],
+  emits: ['update:visible'],
+  setup(props, { slots }) {
+    return () => {
+      if (!props.visible) return null
+      return h('div', { class: 'p-dialog' }, [
+        h('div', { class: 'p-dialog-header' }, props.header),
+        h('div', { class: 'p-dialog-content' }, slots.default?.()),
+        h('div', { class: 'p-dialog-footer' }, slots.footer?.()),
+      ])
+    }
+  },
+})
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function mountComponent(props: { visible?: boolean } = {}) {
+  wrapper = mount(AddStepDialog, {
+    props: {
+      visible: true,
+      ...props,
+    },
+    global: {
+      plugins: [PrimeVue],
+      stubs: {
+        Dialog: DialogStub,
+      },
+    },
+  })
+  return wrapper
+}
+
+async function selectActionType(type: string) {
+  // Simulate changing the action type by accessing the component's internal state
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const vm = wrapper.vm as any
+  vm.actionType = type
+  await nextTick()
+  await nextTick()
+}
+
+describe('AddStepDialog', () => {
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  describe('action type options', () => {
+    it('renders all action type options in the select', () => {
+      mountComponent()
+      const text = wrapper.text()
+      // The select should have the action type options available.
+      // At minimum, the default selected value should be visible
+      const select = wrapper.find('[data-testid="action-type-select"]')
+      expect(select.exists()).toBe(true)
+    })
+
+    it('defaults to agent_run action type', () => {
+      mountComponent()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((wrapper.vm as any).actionType).toBe('agent_run')
+    })
+  })
+
+  describe('model selector visibility', () => {
+    it('shows model selector when action type is agent_run', () => {
+      mountComponent()
+      expect(wrapper.find('[data-testid="model-select"]').exists()).toBe(true)
+    })
+
+    it('hides model selector when action type is git_branch', async () => {
+      mountComponent()
+      await selectActionType('git_branch')
+      expect(wrapper.find('[data-testid="model-select"]').exists()).toBe(false)
+    })
+
+    it('hides model selector when action type is git_pr', async () => {
+      mountComponent()
+      await selectActionType('git_pr')
+      expect(wrapper.find('[data-testid="model-select"]').exists()).toBe(false)
+    })
+
+    it('hides model selector when action type is notification', async () => {
+      mountComponent()
+      await selectActionType('notification')
+      expect(wrapper.find('[data-testid="model-select"]').exists()).toBe(false)
+    })
+
+    it('hides model selector when action type is human', async () => {
+      mountComponent()
+      await selectActionType('human')
+      expect(wrapper.find('[data-testid="model-select"]').exists()).toBe(false)
+    })
+
+    it('hides model selector when action type is ci_poll', async () => {
+      mountComponent()
+      await selectActionType('ci_poll')
+      expect(wrapper.find('[data-testid="model-select"]').exists()).toBe(false)
+    })
+
+    it('hides model selector when action type is hitl_gate', async () => {
+      mountComponent()
+      await selectActionType('hitl_gate')
+      expect(wrapper.find('[data-testid="model-select"]').exists()).toBe(false)
+    })
+
+    it('shows model selector again when switching back to agent_run', async () => {
+      mountComponent()
+      await selectActionType('git_branch')
+      expect(wrapper.find('[data-testid="model-select"]').exists()).toBe(false)
+      await selectActionType('agent_run')
+      expect(wrapper.find('[data-testid="model-select"]').exists()).toBe(true)
+    })
+  })
+
+  describe('conditional config fields — git_branch', () => {
+    it('shows branch_pattern field when action type is git_branch', async () => {
+      mountComponent()
+      await selectActionType('git_branch')
+      expect(wrapper.find('[data-testid="branch-pattern-input"]').exists()).toBe(true)
+    })
+
+    it('hides branch_pattern field for other types', () => {
+      mountComponent()
+      expect(wrapper.find('[data-testid="branch-pattern-input"]').exists()).toBe(false)
+    })
+  })
+
+  describe('conditional config fields — git_pr', () => {
+    it('shows title_template, target_branch, and draft fields', async () => {
+      mountComponent()
+      await selectActionType('git_pr')
+      expect(wrapper.find('[data-testid="title-template-input"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="target-branch-input"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="draft-toggle"]').exists()).toBe(true)
+    })
+
+    it('hides git_pr fields for other types', () => {
+      mountComponent()
+      expect(wrapper.find('[data-testid="title-template-input"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="target-branch-input"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="draft-toggle"]').exists()).toBe(false)
+    })
+  })
+
+  describe('conditional config fields — notification', () => {
+    it('shows message textarea when action type is notification', async () => {
+      mountComponent()
+      await selectActionType('notification')
+      expect(wrapper.find('[data-testid="notification-message-input"]').exists()).toBe(true)
+    })
+
+    it('hides notification message for other types', () => {
+      mountComponent()
+      expect(wrapper.find('[data-testid="notification-message-input"]').exists()).toBe(false)
+    })
+  })
+
+  describe('conditional config fields — human', () => {
+    it('shows message and instructions textareas when action type is human', async () => {
+      mountComponent()
+      await selectActionType('human')
+      expect(wrapper.find('[data-testid="human-message-input"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="human-instructions-input"]').exists()).toBe(true)
+    })
+
+    it('hides human fields for other types', () => {
+      mountComponent()
+      expect(wrapper.find('[data-testid="human-message-input"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="human-instructions-input"]').exists()).toBe(false)
+    })
+  })
+
+  describe('conditional config fields — ci_poll', () => {
+    it('shows info message when action type is ci_poll', async () => {
+      mountComponent()
+      await selectActionType('ci_poll')
+      expect(wrapper.find('[data-testid="ci-poll-info"]').exists()).toBe(true)
+      expect(wrapper.text()).toContain('No additional configuration required')
+    })
+  })
+
+  describe('conditional config fields — hitl_gate', () => {
+    it('shows info message when action type is hitl_gate', async () => {
+      mountComponent()
+      await selectActionType('hitl_gate')
+      expect(wrapper.find('[data-testid="hitl-gate-info"]').exists()).toBe(true)
+      expect(wrapper.text()).toContain('No additional configuration required')
+    })
+  })
+
+  describe('config reset on action type change', () => {
+    it('resets config fields when switching action types', async () => {
+      mountComponent()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm = wrapper.vm as any
+
+      // Set git_branch config
+      await selectActionType('git_branch')
+      vm.config.branch_pattern = 'feat/{key}'
+      await nextTick()
+      expect(vm.config.branch_pattern).toBe('feat/{key}')
+
+      // Switch to git_pr — config should be reset
+      await selectActionType('git_pr')
+      expect(vm.config.branch_pattern).toBeUndefined()
+    })
+
+    it('clears model when switching away from agent_run', async () => {
+      mountComponent()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm = wrapper.vm as any
+      expect(vm.model).toBe('claude-sonnet-4-6')
+
+      await selectActionType('git_branch')
+      expect(vm.model).toBeUndefined()
+    })
+
+    it('restores default model when switching back to agent_run', async () => {
+      mountComponent()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm = wrapper.vm as any
+
+      await selectActionType('git_branch')
+      expect(vm.model).toBeUndefined()
+
+      await selectActionType('agent_run')
+      expect(vm.model).toBe('claude-sonnet-4-6')
+    })
+  })
+
+  describe('form submission', () => {
+    it('includes config fields in emitted step for git_pr', async () => {
+      mountComponent()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm = wrapper.vm as any
+
+      // Fill name
+      vm.name = 'Create PR'
+      await selectActionType('git_pr')
+
+      // Fill config fields
+      vm.config.title_template = 'feat: {summary}'
+      vm.config.target_branch = 'develop'
+      vm.configDraft = true
+      await nextTick()
+
+      // Submit
+      vm.handleAdd()
+      await nextTick()
+
+      const emitted = wrapper.emitted('add')
+      expect(emitted).toBeDefined()
+      expect(emitted).toHaveLength(1)
+
+      const step = emitted![0]![0] as Record<string, unknown>
+      expect(step.action_type).toBe('git_pr')
+      expect(step.config).toBeDefined()
+
+      const stepConfig = step.config as Record<string, unknown>
+      expect(stepConfig.title_template).toBe('feat: {summary}')
+      expect(stepConfig.target_branch).toBe('develop')
+      expect(stepConfig.draft).toBe('true')
+    })
+
+    it('does not include config for agent_run steps', async () => {
+      mountComponent()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm = wrapper.vm as any
+
+      vm.name = 'Implement'
+      await nextTick()
+
+      vm.handleAdd()
+      await nextTick()
+
+      const emitted = wrapper.emitted('add')
+      expect(emitted).toBeDefined()
+
+      const step = emitted![0]![0] as Record<string, unknown>
+      expect(step.action_type).toBe('agent_run')
+      expect(step.config).toBeUndefined()
+    })
+
+    it('validates step name is required', async () => {
+      mountComponent()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm = wrapper.vm as any
+
+      vm.handleAdd()
+      await nextTick()
+
+      expect(wrapper.emitted('add')).toBeUndefined()
+      expect(wrapper.text()).toContain('Step name is required')
+    })
+  })
+})

--- a/frontend/src/features/pipeline/__tests__/PipelineStepCard.spec.ts
+++ b/frontend/src/features/pipeline/__tests__/PipelineStepCard.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import PipelineStepCard from '../PipelineStepCard.vue'
+import type { PipelineStep } from '@/stores/pipelineConfig'
+
+function makeStep(overrides: Partial<PipelineStep> = {}): PipelineStep {
+  return {
+    id: crypto.randomUUID(),
+    name: 'implement',
+    action_type: 'agent_run',
+    model: 'claude-opus-4-6',
+    auto_approve: false,
+    retry_policy: { max_retries: 2, retry_type: 'on-failure' },
+    ...overrides,
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function mountComponent(stepOverrides: Partial<PipelineStep> = {}, props: Record<string, unknown> = {}) {
+  wrapper = mount(PipelineStepCard, {
+    props: {
+      step: makeStep(stepOverrides),
+      index: 0,
+      isAdmin: true,
+      expanded: false,
+      isFirst: true,
+      isLast: false,
+      ...props,
+    },
+    global: {
+      plugins: [PrimeVue],
+    },
+  })
+  return wrapper
+}
+
+describe('PipelineStepCard', () => {
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  describe('action type icon/badge', () => {
+    it('renders action type tag', () => {
+      mountComponent()
+      const tag = wrapper.find('[data-testid="action-type-tag"]')
+      expect(tag.exists()).toBe(true)
+    })
+
+    it('displays correct icon for agent_run', () => {
+      mountComponent({ action_type: 'agent_run' })
+      const tag = wrapper.find('[data-testid="action-type-tag"]')
+      expect(tag.exists()).toBe(true)
+      // The Tag component renders with the icon attribute
+      expect(tag.attributes('icon') || tag.html()).toContain('android')
+    })
+
+    it('displays correct icon for git_branch', () => {
+      mountComponent({ action_type: 'git_branch' })
+      const tag = wrapper.find('[data-testid="action-type-tag"]')
+      expect(tag.html()).toContain('code-branch')
+    })
+
+    it('displays correct icon for git_pr', () => {
+      mountComponent({ action_type: 'git_pr' })
+      const tag = wrapper.find('[data-testid="action-type-tag"]')
+      expect(tag.html()).toContain('arrow-right-arrow-left')
+    })
+
+    it('displays correct icon for notification', () => {
+      mountComponent({ action_type: 'notification' })
+      const tag = wrapper.find('[data-testid="action-type-tag"]')
+      expect(tag.html()).toContain('bell')
+    })
+
+    it('displays correct icon for human', () => {
+      mountComponent({ action_type: 'human' })
+      const tag = wrapper.find('[data-testid="action-type-tag"]')
+      expect(tag.html()).toContain('user')
+    })
+
+    it('displays correct icon for ci_poll', () => {
+      mountComponent({ action_type: 'ci_poll' })
+      const tag = wrapper.find('[data-testid="action-type-tag"]')
+      expect(tag.html()).toContain('sync')
+    })
+
+    it('displays correct icon for hitl_gate', () => {
+      mountComponent({ action_type: 'hitl_gate' })
+      const tag = wrapper.find('[data-testid="action-type-tag"]')
+      expect(tag.html()).toContain('shield')
+    })
+  })
+
+  describe('model label visibility', () => {
+    it('shows model label when model is set', () => {
+      mountComponent({ model: 'claude-opus-4-6' })
+      expect(wrapper.text()).toContain('Claude Opus 4.6')
+    })
+
+    it('hides model label when model is not set', () => {
+      mountComponent({ model: undefined as unknown as PipelineStep['model'] })
+      expect(wrapper.text()).not.toContain('Claude Opus')
+      expect(wrapper.text()).not.toContain('Claude Sonnet')
+      expect(wrapper.text()).not.toContain('Claude Haiku')
+    })
+  })
+
+  describe('step name and action type display', () => {
+    it('displays step name', () => {
+      mountComponent({ name: 'my-step' })
+      expect(wrapper.text()).toContain('my-step')
+    })
+
+    it('displays action type in tag', () => {
+      mountComponent({ action_type: 'git_pr' })
+      expect(wrapper.text()).toContain('git_pr')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add conditional config fields in `AddStepDialog.vue` for 6 new action types: `git_branch`, `git_pr`, `notification`, `human`, `ci_poll`, `hitl_gate`
- Model selector is now conditionally hidden for non-`agent_run` step types; config fields reset on type switch
- Add action type icon badges to `PipelineStepCard.vue` using PrimeVue `Tag` with distinct icons per type
- Add 38 unit tests covering conditional rendering, config state management, form submission, and icon display

## Test plan
- [x] All 38 new unit tests pass (AddStepDialog: 26, PipelineStepCard: 12)
- [x] Full test suite passes (607 tests across 68 files)
- [x] ESLint passes
- [x] No new TypeScript errors introduced (type-check clean for modified files)

Refs: R-3-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)