### PR TITLE
fix(pipeline): remove duplicate renderTemplate in git_pr

### DIFF
--- a/backend/internal/adapter/action/git_pr.go
+++ b/backend/internal/adapter/action/git_pr.go
@@ -93,15 +93,6 @@ func (a *GitPRAction) Execute(ctx context.Context, runCtx *model.RunContext) err
 	return nil
 }
 
-// renderTemplate replaces {key} placeholders in tpl with values from vars.
-func renderTemplate(tpl string, vars map[string]string) string {
-	result := tpl
-	for k, v := range vars {
-		result = strings.ReplaceAll(result, "{"+k+"}", v)
-	}
-	return result
-}
-
 // buildPRBody constructs a standard PR body from story context.
 func buildPRBody(story *model.Story) string {
 	var b strings.Builder


### PR DESCRIPTION
## Summary
- Remove duplicate `renderTemplate` function in `git_pr.go` that conflicts with `helpers.go`
- This was caused by merging both notification action (R-2-3) and git_pr action (R-2-2) which both declared the same helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)