### PR TITLE
feat(cost): add agent_id to cost_records with aggregation query

### DIFF
--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -392,6 +392,9 @@ func (m *mockCostRepo) ListCostsByProjectByRunPaginated(_ context.Context, _ uui
 func (m *mockCostRepo) CountCostsByProjectByRun(_ context.Context, _ uuid.UUID, _ time.Time) (int64, error) {
 	return 0, nil
 }
+func (m *mockCostRepo) ListByProjectByAgent(_ context.Context, _ uuid.UUID) ([]model.AgentCostBreakdown, error) {
+	return nil, nil
+}
 
 type agentRunFixture struct {
 	projectID uuid.UUID

--- a/backend/internal/adapter/postgres/cost_records.sql.go
+++ b/backend/internal/adapter/postgres/cost_records.sql.go
@@ -33,7 +33,7 @@ func (q *Queries) CountCostsByProjectByRun(ctx context.Context, arg CountCostsBy
 }
 
 const getCostByRunStep = `-- name: GetCostByRunStep :one
-SELECT id, run_step_id, project_id, tokens_input, tokens_output, cost_usd, model, created_at FROM cost_records WHERE run_step_id = $1 LIMIT 1
+SELECT id, run_step_id, project_id, tokens_input, tokens_output, cost_usd, model, created_at, agent_id FROM cost_records WHERE run_step_id = $1 LIMIT 1
 `
 
 func (q *Queries) GetCostByRunStep(ctx context.Context, runStepID uuid.UUID) (CostRecord, error) {
@@ -48,14 +48,15 @@ func (q *Queries) GetCostByRunStep(ctx context.Context, runStepID uuid.UUID) (Co
 		&i.CostUsd,
 		&i.Model,
 		&i.CreatedAt,
+		&i.AgentID,
 	)
 	return i, err
 }
 
 const insertCostRecord = `-- name: InsertCostRecord :one
-INSERT INTO cost_records (run_step_id, project_id, tokens_input, tokens_output, cost_usd, model)
-VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, run_step_id, project_id, tokens_input, tokens_output, cost_usd, model, created_at
+INSERT INTO cost_records (run_step_id, project_id, tokens_input, tokens_output, cost_usd, model, agent_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+RETURNING id, run_step_id, project_id, tokens_input, tokens_output, cost_usd, model, created_at, agent_id
 `
 
 type InsertCostRecordParams struct {
@@ -65,6 +66,7 @@ type InsertCostRecordParams struct {
 	TokensOutput int64          `json:"tokens_output"`
 	CostUsd      pgtype.Numeric `json:"cost_usd"`
 	Model        string         `json:"model"`
+	AgentID      pgtype.UUID    `json:"agent_id"`
 }
 
 func (q *Queries) InsertCostRecord(ctx context.Context, arg InsertCostRecordParams) (CostRecord, error) {
@@ -75,6 +77,7 @@ func (q *Queries) InsertCostRecord(ctx context.Context, arg InsertCostRecordPara
 		arg.TokensOutput,
 		arg.CostUsd,
 		arg.Model,
+		arg.AgentID,
 	)
 	var i CostRecord
 	err := row.Scan(
@@ -86,8 +89,63 @@ func (q *Queries) InsertCostRecord(ctx context.Context, arg InsertCostRecordPara
 		&i.CostUsd,
 		&i.Model,
 		&i.CreatedAt,
+		&i.AgentID,
 	)
 	return i, err
+}
+
+const listCostsByProjectByAgent = `-- name: ListCostsByProjectByAgent :many
+SELECT
+  cr.agent_id,
+  COALESCE(a.name, 'Unknown') AS agent_name,
+  SUM(cr.tokens_input)::bigint AS tokens_input,
+  SUM(cr.tokens_output)::bigint AS tokens_output,
+  SUM(cr.cost_usd)::DECIMAL(10,6) AS cost_usd,
+  COUNT(DISTINCT rs.run_id)::int AS runs_count
+FROM cost_records cr
+LEFT JOIN agents a ON a.id = cr.agent_id
+JOIN run_steps rs ON rs.id = cr.run_step_id
+JOIN runs r ON r.id = rs.run_id
+WHERE r.project_id = $1
+  AND cr.agent_id IS NOT NULL
+GROUP BY cr.agent_id, a.name
+ORDER BY cost_usd DESC
+`
+
+type ListCostsByProjectByAgentRow struct {
+	AgentID      pgtype.UUID    `json:"agent_id"`
+	AgentName    string         `json:"agent_name"`
+	TokensInput  int64          `json:"tokens_input"`
+	TokensOutput int64          `json:"tokens_output"`
+	CostUsd      pgtype.Numeric `json:"cost_usd"`
+	RunsCount    int32          `json:"runs_count"`
+}
+
+func (q *Queries) ListCostsByProjectByAgent(ctx context.Context, projectID uuid.UUID) ([]ListCostsByProjectByAgentRow, error) {
+	rows, err := q.db.Query(ctx, listCostsByProjectByAgent, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListCostsByProjectByAgentRow{}
+	for rows.Next() {
+		var i ListCostsByProjectByAgentRow
+		if err := rows.Scan(
+			&i.AgentID,
+			&i.AgentName,
+			&i.TokensInput,
+			&i.TokensOutput,
+			&i.CostUsd,
+			&i.RunsCount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listCostsByProjectByModel = `-- name: ListCostsByProjectByModel :many

--- a/backend/internal/adapter/postgres/cost_repo.go
+++ b/backend/internal/adapter/postgres/cost_repo.go
@@ -37,6 +37,7 @@ func (r *CostRepo) InsertCostRecord(ctx context.Context, record *model.CostRecor
 		TokensOutput: record.TokensOutput,
 		CostUsd:      numericFromFloat64Cost(record.CostUSD),
 		Model:        record.Model,
+		AgentID:      uuidFromPtr(record.AgentID),
 	}
 
 	row, err := r.queries.InsertCostRecord(ctx, params)
@@ -251,6 +252,7 @@ func toDomainCostRecord(c CostRecord) *model.CostRecord {
 		ID:           c.ID,
 		RunStepID:    c.RunStepID,
 		ProjectID:    c.ProjectID,
+		AgentID:      pgtypeToUUIDPtr(c.AgentID),
 		TokensInput:  c.TokensInput,
 		TokensOutput: c.TokensOutput,
 		CostUSD:      numericToFloat64(c.CostUsd),
@@ -268,6 +270,37 @@ func numericFromFloat64Cost(f float64) pgtype.Numeric {
 		Exp:   -6,
 		Valid: true,
 	}
+}
+
+// ListByProjectByAgent returns cost breakdown by agent for a project.
+func (r *CostRepo) ListByProjectByAgent(ctx context.Context, projectID uuid.UUID) ([]model.AgentCostBreakdown, error) {
+	rows, err := r.queries.ListCostsByProjectByAgent(ctx, projectID)
+	if err != nil {
+		return nil, apperrors.NewInternal("failed to list costs by project by agent", err)
+	}
+
+	results := make([]model.AgentCostBreakdown, len(rows))
+	for i, row := range rows {
+		agentID := row.AgentID.Bytes
+		results[i] = model.AgentCostBreakdown{
+			AgentID:      agentID,
+			AgentName:    row.AgentName,
+			TokensInput:  row.TokensInput,
+			TokensOutput: row.TokensOutput,
+			CostUSD:      numericToFloat64(row.CostUsd),
+			RunsCount:    row.RunsCount,
+		}
+	}
+	return results, nil
+}
+
+// pgtypeToUUIDPtr converts a pgtype.UUID to a *uuid.UUID.
+func pgtypeToUUIDPtr(u pgtype.UUID) *uuid.UUID {
+	if !u.Valid {
+		return nil
+	}
+	id := uuid.UUID(u.Bytes)
+	return &id
 }
 
 // toInt64 converts an interface{} from COALESCE aggregate results to int64.

--- a/backend/internal/adapter/postgres/models.go
+++ b/backend/internal/adapter/postgres/models.go
@@ -80,6 +80,7 @@ type CostRecord struct {
 	CostUsd      pgtype.Numeric `json:"cost_usd"`
 	Model        string         `json:"model"`
 	CreatedAt    time.Time      `json:"created_at"`
+	AgentID      pgtype.UUID    `json:"agent_id"`
 }
 
 type Epic struct {

--- a/backend/internal/domain/model/cost_record.go
+++ b/backend/internal/domain/model/cost_record.go
@@ -11,12 +11,23 @@ type CostRecord struct {
 	ID           uuid.UUID
 	RunStepID    uuid.UUID
 	ProjectID    uuid.UUID
+	AgentID      *uuid.UUID
 	TokensInput  int64
 	TokensOutput int64
 	// CostUSD is the total cost in US dollars for this step.
 	CostUSD   float64
 	Model     string
 	CreatedAt time.Time
+}
+
+// AgentCostBreakdown aggregates cost data per agent for a project.
+type AgentCostBreakdown struct {
+	AgentID      uuid.UUID
+	AgentName    string
+	TokensInput  int64
+	TokensOutput int64
+	CostUSD      float64
+	RunsCount    int32
 }
 
 // CostEvent is an intermediate accumulation type parsed from agent NDJSON output.

--- a/backend/internal/domain/port/cost_repository.go
+++ b/backend/internal/domain/port/cost_repository.go
@@ -45,4 +45,7 @@ type CostRepository interface {
 
 	// CountCostsByProjectByRun returns the count of distinct runs with costs.
 	CountCostsByProjectByRun(ctx context.Context, projectID uuid.UUID, since time.Time) (int64, error)
+
+	// ListByProjectByAgent returns cost breakdown by agent for a project.
+	ListByProjectByAgent(ctx context.Context, projectID uuid.UUID) ([]model.AgentCostBreakdown, error)
 }

--- a/backend/internal/domain/service/cost_service_test.go
+++ b/backend/internal/domain/service/cost_service_test.go
@@ -119,6 +119,10 @@ func (m *mockCostRepo) CountCostsByProjectByRun(ctx context.Context, projectID u
 	return 0, nil
 }
 
+func (m *mockCostRepo) ListByProjectByAgent(_ context.Context, _ uuid.UUID) ([]model.AgentCostBreakdown, error) {
+	return []model.AgentCostBreakdown{}, nil
+}
+
 type mockProjectRepoForCost struct {
 	project *model.Project
 	err     error

--- a/backend/migrations/000028_add_agent_id_to_cost_records.down.sql
+++ b/backend/migrations/000028_add_agent_id_to_cost_records.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_cost_records_agent_id;
+ALTER TABLE cost_records DROP COLUMN IF EXISTS agent_id;

--- a/backend/migrations/000028_add_agent_id_to_cost_records.up.sql
+++ b/backend/migrations/000028_add_agent_id_to_cost_records.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE cost_records ADD COLUMN agent_id UUID REFERENCES agents(id) ON DELETE SET NULL;
+CREATE INDEX idx_cost_records_agent_id ON cost_records(agent_id);

--- a/backend/queries/cost_records.sql
+++ b/backend/queries/cost_records.sql
@@ -1,6 +1,6 @@
 -- name: InsertCostRecord :one
-INSERT INTO cost_records (run_step_id, project_id, tokens_input, tokens_output, cost_usd, model)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO cost_records (run_step_id, project_id, tokens_input, tokens_output, cost_usd, model, agent_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
 RETURNING *;
 
 -- name: GetCostByRunStep :one
@@ -107,3 +107,20 @@ SELECT COUNT(DISTINCT rs2.run_id)
 FROM cost_records cr
 JOIN run_steps rs2 ON rs2.id = cr.run_step_id
 WHERE cr.project_id = $1 AND cr.created_at >= $2;
+
+-- name: ListCostsByProjectByAgent :many
+SELECT
+  cr.agent_id,
+  COALESCE(a.name, 'Unknown') AS agent_name,
+  SUM(cr.tokens_input)::bigint AS tokens_input,
+  SUM(cr.tokens_output)::bigint AS tokens_output,
+  SUM(cr.cost_usd)::DECIMAL(10,6) AS cost_usd,
+  COUNT(DISTINCT rs.run_id)::int AS runs_count
+FROM cost_records cr
+LEFT JOIN agents a ON a.id = cr.agent_id
+JOIN run_steps rs ON rs.id = cr.run_step_id
+JOIN runs r ON r.id = rs.run_id
+WHERE r.project_id = $1
+  AND cr.agent_id IS NOT NULL
+GROUP BY cr.agent_id, a.name
+ORDER BY cost_usd DESC;


### PR DESCRIPTION
## Summary
- Add `agent_id` nullable UUID column to `cost_records` table with FK to `agents(id)` ON DELETE SET NULL (migration 000028)
- Add `AgentCostBreakdown` domain model and `ListByProjectByAgent` method to `CostRepository` port
- Add `ListCostsByProjectByAgent` sqlc query aggregating tokens, cost, and run count per agent for a project
- Update `InsertCostRecord` to accept optional `agent_id` parameter
- Update adapter with conversion helpers and mock implementations in test files

## Test plan
- [x] `go build ./...` compiles without errors
- [x] `golangci-lint run ./...` passes with zero issues
- [x] `go test ./... -short` all existing tests pass
- [ ] Integration test with testcontainers verifying migration applies and query returns correct aggregation

Refs: R-5-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)