### PR TITLE
feat(pipeline): add PipelineGroup backend model with YAML parsing and validation

### DIFF
--- a/backend/internal/domain/model/pipeline_config.go
+++ b/backend/internal/domain/model/pipeline_config.go
@@ -1,9 +1,11 @@
 package model
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
 )
 
 // PipelineConfig represents a pipeline configuration for a project.
@@ -18,49 +20,73 @@ type PipelineConfig struct {
 
 // PipelineStep represents a single step in the pipeline YAML.
 type PipelineStep struct {
-	ID          string            `yaml:"id"`
-	Name        string            `yaml:"name"`
-	ActionType  string            `yaml:"action_type"`
-	Model       string            `yaml:"model,omitempty"`
-	AutoApprove bool              `yaml:"auto_approve"`
-	RetryPolicy RetryPolicy       `yaml:"retry_policy"`
-	Config      map[string]string `yaml:"config,omitempty"`
+	ID          string            `yaml:"id"          json:"id"`
+	Name        string            `yaml:"name"        json:"name"`
+	ActionType  string            `yaml:"action_type" json:"action_type"`
+	Description string            `yaml:"description,omitempty" json:"description,omitempty"`
+	Model       string            `yaml:"model,omitempty"       json:"model,omitempty"`
+	AutoApprove bool              `yaml:"auto_approve"          json:"auto_approve"`
+	RetryPolicy RetryPolicy       `yaml:"retry_policy"          json:"retry_policy"`
+	Config      map[string]string `yaml:"config,omitempty"      json:"config,omitempty"`
 }
 
 // RetryPolicy defines retry behavior for a pipeline step.
 type RetryPolicy struct {
-	MaxRetries int    `yaml:"max_retries"`
-	RetryType  string `yaml:"retry_type"` // none, on-failure, always
+	MaxRetries int    `yaml:"max_retries" json:"max_retries"`
+	RetryType  string `yaml:"retry_type"  json:"retry_type"` // none, on-failure, always
 }
 
 // PipelineGroup represents a named group of steps in the pipeline YAML.
 type PipelineGroup struct {
-	ID    string         `yaml:"id"`
-	Name  string         `yaml:"name"`
-	Steps []PipelineStep `yaml:"steps"`
+	ID    string         `yaml:"id"    json:"id"`
+	Name  string         `yaml:"name"  json:"name"`
+	Steps []PipelineStep `yaml:"steps" json:"steps"`
 }
 
 // PipelineConfigYAML represents the parsed YAML structure.
-// Supports the groups-based format. The legacy flat steps format is handled
-// via backward-compatible parsing in story R-1-3.
+// Always uses groups. Legacy flat-steps YAML is auto-wrapped into a single
+// "Default" group by ParsePipelineConfigYAML.
 type PipelineConfigYAML struct {
+	Groups []PipelineGroup `yaml:"groups" json:"groups"`
+}
+
+// pipelineConfigRawYAML is an intermediate struct for unmarshalling that
+// handles both the new groups format and the legacy flat steps format.
+type pipelineConfigRawYAML struct {
 	Groups []PipelineGroup `yaml:"groups"`
-	// Steps is kept for backward-compatible parsing of legacy YAML that uses
-	// a flat steps array. New configs always use groups.
-	Steps []PipelineStep `yaml:"steps"`
+	Steps  []PipelineStep  `yaml:"steps"` // legacy flat format
+}
+
+// ParsePipelineConfigYAML parses pipeline config YAML with backward
+// compatibility. If the YAML has a top-level "steps:" array (old format),
+// the steps are automatically wrapped in a single PipelineGroup named "Default".
+func ParsePipelineConfigYAML(data []byte) (*PipelineConfigYAML, error) {
+	var raw pipelineConfigRawYAML
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("invalid YAML: %w", err)
+	}
+
+	cfg := &PipelineConfigYAML{}
+
+	if len(raw.Groups) > 0 {
+		cfg.Groups = raw.Groups
+	} else if len(raw.Steps) > 0 {
+		// Legacy: wrap flat steps in a single default group
+		cfg.Groups = []PipelineGroup{
+			{ID: "default", Name: "Default", Steps: raw.Steps},
+		}
+	}
+
+	return cfg, nil
 }
 
 // FlatSteps returns all steps across all groups in order.
-// Falls back to the legacy Steps field if Groups is empty.
 func (c *PipelineConfigYAML) FlatSteps() []PipelineStep {
-	if len(c.Groups) > 0 {
-		var steps []PipelineStep
-		for _, g := range c.Groups {
-			steps = append(steps, g.Steps...)
-		}
-		return steps
+	var steps []PipelineStep
+	for _, g := range c.Groups {
+		steps = append(steps, g.Steps...)
 	}
-	return c.Steps
+	return steps
 }
 
 // ValidActionTypes defines the set of valid pipeline step action_type values.

--- a/backend/internal/domain/model/pipeline_config_test.go
+++ b/backend/internal/domain/model/pipeline_config_test.go
@@ -1,0 +1,262 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestParsePipelineConfigYAML_GroupsFormat(t *testing.T) {
+	yaml := []byte(`groups:
+  - id: setup
+    name: Setup
+    steps:
+      - name: create-branch
+        action_type: git_branch
+  - id: dev
+    name: Development
+    steps:
+      - name: dev-agent
+        action_type: agent_run
+      - name: review-agent
+        action_type: agent_run
+`)
+
+	cfg, err := ParsePipelineConfigYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.Groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(cfg.Groups))
+	}
+
+	if cfg.Groups[0].Name != "Setup" {
+		t.Errorf("expected group[0].Name = %q, got %q", "Setup", cfg.Groups[0].Name)
+	}
+	if cfg.Groups[0].ID != "setup" {
+		t.Errorf("expected group[0].ID = %q, got %q", "setup", cfg.Groups[0].ID)
+	}
+	if len(cfg.Groups[0].Steps) != 1 {
+		t.Fatalf("expected 1 step in group[0], got %d", len(cfg.Groups[0].Steps))
+	}
+	if cfg.Groups[0].Steps[0].ActionType != "git_branch" {
+		t.Errorf("expected group[0].steps[0].action_type = %q, got %q", "git_branch", cfg.Groups[0].Steps[0].ActionType)
+	}
+
+	if cfg.Groups[1].Name != "Development" {
+		t.Errorf("expected group[1].Name = %q, got %q", "Development", cfg.Groups[1].Name)
+	}
+	if len(cfg.Groups[1].Steps) != 2 {
+		t.Fatalf("expected 2 steps in group[1], got %d", len(cfg.Groups[1].Steps))
+	}
+}
+
+func TestParsePipelineConfigYAML_LegacyFlatSteps(t *testing.T) {
+	yaml := []byte(`steps:
+  - name: implement
+    action_type: implement
+  - name: review
+    action_type: review
+  - name: merge
+    action_type: merge
+`)
+
+	cfg, err := ParsePipelineConfigYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Legacy steps should be wrapped in a single "Default" group
+	if len(cfg.Groups) != 1 {
+		t.Fatalf("expected 1 group (auto-wrapped), got %d", len(cfg.Groups))
+	}
+
+	group := cfg.Groups[0]
+	if group.ID != "default" {
+		t.Errorf("expected auto-wrapped group ID %q, got %q", "default", group.ID)
+	}
+	if group.Name != "Default" {
+		t.Errorf("expected auto-wrapped group Name %q, got %q", "Default", group.Name)
+	}
+	if len(group.Steps) != 3 {
+		t.Fatalf("expected 3 steps in auto-wrapped group, got %d", len(group.Steps))
+	}
+	if group.Steps[0].Name != "implement" {
+		t.Errorf("expected step[0].Name = %q, got %q", "implement", group.Steps[0].Name)
+	}
+	if group.Steps[1].Name != "review" {
+		t.Errorf("expected step[1].Name = %q, got %q", "review", group.Steps[1].Name)
+	}
+	if group.Steps[2].Name != "merge" {
+		t.Errorf("expected step[2].Name = %q, got %q", "merge", group.Steps[2].Name)
+	}
+}
+
+func TestParsePipelineConfigYAML_EmptyInput(t *testing.T) {
+	cfg, err := ParsePipelineConfigYAML([]byte(""))
+	if err != nil {
+		t.Fatalf("unexpected error for empty input: %v", err)
+	}
+	if len(cfg.Groups) != 0 {
+		t.Errorf("expected 0 groups for empty input, got %d", len(cfg.Groups))
+	}
+}
+
+func TestParsePipelineConfigYAML_InvalidYAML(t *testing.T) {
+	_, err := ParsePipelineConfigYAML([]byte("{{not valid yaml"))
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+}
+
+func TestParsePipelineConfigYAML_GroupsPreferredOverSteps(t *testing.T) {
+	// If both groups and steps are present, groups should take precedence
+	yaml := []byte(`groups:
+  - id: g1
+    name: G1
+    steps:
+      - name: s1
+        action_type: agent_run
+steps:
+  - name: legacy
+    action_type: implement
+`)
+
+	cfg, err := ParsePipelineConfigYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.Groups) != 1 {
+		t.Fatalf("expected 1 group (groups take precedence), got %d", len(cfg.Groups))
+	}
+	if cfg.Groups[0].Name != "G1" {
+		t.Errorf("expected group from groups field, got %q", cfg.Groups[0].Name)
+	}
+}
+
+func TestParsePipelineConfigYAML_StepConfig(t *testing.T) {
+	yaml := []byte(`groups:
+  - id: setup
+    name: Setup
+    steps:
+      - name: create-branch
+        action_type: git_branch
+        config:
+          base_branch: main
+          target_branch: develop
+`)
+
+	cfg, err := ParsePipelineConfigYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	step := cfg.Groups[0].Steps[0]
+	if step.Config == nil {
+		t.Fatal("expected non-nil Config map")
+	}
+	if step.Config["base_branch"] != "main" {
+		t.Errorf("expected config[base_branch] = %q, got %q", "main", step.Config["base_branch"])
+	}
+	if step.Config["target_branch"] != "develop" {
+		t.Errorf("expected config[target_branch] = %q, got %q", "develop", step.Config["target_branch"])
+	}
+}
+
+func TestParsePipelineConfigYAML_StepDescription(t *testing.T) {
+	yaml := []byte(`groups:
+  - id: setup
+    name: Setup
+    steps:
+      - name: create-branch
+        action_type: git_branch
+        description: Create feature branch from base
+`)
+
+	cfg, err := ParsePipelineConfigYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	step := cfg.Groups[0].Steps[0]
+	if step.Description != "Create feature branch from base" {
+		t.Errorf("expected description %q, got %q", "Create feature branch from base", step.Description)
+	}
+}
+
+func TestFlatSteps_MultipleGroups(t *testing.T) {
+	cfg := &PipelineConfigYAML{
+		Groups: []PipelineGroup{
+			{
+				ID:   "g1",
+				Name: "G1",
+				Steps: []PipelineStep{
+					{Name: "s1", ActionType: "git_branch"},
+					{Name: "s2", ActionType: "agent_run"},
+				},
+			},
+			{
+				ID:   "g2",
+				Name: "G2",
+				Steps: []PipelineStep{
+					{Name: "s3", ActionType: "git_pr"},
+				},
+			},
+			{
+				ID:   "g3",
+				Name: "G3",
+				Steps: []PipelineStep{
+					{Name: "s4", ActionType: "ci_poll"},
+					{Name: "s5", ActionType: "notification"},
+				},
+			},
+		},
+	}
+
+	flat := cfg.FlatSteps()
+	if len(flat) != 5 {
+		t.Fatalf("expected 5 flat steps, got %d", len(flat))
+	}
+
+	expectedNames := []string{"s1", "s2", "s3", "s4", "s5"}
+	for i, expected := range expectedNames {
+		if flat[i].Name != expected {
+			t.Errorf("flat step[%d]: expected name %q, got %q", i, expected, flat[i].Name)
+		}
+	}
+}
+
+func TestFlatSteps_EmptyGroups(t *testing.T) {
+	cfg := &PipelineConfigYAML{
+		Groups: []PipelineGroup{},
+	}
+
+	flat := cfg.FlatSteps()
+	if len(flat) != 0 {
+		t.Errorf("expected 0 flat steps for empty groups, got %d", len(flat))
+	}
+}
+
+func TestValidActionTypes_NewTypes(t *testing.T) {
+	newTypes := []string{"agent_run", "git_branch", "git_pr", "notification", "human", "ci_poll", "hitl_gate"}
+	for _, at := range newTypes {
+		if !ValidActionTypes[at] {
+			t.Errorf("expected action type %q to be valid", at)
+		}
+	}
+}
+
+func TestValidActionTypes_LegacyTypes(t *testing.T) {
+	legacyTypes := []string{"implement", "review", "merge", "test", "custom"}
+	for _, at := range legacyTypes {
+		if !ValidActionTypes[at] {
+			t.Errorf("expected legacy action type %q to be valid", at)
+		}
+	}
+}
+
+func TestValidActionTypes_InvalidType(t *testing.T) {
+	if ValidActionTypes["unknown_action"] {
+		t.Error("expected unknown_action to be invalid")
+	}
+}

--- a/backend/internal/domain/service/pipeline_config_service.go
+++ b/backend/internal/domain/service/pipeline_config_service.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"gopkg.in/yaml.v3"
 
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
 	"github.com/zakari/hopeitworks/backend/internal/domain/port"
@@ -19,10 +18,12 @@ const DefaultPipelineConfigYAML = `groups:
     name: Setup
     steps:
       - id: 880e8400-e29b-41d4-a716-446655440001
-        name: branch
+        name: create-branch
         action_type: git_branch
-        model: claude-sonnet-4-6
+        description: Create feature branch from base
         auto_approve: true
+        config:
+          base_branch: main
         retry_policy:
           max_retries: 1
           retry_type: on-failure
@@ -30,32 +31,53 @@ const DefaultPipelineConfigYAML = `groups:
     name: Development
     steps:
       - id: 880e8400-e29b-41d4-a716-446655440002
-        name: implement
+        name: dev-agent
         action_type: agent_run
+        description: Run development agent
         model: claude-opus-4-6
-        auto_approve: false
-        retry_policy:
-          max_retries: 3
-          retry_type: on-failure
-      - id: 880e8400-e29b-41d4-a716-446655440003
-        name: review
-        action_type: agent_run
-        model: claude-sonnet-4-6
         auto_approve: false
         retry_policy:
           max_retries: 2
           retry_type: on-failure
-  - id: finalize
-    name: Finalize
+  - id: review
+    name: Review
+    steps:
+      - id: 880e8400-e29b-41d4-a716-446655440003
+        name: review-agent
+        action_type: agent_run
+        description: Run code review agent
+        model: claude-sonnet-4-6
+        auto_approve: false
+        retry_policy:
+          max_retries: 1
+          retry_type: on-failure
+  - id: merge
+    name: Merge
     steps:
       - id: 880e8400-e29b-41d4-a716-446655440004
-        name: merge
+        name: create-pr
         action_type: git_pr
+        description: Create and merge pull request
         model: claude-sonnet-4-6
         auto_approve: true
         retry_policy:
           max_retries: 1
           retry_type: on-failure
+  - id: delivery
+    name: Delivery
+    steps:
+      - id: 880e8400-e29b-41d4-a716-446655440005
+        name: poll-ci
+        action_type: ci_poll
+        description: Wait for CI to pass
+        auto_approve: true
+        config:
+          timeout_minutes: "30"
+      - id: 880e8400-e29b-41d4-a716-446655440006
+        name: notify
+        action_type: notification
+        description: Send completion notification
+        auto_approve: true
 `
 
 // PipelineConfigService provides business logic for pipeline config operations.
@@ -96,50 +118,67 @@ func (s *PipelineConfigService) SeedDefault(ctx context.Context, projectID uuid.
 }
 
 // validatePipelineConfigYAML parses and validates the pipeline config YAML.
+// Validates group structure (non-empty names, non-empty steps) and step-level
+// fields (name, action_type). Uses ParsePipelineConfigYAML for backward-
+// compatible parsing of both groups and legacy flat-steps formats.
 func validatePipelineConfigYAML(configYAML string) error {
 	if configYAML == "" {
 		return errors.NewValidation("config_yaml", "is required")
 	}
 
-	var parsed model.PipelineConfigYAML
-	if err := yaml.Unmarshal([]byte(configYAML), &parsed); err != nil {
+	parsed, err := model.ParsePipelineConfigYAML([]byte(configYAML))
+	if err != nil {
 		return &errors.DomainError{
 			Category: errors.CategoryValidation,
 			Code:     "INVALID_PIPELINE_CONFIG",
-			Message:  fmt.Sprintf("invalid YAML: %v", err),
+			Message:  err.Error(),
 		}
 	}
 
-	steps := parsed.FlatSteps()
-	if len(steps) == 0 {
+	if len(parsed.Groups) == 0 {
 		return &errors.DomainError{
 			Category: errors.CategoryValidation,
 			Code:     "INVALID_PIPELINE_CONFIG",
-			Message:  "pipeline config must have at least one step",
+			Message:  "pipeline config must have at least one group",
 		}
 	}
 
-	for _, step := range steps {
-		if step.Name == "" {
+	for i, group := range parsed.Groups {
+		if group.Name == "" {
 			return &errors.DomainError{
 				Category: errors.CategoryValidation,
 				Code:     "INVALID_PIPELINE_CONFIG",
-				Message:  "each step must have a name",
+				Message:  fmt.Sprintf("groups[%d].name: group name is required", i),
 			}
 		}
-		if step.ActionType == "" {
+		if len(group.Steps) == 0 {
 			return &errors.DomainError{
 				Category: errors.CategoryValidation,
 				Code:     "INVALID_PIPELINE_CONFIG",
-				Message:  fmt.Sprintf("step '%s' must have an action_type", step.Name),
+				Message:  fmt.Sprintf("groups[%d].steps: group must have at least one step", i),
 			}
 		}
-		// TODO(S-3-3): Replace with ActionRegistry validation once implemented.
-		if !model.ValidActionTypes[step.ActionType] {
-			return &errors.DomainError{
-				Category: errors.CategoryValidation,
-				Code:     "INVALID_PIPELINE_CONFIG",
-				Message:  fmt.Sprintf("invalid action_type: %s", step.ActionType),
+		for j, step := range group.Steps {
+			if step.Name == "" {
+				return &errors.DomainError{
+					Category: errors.CategoryValidation,
+					Code:     "INVALID_PIPELINE_CONFIG",
+					Message:  fmt.Sprintf("groups[%d].steps[%d].name: step name is required", i, j),
+				}
+			}
+			if step.ActionType == "" {
+				return &errors.DomainError{
+					Category: errors.CategoryValidation,
+					Code:     "INVALID_PIPELINE_CONFIG",
+					Message:  fmt.Sprintf("groups[%d].steps[%d].action_type: action type is required for step '%s'", i, j, step.Name),
+				}
+			}
+			if !model.ValidActionTypes[step.ActionType] {
+				return &errors.DomainError{
+					Category: errors.CategoryValidation,
+					Code:     "INVALID_ACTION_TYPE",
+					Message:  fmt.Sprintf("groups[%d].steps[%d].action_type: unknown action type: %s", i, j, step.ActionType),
+				}
 			}
 		}
 	}

--- a/backend/internal/domain/service/pipeline_config_service_test.go
+++ b/backend/internal/domain/service/pipeline_config_service_test.go
@@ -149,6 +149,26 @@ func TestPipelineConfigService_Upsert_InvalidYAML(t *testing.T) {
   - name: my_step
     action_type: invalid_action
 `,
+			errCode: "INVALID_ACTION_TYPE",
+		},
+		{
+			name: "group with empty name",
+			yaml: `groups:
+  - id: g1
+    name: ""
+    steps:
+      - name: s1
+        action_type: agent_run
+`,
+			errCode: "INVALID_PIPELINE_CONFIG",
+		},
+		{
+			name: "group with no steps",
+			yaml: `groups:
+  - id: g1
+    name: EmptyGroup
+    steps: []
+`,
 			errCode: "INVALID_PIPELINE_CONFIG",
 		},
 	}
@@ -249,5 +269,137 @@ func TestPipelineConfigService_SeedDefault(t *testing.T) {
 	}
 	if result.Version != 1 {
 		t.Errorf("expected version 1, got %d", result.Version)
+	}
+}
+
+func TestPipelineConfigService_SeedDefault_ParsesCorrectly(t *testing.T) {
+	// Verify the default YAML is valid and has the expected groups
+	parsed, err := model.ParsePipelineConfigYAML([]byte(DefaultPipelineConfigYAML))
+	if err != nil {
+		t.Fatalf("default YAML failed to parse: %v", err)
+	}
+
+	expectedGroups := []struct {
+		name        string
+		actionTypes []string
+	}{
+		{"Setup", []string{"git_branch"}},
+		{"Development", []string{"agent_run"}},
+		{"Review", []string{"agent_run"}},
+		{"Merge", []string{"git_pr"}},
+		{"Delivery", []string{"ci_poll", "notification"}},
+	}
+
+	if len(parsed.Groups) != len(expectedGroups) {
+		t.Fatalf("expected %d groups, got %d", len(expectedGroups), len(parsed.Groups))
+	}
+
+	for i, expected := range expectedGroups {
+		group := parsed.Groups[i]
+		if group.Name != expected.name {
+			t.Errorf("group[%d]: expected name %q, got %q", i, expected.name, group.Name)
+		}
+		if len(group.Steps) != len(expected.actionTypes) {
+			t.Errorf("group[%d] %q: expected %d steps, got %d", i, expected.name, len(expected.actionTypes), len(group.Steps))
+			continue
+		}
+		for j, expectedAction := range expected.actionTypes {
+			if group.Steps[j].ActionType != expectedAction {
+				t.Errorf("group[%d].steps[%d]: expected action_type %q, got %q", i, j, expectedAction, group.Steps[j].ActionType)
+			}
+		}
+	}
+}
+
+func TestPipelineConfigService_Upsert_NewActionTypes(t *testing.T) {
+	repo := newMockPipelineConfigRepo()
+	svc := NewPipelineConfigService(repo)
+
+	projectID := uuid.New()
+	configYAML := `groups:
+  - id: g1
+    name: AllNewTypes
+    steps:
+      - name: s1
+        action_type: agent_run
+      - name: s2
+        action_type: git_branch
+      - name: s3
+        action_type: git_pr
+      - name: s4
+        action_type: notification
+      - name: s5
+        action_type: human
+      - name: s6
+        action_type: ci_poll
+      - name: s7
+        action_type: hitl_gate
+`
+
+	result, err := svc.Upsert(context.Background(), projectID, configYAML)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestPipelineConfigService_Upsert_GroupsFormat(t *testing.T) {
+	repo := newMockPipelineConfigRepo()
+	svc := NewPipelineConfigService(repo)
+
+	projectID := uuid.New()
+	configYAML := `groups:
+  - id: setup
+    name: Setup
+    steps:
+      - name: branch
+        action_type: git_branch
+  - id: dev
+    name: Development
+    steps:
+      - name: implement
+        action_type: agent_run
+  - id: review
+    name: Review
+    steps:
+      - name: review
+        action_type: agent_run
+`
+
+	result, err := svc.Upsert(context.Background(), projectID, configYAML)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestPipelineConfigService_Upsert_InvalidActionType_ErrorCode(t *testing.T) {
+	repo := newMockPipelineConfigRepo()
+	svc := NewPipelineConfigService(repo)
+
+	projectID := uuid.New()
+	configYAML := `groups:
+  - id: g1
+    name: MyGroup
+    steps:
+      - name: s1
+        action_type: unknown_action
+`
+
+	_, err := svc.Upsert(context.Background(), projectID, configYAML)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	domainErr, ok := err.(*errors.DomainError)
+	if !ok {
+		t.Fatalf("expected DomainError, got %T", err)
+	}
+	if domainErr.Code != "INVALID_ACTION_TYPE" {
+		t.Errorf("expected error code INVALID_ACTION_TYPE, got %q", domainErr.Code)
 	}
 }

--- a/backend/internal/domain/service/run_service.go
+++ b/backend/internal/domain/service/run_service.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"gopkg.in/yaml.v3"
 
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
 	"github.com/zakari/hopeitworks/backend/internal/domain/port"
@@ -301,9 +300,9 @@ func (s *RunService) LaunchRun(ctx context.Context, projectID, storyID uuid.UUID
 		return nil, err
 	}
 
-	// 5. Parse YAML steps
-	var parsed model.PipelineConfigYAML
-	if err := yaml.Unmarshal([]byte(pipelineCfg.ConfigYAML), &parsed); err != nil {
+	// 5. Parse YAML steps (backward-compatible: legacy flat steps auto-wrapped in group)
+	parsed, err := model.ParsePipelineConfigYAML([]byte(pipelineCfg.ConfigYAML))
+	if err != nil {
 		return nil, errors.NewInternal("parse pipeline config", err)
 	}
 	flatSteps := parsed.FlatSteps()

--- a/backend/internal/integration/pipeline_validation_test.go
+++ b/backend/internal/integration/pipeline_validation_test.go
@@ -294,8 +294,9 @@ func TestIntegration_PipelineValidation_RunCreation(t *testing.T) {
 		if err := json.Unmarshal(run.PipelineConfigSnapshot, &snapshot); err != nil {
 			t.Fatalf("failed to unmarshal config snapshot: %v", err)
 		}
-		if len(snapshot.Steps) != 3 {
-			t.Errorf("expected 3 steps in snapshot, got %d", len(snapshot.Steps))
+		flatSteps := snapshot.FlatSteps()
+		if len(flatSteps) != 3 {
+			t.Errorf("expected 3 steps in snapshot, got %d", len(flatSteps))
 		}
 	})
 


### PR DESCRIPTION
## Summary
- Implements story R-1-3: PipelineGroup in backend model + YAML parsing + validation
- Adds `ParsePipelineConfigYAML()` function with backward-compatible auto-wrapping of legacy flat-steps YAML into a "Default" group
- Updates `DefaultPipelineConfigYAML` to use the 5-group structure: Setup (git_branch), Development (agent_run), Review (agent_run), Merge (git_pr), Delivery (ci_poll + notification)
- Adds group-level validation (non-empty name, non-empty steps) and uses `INVALID_ACTION_TYPE` error code for unknown action types
- Adds `Description` field and JSON tags to domain model structs
- Updates `run_service.go` LaunchRun to use `ParsePipelineConfigYAML` for backward-compatible parsing
- Adds comprehensive unit tests for parsing, validation, FlatSteps, and new action types

## Acceptance Criteria Coverage
- ✅ AC #1: PipelineGroup struct with ID, Name, Steps; PipelineConfigYAML uses Groups
- ✅ AC #2: PipelineStep has Config map[string]string field
- ✅ AC #3: New action types accepted (git_branch, git_pr, notification, human, ci_poll, hitl_gate)
- ✅ AC #4: Legacy flat-steps YAML auto-wrapped in "Default" group
- ✅ AC #5: Default config uses groups (Setup/Development/Review/Merge/Delivery)
- ✅ AC #6: Validation rejects unknown action types with INVALID_ACTION_TYPE code
- ✅ AC #7: Validation rejects empty group names
- ✅ AC #8: Validation rejects groups with no steps

## Test plan
- [x] Unit tests for `ParsePipelineConfigYAML` (groups format, legacy flat steps, empty input, invalid YAML, groups-preferred-over-steps)
- [x] Unit tests for `FlatSteps` (multiple groups, empty groups)
- [x] Unit tests for `ValidActionTypes` (new types, legacy types, invalid type)
- [x] Unit tests for validation (empty group name, empty steps, invalid action type error code)
- [x] Unit tests for default config parsing (5 groups with correct action types)
- [x] All existing tests updated and passing
- [x] `go test ./... -short` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)