### PR TITLE
feat(pipeline): add git_branch action for feature branch creation

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -202,6 +202,11 @@ func run() error {
 	actionReg.Register(hitlGateAction)
 	logger.Info("hitl_gate action registered")
 
+	// Git Branch action (no Docker required)
+	gitBranchAction := actionadapter.NewGitBranchAction(gitProvider, storyRepo, logger)
+	actionReg.Register(gitBranchAction)
+	logger.Info("git_branch action registered")
+
 	// Cost tracking (for agent_run action)
 	costSvc := costService
 

--- a/backend/internal/adapter/action/git_branch.go
+++ b/backend/internal/adapter/action/git_branch.go
@@ -1,0 +1,94 @@
+package action
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+)
+
+var nonAlphanumeric = regexp.MustCompile(`[^a-z0-9]+`)
+
+// GitBranchAction implements model.Action for creating a Git feature branch.
+// It renders the branch name from a configurable pattern using RunContext variables,
+// delegates creation to GitProvider, and stores the result in RunContext.Metadata.
+type GitBranchAction struct {
+	gitProvider port.GitProvider
+	storyRepo   port.StoryRepository
+	logger      *slog.Logger
+}
+
+// NewGitBranchAction creates a new GitBranchAction.
+func NewGitBranchAction(gitProvider port.GitProvider, storyRepo port.StoryRepository, logger *slog.Logger) *GitBranchAction {
+	return &GitBranchAction{
+		gitProvider: gitProvider,
+		storyRepo:   storyRepo,
+		logger:      logger,
+	}
+}
+
+// Name returns the action identifier.
+func (a *GitBranchAction) Name() string { return "git_branch" }
+
+// Execute creates a feature branch from a configurable pattern.
+// It reads branch_pattern and base_branch from step config, derives a slug from
+// the story title, and calls GitProvider.CreateBranch. On success, the rendered
+// branch name is stored in runCtx.Metadata["branch_name"].
+func (a *GitBranchAction) Execute(ctx context.Context, runCtx *model.RunContext) error {
+	cfg := runCtx.RunStep.Config
+	if cfg == nil {
+		cfg = make(map[string]string)
+	}
+
+	pattern := cfg["branch_pattern"]
+	if pattern == "" {
+		pattern = "feat/{story_key}-{slug}"
+	}
+	baseBranch := cfg["base_branch"]
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+
+	workDir := cfg["work_dir"]
+	if workDir == "" {
+		if wd, ok := runCtx.Metadata["work_dir"].(string); ok && wd != "" {
+			workDir = wd
+		} else {
+			return fmt.Errorf("git_branch: work_dir not configured and not in metadata")
+		}
+	}
+
+	story, err := a.storyRepo.GetByID(ctx, runCtx.StoryID)
+	if err != nil {
+		return fmt.Errorf("fetch story: %w", err)
+	}
+
+	slug := slugify(story.Title)
+	branchName := strings.ReplaceAll(pattern, "{story_key}", story.Key)
+	branchName = strings.ReplaceAll(branchName, "{slug}", slug)
+
+	a.logger.Info("creating branch",
+		"branch", branchName,
+		"base", baseBranch,
+		"story_key", story.Key,
+		"work_dir", workDir,
+	)
+
+	if err := a.gitProvider.CreateBranch(ctx, workDir, branchName); err != nil {
+		return fmt.Errorf("create branch %q: %w", branchName, err)
+	}
+
+	runCtx.Metadata["branch_name"] = branchName
+	return nil
+}
+
+// slugify converts a story title to a URL-safe lowercase slug.
+func slugify(title string) string {
+	lower := strings.ToLower(title)
+	slug := nonAlphanumeric.ReplaceAllString(lower, "-")
+	return strings.Trim(slug, "-")
+}

--- a/backend/internal/adapter/action/git_branch_test.go
+++ b/backend/internal/adapter/action/git_branch_test.go
@@ -1,0 +1,443 @@
+package action_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/adapter/action"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	apperrors "github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// --- git_branch-specific mocks ---
+
+type branchCall struct {
+	WorkDir    string
+	BranchName string
+}
+
+type gbMockGitProvider struct {
+	mu             sync.Mutex
+	createBranchFn func(ctx context.Context, workDir, branchName string) error
+	branchCalls    []branchCall
+}
+
+func (m *gbMockGitProvider) CloneRepo(_ context.Context, _ string, _ string) error { return nil }
+func (m *gbMockGitProvider) CreateBranch(ctx context.Context, workDir, branchName string) error {
+	m.mu.Lock()
+	m.branchCalls = append(m.branchCalls, branchCall{WorkDir: workDir, BranchName: branchName})
+	m.mu.Unlock()
+	if m.createBranchFn != nil {
+		return m.createBranchFn(ctx, workDir, branchName)
+	}
+	return nil
+}
+func (m *gbMockGitProvider) Push(_ context.Context, _ string, _ string) error { return nil }
+func (m *gbMockGitProvider) CreatePR(_ context.Context, _ string, _ string, _ string, _ string) (string, error) {
+	return "", nil
+}
+func (m *gbMockGitProvider) MergePR(_ context.Context, _ string, _ string) error { return nil }
+func (m *gbMockGitProvider) GetCIStatus(_ context.Context, _ string) (string, error) {
+	return "pass", nil
+}
+func (m *gbMockGitProvider) GetPRDiff(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
+func (m *gbMockGitProvider) getBranchCalls() []branchCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]branchCall, len(m.branchCalls))
+	copy(result, m.branchCalls)
+	return result
+}
+
+type gbMockStoryRepo struct {
+	getByIDFn func(ctx context.Context, id uuid.UUID) (*model.Story, error)
+}
+
+func (m *gbMockStoryRepo) Create(_ context.Context, s *model.Story) (*model.Story, error) {
+	return s, nil
+}
+func (m *gbMockStoryRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Story, error) {
+	if m.getByIDFn != nil {
+		return m.getByIDFn(ctx, id)
+	}
+	return nil, apperrors.NewNotFound("story", id)
+}
+func (m *gbMockStoryRepo) GetByKey(_ context.Context, _ uuid.UUID, _ string) (*model.Story, error) {
+	return nil, nil
+}
+func (m *gbMockStoryRepo) ListByProject(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Story, error) {
+	return nil, nil
+}
+func (m *gbMockStoryRepo) ListByStatus(_ context.Context, _ uuid.UUID, _ []string, _, _ int32) ([]*model.Story, error) {
+	return nil, nil
+}
+func (m *gbMockStoryRepo) ListByEpic(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Story, error) {
+	return nil, nil
+}
+func (m *gbMockStoryRepo) CountByProject(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+func (m *gbMockStoryRepo) CountByStatus(_ context.Context, _ uuid.UUID, _ []string) (int64, error) {
+	return 0, nil
+}
+func (m *gbMockStoryRepo) Update(_ context.Context, s *model.Story) (*model.Story, error) {
+	return s, nil
+}
+func (m *gbMockStoryRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
+
+// --- Helpers ---
+
+func gbRunCtx(cfg map[string]string, metadata map[string]any) *model.RunContext {
+	runID := uuid.New()
+	stepID := uuid.New()
+	projectID := uuid.New()
+	storyID := uuid.New()
+
+	return &model.RunContext{
+		Run: &model.Run{
+			ID:        runID,
+			ProjectID: projectID,
+			StoryID:   storyID,
+			Status:    model.RunStatusRunning,
+		},
+		RunStep: &model.RunStep{
+			ID:     stepID,
+			RunID:  runID,
+			Action: "git_branch",
+			Status: model.StepStatusRunning,
+			Config: cfg,
+		},
+		ProjectID: projectID,
+		StoryID:   storyID,
+		Metadata:  metadata,
+	}
+}
+
+// --- Tests ---
+
+func TestGitBranchAction_Name(t *testing.T) {
+	a := action.NewGitBranchAction(nil, nil, testLogger())
+	if a.Name() != "git_branch" {
+		t.Fatalf("expected Name() = %q, got %q", "git_branch", a.Name())
+	}
+}
+
+func TestGitBranchAction_Execute_HappyPath(t *testing.T) {
+	storyID := uuid.New()
+	gitProvider := &gbMockGitProvider{}
+	storyRepo := &gbMockStoryRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			return &model.Story{ID: id, Key: "S-03", Title: "Add login page"}, nil
+		},
+	}
+
+	a := action.NewGitBranchAction(gitProvider, storyRepo, testLogger())
+
+	cfg := map[string]string{
+		"branch_pattern": "feat/{story_key}-{slug}",
+		"base_branch":    "main",
+		"work_dir":       "/tmp/repo",
+	}
+	runCtx := gbRunCtx(cfg, map[string]any{})
+	runCtx.StoryID = storyID
+
+	err := a.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	// Verify CreateBranch was called with correct args
+	calls := gitProvider.getBranchCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 CreateBranch call, got %d", len(calls))
+	}
+	if calls[0].WorkDir != "/tmp/repo" {
+		t.Fatalf("expected work_dir %q, got %q", "/tmp/repo", calls[0].WorkDir)
+	}
+	if calls[0].BranchName != "feat/S-03-add-login-page" {
+		t.Fatalf("expected branch %q, got %q", "feat/S-03-add-login-page", calls[0].BranchName)
+	}
+
+	// Verify metadata was set
+	branchName, ok := runCtx.Metadata["branch_name"].(string)
+	if !ok || branchName != "feat/S-03-add-login-page" {
+		t.Fatalf("expected Metadata[branch_name] = %q, got %v", "feat/S-03-add-login-page", runCtx.Metadata["branch_name"])
+	}
+}
+
+func TestGitBranchAction_SlugDerivation(t *testing.T) {
+	tests := []struct {
+		title    string
+		expected string
+	}{
+		{"Add login page", "add-login-page"},
+		{"Add login (OAuth)", "add-login-oauth"},
+		{"Hello World!", "hello-world"},
+		{"  spaces  ", "spaces"},
+		{"UPPERCASE Title", "uppercase-title"},
+		{"multiple---hyphens", "multiple-hyphens"},
+		{"special!@#$%^&*chars", "special-chars"},
+		{"trailing-", "trailing"},
+		{"-leading", "leading"},
+		{"a", "a"},
+		{"123-numeric", "123-numeric"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.title, func(t *testing.T) {
+			gitProvider := &gbMockGitProvider{}
+			storyRepo := &gbMockStoryRepo{
+				getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+					return &model.Story{ID: id, Key: "S-01", Title: tc.title}, nil
+				},
+			}
+
+			a := action.NewGitBranchAction(gitProvider, storyRepo, testLogger())
+
+			cfg := map[string]string{
+				"branch_pattern": "feat/{story_key}-{slug}",
+				"work_dir":       "/tmp/repo",
+			}
+			runCtx := gbRunCtx(cfg, map[string]any{})
+
+			err := a.Execute(context.Background(), runCtx)
+			if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+
+			calls := gitProvider.getBranchCalls()
+			if len(calls) != 1 {
+				t.Fatalf("expected 1 CreateBranch call, got %d", len(calls))
+			}
+
+			expectedBranch := "feat/S-01-" + tc.expected
+			if calls[0].BranchName != expectedBranch {
+				t.Fatalf("expected branch %q, got %q", expectedBranch, calls[0].BranchName)
+			}
+		})
+	}
+}
+
+func TestGitBranchAction_Execute_DefaultBaseBranch(t *testing.T) {
+	gitProvider := &gbMockGitProvider{}
+	storyRepo := &gbMockStoryRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			return &model.Story{ID: id, Key: "S-05", Title: "Some feature"}, nil
+		},
+	}
+
+	a := action.NewGitBranchAction(gitProvider, storyRepo, testLogger())
+
+	// No base_branch in config — should default to "main"
+	cfg := map[string]string{
+		"work_dir": "/tmp/repo",
+	}
+	runCtx := gbRunCtx(cfg, map[string]any{})
+
+	err := a.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	calls := gitProvider.getBranchCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 CreateBranch call, got %d", len(calls))
+	}
+
+	// Verify branch was created (default pattern "feat/{story_key}-{slug}")
+	if calls[0].BranchName != "feat/S-05-some-feature" {
+		t.Fatalf("expected branch %q, got %q", "feat/S-05-some-feature", calls[0].BranchName)
+	}
+}
+
+func TestGitBranchAction_Execute_CustomFixPattern(t *testing.T) {
+	gitProvider := &gbMockGitProvider{}
+	storyRepo := &gbMockStoryRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			return &model.Story{ID: id, Key: "BUG-7", Title: "Fix null pointer"}, nil
+		},
+	}
+
+	a := action.NewGitBranchAction(gitProvider, storyRepo, testLogger())
+
+	cfg := map[string]string{
+		"branch_pattern": "fix/{story_key}-{slug}",
+		"work_dir":       "/tmp/repo",
+	}
+	runCtx := gbRunCtx(cfg, map[string]any{})
+
+	err := a.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	calls := gitProvider.getBranchCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 CreateBranch call, got %d", len(calls))
+	}
+	if !strings.HasPrefix(calls[0].BranchName, "fix/") {
+		t.Fatalf("expected branch to start with %q, got %q", "fix/", calls[0].BranchName)
+	}
+	if calls[0].BranchName != "fix/BUG-7-fix-null-pointer" {
+		t.Fatalf("expected branch %q, got %q", "fix/BUG-7-fix-null-pointer", calls[0].BranchName)
+	}
+}
+
+func TestGitBranchAction_Execute_GitProviderFailure(t *testing.T) {
+	gitProvider := &gbMockGitProvider{
+		createBranchFn: func(_ context.Context, _, _ string) error {
+			return fmt.Errorf("git checkout failed: branch already exists")
+		},
+	}
+	storyRepo := &gbMockStoryRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			return &model.Story{ID: id, Key: "S-01", Title: "Test"}, nil
+		},
+	}
+
+	a := action.NewGitBranchAction(gitProvider, storyRepo, testLogger())
+
+	cfg := map[string]string{
+		"work_dir": "/tmp/repo",
+	}
+	runCtx := gbRunCtx(cfg, map[string]any{})
+
+	err := a.Execute(context.Background(), runCtx)
+	if err == nil {
+		t.Fatal("expected error when CreateBranch fails")
+	}
+	if !strings.Contains(err.Error(), "create branch") {
+		t.Fatalf("expected error containing %q, got %q", "create branch", err.Error())
+	}
+
+	// Verify metadata was NOT set
+	if _, exists := runCtx.Metadata["branch_name"]; exists {
+		t.Fatal("expected branch_name metadata to NOT be set on failure")
+	}
+}
+
+func TestGitBranchAction_Execute_StoryNotFound(t *testing.T) {
+	gitProvider := &gbMockGitProvider{}
+	storyRepo := &gbMockStoryRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			return nil, apperrors.NewNotFound("story", id)
+		},
+	}
+
+	a := action.NewGitBranchAction(gitProvider, storyRepo, testLogger())
+
+	cfg := map[string]string{
+		"work_dir": "/tmp/repo",
+	}
+	runCtx := gbRunCtx(cfg, map[string]any{})
+
+	err := a.Execute(context.Background(), runCtx)
+	if err == nil {
+		t.Fatal("expected error when story not found")
+	}
+	if !strings.Contains(err.Error(), "fetch story") {
+		t.Fatalf("expected error containing %q, got %q", "fetch story", err.Error())
+	}
+
+	// Verify GitProvider was NOT called
+	calls := gitProvider.getBranchCalls()
+	if len(calls) != 0 {
+		t.Fatalf("expected no CreateBranch calls when story fetch fails, got %d", len(calls))
+	}
+}
+
+func TestGitBranchAction_Execute_MissingWorkDir(t *testing.T) {
+	gitProvider := &gbMockGitProvider{}
+	storyRepo := &gbMockStoryRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			return &model.Story{ID: id, Key: "S-01", Title: "Test"}, nil
+		},
+	}
+
+	a := action.NewGitBranchAction(gitProvider, storyRepo, testLogger())
+
+	// No work_dir in config or metadata
+	cfg := map[string]string{}
+	runCtx := gbRunCtx(cfg, map[string]any{})
+
+	err := a.Execute(context.Background(), runCtx)
+	if err == nil {
+		t.Fatal("expected error when work_dir is missing")
+	}
+	if !strings.Contains(err.Error(), "work_dir") {
+		t.Fatalf("expected error containing %q, got %q", "work_dir", err.Error())
+	}
+
+	// Verify GitProvider was NOT called
+	calls := gitProvider.getBranchCalls()
+	if len(calls) != 0 {
+		t.Fatalf("expected no CreateBranch calls when work_dir missing, got %d", len(calls))
+	}
+}
+
+func TestGitBranchAction_Execute_WorkDirFromMetadata(t *testing.T) {
+	gitProvider := &gbMockGitProvider{}
+	storyRepo := &gbMockStoryRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			return &model.Story{ID: id, Key: "S-01", Title: "Test"}, nil
+		},
+	}
+
+	a := action.NewGitBranchAction(gitProvider, storyRepo, testLogger())
+
+	// work_dir only in metadata, not in config
+	cfg := map[string]string{}
+	runCtx := gbRunCtx(cfg, map[string]any{
+		"work_dir": "/tmp/from-metadata",
+	})
+
+	err := a.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	calls := gitProvider.getBranchCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 CreateBranch call, got %d", len(calls))
+	}
+	if calls[0].WorkDir != "/tmp/from-metadata" {
+		t.Fatalf("expected work_dir %q, got %q", "/tmp/from-metadata", calls[0].WorkDir)
+	}
+}
+
+func TestGitBranchAction_Execute_NilConfig(t *testing.T) {
+	gitProvider := &gbMockGitProvider{}
+	storyRepo := &gbMockStoryRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			return &model.Story{ID: id, Key: "S-01", Title: "Test"}, nil
+		},
+	}
+
+	a := action.NewGitBranchAction(gitProvider, storyRepo, testLogger())
+
+	// nil Config on RunStep, work_dir in metadata
+	runCtx := gbRunCtx(nil, map[string]any{
+		"work_dir": "/tmp/repo",
+	})
+
+	err := a.Execute(context.Background(), runCtx)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	calls := gitProvider.getBranchCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 CreateBranch call, got %d", len(calls))
+	}
+	// Default pattern should be used
+	if !strings.HasPrefix(calls[0].BranchName, "feat/S-01-") {
+		t.Fatalf("expected branch to use default pattern, got %q", calls[0].BranchName)
+	}
+}

--- a/backend/internal/domain/model/run.go
+++ b/backend/internal/domain/model/run.go
@@ -87,6 +87,9 @@ type RunStep struct {
 	// ParentStepID is the ID of the step this was retried from; nil for original steps.
 	ParentStepID *uuid.UUID
 	CreatedAt    time.Time
+	// Config holds step-specific configuration from the pipeline YAML.
+	// This is a transient field populated by the executor at runtime, not persisted in the database.
+	Config map[string]string
 }
 
 var validRunTransitions = map[RunStatus][]RunStatus{

--- a/backend/internal/domain/service/pipeline_executor.go
+++ b/backend/internal/domain/service/pipeline_executor.go
@@ -216,6 +216,13 @@ func (e *PipelineExecutor) executeStep(ctx context.Context, run *model.Run, step
 		return fmt.Errorf("action lookup failed for %q: %w", step.Action, err)
 	}
 
+	// Inject per-step config from the pipeline config snapshot into step.Config.
+	// This makes step-specific config (e.g., branch_pattern, base_branch) available
+	// to actions via runCtx.RunStep.Config without parsing the snapshot themselves.
+	if step.Config == nil {
+		step.Config = e.extractStepConfig(run.PipelineConfigSnapshot, step.StepOrder)
+	}
+
 	// Build run context
 	runCtx := &model.RunContext{
 		Run:       run,
@@ -401,4 +408,24 @@ func (e *PipelineExecutor) publishEvent(ctx context.Context, projectID uuid.UUID
 	if err := e.eventPub.Publish(ctx, event); err != nil {
 		e.logger.Error("failed to publish event", "event_type", event.EventName(), "error", err)
 	}
+}
+
+// extractStepConfig parses the pipeline config snapshot and returns the Config
+// map for the step at the given order index. Returns nil if parsing fails or
+// the step has no config.
+func (e *PipelineExecutor) extractStepConfig(snapshot json.RawMessage, stepOrder int) map[string]string {
+	if len(snapshot) == 0 {
+		return nil
+	}
+	var parsed model.PipelineConfigYAML
+	if err := json.Unmarshal(snapshot, &parsed); err != nil {
+		e.logger.Warn("failed to parse pipeline config snapshot for step config",
+			"step_order", stepOrder, "error", err)
+		return nil
+	}
+	flatSteps := parsed.FlatSteps()
+	if stepOrder < 0 || stepOrder >= len(flatSteps) {
+		return nil
+	}
+	return flatSteps[stepOrder].Config
 }


### PR DESCRIPTION
## Summary
- **New `git_branch` action** (`backend/internal/adapter/action/git_branch.go`) implementing `model.Action` — creates a Git feature branch from a configurable pattern (`feat/{story_key}-{slug}`) using story key and slugified title, delegates to `GitProvider.CreateBranch`, and stores the branch name in `RunContext.Metadata["branch_name"]` for downstream actions
- **Added `Config map[string]string` to `RunStep`** — transient field (not persisted in DB) populated at runtime by the pipeline executor from `PipelineConfigSnapshot`, making step-specific YAML config accessible to all actions via `runCtx.RunStep.Config`
- **Registered `git_branch` action** in `main.go` alongside existing actions (ci_poll, hitl_gate, agent_run)

### Changes
| File | Change |
|------|--------|
| `backend/internal/adapter/action/git_branch.go` | New `GitBranchAction` with `slugify()` helper |
| `backend/internal/adapter/action/git_branch_test.go` | 10 unit tests: happy path, slug derivation (table-driven), defaults, custom pattern, errors |
| `backend/internal/domain/model/run.go` | Add `Config map[string]string` to `RunStep` |
| `backend/internal/domain/service/pipeline_executor.go` | Inject step config from snapshot + `extractStepConfig` helper |
| `backend/cmd/api/main.go` | Register `GitBranchAction` in action registry |

## Test plan
- [x] All 10 git_branch unit tests pass (happy path, slug derivation, default base branch, custom pattern, GitProvider failure, story not found, missing work_dir, work_dir from metadata, nil config)
- [x] All 58 action package tests pass (no regressions)
- [x] All service package tests pass (pipeline executor changes are backward-compatible)
- [x] Full backend build succeeds (`go build ./...`)
- [x] `go vet` passes on all changed packages
- [x] `gofmt` reports no formatting issues

Refs: R-2-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)