### PR TITLE
feat(pipeline): update default pipeline config to use named groups

### DIFF
--- a/backend/internal/domain/service/pipeline_config_service.go
+++ b/backend/internal/domain/service/pipeline_config_service.go
@@ -17,67 +17,54 @@ const DefaultPipelineConfigYAML = `groups:
   - id: setup
     name: Setup
     steps:
-      - id: 880e8400-e29b-41d4-a716-446655440001
-        name: create-branch
+      - id: git-branch
+        name: Create Branch
         action_type: git_branch
-        description: Create feature branch from base
-        auto_approve: true
         config:
           base_branch: main
-        retry_policy:
-          max_retries: 1
-          retry_type: on-failure
+
   - id: development
     name: Development
     steps:
-      - id: 880e8400-e29b-41d4-a716-446655440002
-        name: dev-agent
+      - id: agent-implement
+        name: Implement Story
         action_type: agent_run
-        description: Run development agent
-        model: claude-opus-4-6
-        auto_approve: false
-        retry_policy:
-          max_retries: 2
-          retry_type: on-failure
+        config:
+          role: dev
+          phase: dev-story
+
   - id: review
     name: Review
     steps:
-      - id: 880e8400-e29b-41d4-a716-446655440003
-        name: review-agent
+      - id: agent-review
+        name: Code Review
         action_type: agent_run
-        description: Run code review agent
-        model: claude-sonnet-4-6
-        auto_approve: false
-        retry_policy:
-          max_retries: 1
-          retry_type: on-failure
+        config:
+          role: review
+          phase: code-review
+
   - id: merge
     name: Merge
     steps:
-      - id: 880e8400-e29b-41d4-a716-446655440004
-        name: create-pr
+      - id: git-pr
+        name: Create & Merge PR
         action_type: git_pr
-        description: Create and merge pull request
-        model: claude-sonnet-4-6
-        auto_approve: true
-        retry_policy:
-          max_retries: 1
-          retry_type: on-failure
+        config:
+          strategy: squash
+
   - id: delivery
     name: Delivery
     steps:
-      - id: 880e8400-e29b-41d4-a716-446655440005
-        name: poll-ci
+      - id: ci-poll
+        name: Wait for CI
         action_type: ci_poll
-        description: Wait for CI to pass
-        auto_approve: true
         config:
           timeout_minutes: "30"
-      - id: 880e8400-e29b-41d4-a716-446655440006
-        name: notify
+      - id: notify
+        name: Notify Completion
         action_type: notification
-        description: Send completion notification
-        auto_approve: true
+        config:
+          channel: default
 `
 
 // PipelineConfigService provides business logic for pipeline config operations.

--- a/backend/internal/domain/service/pipeline_config_service_test.go
+++ b/backend/internal/domain/service/pipeline_config_service_test.go
@@ -279,33 +279,84 @@ func TestPipelineConfigService_SeedDefault_ParsesCorrectly(t *testing.T) {
 		t.Fatalf("default YAML failed to parse: %v", err)
 	}
 
-	expectedGroups := []struct {
-		name        string
-		actionTypes []string
-	}{
-		{"Setup", []string{"git_branch"}},
-		{"Development", []string{"agent_run"}},
-		{"Review", []string{"agent_run"}},
-		{"Merge", []string{"git_pr"}},
-		{"Delivery", []string{"ci_poll", "notification"}},
+	// AC #1: 5 groups with correct names and IDs
+	type expectedStep struct {
+		id         string
+		name       string
+		actionType string
+		config     map[string]string
+	}
+	type expectedGroup struct {
+		id    string
+		name  string
+		steps []expectedStep
 	}
 
-	if len(parsed.Groups) != len(expectedGroups) {
-		t.Fatalf("expected %d groups, got %d", len(expectedGroups), len(parsed.Groups))
+	expected := []expectedGroup{
+		{
+			id: "setup", name: "Setup",
+			steps: []expectedStep{
+				{id: "git-branch", name: "Create Branch", actionType: "git_branch", config: map[string]string{"base_branch": "main"}},
+			},
+		},
+		{
+			id: "development", name: "Development",
+			steps: []expectedStep{
+				{id: "agent-implement", name: "Implement Story", actionType: "agent_run", config: map[string]string{"role": "dev", "phase": "dev-story"}},
+			},
+		},
+		{
+			id: "review", name: "Review",
+			steps: []expectedStep{
+				{id: "agent-review", name: "Code Review", actionType: "agent_run", config: map[string]string{"role": "review", "phase": "code-review"}},
+			},
+		},
+		{
+			id: "merge", name: "Merge",
+			steps: []expectedStep{
+				{id: "git-pr", name: "Create & Merge PR", actionType: "git_pr", config: map[string]string{"strategy": "squash"}},
+			},
+		},
+		{
+			id: "delivery", name: "Delivery",
+			steps: []expectedStep{
+				{id: "ci-poll", name: "Wait for CI", actionType: "ci_poll", config: map[string]string{"timeout_minutes": "30"}},
+				{id: "notify", name: "Notify Completion", actionType: "notification", config: map[string]string{"channel": "default"}},
+			},
+		},
 	}
 
-	for i, expected := range expectedGroups {
+	if len(parsed.Groups) != len(expected) {
+		t.Fatalf("expected %d groups, got %d", len(expected), len(parsed.Groups))
+	}
+
+	for i, eg := range expected {
 		group := parsed.Groups[i]
-		if group.Name != expected.name {
-			t.Errorf("group[%d]: expected name %q, got %q", i, expected.name, group.Name)
+		if group.ID != eg.id {
+			t.Errorf("group[%d]: expected id %q, got %q", i, eg.id, group.ID)
 		}
-		if len(group.Steps) != len(expected.actionTypes) {
-			t.Errorf("group[%d] %q: expected %d steps, got %d", i, expected.name, len(expected.actionTypes), len(group.Steps))
+		if group.Name != eg.name {
+			t.Errorf("group[%d]: expected name %q, got %q", i, eg.name, group.Name)
+		}
+		if len(group.Steps) != len(eg.steps) {
+			t.Errorf("group[%d] %q: expected %d steps, got %d", i, eg.name, len(eg.steps), len(group.Steps))
 			continue
 		}
-		for j, expectedAction := range expected.actionTypes {
-			if group.Steps[j].ActionType != expectedAction {
-				t.Errorf("group[%d].steps[%d]: expected action_type %q, got %q", i, j, expectedAction, group.Steps[j].ActionType)
+		for j, es := range eg.steps {
+			step := group.Steps[j]
+			if step.ID != es.id {
+				t.Errorf("group[%d].steps[%d]: expected id %q, got %q", i, j, es.id, step.ID)
+			}
+			if step.Name != es.name {
+				t.Errorf("group[%d].steps[%d]: expected name %q, got %q", i, j, es.name, step.Name)
+			}
+			if step.ActionType != es.actionType {
+				t.Errorf("group[%d].steps[%d]: expected action_type %q, got %q", i, j, es.actionType, step.ActionType)
+			}
+			for key, val := range es.config {
+				if step.Config[key] != val {
+					t.Errorf("group[%d].steps[%d].config[%s]: expected %q, got %q", i, j, key, val, step.Config[key])
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Updated `DefaultPipelineConfigYAML` constant to use kebab-case step IDs (`git-branch`, `agent-implement`, `agent-review`, `git-pr`, `ci-poll`, `notify`) instead of hardcoded UUIDs
- Added human-readable step names (`Create Branch`, `Implement Story`, `Code Review`, `Create & Merge PR`, `Wait for CI`, `Notify Completion`)
- Added role/phase config keys to agent steps (`role: dev`, `phase: dev-story` for development; `role: review`, `phase: code-review` for review)
- Added strategy and channel config keys (`strategy: squash` for merge, `channel: default` for notification)
- Simplified default config by removing per-step `description`, `model`, `auto_approve`, and `retry_policy` fields (these are runtime concerns, not config defaults)
- Updated `TestPipelineConfigService_SeedDefault_ParsesCorrectly` to verify all group IDs, step IDs, step names, action types, and config keys

## Test plan
- [x] All existing backend unit tests pass (`go test ./... -short`)
- [x] Backward-compat parsing for flat `steps:` YAML still works (existing `TestParsePipelineConfigYAML_LegacyFlatSteps` passes)
- [x] Default YAML parses into 5 groups: Setup, Development, Review, Merge, Delivery
- [x] golangci-lint passes

Refs: R-6-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)