### PR TITLE
feat(ui): add By Agent tab to cost dashboard

### DIFF
--- a/frontend/src/composables/useCosts.ts
+++ b/frontend/src/composables/useCosts.ts
@@ -5,6 +5,7 @@ import type { components } from '@/api/schema'
 type CostSummary = components['schemas']['CostSummary']
 type CostDataPoint = components['schemas']['CostDataPoint']
 type RunCostRow = components['schemas']['RunCostRow']
+type AgentCostBreakdown = components['schemas']['AgentCostBreakdown']
 
 /**
  * Composable for fetching and managing cost data for a project.
@@ -15,6 +16,9 @@ export function useCosts(projectId: string) {
   const summary = ref<CostSummary | null>(null)
   const chartData = ref<CostDataPoint[]>([])
   const runs = ref<RunCostRow[]>([])
+  const agentCosts = ref<AgentCostBreakdown[]>([])
+  const agentCostsLoading = ref(false)
+  const agentCostsError = ref<string | null>(null)
   const isLoading = ref(false)
   const error = ref<string | null>(null)
 
@@ -46,6 +50,24 @@ export function useCosts(projectId: string) {
     }
   }
 
+  /** Fetch cost data aggregated by agent for the project. */
+  async function fetchAgentCosts() {
+    agentCostsLoading.value = true
+    agentCostsError.value = null
+    try {
+      const { data, error: err } = await apiClient.GET(
+        '/projects/{projectId}/costs/agents',
+        { params: { path: { projectId } } },
+      )
+      if (err) throw new Error('Failed to load agent costs')
+      agentCosts.value = data ?? []
+    } catch (e) {
+      agentCostsError.value = e instanceof Error ? e.message : 'Failed to load agent costs'
+    } finally {
+      agentCostsLoading.value = false
+    }
+  }
+
   /** Update the active period and re-fetch all cost data. */
   function setPeriod(p: '7d' | '30d') {
     period.value = p
@@ -54,5 +76,18 @@ export function useCosts(projectId: string) {
 
   onMounted(fetchAll)
 
-  return { period, summary, chartData, runs, isLoading, error, fetchAll, setPeriod }
+  return {
+    period,
+    summary,
+    chartData,
+    runs,
+    isLoading,
+    error,
+    fetchAll,
+    setPeriod,
+    agentCosts,
+    agentCostsLoading,
+    agentCostsError,
+    fetchAgentCosts,
+  }
 }

--- a/frontend/src/features/costs/AgentCostTable.vue
+++ b/frontend/src/features/costs/AgentCostTable.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import DataTable from 'primevue/datatable'
+import Column from 'primevue/column'
+import Skeleton from 'primevue/skeleton'
+import { formatCostUSD, formatTokenCount } from '@/utils/formatCost'
+import type { components } from '@/api/schema'
+
+type AgentCostBreakdown = components['schemas']['AgentCostBreakdown']
+
+const props = defineProps<{
+  data: AgentCostBreakdown[]
+  isLoading: boolean
+}>()
+
+const totalCost = computed(() => props.data.reduce((sum, r) => sum + r.cost_usd, 0))
+
+function percentOf(cost: number): string {
+  if (totalCost.value === 0) return '0.0%'
+  return ((cost / totalCost.value) * 100).toFixed(1) + '%'
+}
+
+const skeletonRows = [1, 2, 3]
+</script>
+
+<template>
+  <div class="rounded-lg border border-surface-200 bg-surface-0">
+    <div class="border-b border-surface-200 px-4 py-3">
+      <h3 class="font-semibold">Cost by Agent</h3>
+    </div>
+
+    <!-- Skeleton loading state -->
+    <div v-if="isLoading" class="divide-y divide-surface-100">
+      <div v-for="n in skeletonRows" :key="n" class="flex items-center gap-4 px-4 py-3">
+        <Skeleton width="6rem" height="1.25rem" />
+        <Skeleton width="3rem" height="1.25rem" />
+        <Skeleton width="5rem" height="1.25rem" />
+        <Skeleton width="5rem" height="1.25rem" />
+        <Skeleton width="5rem" height="1.25rem" class="ml-auto" />
+        <Skeleton width="4rem" height="1.25rem" />
+      </div>
+    </div>
+
+    <!-- Empty state -->
+    <div
+      v-else-if="data.length === 0"
+      class="flex flex-col items-center justify-center py-10"
+      data-testid="agent-cost-empty"
+    >
+      <i class="pi pi-users mb-3 text-3xl text-surface-300" />
+      <p class="text-surface-500">No agent cost data available</p>
+    </div>
+
+    <!-- Data table -->
+    <DataTable
+      v-else
+      :value="data"
+      :default-sort-order="-1"
+      sort-field="cost_usd"
+      data-testid="agent-cost-table"
+    >
+      <Column field="agent_name" header="Agent Name" sortable />
+      <Column field="runs_count" header="Runs" sortable />
+      <Column field="tokens_input" header="Tokens In" sortable>
+        <template #body="{ data: row }">
+          {{ formatTokenCount(row.tokens_input) }}
+        </template>
+      </Column>
+      <Column field="tokens_output" header="Tokens Out" sortable>
+        <template #body="{ data: row }">
+          {{ formatTokenCount(row.tokens_output) }}
+        </template>
+      </Column>
+      <Column field="cost_usd" header="Cost (USD)" sortable>
+        <template #body="{ data: row }">
+          {{ formatCostUSD(row.cost_usd) }}
+        </template>
+      </Column>
+      <Column header="% of Total">
+        <template #body="{ data: row }">
+          {{ percentOf(row.cost_usd) }}
+        </template>
+      </Column>
+    </DataTable>
+  </div>
+</template>

--- a/frontend/src/views/CostDashboardView.vue
+++ b/frontend/src/views/CostDashboardView.vue
@@ -1,20 +1,50 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import Button from 'primevue/button'
 import Message from 'primevue/message'
 import ProgressBar from 'primevue/progressbar'
+import Tabs from 'primevue/tabs'
+import TabList from 'primevue/tablist'
+import Tab from 'primevue/tab'
+import TabPanels from 'primevue/tabpanels'
+import TabPanel from 'primevue/tabpanel'
 import { useCosts } from '@/composables/useCosts'
 import { formatCostUSD } from '@/utils/formatCost'
 import CostSummaryCard from '@/features/costs/CostSummaryCard.vue'
 import CostChart from '@/features/costs/CostChart.vue'
 import RunCostTable from '@/features/costs/RunCostTable.vue'
+import AgentCostTable from '@/features/costs/AgentCostTable.vue'
 
 const route = useRoute()
 const router = useRouter()
 
 const projectId = route.params.id as string
-const { period, summary, chartData, runs, isLoading, error, fetchAll, setPeriod } =
-  useCosts(projectId)
+const {
+  period,
+  summary,
+  chartData,
+  runs,
+  isLoading,
+  error,
+  fetchAll,
+  setPeriod,
+  agentCosts,
+  agentCostsLoading,
+  agentCostsError,
+  fetchAgentCosts,
+} = useCosts(projectId)
+
+const activeTab = ref('overview')
+const agentCostsFetched = ref(false)
+
+function onTabChange(value: string | number) {
+  activeTab.value = String(value)
+  if (value === 'by-agent' && !agentCostsFetched.value) {
+    agentCostsFetched.value = true
+    fetchAgentCosts()
+  }
+}
 
 function onRunNavigate(runId: string) {
   router.push({ name: 'run-detail', params: { id: runId } })
@@ -28,7 +58,7 @@ function budgetPercent(total: number, limit: number): number {
 
 <template>
   <div class="flex flex-col gap-6 p-6">
-    <!-- Error state -->
+    <!-- Error state (overview) -->
     <Message
       v-if="error"
       severity="error"
@@ -42,78 +72,122 @@ function budgetPercent(total: number, limit: number): number {
     </Message>
 
     <template v-if="!error">
-      <!-- Period toggle -->
-      <div class="flex items-center gap-2">
-        <span class="text-sm font-medium text-surface-600">Period:</span>
-        <Button
-          label="7d"
-          size="small"
-          :outlined="period !== '7d'"
-          data-testid="period-7d"
-          @click="setPeriod('7d')"
-        />
-        <Button
-          label="30d"
-          size="small"
-          :outlined="period !== '30d'"
-          data-testid="period-30d"
-          @click="setPeriod('30d')"
-        />
-      </div>
+      <Tabs :value="activeTab" @update:value="onTabChange" data-testid="cost-tabs">
+        <TabList>
+          <Tab value="overview" data-testid="tab-overview">Overview</Tab>
+          <Tab value="by-agent" data-testid="tab-by-agent">By Agent</Tab>
+        </TabList>
 
-      <!-- Summary cards -->
-      <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <CostSummaryCard
-          label="Total cost this week"
-          :value="summary ? formatCostUSD(summary.total_cost_week_usd ?? 0) : '$0.00'"
-          :tokens-input="summary?.total_tokens_input"
-          :tokens-output="summary?.total_tokens_output"
-          :is-loading="isLoading"
-          data-testid="card-week"
-        />
-        <CostSummaryCard
-          label="Total cost this month"
-          :value="summary ? formatCostUSD(summary.total_cost_month_usd ?? 0) : '$0.00'"
-          :is-loading="isLoading"
-          data-testid="card-month"
-        />
-        <CostSummaryCard
-          label="Average cost per story"
-          :value="summary ? formatCostUSD(summary.avg_cost_per_story_usd) : '$0.00'"
-          :is-loading="isLoading"
-          data-testid="card-avg"
-        />
-      </div>
+        <TabPanels>
+          <!-- Overview tab (existing content) -->
+          <TabPanel value="overview">
+            <div class="flex flex-col gap-6 pt-4">
+              <!-- Period toggle -->
+              <div class="flex items-center gap-2">
+                <span class="text-sm font-medium text-surface-600">Period:</span>
+                <Button
+                  label="7d"
+                  size="small"
+                  :outlined="period !== '7d'"
+                  data-testid="period-7d"
+                  @click="setPeriod('7d')"
+                />
+                <Button
+                  label="30d"
+                  size="small"
+                  :outlined="period !== '30d'"
+                  data-testid="period-30d"
+                  @click="setPeriod('30d')"
+                />
+              </div>
 
-      <!-- Budget progress bar -->
-      <div
-        v-if="summary && (summary.budget_limit_usd ?? 0) > 0"
-        class="rounded-lg border border-surface-200 bg-surface-0 p-4"
-        data-testid="budget-bar"
-      >
-        <div class="mb-2 flex items-center justify-between text-sm">
-          <span class="font-medium">Budget usage</span>
-          <span class="text-surface-500">
-            {{ formatCostUSD(summary.total_cost_usd) }} /
-            {{ formatCostUSD(summary.budget_limit_usd ?? 0) }} used
-          </span>
-        </div>
-        <ProgressBar
-          :value="budgetPercent(summary.total_cost_usd, summary.budget_limit_usd ?? 0)"
-          :show-value="false"
-        />
-      </div>
+              <!-- Summary cards -->
+              <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <CostSummaryCard
+                  label="Total cost this week"
+                  :value="summary ? formatCostUSD(summary.total_cost_week_usd ?? 0) : '$0.00'"
+                  :tokens-input="summary?.total_tokens_input"
+                  :tokens-output="summary?.total_tokens_output"
+                  :is-loading="isLoading"
+                  data-testid="card-week"
+                />
+                <CostSummaryCard
+                  label="Total cost this month"
+                  :value="summary ? formatCostUSD(summary.total_cost_month_usd ?? 0) : '$0.00'"
+                  :is-loading="isLoading"
+                  data-testid="card-month"
+                />
+                <CostSummaryCard
+                  label="Average cost per story"
+                  :value="summary ? formatCostUSD(summary.avg_cost_per_story_usd) : '$0.00'"
+                  :is-loading="isLoading"
+                  data-testid="card-avg"
+                />
+              </div>
 
-      <!-- Cost over time chart -->
-      <CostChart :data="chartData" :is-loading="isLoading" data-testid="cost-chart" />
+              <!-- Budget progress bar -->
+              <div
+                v-if="summary && (summary.budget_limit_usd ?? 0) > 0"
+                class="rounded-lg border border-surface-200 bg-surface-0 p-4"
+                data-testid="budget-bar"
+              >
+                <div class="mb-2 flex items-center justify-between text-sm">
+                  <span class="font-medium">Budget usage</span>
+                  <span class="text-surface-500">
+                    {{ formatCostUSD(summary.total_cost_usd) }} /
+                    {{ formatCostUSD(summary.budget_limit_usd ?? 0) }} used
+                  </span>
+                </div>
+                <ProgressBar
+                  :value="budgetPercent(summary.total_cost_usd, summary.budget_limit_usd ?? 0)"
+                  :show-value="false"
+                />
+              </div>
 
-      <!-- Recent runs table -->
-      <RunCostTable
-        :runs="runs"
-        :is-loading="isLoading"
-        data-testid="runs-table"
-        @navigate="onRunNavigate"
-      />
+              <!-- Cost over time chart -->
+              <CostChart :data="chartData" :is-loading="isLoading" data-testid="cost-chart" />
+
+              <!-- Recent runs table -->
+              <RunCostTable
+                :runs="runs"
+                :is-loading="isLoading"
+                data-testid="runs-table"
+                @navigate="onRunNavigate"
+              />
+            </div>
+          </TabPanel>
+
+          <!-- By Agent tab -->
+          <TabPanel value="by-agent">
+            <div class="flex flex-col gap-6 pt-4">
+              <Message
+                v-if="agentCostsError"
+                severity="error"
+                :closable="false"
+                data-testid="agent-cost-error"
+              >
+                <div class="flex items-center gap-3">
+                  <span>{{ agentCostsError }}</span>
+                  <Button
+                    label="Retry"
+                    severity="secondary"
+                    text
+                    size="small"
+                    @click="fetchAgentCosts()"
+                  />
+                </div>
+              </Message>
+
+              <AgentCostTable
+                v-else
+                :data="agentCosts"
+                :is-loading="agentCostsLoading"
+                data-testid="agent-cost-section"
+              />
+            </div>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
     </template>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Add **AgentCostTable.vue** component displaying agent cost breakdown with columns: Agent Name, Runs, Tokens In, Tokens Out, Cost (USD), % of Total
- Extend **useCosts.ts** composable with `fetchAgentCosts()` method calling `GET /projects/{projectId}/costs/agents`
- Update **CostDashboardView.vue** to use PrimeVue `Tabs` with "Overview" (existing content) and "By Agent" tabs, with lazy-loading of agent data on tab activation

## Acceptance Criteria
- [x] "By Agent" tab exists in cost dashboard
- [x] AgentCostTable displays correct columns (Agent Name, Runs, Tokens In/Out, Cost USD, % of Total)
- [x] Percentage of total calculated client-side
- [x] Empty state when no agent-linked costs exist
- [x] Data fetched via useCosts composable (fetchAgentCosts)
- [x] Lint and type-check pass

## Test plan
- [ ] Navigate to a project's cost dashboard and verify both tabs appear
- [ ] Click "By Agent" tab and verify table loads with correct columns
- [ ] Verify percentage column sums to ~100% across all agents
- [ ] Verify empty state message when no agent cost data exists
- [ ] Verify `npm run lint` and `npm run type-check` pass

Refs: R-5-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)