### PR TITLE
feat(cost): record agent_id when calling RecordStepCost

### DIFF
--- a/backend/internal/adapter/action/agent_run.go
+++ b/backend/internal/adapter/action/agent_run.go
@@ -283,7 +283,8 @@ func (a *AgentRunAction) streamAndWait(
 	// Record accumulated cost events, regardless of exit code.
 	// Cost recording failure is non-fatal.
 	if len(costEvents) > 0 {
-		if err := a.costSvc.RecordStepCost(ctx, runCtx.RunStep.ID, runCtx.ProjectID, costEvents); err != nil {
+		agentID := extractAgentID(runCtx)
+		if err := a.costSvc.RecordStepCost(ctx, runCtx.RunStep.ID, runCtx.ProjectID, costEvents, agentID); err != nil {
 			a.logger.Warn("failed to record step cost",
 				"step_id", stepID, "error", err)
 		}
@@ -347,6 +348,31 @@ func (a *AgentRunAction) publishLogEvent(ctx context.Context, runCtx *model.RunC
 	if err := a.eventPub.Publish(ctx, event); err != nil {
 		a.logger.Warn("failed to publish log event", "error", err)
 	}
+}
+
+// extractAgentID extracts the agent ID from the run context.
+// It checks RunStep.Config["agent_id"] and Metadata["agent_id"] for a valid UUID string.
+// Returns nil if no agent ID is available.
+func extractAgentID(runCtx *model.RunContext) *uuid.UUID {
+	// Check step config first
+	if runCtx.RunStep != nil && runCtx.RunStep.Config != nil {
+		if raw, ok := runCtx.RunStep.Config["agent_id"]; ok && raw != "" {
+			if id, err := uuid.Parse(raw); err == nil {
+				return &id
+			}
+		}
+	}
+
+	// Fallback to metadata
+	if runCtx.Metadata != nil {
+		if raw, ok := runCtx.Metadata["agent_id"].(string); ok && raw != "" {
+			if id, err := uuid.Parse(raw); err == nil {
+				return &id
+			}
+		}
+	}
+
+	return nil
 }
 
 // derefString safely dereferences a string pointer, returning empty string if nil.

--- a/backend/internal/adapter/postgres/hitl_requests.sql.go
+++ b/backend/internal/adapter/postgres/hitl_requests.sql.go
@@ -44,7 +44,7 @@ func (q *Queries) CountPendingHITLRequestsByProject(ctx context.Context, project
 const createHITLRequest = `-- name: CreateHITLRequest :one
 INSERT INTO hitl_requests (id, run_step_id, gate_type, diff_content, message, status, created_at)
 VALUES ($1, $2, $3, $4, $5, $6, now())
-RETURNING id, run_step_id, gate_type, diff_content, message, status, resolved_at, resolved_by, rejection_reason, created_at, diff_url
+RETURNING id, run_step_id, gate_type, diff_content, status, resolved_at, resolved_by, rejection_reason, created_at, diff_url, message
 `
 
 type CreateHITLRequestParams struct {
@@ -71,19 +71,19 @@ func (q *Queries) CreateHITLRequest(ctx context.Context, arg CreateHITLRequestPa
 		&i.RunStepID,
 		&i.GateType,
 		&i.DiffContent,
-		&i.Message,
 		&i.Status,
 		&i.ResolvedAt,
 		&i.ResolvedBy,
 		&i.RejectionReason,
 		&i.CreatedAt,
 		&i.DiffUrl,
+		&i.Message,
 	)
 	return i, err
 }
 
 const getHITLRequest = `-- name: GetHITLRequest :one
-SELECT id, run_step_id, gate_type, diff_content, message, status, resolved_at, resolved_by, rejection_reason, created_at, diff_url FROM hitl_requests WHERE id = $1
+SELECT id, run_step_id, gate_type, diff_content, status, resolved_at, resolved_by, rejection_reason, created_at, diff_url, message FROM hitl_requests WHERE id = $1
 `
 
 func (q *Queries) GetHITLRequest(ctx context.Context, id uuid.UUID) (HitlRequest, error) {
@@ -94,19 +94,19 @@ func (q *Queries) GetHITLRequest(ctx context.Context, id uuid.UUID) (HitlRequest
 		&i.RunStepID,
 		&i.GateType,
 		&i.DiffContent,
-		&i.Message,
 		&i.Status,
 		&i.ResolvedAt,
 		&i.ResolvedBy,
 		&i.RejectionReason,
 		&i.CreatedAt,
 		&i.DiffUrl,
+		&i.Message,
 	)
 	return i, err
 }
 
 const getHITLRequestByRunStepID = `-- name: GetHITLRequestByRunStepID :one
-SELECT id, run_step_id, gate_type, diff_content, message, status, resolved_at, resolved_by, rejection_reason, created_at, diff_url FROM hitl_requests WHERE run_step_id = $1 LIMIT 1
+SELECT id, run_step_id, gate_type, diff_content, status, resolved_at, resolved_by, rejection_reason, created_at, diff_url, message FROM hitl_requests WHERE run_step_id = $1 LIMIT 1
 `
 
 func (q *Queries) GetHITLRequestByRunStepID(ctx context.Context, runStepID uuid.UUID) (HitlRequest, error) {
@@ -117,19 +117,19 @@ func (q *Queries) GetHITLRequestByRunStepID(ctx context.Context, runStepID uuid.
 		&i.RunStepID,
 		&i.GateType,
 		&i.DiffContent,
-		&i.Message,
 		&i.Status,
 		&i.ResolvedAt,
 		&i.ResolvedBy,
 		&i.RejectionReason,
 		&i.CreatedAt,
 		&i.DiffUrl,
+		&i.Message,
 	)
 	return i, err
 }
 
 const listHITLRequestsFiltered = `-- name: ListHITLRequestsFiltered :many
-SELECT id, run_step_id, gate_type, diff_content, message, status, resolved_at, resolved_by, rejection_reason, created_at, diff_url FROM hitl_requests
+SELECT id, run_step_id, gate_type, diff_content, status, resolved_at, resolved_by, rejection_reason, created_at, diff_url, message FROM hitl_requests
 WHERE ($1::text = '' OR status = $1::text)
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3
@@ -155,13 +155,13 @@ func (q *Queries) ListHITLRequestsFiltered(ctx context.Context, arg ListHITLRequ
 			&i.RunStepID,
 			&i.GateType,
 			&i.DiffContent,
-			&i.Message,
 			&i.Status,
 			&i.ResolvedAt,
 			&i.ResolvedBy,
 			&i.RejectionReason,
 			&i.CreatedAt,
 			&i.DiffUrl,
+			&i.Message,
 		); err != nil {
 			return nil, err
 		}
@@ -230,7 +230,7 @@ const updateHITLRequestStatus = `-- name: UpdateHITLRequestStatus :one
 UPDATE hitl_requests
 SET status = $2, resolved_at = $3, resolved_by = $4, rejection_reason = $5
 WHERE id = $1
-RETURNING id, run_step_id, gate_type, diff_content, message, status, resolved_at, resolved_by, rejection_reason, created_at, diff_url
+RETURNING id, run_step_id, gate_type, diff_content, status, resolved_at, resolved_by, rejection_reason, created_at, diff_url, message
 `
 
 type UpdateHITLRequestStatusParams struct {
@@ -255,13 +255,13 @@ func (q *Queries) UpdateHITLRequestStatus(ctx context.Context, arg UpdateHITLReq
 		&i.RunStepID,
 		&i.GateType,
 		&i.DiffContent,
-		&i.Message,
 		&i.Status,
 		&i.ResolvedAt,
 		&i.ResolvedBy,
 		&i.RejectionReason,
 		&i.CreatedAt,
 		&i.DiffUrl,
+		&i.Message,
 	)
 	return i, err
 }

--- a/backend/internal/adapter/postgres/models.go
+++ b/backend/internal/adapter/postgres/models.go
@@ -125,13 +125,13 @@ type HitlRequest struct {
 	RunStepID       uuid.UUID          `json:"run_step_id"`
 	GateType        string             `json:"gate_type"`
 	DiffContent     pgtype.Text        `json:"diff_content"`
-	Message         pgtype.Text        `json:"message"`
 	Status          string             `json:"status"`
 	ResolvedAt      pgtype.Timestamptz `json:"resolved_at"`
 	ResolvedBy      pgtype.UUID        `json:"resolved_by"`
 	RejectionReason pgtype.Text        `json:"rejection_reason"`
 	CreatedAt       time.Time          `json:"created_at"`
 	DiffUrl         pgtype.Text        `json:"diff_url"`
+	Message         pgtype.Text        `json:"message"`
 }
 
 type NotificationConfig struct {

--- a/backend/internal/domain/service/cost_service.go
+++ b/backend/internal/domain/service/cost_service.go
@@ -39,8 +39,9 @@ func NewCostService(
 	}
 }
 
-// RecordStepCost aggregates cost events and inserts a single cost record for a step.
-func (s *CostService) RecordStepCost(ctx context.Context, stepID, projectID uuid.UUID, events []model.CostEvent) error {
+// RecordStepCost aggregates cost events and inserts a single cost record for a step,
+// optionally attributed to an agent.
+func (s *CostService) RecordStepCost(ctx context.Context, stepID, projectID uuid.UUID, events []model.CostEvent, agentID *uuid.UUID) error {
 	if len(events) == 0 {
 		return nil
 	}
@@ -68,6 +69,7 @@ func (s *CostService) RecordStepCost(ctx context.Context, stepID, projectID uuid
 	record := &model.CostRecord{
 		RunStepID:    stepID,
 		ProjectID:    projectID,
+		AgentID:      agentID,
 		TokensInput:  totalInput,
 		TokensOutput: totalOutput,
 		CostUSD:      costUSD,

--- a/backend/internal/domain/service/cost_service_test.go
+++ b/backend/internal/domain/service/cost_service_test.go
@@ -263,7 +263,7 @@ func TestRecordStepCost_EmptyEvents_NoOp(t *testing.T) {
 	costRepo := &mockCostRepo{}
 	svc := newTestCostService(costRepo, nil, nil, nil)
 
-	err := svc.RecordStepCost(context.Background(), uuid.New(), uuid.New(), []model.CostEvent{})
+	err := svc.RecordStepCost(context.Background(), uuid.New(), uuid.New(), []model.CostEvent{}, nil)
 	assert.NoError(t, err)
 	assert.Empty(t, costRepo.insertCalls)
 }
@@ -310,7 +310,7 @@ func TestRecordStepCost_KnownModel_CorrectCost(t *testing.T) {
 				{InputTokens: tt.inputTokens, OutputTokens: tt.outputTokens, Model: tt.model},
 			}
 
-			err := svc.RecordStepCost(context.Background(), stepID, projectID, events)
+			err := svc.RecordStepCost(context.Background(), stepID, projectID, events, nil)
 			require.NoError(t, err)
 			require.Len(t, costRepo.insertCalls, 1)
 
@@ -333,13 +333,14 @@ func TestRecordStepCost_UnknownModel_ZeroCost(t *testing.T) {
 		{InputTokens: 1000, OutputTokens: 500, Model: "unknown-model"},
 	}
 
-	err := svc.RecordStepCost(context.Background(), uuid.New(), uuid.New(), events)
+	err := svc.RecordStepCost(context.Background(), uuid.New(), uuid.New(), events, nil)
 	require.NoError(t, err)
 	require.Len(t, costRepo.insertCalls, 1)
 
 	inserted := costRepo.insertCalls[0]
 	assert.Equal(t, float64(0), inserted.CostUSD)
 	assert.Equal(t, "unknown-model", inserted.Model)
+	assert.Nil(t, inserted.AgentID)
 }
 
 func TestRecordStepCost_MultipleEvents_Aggregated(t *testing.T) {
@@ -351,7 +352,7 @@ func TestRecordStepCost_MultipleEvents_Aggregated(t *testing.T) {
 		{InputTokens: 500_000, OutputTokens: 100_000, Model: "claude-opus-4-6"},
 	}
 
-	err := svc.RecordStepCost(context.Background(), uuid.New(), uuid.New(), events)
+	err := svc.RecordStepCost(context.Background(), uuid.New(), uuid.New(), events, nil)
 	require.NoError(t, err)
 	require.Len(t, costRepo.insertCalls, 1) // Single insert, not two
 
@@ -374,8 +375,55 @@ func TestRecordStepCost_RepoError_Propagated(t *testing.T) {
 		{InputTokens: 1000, OutputTokens: 500, Model: "claude-opus-4-6"},
 	}
 
-	err := svc.RecordStepCost(context.Background(), uuid.New(), uuid.New(), events)
+	err := svc.RecordStepCost(context.Background(), uuid.New(), uuid.New(), events, nil)
 	assert.Error(t, err)
+}
+
+func TestRecordStepCost_WithAgentID(t *testing.T) {
+	costRepo := &mockCostRepo{}
+	svc := newTestCostService(costRepo, nil, nil, nil)
+
+	stepID := uuid.New()
+	projectID := uuid.New()
+	agentID := uuid.New()
+	events := []model.CostEvent{
+		{InputTokens: 1_000_000, OutputTokens: 100_000, Model: "claude-opus-4-6"},
+	}
+
+	err := svc.RecordStepCost(context.Background(), stepID, projectID, events, &agentID)
+	require.NoError(t, err)
+	require.Len(t, costRepo.insertCalls, 1)
+
+	inserted := costRepo.insertCalls[0]
+	assert.Equal(t, stepID, inserted.RunStepID)
+	assert.Equal(t, projectID, inserted.ProjectID)
+	require.NotNil(t, inserted.AgentID)
+	assert.Equal(t, agentID, *inserted.AgentID)
+	assert.Equal(t, int64(1_000_000), inserted.TokensInput)
+	assert.Equal(t, int64(100_000), inserted.TokensOutput)
+	// 15*1 + 75*0.1 = 22.5
+	assert.InDelta(t, 22.5, inserted.CostUSD, 0.001)
+}
+
+func TestRecordStepCost_WithoutAgentID(t *testing.T) {
+	costRepo := &mockCostRepo{}
+	svc := newTestCostService(costRepo, nil, nil, nil)
+
+	stepID := uuid.New()
+	projectID := uuid.New()
+	events := []model.CostEvent{
+		{InputTokens: 1_000_000, OutputTokens: 100_000, Model: "claude-opus-4-6"},
+	}
+
+	err := svc.RecordStepCost(context.Background(), stepID, projectID, events, nil)
+	require.NoError(t, err)
+	require.Len(t, costRepo.insertCalls, 1)
+
+	inserted := costRepo.insertCalls[0]
+	assert.Equal(t, stepID, inserted.RunStepID)
+	assert.Equal(t, projectID, inserted.ProjectID)
+	assert.Nil(t, inserted.AgentID)
+	assert.InDelta(t, 22.5, inserted.CostUSD, 0.001)
 }
 
 // --- GetProjectCosts tests ---


### PR DESCRIPTION
## Summary
- Add `agentID *uuid.UUID` parameter to `CostService.RecordStepCost` so cost records are attributed to the agent that ran the step
- Add `extractAgentID` helper in `AgentRunAction` that reads agent_id from `RunStep.Config["agent_id"]` or `Metadata["agent_id"]`, returning nil when absent
- Add `TestRecordStepCost_WithAgentID` and `TestRecordStepCost_WithoutAgentID` unit tests; update all existing call sites to pass nil for backward compatibility

## Test plan
- [x] `go build ./...` compiles without errors
- [x] `go vet ./...` passes
- [x] `go test ./... -short` — all tests pass
- [x] `TestRecordStepCost_WithAgentID` verifies agent_id is persisted in the cost record
- [x] `TestRecordStepCost_WithoutAgentID` verifies nil agent_id is accepted without error

Refs: R-5-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)