### PR TITLE
feat(action): implement notification action for pipeline events

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -202,6 +202,11 @@ func run() error {
 	actionReg.Register(hitlGateAction)
 	logger.Info("hitl_gate action registered")
 
+	// Notification action (no Docker required)
+	notificationAction := actionadapter.NewNotificationAction(eventRepo, storyRepo, logger)
+	actionReg.Register(notificationAction)
+	logger.Info("notification action registered")
+
 	// Cost tracking (for agent_run action)
 	costSvc := costService
 

--- a/backend/internal/adapter/action/helpers.go
+++ b/backend/internal/adapter/action/helpers.go
@@ -1,0 +1,12 @@
+package action
+
+import "strings"
+
+// renderTemplate replaces {key} placeholders in tpl with values from vars.
+func renderTemplate(tpl string, vars map[string]string) string {
+	result := tpl
+	for k, v := range vars {
+		result = strings.ReplaceAll(result, "{"+k+"}", v)
+	}
+	return result
+}

--- a/backend/internal/adapter/action/notification.go
+++ b/backend/internal/adapter/action/notification.go
@@ -1,0 +1,92 @@
+package action
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+)
+
+// NotificationAction implements model.Action for publishing a notification event.
+// It renders a configurable message template with RunContext variables and publishes
+// a "notification.sent" event via EventPublisher. Failures are non-fatal.
+type NotificationAction struct {
+	eventPub  port.EventPublisher
+	storyRepo port.StoryRepository
+	logger    *slog.Logger
+}
+
+// NewNotificationAction creates a new NotificationAction.
+func NewNotificationAction(
+	eventPub port.EventPublisher,
+	storyRepo port.StoryRepository,
+	logger *slog.Logger,
+) *NotificationAction {
+	return &NotificationAction{eventPub: eventPub, storyRepo: storyRepo, logger: logger}
+}
+
+// Name returns the action name.
+func (a *NotificationAction) Name() string { return "notification" }
+
+// Execute publishes a notification event with a rendered message template.
+func (a *NotificationAction) Execute(ctx context.Context, runCtx *model.RunContext) error {
+	// Read message template from metadata (populated from pipeline config)
+	msgTemplate, ok := runCtx.Metadata["message"].(string)
+	if !ok || msgTemplate == "" {
+		msgTemplate = "Pipeline step {step_name} completed"
+	}
+
+	storyKey := ""
+	story, err := a.storyRepo.GetByID(ctx, runCtx.StoryID)
+	if err != nil {
+		a.logger.Warn("notification: failed to fetch story, proceeding with empty story_key",
+			"story_id", runCtx.StoryID, "error", err)
+	} else {
+		storyKey = story.Key
+	}
+
+	branchName, _ := runCtx.Metadata["branch_name"].(string)
+	prURL, _ := runCtx.Metadata["pr_url"].(string)
+
+	message := renderTemplate(msgTemplate, map[string]string{
+		"story_key":   storyKey,
+		"step_name":   runCtx.RunStep.StepName,
+		"run_id":      runCtx.Run.ID.String(),
+		"branch_name": branchName,
+		"pr_url":      prURL,
+	})
+
+	payload := map[string]string{
+		"message":   message,
+		"step_id":   runCtx.RunStep.ID.String(),
+		"run_id":    runCtx.Run.ID.String(),
+		"story_key": storyKey,
+	}
+	payloadJSON, marshalErr := json.Marshal(payload)
+	if marshalErr != nil {
+		a.logger.Warn("notification: failed to marshal payload", "error", marshalErr)
+		return nil // non-fatal
+	}
+
+	event := model.Event{
+		ID:         uuid.New(),
+		ProjectID:  runCtx.ProjectID,
+		EntityType: "notification",
+		EntityID:   runCtx.RunStep.ID,
+		Action:     "sent",
+		Payload:    payloadJSON,
+	}
+
+	if pubErr := a.eventPub.Publish(ctx, event); pubErr != nil {
+		a.logger.Warn("notification: failed to publish event",
+			"story_key", storyKey,
+			"run_id", runCtx.Run.ID,
+			"error", pubErr,
+		)
+	}
+
+	return nil
+}

--- a/backend/internal/adapter/action/notification_test.go
+++ b/backend/internal/adapter/action/notification_test.go
@@ -1,0 +1,386 @@
+package action_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/adapter/action"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	apperrors "github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// --- Notification-specific mocks ---
+
+type notificationMockEventPublisher struct {
+	mu              sync.Mutex
+	publishFn       func(ctx context.Context, event model.Event) error
+	publishedEvents []model.Event
+}
+
+func (m *notificationMockEventPublisher) Publish(ctx context.Context, event model.Event) error {
+	m.mu.Lock()
+	m.publishedEvents = append(m.publishedEvents, event)
+	m.mu.Unlock()
+	if m.publishFn != nil {
+		return m.publishFn(ctx, event)
+	}
+	return nil
+}
+
+type notificationMockStoryRepo struct {
+	getByIDFn func(ctx context.Context, id uuid.UUID) (*model.Story, error)
+}
+
+func (m *notificationMockStoryRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Story, error) {
+	if m.getByIDFn != nil {
+		return m.getByIDFn(ctx, id)
+	}
+	return nil, apperrors.NewNotFound("story", id)
+}
+
+func (m *notificationMockStoryRepo) GetByKey(_ context.Context, _ uuid.UUID, _ string) (*model.Story, error) {
+	return nil, apperrors.NewNotFound("story", uuid.Nil)
+}
+
+func (m *notificationMockStoryRepo) Create(_ context.Context, _ *model.Story) (*model.Story, error) {
+	return nil, nil
+}
+
+func (m *notificationMockStoryRepo) Update(_ context.Context, _ *model.Story) (*model.Story, error) {
+	return nil, nil
+}
+
+func (m *notificationMockStoryRepo) Delete(_ context.Context, _ uuid.UUID) error {
+	return nil
+}
+
+func (m *notificationMockStoryRepo) ListByProject(_ context.Context, _ uuid.UUID, _ int32, _ int32) ([]*model.Story, error) {
+	return nil, nil
+}
+
+func (m *notificationMockStoryRepo) ListByStatus(_ context.Context, _ uuid.UUID, _ []string, _ int32, _ int32) ([]*model.Story, error) {
+	return nil, nil
+}
+
+func (m *notificationMockStoryRepo) ListByEpic(_ context.Context, _ uuid.UUID, _ int32, _ int32) ([]*model.Story, error) {
+	return nil, nil
+}
+
+func (m *notificationMockStoryRepo) CountByProject(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+
+func (m *notificationMockStoryRepo) CountByStatus(_ context.Context, _ uuid.UUID, _ []string) (int64, error) {
+	return 0, nil
+}
+
+// --- Tests ---
+
+func TestNotificationAction_Name(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	eventPub := &notificationMockEventPublisher{}
+	storyRepo := &notificationMockStoryRepo{}
+
+	notif := action.NewNotificationAction(eventPub, storyRepo, logger)
+
+	if got := notif.Name(); got != "notification" {
+		t.Errorf("Name() = %q, want %q", got, "notification")
+	}
+}
+
+func TestNotificationAction_Execute_HappyPath(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	eventPub := &notificationMockEventPublisher{}
+	storyRepo := &notificationMockStoryRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			return &model.Story{
+				ID:  id,
+				Key: "S-01",
+			}, nil
+		},
+	}
+
+	notif := action.NewNotificationAction(eventPub, storyRepo, logger)
+
+	projectID := uuid.New()
+	storyID := uuid.New()
+	runID := uuid.New()
+	stepID := uuid.New()
+
+	runCtx := &model.RunContext{
+		ProjectID: projectID,
+		StoryID:   storyID,
+		Run: &model.Run{
+			ID: runID,
+		},
+		RunStep: &model.RunStep{
+			ID:       stepID,
+			StepName: "deploy",
+		},
+		Metadata: map[string]interface{}{
+			"message":     "Story {story_key} deployed successfully",
+			"branch_name": "feat/S-01-login",
+		},
+	}
+
+	err := notif.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want nil", err)
+	}
+
+	// Verify event published
+	if len(eventPub.publishedEvents) != 1 {
+		t.Fatalf("published %d events, want 1", len(eventPub.publishedEvents))
+	}
+
+	event := eventPub.publishedEvents[0]
+
+	if event.EntityType != "notification" {
+		t.Errorf("EntityType = %q, want %q", event.EntityType, "notification")
+	}
+	if event.Action != "sent" {
+		t.Errorf("Action = %q, want %q", event.Action, "sent")
+	}
+	if event.EntityID != stepID {
+		t.Errorf("EntityID = %v, want %v", event.EntityID, stepID)
+	}
+	if event.ProjectID != projectID {
+		t.Errorf("ProjectID = %v, want %v", event.ProjectID, projectID)
+	}
+
+	// Verify payload
+	var payload map[string]string
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	expectedMessage := "Story S-01 deployed successfully"
+	if payload["message"] != expectedMessage {
+		t.Errorf("payload[message] = %q, want %q", payload["message"], expectedMessage)
+	}
+	if payload["story_key"] != "S-01" {
+		t.Errorf("payload[story_key] = %q, want %q", payload["story_key"], "S-01")
+	}
+	if payload["step_id"] != stepID.String() {
+		t.Errorf("payload[step_id] = %q, want %q", payload["step_id"], stepID.String())
+	}
+	if payload["run_id"] != runID.String() {
+		t.Errorf("payload[run_id] = %q, want %q", payload["run_id"], runID.String())
+	}
+}
+
+func TestNotificationAction_Execute_TemplateRendering(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	eventPub := &notificationMockEventPublisher{}
+	storyRepo := &notificationMockStoryRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			return &model.Story{
+				ID:  id,
+				Key: "S-03",
+			}, nil
+		},
+	}
+
+	notif := action.NewNotificationAction(eventPub, storyRepo, logger)
+
+	projectID := uuid.New()
+	storyID := uuid.New()
+	runID := uuid.New()
+	stepID := uuid.New()
+
+	runCtx := &model.RunContext{
+		ProjectID: projectID,
+		StoryID:   storyID,
+		Run: &model.Run{
+			ID: runID,
+		},
+		RunStep: &model.RunStep{
+			ID:       stepID,
+			StepName: "create-pr",
+		},
+		Metadata: map[string]interface{}{
+			"message":     "Branch {branch_name} created for {story_key}",
+			"branch_name": "feat/S-03-login",
+		},
+	}
+
+	err := notif.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want nil", err)
+	}
+
+	// Verify rendered message
+	event := eventPub.publishedEvents[0]
+	var payload map[string]string
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	expectedMessage := "Branch feat/S-03-login created for S-03"
+	if payload["message"] != expectedMessage {
+		t.Errorf("payload[message] = %q, want %q", payload["message"], expectedMessage)
+	}
+}
+
+func TestNotificationAction_Execute_MissingMessageConfig(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	eventPub := &notificationMockEventPublisher{}
+	storyRepo := &notificationMockStoryRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			return &model.Story{
+				ID:  id,
+				Key: "S-02",
+			}, nil
+		},
+	}
+
+	notif := action.NewNotificationAction(eventPub, storyRepo, logger)
+
+	projectID := uuid.New()
+	storyID := uuid.New()
+	runID := uuid.New()
+	stepID := uuid.New()
+
+	runCtx := &model.RunContext{
+		ProjectID: projectID,
+		StoryID:   storyID,
+		Run: &model.Run{
+			ID: runID,
+		},
+		RunStep: &model.RunStep{
+			ID:       stepID,
+			StepName: "notify",
+		},
+		Metadata: map[string]interface{}{}, // No message key
+	}
+
+	err := notif.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want nil", err)
+	}
+
+	// Verify default message was used
+	if len(eventPub.publishedEvents) != 1 {
+		t.Fatalf("published %d events, want 1", len(eventPub.publishedEvents))
+	}
+
+	event := eventPub.publishedEvents[0]
+	var payload map[string]string
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	expectedMessage := "Pipeline step notify completed"
+	if payload["message"] != expectedMessage {
+		t.Errorf("payload[message] = %q, want %q", payload["message"], expectedMessage)
+	}
+}
+
+func TestNotificationAction_Execute_EventPublisherFailure(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	eventPub := &notificationMockEventPublisher{
+		publishFn: func(_ context.Context, _ model.Event) error {
+			return apperrors.NewInternal("publish failed", nil)
+		},
+	}
+	storyRepo := &notificationMockStoryRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			return &model.Story{
+				ID:  id,
+				Key: "S-04",
+			}, nil
+		},
+	}
+
+	notif := action.NewNotificationAction(eventPub, storyRepo, logger)
+
+	projectID := uuid.New()
+	storyID := uuid.New()
+	runID := uuid.New()
+	stepID := uuid.New()
+
+	runCtx := &model.RunContext{
+		ProjectID: projectID,
+		StoryID:   storyID,
+		Run: &model.Run{
+			ID: runID,
+		},
+		RunStep: &model.RunStep{
+			ID:       stepID,
+			StepName: "notify",
+		},
+		Metadata: map[string]interface{}{
+			"message": "Test message",
+		},
+	}
+
+	// Should not return error even if publisher fails (non-fatal)
+	err := notif.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Errorf("Execute() error = %v, want nil (EventPublisher failures are non-fatal)", err)
+	}
+}
+
+func TestNotificationAction_Execute_StoryLookupFailure(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	eventPub := &notificationMockEventPublisher{}
+	storyRepo := &notificationMockStoryRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			return nil, apperrors.NewNotFound("story", id)
+		},
+	}
+
+	notif := action.NewNotificationAction(eventPub, storyRepo, logger)
+
+	projectID := uuid.New()
+	storyID := uuid.New()
+	runID := uuid.New()
+	stepID := uuid.New()
+
+	runCtx := &model.RunContext{
+		ProjectID: projectID,
+		StoryID:   storyID,
+		Run: &model.Run{
+			ID: runID,
+		},
+		RunStep: &model.RunStep{
+			ID:       stepID,
+			StepName: "notify",
+		},
+		Metadata: map[string]interface{}{
+			"message": "Story {story_key} failed",
+		},
+	}
+
+	// Should not return error even if story lookup fails
+	err := notif.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Errorf("Execute() error = %v, want nil (story lookup failures are non-fatal)", err)
+	}
+
+	// Verify event was still published with empty story_key
+	if len(eventPub.publishedEvents) != 1 {
+		t.Fatalf("published %d events, want 1", len(eventPub.publishedEvents))
+	}
+
+	event := eventPub.publishedEvents[0]
+	var payload map[string]string
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	if payload["story_key"] != "" {
+		t.Errorf("payload[story_key] = %q, want empty string", payload["story_key"])
+	}
+
+	// Message should have empty story_key placeholder
+	expectedMessage := "Story  failed"
+	if payload["message"] != expectedMessage {
+		t.Errorf("payload[message] = %q, want %q", payload["message"], expectedMessage)
+	}
+}


### PR DESCRIPTION
## Summary
Implements the `notification` action that publishes user-defined messages as platform events, enabling pipeline steps to surface progress updates to the SSE stream and external notification channels (Discord, webhooks).

## Implementation
- **NotificationAction** in `backend/internal/adapter/action/notification.go`
  - Reads message template from `runCtx.Metadata["message"]`
  - Renders template with variables: `{story_key}`, `{step_name}`, `{run_id}`, `{branch_name}`, `{pr_url}`
  - Publishes `notification.sent` event via EventPublisher
  - Non-fatal: logs errors but never fails the pipeline step
- **renderTemplate helper** in `helpers.go` for placeholder substitution
- **DI registration** in `cmd/api/main.go`
- **Comprehensive unit tests** (6 test cases covering all acceptance criteria)

## Technical Notes
- Uses `Metadata["message"]` instead of `RunStep.Config` (R-1-3 not yet implemented)
- Pattern matches existing actions (`ci_poll`, `hitl_gate`)
- All tests pass, `go vet` clean, builds successfully

## Story
Closes R-2-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)