### PR TITLE
fix(pipeline): use remote API for git_branch, git_pr and ci_poll

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -203,12 +203,12 @@ func run() error {
 	logger.Info("hitl_gate action registered")
 
 	// Git Branch action (no Docker required)
-	gitBranchAction := actionadapter.NewGitBranchAction(gitProviderFactory, storyRepo, logger)
+	gitBranchAction := actionadapter.NewGitBranchAction(gitProviderFactory, storyRepo, projectRepo, logger)
 	actionReg.Register(gitBranchAction)
 	logger.Info("git_branch action registered")
 
 	// Git PR action (no Docker required)
-	gitPRAction := actionadapter.NewGitPRAction(gitProviderFactory, storyRepo, logger)
+	gitPRAction := actionadapter.NewGitPRAction(gitProviderFactory, storyRepo, projectRepo, logger)
 	actionReg.Register(gitPRAction)
 	logger.Info("git_pr action registered")
 

--- a/backend/internal/adapter/action/ci_poll.go
+++ b/backend/internal/adapter/action/ci_poll.go
@@ -59,8 +59,6 @@ func (a *CIPollAction) Execute(ctx context.Context, runCtx *model.RunContext) er
 		return fmt.Errorf("resolve git provider: %w", err)
 	}
 
-	workDir, _ := runCtx.Metadata["work_dir"].(string)
-
 	pollInterval := a.config.DefaultPollInterval
 	if secs, ok := runCtx.Metadata["poll_interval_seconds"].(float64); ok && secs > 0 {
 		pollInterval = time.Duration(secs) * time.Second
@@ -85,9 +83,9 @@ func (a *CIPollAction) Execute(ctx context.Context, runCtx *model.RunContext) er
 			}
 			return fmt.Errorf("CI_POLL_TIMEOUT: timed out after %v waiting for CI on %s", timeout, prURL)
 		case <-ticker.C:
-			status, err := gitProvider.GetCIStatus(pollCtx, workDir)
+			status, err := gitProvider.GetRemoteCIStatus(pollCtx, prURL)
 			if err != nil {
-				a.logger.Warn("ci_poll: GetCIStatus error", "error", err, "pr_url", prURL)
+				a.logger.Warn("ci_poll: GetRemoteCIStatus error", "error", err, "pr_url", prURL)
 				a.publishPollingEvent(ctx, runCtx, prURL, "error")
 				continue
 			}

--- a/backend/internal/adapter/action/ci_poll_test.go
+++ b/backend/internal/adapter/action/ci_poll_test.go
@@ -23,25 +23,34 @@ const (
 // --- Mocks for CIPollAction ---
 
 type ciMockGitProvider struct {
-	mu            sync.Mutex
-	getCIStatusFn func(ctx context.Context, workDir string) (string, error)
-	calls         int
+	mu                  sync.Mutex
+	getRemoteCIStatusFn func(ctx context.Context, prURL string) (string, error)
+	calls               int
 }
 
-func (m *ciMockGitProvider) GetCIStatus(ctx context.Context, workDir string) (string, error) {
+func (m *ciMockGitProvider) GetRemoteCIStatus(ctx context.Context, prURL string) (string, error) {
 	m.mu.Lock()
 	m.calls++
 	m.mu.Unlock()
-	return m.getCIStatusFn(ctx, workDir)
+	return m.getRemoteCIStatusFn(ctx, prURL)
 }
 
 func (m *ciMockGitProvider) CloneRepo(_ context.Context, _ string, _ string) error    { return nil }
 func (m *ciMockGitProvider) CreateBranch(_ context.Context, _ string, _ string) error { return nil }
-func (m *ciMockGitProvider) Push(_ context.Context, _ string, _ string) error         { return nil }
+func (m *ciMockGitProvider) CreateRemoteBranch(_ context.Context, _ string, _ string, _ string) error {
+	return nil
+}
+func (m *ciMockGitProvider) Push(_ context.Context, _ string, _ string) error { return nil }
 func (m *ciMockGitProvider) CreatePR(_ context.Context, _ string, _ string, _ string, _ string) (string, error) {
 	return "", nil
 }
-func (m *ciMockGitProvider) MergePR(_ context.Context, _ string, _ string) error   { return nil }
+func (m *ciMockGitProvider) CreateRemotePR(_ context.Context, _ string, _ string, _ string, _ string, _ string) (string, error) {
+	return "", nil
+}
+func (m *ciMockGitProvider) MergePR(_ context.Context, _ string, _ string) error { return nil }
+func (m *ciMockGitProvider) GetCIStatus(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
 func (m *ciMockGitProvider) GetPRDiff(_ context.Context, _ string) (string, error) { return "", nil }
 
 func (m *ciMockGitProvider) getCalls() int {
@@ -124,7 +133,11 @@ func TestCIPollAction_Name(t *testing.T) {
 }
 
 func TestCIPollAction_Execute_MissingPRURL(t *testing.T) {
-	gitProvider := &ciMockGitProvider{}
+	gitProvider := &ciMockGitProvider{
+		getRemoteCIStatusFn: func(_ context.Context, _ string) (string, error) {
+			return ciStatusPass, nil
+		},
+	}
 	factory := &ciMockGitProviderFactory{provider: gitProvider}
 	eventPub := &ciMockEventPublisher{}
 
@@ -139,15 +152,15 @@ func TestCIPollAction_Execute_MissingPRURL(t *testing.T) {
 		t.Fatalf("expected error to contain %q, got %q", "CI_POLL_MISSING_PR_URL", err.Error())
 	}
 
-	// GetCIStatus should never be called
+	// GetRemoteCIStatus should never be called
 	if gitProvider.getCalls() != 0 {
-		t.Fatalf("expected 0 GetCIStatus calls, got %d", gitProvider.getCalls())
+		t.Fatalf("expected 0 GetRemoteCIStatus calls, got %d", gitProvider.getCalls())
 	}
 }
 
 func TestCIPollAction_Execute_HappyPath_PassOnFirstTick(t *testing.T) {
 	gitProvider := &ciMockGitProvider{
-		getCIStatusFn: func(_ context.Context, _ string) (string, error) {
+		getRemoteCIStatusFn: func(_ context.Context, _ string) (string, error) {
 			return ciStatusPass, nil
 		},
 	}
@@ -164,9 +177,9 @@ func TestCIPollAction_Execute_HappyPath_PassOnFirstTick(t *testing.T) {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 
-	// One GetCIStatus call for the "pass"
+	// One GetRemoteCIStatus call for the "pass"
 	if gitProvider.getCalls() != 1 {
-		t.Fatalf("expected 1 GetCIStatus call, got %d", gitProvider.getCalls())
+		t.Fatalf("expected 1 GetRemoteCIStatus call, got %d", gitProvider.getCalls())
 	}
 
 	// One event published (for the "pass" status)
@@ -185,7 +198,7 @@ func TestCIPollAction_Execute_HappyPath_PassOnFirstTick(t *testing.T) {
 func TestCIPollAction_Execute_PendingThenPass(t *testing.T) {
 	callCount := 0
 	gitProvider := &ciMockGitProvider{
-		getCIStatusFn: func(_ context.Context, _ string) (string, error) {
+		getRemoteCIStatusFn: func(_ context.Context, _ string) (string, error) {
 			callCount++
 			if callCount < 3 {
 				return ciStatusPending, nil
@@ -208,7 +221,7 @@ func TestCIPollAction_Execute_PendingThenPass(t *testing.T) {
 
 	// 3 calls: pending, pending, pass
 	if gitProvider.getCalls() != 3 {
-		t.Fatalf("expected 3 GetCIStatus calls, got %d", gitProvider.getCalls())
+		t.Fatalf("expected 3 GetRemoteCIStatus calls, got %d", gitProvider.getCalls())
 	}
 
 	// 3 events published (2 pending + 1 pass)
@@ -226,7 +239,7 @@ func TestCIPollAction_Execute_PendingThenPass(t *testing.T) {
 func TestCIPollAction_Execute_CIFailure(t *testing.T) {
 	prURL := "https://github.com/owner/repo/pull/3"
 	gitProvider := &ciMockGitProvider{
-		getCIStatusFn: func(_ context.Context, _ string) (string, error) {
+		getRemoteCIStatusFn: func(_ context.Context, _ string) (string, error) {
 			return ciStatusFail, nil
 		},
 	}
@@ -250,7 +263,7 @@ func TestCIPollAction_Execute_CIFailure(t *testing.T) {
 
 func TestCIPollAction_Execute_Timeout(t *testing.T) {
 	gitProvider := &ciMockGitProvider{
-		getCIStatusFn: func(_ context.Context, _ string) (string, error) {
+		getRemoteCIStatusFn: func(_ context.Context, _ string) (string, error) {
 			return ciStatusPending, nil
 		},
 	}
@@ -279,7 +292,7 @@ func TestCIPollAction_Execute_Timeout(t *testing.T) {
 func TestCIPollAction_Execute_ContextCancellation(t *testing.T) {
 	ready := make(chan struct{})
 	gitProvider := &ciMockGitProvider{
-		getCIStatusFn: func(ctx context.Context, _ string) (string, error) {
+		getRemoteCIStatusFn: func(ctx context.Context, _ string) (string, error) {
 			// Signal that we're inside the poll loop, then block.
 			select {
 			case ready <- struct{}{}:

--- a/backend/internal/adapter/action/git_branch.go
+++ b/backend/internal/adapter/action/git_branch.go
@@ -15,18 +15,20 @@ var nonAlphanumeric = regexp.MustCompile(`[^a-z0-9]+`)
 
 // GitBranchAction implements model.Action for creating a Git feature branch.
 // It renders the branch name from a configurable pattern using RunContext variables,
-// delegates creation to GitProvider, and stores the result in RunContext.Metadata.
+// delegates creation to GitProvider via remote API, and stores the result in RunContext.Metadata.
 type GitBranchAction struct {
 	gitProviderFactory port.GitProviderFactory
 	storyRepo          port.StoryRepository
+	projectRepo        port.ProjectRepository
 	logger             *slog.Logger
 }
 
 // NewGitBranchAction creates a new GitBranchAction.
-func NewGitBranchAction(gitProviderFactory port.GitProviderFactory, storyRepo port.StoryRepository, logger *slog.Logger) *GitBranchAction {
+func NewGitBranchAction(gitProviderFactory port.GitProviderFactory, storyRepo port.StoryRepository, projectRepo port.ProjectRepository, logger *slog.Logger) *GitBranchAction {
 	return &GitBranchAction{
 		gitProviderFactory: gitProviderFactory,
 		storyRepo:          storyRepo,
+		projectRepo:        projectRepo,
 		logger:             logger,
 	}
 }
@@ -36,12 +38,20 @@ func (a *GitBranchAction) Name() string { return "git_branch" }
 
 // Execute creates a feature branch from a configurable pattern.
 // It reads branch_pattern and base_branch from step config, derives a slug from
-// the story title, and calls GitProvider.CreateBranch. On success, the rendered
-// branch name is stored in runCtx.Metadata["branch_name"].
+// the story title, and calls GitProvider.CreateRemoteBranch via API (no local clone needed).
+// On success, the rendered branch name is stored in runCtx.Metadata["branch_name"].
 func (a *GitBranchAction) Execute(ctx context.Context, runCtx *model.RunContext) error {
 	gitProvider, err := a.gitProviderFactory.ForProjectID(ctx, runCtx.ProjectID)
 	if err != nil {
 		return fmt.Errorf("resolve git provider: %w", err)
+	}
+
+	project, err := a.projectRepo.GetByID(ctx, runCtx.ProjectID)
+	if err != nil {
+		return fmt.Errorf("fetch project: %w", err)
+	}
+	if project.RepoURL == nil || *project.RepoURL == "" {
+		return fmt.Errorf("git_branch: project has no repo_url configured")
 	}
 
 	cfg := runCtx.RunStep.Config
@@ -58,15 +68,6 @@ func (a *GitBranchAction) Execute(ctx context.Context, runCtx *model.RunContext)
 		baseBranch = "main"
 	}
 
-	workDir := cfg["work_dir"]
-	if workDir == "" {
-		if wd, ok := runCtx.Metadata["work_dir"].(string); ok && wd != "" {
-			workDir = wd
-		} else {
-			return fmt.Errorf("git_branch: work_dir not configured and not in metadata")
-		}
-	}
-
 	story, err := a.storyRepo.GetByID(ctx, runCtx.StoryID)
 	if err != nil {
 		return fmt.Errorf("fetch story: %w", err)
@@ -76,14 +77,14 @@ func (a *GitBranchAction) Execute(ctx context.Context, runCtx *model.RunContext)
 	branchName := strings.ReplaceAll(pattern, "{story_key}", story.Key)
 	branchName = strings.ReplaceAll(branchName, "{slug}", slug)
 
-	a.logger.Info("creating branch",
+	a.logger.Info("creating remote branch",
 		"branch", branchName,
 		"base", baseBranch,
 		"story_key", story.Key,
-		"work_dir", workDir,
+		"repo_url", *project.RepoURL,
 	)
 
-	if err := gitProvider.CreateBranch(ctx, workDir, branchName); err != nil {
+	if err := gitProvider.CreateRemoteBranch(ctx, *project.RepoURL, branchName, baseBranch); err != nil {
 		return fmt.Errorf("create branch %q: %w", branchName, err)
 	}
 

--- a/backend/internal/adapter/action/git_branch_test.go
+++ b/backend/internal/adapter/action/git_branch_test.go
@@ -16,24 +16,28 @@ import (
 
 // --- git_branch-specific mocks ---
 
-type branchCall struct {
-	WorkDir    string
+type remoteBranchCall struct {
+	RepoURL    string
 	BranchName string
+	BaseBranch string
 }
 
 type gbMockGitProvider struct {
-	mu             sync.Mutex
-	createBranchFn func(ctx context.Context, workDir, branchName string) error
-	branchCalls    []branchCall
+	mu                   sync.Mutex
+	createRemoteBranchFn func(ctx context.Context, repoURL, branchName, baseBranch string) error
+	remoteBranchCalls    []remoteBranchCall
 }
 
 func (m *gbMockGitProvider) CloneRepo(_ context.Context, _ string, _ string) error { return nil }
-func (m *gbMockGitProvider) CreateBranch(ctx context.Context, workDir, branchName string) error {
+func (m *gbMockGitProvider) CreateBranch(_ context.Context, _ string, _ string) error {
+	return nil
+}
+func (m *gbMockGitProvider) CreateRemoteBranch(ctx context.Context, repoURL, branchName, baseBranch string) error {
 	m.mu.Lock()
-	m.branchCalls = append(m.branchCalls, branchCall{WorkDir: workDir, BranchName: branchName})
+	m.remoteBranchCalls = append(m.remoteBranchCalls, remoteBranchCall{RepoURL: repoURL, BranchName: branchName, BaseBranch: baseBranch})
 	m.mu.Unlock()
-	if m.createBranchFn != nil {
-		return m.createBranchFn(ctx, workDir, branchName)
+	if m.createRemoteBranchFn != nil {
+		return m.createRemoteBranchFn(ctx, repoURL, branchName, baseBranch)
 	}
 	return nil
 }
@@ -41,19 +45,25 @@ func (m *gbMockGitProvider) Push(_ context.Context, _ string, _ string) error { 
 func (m *gbMockGitProvider) CreatePR(_ context.Context, _ string, _ string, _ string, _ string) (string, error) {
 	return "", nil
 }
+func (m *gbMockGitProvider) CreateRemotePR(_ context.Context, _ string, _ string, _ string, _ string, _ string) (string, error) {
+	return "", nil
+}
 func (m *gbMockGitProvider) MergePR(_ context.Context, _ string, _ string) error { return nil }
 func (m *gbMockGitProvider) GetCIStatus(_ context.Context, _ string) (string, error) {
-	return "pass", nil
+	return ciStatusPass, nil
+}
+func (m *gbMockGitProvider) GetRemoteCIStatus(_ context.Context, _ string) (string, error) {
+	return ciStatusPass, nil
 }
 func (m *gbMockGitProvider) GetPRDiff(_ context.Context, _ string) (string, error) {
 	return "", nil
 }
 
-func (m *gbMockGitProvider) getBranchCalls() []branchCall {
+func (m *gbMockGitProvider) getRemoteBranchCalls() []remoteBranchCall {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	result := make([]branchCall, len(m.branchCalls))
-	copy(result, m.branchCalls)
+	result := make([]remoteBranchCall, len(m.remoteBranchCalls))
+	copy(result, m.remoteBranchCalls)
 	return result
 }
 
@@ -102,7 +112,40 @@ func (m *gbMockStoryRepo) Update(_ context.Context, s *model.Story) (*model.Stor
 }
 func (m *gbMockStoryRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
 
+type gbMockProjectRepo struct {
+	getByIDFn func(ctx context.Context, id uuid.UUID) (*model.Project, error)
+}
+
+func (m *gbMockProjectRepo) Create(_ context.Context, p *model.Project) (*model.Project, error) {
+	return p, nil
+}
+func (m *gbMockProjectRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Project, error) {
+	if m.getByIDFn != nil {
+		return m.getByIDFn(ctx, id)
+	}
+	return nil, apperrors.NewNotFound("project", id)
+}
+func (m *gbMockProjectRepo) List(_ context.Context, _, _ int32) ([]*model.Project, error) {
+	return nil, nil
+}
+func (m *gbMockProjectRepo) Count(_ context.Context) (int64, error) { return 0, nil }
+func (m *gbMockProjectRepo) Update(_ context.Context, p *model.Project) (*model.Project, error) {
+	return p, nil
+}
+func (m *gbMockProjectRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
+func (m *gbMockProjectRepo) IncrementCircuitBreakerCount(_ context.Context, _ uuid.UUID) (*model.Project, error) {
+	return nil, nil
+}
+func (m *gbMockProjectRepo) ResetCircuitBreaker(_ context.Context, _ uuid.UUID) (*model.Project, error) {
+	return nil, nil
+}
+
 // --- Helpers ---
+
+const (
+	testRepoURL    = "https://github.com/owner/repo"
+	testBaseBranch = "main"
+)
 
 func gbRunCtx(cfg map[string]string, metadata map[string]any) *model.RunContext {
 	runID := uuid.New()
@@ -130,10 +173,19 @@ func gbRunCtx(cfg map[string]string, metadata map[string]any) *model.RunContext 
 	}
 }
 
+func gbDefaultProjectRepo(_ uuid.UUID) *gbMockProjectRepo {
+	repoURL := testRepoURL
+	return &gbMockProjectRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Project, error) {
+			return &model.Project{ID: id, RepoURL: &repoURL}, nil
+		},
+	}
+}
+
 // --- Tests ---
 
 func TestGitBranchAction_Name(t *testing.T) {
-	a := action.NewGitBranchAction(&gbMockGitProviderFactory{}, nil, testLogger())
+	a := action.NewGitBranchAction(&gbMockGitProviderFactory{}, nil, nil, testLogger())
 	if a.Name() != "git_branch" {
 		t.Fatalf("expected Name() = %q, got %q", "git_branch", a.Name())
 	}
@@ -141,6 +193,7 @@ func TestGitBranchAction_Name(t *testing.T) {
 
 func TestGitBranchAction_Execute_HappyPath(t *testing.T) {
 	storyID := uuid.New()
+	projectID := uuid.New()
 	gitProvider := &gbMockGitProvider{}
 	factory := &gbMockGitProviderFactory{provider: gitProvider}
 	storyRepo := &gbMockStoryRepo{
@@ -148,32 +201,36 @@ func TestGitBranchAction_Execute_HappyPath(t *testing.T) {
 			return &model.Story{ID: id, Key: "S-03", Title: "Add login page"}, nil
 		},
 	}
+	projectRepo := gbDefaultProjectRepo(projectID)
 
-	a := action.NewGitBranchAction(factory, storyRepo, testLogger())
+	a := action.NewGitBranchAction(factory, storyRepo, projectRepo, testLogger())
 
 	cfg := map[string]string{
 		"branch_pattern": "feat/{story_key}-{slug}",
-		"base_branch":    "main",
-		"work_dir":       "/tmp/repo",
+		"base_branch":    testBaseBranch,
 	}
 	runCtx := gbRunCtx(cfg, map[string]any{})
 	runCtx.StoryID = storyID
+	runCtx.ProjectID = projectID
 
 	err := a.Execute(context.Background(), runCtx)
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 
-	// Verify CreateBranch was called with correct args
-	calls := gitProvider.getBranchCalls()
+	// Verify CreateRemoteBranch was called with correct args
+	calls := gitProvider.getRemoteBranchCalls()
 	if len(calls) != 1 {
-		t.Fatalf("expected 1 CreateBranch call, got %d", len(calls))
+		t.Fatalf("expected 1 CreateRemoteBranch call, got %d", len(calls))
 	}
-	if calls[0].WorkDir != "/tmp/repo" {
-		t.Fatalf("expected work_dir %q, got %q", "/tmp/repo", calls[0].WorkDir)
+	if calls[0].RepoURL != testRepoURL {
+		t.Fatalf("expected repo_url %q, got %q", testRepoURL, calls[0].RepoURL)
 	}
 	if calls[0].BranchName != "feat/S-03-add-login-page" {
 		t.Fatalf("expected branch %q, got %q", "feat/S-03-add-login-page", calls[0].BranchName)
+	}
+	if calls[0].BaseBranch != testBaseBranch {
+		t.Fatalf("expected base_branch %q, got %q", testBaseBranch, calls[0].BaseBranch)
 	}
 
 	// Verify metadata was set
@@ -203,6 +260,7 @@ func TestGitBranchAction_SlugDerivation(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.title, func(t *testing.T) {
+			projectID := uuid.New()
 			gitProvider := &gbMockGitProvider{}
 			factory := &gbMockGitProviderFactory{provider: gitProvider}
 			storyRepo := &gbMockStoryRepo{
@@ -210,23 +268,24 @@ func TestGitBranchAction_SlugDerivation(t *testing.T) {
 					return &model.Story{ID: id, Key: "S-01", Title: tc.title}, nil
 				},
 			}
+			projectRepo := gbDefaultProjectRepo(projectID)
 
-			a := action.NewGitBranchAction(factory, storyRepo, testLogger())
+			a := action.NewGitBranchAction(factory, storyRepo, projectRepo, testLogger())
 
 			cfg := map[string]string{
 				"branch_pattern": "feat/{story_key}-{slug}",
-				"work_dir":       "/tmp/repo",
 			}
 			runCtx := gbRunCtx(cfg, map[string]any{})
+			runCtx.ProjectID = projectID
 
 			err := a.Execute(context.Background(), runCtx)
 			if err != nil {
 				t.Fatalf("expected nil error, got %v", err)
 			}
 
-			calls := gitProvider.getBranchCalls()
+			calls := gitProvider.getRemoteBranchCalls()
 			if len(calls) != 1 {
-				t.Fatalf("expected 1 CreateBranch call, got %d", len(calls))
+				t.Fatalf("expected 1 CreateRemoteBranch call, got %d", len(calls))
 			}
 
 			expectedBranch := "feat/S-01-" + tc.expected
@@ -238,6 +297,7 @@ func TestGitBranchAction_SlugDerivation(t *testing.T) {
 }
 
 func TestGitBranchAction_Execute_DefaultBaseBranch(t *testing.T) {
+	projectID := uuid.New()
 	gitProvider := &gbMockGitProvider{}
 	factory := &gbMockGitProviderFactory{provider: gitProvider}
 	storyRepo := &gbMockStoryRepo{
@@ -245,32 +305,36 @@ func TestGitBranchAction_Execute_DefaultBaseBranch(t *testing.T) {
 			return &model.Story{ID: id, Key: "S-05", Title: "Some feature"}, nil
 		},
 	}
+	projectRepo := gbDefaultProjectRepo(projectID)
 
-	a := action.NewGitBranchAction(factory, storyRepo, testLogger())
+	a := action.NewGitBranchAction(factory, storyRepo, projectRepo, testLogger())
 
 	// No base_branch in config — should default to "main"
-	cfg := map[string]string{
-		"work_dir": "/tmp/repo",
-	}
+	cfg := map[string]string{}
 	runCtx := gbRunCtx(cfg, map[string]any{})
+	runCtx.ProjectID = projectID
 
 	err := a.Execute(context.Background(), runCtx)
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 
-	calls := gitProvider.getBranchCalls()
+	calls := gitProvider.getRemoteBranchCalls()
 	if len(calls) != 1 {
-		t.Fatalf("expected 1 CreateBranch call, got %d", len(calls))
+		t.Fatalf("expected 1 CreateRemoteBranch call, got %d", len(calls))
 	}
 
 	// Verify branch was created (default pattern "feat/{story_key}-{slug}")
 	if calls[0].BranchName != "feat/S-05-some-feature" {
 		t.Fatalf("expected branch %q, got %q", "feat/S-05-some-feature", calls[0].BranchName)
 	}
+	if calls[0].BaseBranch != testBaseBranch {
+		t.Fatalf("expected base_branch %q, got %q", testBaseBranch, calls[0].BaseBranch)
+	}
 }
 
 func TestGitBranchAction_Execute_CustomFixPattern(t *testing.T) {
+	projectID := uuid.New()
 	gitProvider := &gbMockGitProvider{}
 	factory := &gbMockGitProviderFactory{provider: gitProvider}
 	storyRepo := &gbMockStoryRepo{
@@ -278,23 +342,24 @@ func TestGitBranchAction_Execute_CustomFixPattern(t *testing.T) {
 			return &model.Story{ID: id, Key: "BUG-7", Title: "Fix null pointer"}, nil
 		},
 	}
+	projectRepo := gbDefaultProjectRepo(projectID)
 
-	a := action.NewGitBranchAction(factory, storyRepo, testLogger())
+	a := action.NewGitBranchAction(factory, storyRepo, projectRepo, testLogger())
 
 	cfg := map[string]string{
 		"branch_pattern": "fix/{story_key}-{slug}",
-		"work_dir":       "/tmp/repo",
 	}
 	runCtx := gbRunCtx(cfg, map[string]any{})
+	runCtx.ProjectID = projectID
 
 	err := a.Execute(context.Background(), runCtx)
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 
-	calls := gitProvider.getBranchCalls()
+	calls := gitProvider.getRemoteBranchCalls()
 	if len(calls) != 1 {
-		t.Fatalf("expected 1 CreateBranch call, got %d", len(calls))
+		t.Fatalf("expected 1 CreateRemoteBranch call, got %d", len(calls))
 	}
 	if !strings.HasPrefix(calls[0].BranchName, "fix/") {
 		t.Fatalf("expected branch to start with %q, got %q", "fix/", calls[0].BranchName)
@@ -305,9 +370,10 @@ func TestGitBranchAction_Execute_CustomFixPattern(t *testing.T) {
 }
 
 func TestGitBranchAction_Execute_GitProviderFailure(t *testing.T) {
+	projectID := uuid.New()
 	gitProvider := &gbMockGitProvider{
-		createBranchFn: func(_ context.Context, _, _ string) error {
-			return fmt.Errorf("git checkout failed: branch already exists")
+		createRemoteBranchFn: func(_ context.Context, _, _, _ string) error {
+			return fmt.Errorf("git API failed: branch already exists")
 		},
 	}
 	factory := &gbMockGitProviderFactory{provider: gitProvider}
@@ -316,17 +382,17 @@ func TestGitBranchAction_Execute_GitProviderFailure(t *testing.T) {
 			return &model.Story{ID: id, Key: "S-01", Title: "Test"}, nil
 		},
 	}
+	projectRepo := gbDefaultProjectRepo(projectID)
 
-	a := action.NewGitBranchAction(factory, storyRepo, testLogger())
+	a := action.NewGitBranchAction(factory, storyRepo, projectRepo, testLogger())
 
-	cfg := map[string]string{
-		"work_dir": "/tmp/repo",
-	}
+	cfg := map[string]string{}
 	runCtx := gbRunCtx(cfg, map[string]any{})
+	runCtx.ProjectID = projectID
 
 	err := a.Execute(context.Background(), runCtx)
 	if err == nil {
-		t.Fatal("expected error when CreateBranch fails")
+		t.Fatal("expected error when CreateRemoteBranch fails")
 	}
 	if !strings.Contains(err.Error(), "create branch") {
 		t.Fatalf("expected error containing %q, got %q", "create branch", err.Error())
@@ -339,6 +405,7 @@ func TestGitBranchAction_Execute_GitProviderFailure(t *testing.T) {
 }
 
 func TestGitBranchAction_Execute_StoryNotFound(t *testing.T) {
+	projectID := uuid.New()
 	gitProvider := &gbMockGitProvider{}
 	factory := &gbMockGitProviderFactory{provider: gitProvider}
 	storyRepo := &gbMockStoryRepo{
@@ -346,13 +413,13 @@ func TestGitBranchAction_Execute_StoryNotFound(t *testing.T) {
 			return nil, apperrors.NewNotFound("story", id)
 		},
 	}
+	projectRepo := gbDefaultProjectRepo(projectID)
 
-	a := action.NewGitBranchAction(factory, storyRepo, testLogger())
+	a := action.NewGitBranchAction(factory, storyRepo, projectRepo, testLogger())
 
-	cfg := map[string]string{
-		"work_dir": "/tmp/repo",
-	}
+	cfg := map[string]string{}
 	runCtx := gbRunCtx(cfg, map[string]any{})
+	runCtx.ProjectID = projectID
 
 	err := a.Execute(context.Background(), runCtx)
 	if err == nil {
@@ -363,13 +430,14 @@ func TestGitBranchAction_Execute_StoryNotFound(t *testing.T) {
 	}
 
 	// Verify GitProvider was NOT called
-	calls := gitProvider.getBranchCalls()
+	calls := gitProvider.getRemoteBranchCalls()
 	if len(calls) != 0 {
-		t.Fatalf("expected no CreateBranch calls when story fetch fails, got %d", len(calls))
+		t.Fatalf("expected no CreateRemoteBranch calls when story fetch fails, got %d", len(calls))
 	}
 }
 
-func TestGitBranchAction_Execute_MissingWorkDir(t *testing.T) {
+func TestGitBranchAction_Execute_MissingRepoURL(t *testing.T) {
+	projectID := uuid.New()
 	gitProvider := &gbMockGitProvider{}
 	factory := &gbMockGitProviderFactory{provider: gitProvider}
 	storyRepo := &gbMockStoryRepo{
@@ -377,60 +445,36 @@ func TestGitBranchAction_Execute_MissingWorkDir(t *testing.T) {
 			return &model.Story{ID: id, Key: "S-01", Title: "Test"}, nil
 		},
 	}
+	// Project has no repo_url
+	projectRepo := &gbMockProjectRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Project, error) {
+			return &model.Project{ID: id}, nil
+		},
+	}
 
-	a := action.NewGitBranchAction(factory, storyRepo, testLogger())
+	a := action.NewGitBranchAction(factory, storyRepo, projectRepo, testLogger())
 
-	// No work_dir in config or metadata
 	cfg := map[string]string{}
 	runCtx := gbRunCtx(cfg, map[string]any{})
+	runCtx.ProjectID = projectID
 
 	err := a.Execute(context.Background(), runCtx)
 	if err == nil {
-		t.Fatal("expected error when work_dir is missing")
+		t.Fatal("expected error when repo_url is missing")
 	}
-	if !strings.Contains(err.Error(), "work_dir") {
-		t.Fatalf("expected error containing %q, got %q", "work_dir", err.Error())
+	if !strings.Contains(err.Error(), "repo_url") {
+		t.Fatalf("expected error containing %q, got %q", "repo_url", err.Error())
 	}
 
 	// Verify GitProvider was NOT called
-	calls := gitProvider.getBranchCalls()
+	calls := gitProvider.getRemoteBranchCalls()
 	if len(calls) != 0 {
-		t.Fatalf("expected no CreateBranch calls when work_dir missing, got %d", len(calls))
-	}
-}
-
-func TestGitBranchAction_Execute_WorkDirFromMetadata(t *testing.T) {
-	gitProvider := &gbMockGitProvider{}
-	factory := &gbMockGitProviderFactory{provider: gitProvider}
-	storyRepo := &gbMockStoryRepo{
-		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
-			return &model.Story{ID: id, Key: "S-01", Title: "Test"}, nil
-		},
-	}
-
-	a := action.NewGitBranchAction(factory, storyRepo, testLogger())
-
-	// work_dir only in metadata, not in config
-	cfg := map[string]string{}
-	runCtx := gbRunCtx(cfg, map[string]any{
-		"work_dir": "/tmp/from-metadata",
-	})
-
-	err := a.Execute(context.Background(), runCtx)
-	if err != nil {
-		t.Fatalf("expected nil error, got %v", err)
-	}
-
-	calls := gitProvider.getBranchCalls()
-	if len(calls) != 1 {
-		t.Fatalf("expected 1 CreateBranch call, got %d", len(calls))
-	}
-	if calls[0].WorkDir != "/tmp/from-metadata" {
-		t.Fatalf("expected work_dir %q, got %q", "/tmp/from-metadata", calls[0].WorkDir)
+		t.Fatalf("expected no CreateRemoteBranch calls when repo_url missing, got %d", len(calls))
 	}
 }
 
 func TestGitBranchAction_Execute_NilConfig(t *testing.T) {
+	projectID := uuid.New()
 	gitProvider := &gbMockGitProvider{}
 	factory := &gbMockGitProviderFactory{provider: gitProvider}
 	storyRepo := &gbMockStoryRepo{
@@ -438,22 +482,22 @@ func TestGitBranchAction_Execute_NilConfig(t *testing.T) {
 			return &model.Story{ID: id, Key: "S-01", Title: "Test"}, nil
 		},
 	}
+	projectRepo := gbDefaultProjectRepo(projectID)
 
-	a := action.NewGitBranchAction(factory, storyRepo, testLogger())
+	a := action.NewGitBranchAction(factory, storyRepo, projectRepo, testLogger())
 
-	// nil Config on RunStep, work_dir in metadata
-	runCtx := gbRunCtx(nil, map[string]any{
-		"work_dir": "/tmp/repo",
-	})
+	// nil Config on RunStep
+	runCtx := gbRunCtx(nil, map[string]any{})
+	runCtx.ProjectID = projectID
 
 	err := a.Execute(context.Background(), runCtx)
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 
-	calls := gitProvider.getBranchCalls()
+	calls := gitProvider.getRemoteBranchCalls()
 	if len(calls) != 1 {
-		t.Fatalf("expected 1 CreateBranch call, got %d", len(calls))
+		t.Fatalf("expected 1 CreateRemoteBranch call, got %d", len(calls))
 	}
 	// Default pattern should be used
 	if !strings.HasPrefix(calls[0].BranchName, "feat/S-01-") {

--- a/backend/internal/adapter/action/git_pr.go
+++ b/backend/internal/adapter/action/git_pr.go
@@ -17,28 +17,36 @@ import (
 type GitPRAction struct {
 	gitProviderFactory port.GitProviderFactory
 	storyRepo          port.StoryRepository
+	projectRepo        port.ProjectRepository
 	logger             *slog.Logger
 }
 
 // NewGitPRAction creates a new GitPRAction.
-func NewGitPRAction(gitProviderFactory port.GitProviderFactory, storyRepo port.StoryRepository, logger *slog.Logger) *GitPRAction {
-	return &GitPRAction{gitProviderFactory: gitProviderFactory, storyRepo: storyRepo, logger: logger}
+func NewGitPRAction(gitProviderFactory port.GitProviderFactory, storyRepo port.StoryRepository, projectRepo port.ProjectRepository, logger *slog.Logger) *GitPRAction {
+	return &GitPRAction{gitProviderFactory: gitProviderFactory, storyRepo: storyRepo, projectRepo: projectRepo, logger: logger}
 }
 
 // Name returns the action identifier.
 func (a *GitPRAction) Name() string { return "git_pr" }
 
-// Execute creates a pull request using the GitProvider.
+// Execute creates a pull request using the GitProvider via remote API (no local clone needed).
 // It reads configuration from runCtx.Metadata:
 //   - title_template: PR title template with {story_key}, {story_title}, {scope}, {branch_name} placeholders
 //   - target_branch: base branch for the PR (default: "main")
 //   - draft: "true" to create a draft PR
-//   - work_dir: working directory for git operations
 //   - branch_name: source branch (required, typically set by git_branch step)
 func (a *GitPRAction) Execute(ctx context.Context, runCtx *model.RunContext) error {
 	gitProvider, err := a.gitProviderFactory.ForProjectID(ctx, runCtx.ProjectID)
 	if err != nil {
 		return fmt.Errorf("resolve git provider: %w", err)
+	}
+
+	project, err := a.projectRepo.GetByID(ctx, runCtx.ProjectID)
+	if err != nil {
+		return fmt.Errorf("fetch project: %w", err)
+	}
+	if project.RepoURL == nil || *project.RepoURL == "" {
+		return fmt.Errorf("git_pr: project has no repo_url configured")
 	}
 
 	// Read config from metadata
@@ -51,11 +59,6 @@ func (a *GitPRAction) Execute(ctx context.Context, runCtx *model.RunContext) err
 		targetBranch = "main"
 	}
 	draft := metadataString(runCtx.Metadata, "draft") == "true"
-
-	workDir := metadataString(runCtx.Metadata, "work_dir")
-	if workDir == "" {
-		return fmt.Errorf("git_pr: work_dir not found in run context metadata")
-	}
 
 	branchName := metadataString(runCtx.Metadata, "branch_name")
 	if branchName == "" {
@@ -88,7 +91,7 @@ func (a *GitPRAction) Execute(ctx context.Context, runCtx *model.RunContext) err
 		"branch", branchName, "target", targetBranch,
 		"story_key", story.Key, "draft", draft)
 
-	prURL, err := gitProvider.CreatePR(ctx, workDir, title, body, targetBranch)
+	prURL, err := gitProvider.CreateRemotePR(ctx, *project.RepoURL, title, body, branchName, targetBranch)
 	if err != nil {
 		return fmt.Errorf("create PR: %w", err)
 	}

--- a/backend/internal/adapter/action/git_pr_test.go
+++ b/backend/internal/adapter/action/git_pr_test.go
@@ -10,46 +10,58 @@ import (
 	"github.com/zakari/hopeitworks/backend/internal/adapter/action"
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
 	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	apperrors "github.com/zakari/hopeitworks/backend/pkg/errors"
 )
 
 const (
 	testPRURL     = "https://github.com/owner/repo/pull/42"
 	testPRURLAlt  = "https://github.com/owner/repo/pull/1"
-	testWorkDir   = "/tmp/clone/repo"
 	testBranchPR  = "feat/S-03-add-login-page"
 	testBranchAlt = "feat/S-03-test"
+	prTestRepoURL = "https://github.com/owner/repo"
 )
 
 // --- Mocks for GitPRAction ---
 
-type prMockGitProvider struct {
-	createPRFn func(ctx context.Context, workDir, title, body, baseBranch string) (string, error)
-	calls      []prCreatePRCall
-}
-
-type prCreatePRCall struct {
-	WorkDir    string
+type prRemoteCreatePRCall struct {
+	RepoURL    string
 	Title      string
 	Body       string
+	HeadBranch string
 	BaseBranch string
 }
 
-func (m *prMockGitProvider) CreatePR(ctx context.Context, workDir, title, body, baseBranch string) (string, error) {
-	m.calls = append(m.calls, prCreatePRCall{
-		WorkDir:    workDir,
+type prMockGitProvider struct {
+	createRemotePRFn func(ctx context.Context, repoURL, title, body, headBranch, baseBranch string) (string, error)
+	calls            []prRemoteCreatePRCall
+}
+
+func (m *prMockGitProvider) CreateRemotePR(ctx context.Context, repoURL, title, body, headBranch, baseBranch string) (string, error) {
+	m.calls = append(m.calls, prRemoteCreatePRCall{
+		RepoURL:    repoURL,
 		Title:      title,
 		Body:       body,
+		HeadBranch: headBranch,
 		BaseBranch: baseBranch,
 	})
-	return m.createPRFn(ctx, workDir, title, body, baseBranch)
+	return m.createRemotePRFn(ctx, repoURL, title, body, headBranch, baseBranch)
 }
 
 func (m *prMockGitProvider) CloneRepo(_ context.Context, _ string, _ string) error    { return nil }
 func (m *prMockGitProvider) CreateBranch(_ context.Context, _ string, _ string) error { return nil }
-func (m *prMockGitProvider) Push(_ context.Context, _ string, _ string) error         { return nil }
-func (m *prMockGitProvider) MergePR(_ context.Context, _ string, _ string) error      { return nil }
-func (m *prMockGitProvider) GetCIStatus(_ context.Context, _ string) (string, error)  { return "", nil }
-func (m *prMockGitProvider) GetPRDiff(_ context.Context, _ string) (string, error)    { return "", nil }
+func (m *prMockGitProvider) CreateRemoteBranch(_ context.Context, _ string, _ string, _ string) error {
+	return nil
+}
+func (m *prMockGitProvider) Push(_ context.Context, _ string, _ string) error { return nil }
+func (m *prMockGitProvider) CreatePR(_ context.Context, _ string, _ string, _ string, _ string) (string, error) {
+	return "", nil
+}
+func (m *prMockGitProvider) MergePR(_ context.Context, _ string, _ string) error     { return nil }
+func (m *prMockGitProvider) GetCIStatus(_ context.Context, _ string) (string, error) { return "", nil }
+func (m *prMockGitProvider) GetRemoteCIStatus(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+func (m *prMockGitProvider) GetPRDiff(_ context.Context, _ string) (string, error) { return "", nil }
 
 type prMockGitProviderFactory struct {
 	provider port.GitProvider
@@ -94,6 +106,34 @@ func (m *prMockStoryRepo) Update(_ context.Context, _ *model.Story) (*model.Stor
 }
 func (m *prMockStoryRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
 
+type prMockProjectRepo struct {
+	getByIDFn func(ctx context.Context, id uuid.UUID) (*model.Project, error)
+}
+
+func (m *prMockProjectRepo) Create(_ context.Context, p *model.Project) (*model.Project, error) {
+	return p, nil
+}
+func (m *prMockProjectRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Project, error) {
+	if m.getByIDFn != nil {
+		return m.getByIDFn(ctx, id)
+	}
+	return nil, apperrors.NewNotFound("project", id)
+}
+func (m *prMockProjectRepo) List(_ context.Context, _, _ int32) ([]*model.Project, error) {
+	return nil, nil
+}
+func (m *prMockProjectRepo) Count(_ context.Context) (int64, error) { return 0, nil }
+func (m *prMockProjectRepo) Update(_ context.Context, p *model.Project) (*model.Project, error) {
+	return p, nil
+}
+func (m *prMockProjectRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
+func (m *prMockProjectRepo) IncrementCircuitBreakerCount(_ context.Context, _ uuid.UUID) (*model.Project, error) {
+	return nil, nil
+}
+func (m *prMockProjectRepo) ResetCircuitBreaker(_ context.Context, _ uuid.UUID) (*model.Project, error) {
+	return nil, nil
+}
+
 // --- Helpers ---
 
 func buildPRRunCtx(metadata map[string]any) *model.RunContext {
@@ -133,10 +173,19 @@ func newTestStory(storyID uuid.UUID) *model.Story {
 	}
 }
 
+func prDefaultProjectRepo() *prMockProjectRepo {
+	repoURL := prTestRepoURL
+	return &prMockProjectRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Project, error) {
+			return &model.Project{ID: id, RepoURL: &repoURL}, nil
+		},
+	}
+}
+
 // --- Tests ---
 
 func TestGitPRAction_Name(t *testing.T) {
-	a := action.NewGitPRAction(&prMockGitProviderFactory{}, nil, testLogger())
+	a := action.NewGitPRAction(&prMockGitProviderFactory{}, nil, nil, testLogger())
 	if a.Name() != "git_pr" {
 		t.Fatalf("expected Name() = %q, got %q", "git_pr", a.Name())
 	}
@@ -144,7 +193,7 @@ func TestGitPRAction_Name(t *testing.T) {
 
 func TestGitPRAction_Execute_HappyPath(t *testing.T) {
 	gitProvider := &prMockGitProvider{
-		createPRFn: func(_ context.Context, _, _, _, _ string) (string, error) {
+		createRemotePRFn: func(_ context.Context, _, _, _, _, _ string) (string, error) {
 			return testPRURL, nil
 		},
 	}
@@ -159,11 +208,11 @@ func TestGitPRAction_Execute_HappyPath(t *testing.T) {
 			return newTestStory(storyID), nil
 		},
 	}
+	projectRepo := prDefaultProjectRepo()
 
-	a := action.NewGitPRAction(factory, storyRepo, testLogger())
+	a := action.NewGitPRAction(factory, storyRepo, projectRepo, testLogger())
 	runCtx := buildPRRunCtx(map[string]any{
 		"branch_name":    testBranchPR,
-		"work_dir":       testWorkDir,
 		"target_branch":  "develop",
 		"title_template": "feat({scope}): {story_title}",
 	})
@@ -180,16 +229,19 @@ func TestGitPRAction_Execute_HappyPath(t *testing.T) {
 		t.Fatalf("expected Metadata[pr_url] = %q, got %q", testPRURL, prURL)
 	}
 
-	// Verify CreatePR was called with correct args
+	// Verify CreateRemotePR was called with correct args
 	if len(gitProvider.calls) != 1 {
-		t.Fatalf("expected 1 CreatePR call, got %d", len(gitProvider.calls))
+		t.Fatalf("expected 1 CreateRemotePR call, got %d", len(gitProvider.calls))
 	}
 	call := gitProvider.calls[0]
-	if call.WorkDir != testWorkDir {
-		t.Errorf("expected workDir = %q, got %q", testWorkDir, call.WorkDir)
+	if call.RepoURL != prTestRepoURL {
+		t.Errorf("expected repoURL = %q, got %q", prTestRepoURL, call.RepoURL)
 	}
 	if call.Title != "feat(backend): Add login page" {
 		t.Errorf("expected title = %q, got %q", "feat(backend): Add login page", call.Title)
+	}
+	if call.HeadBranch != testBranchPR {
+		t.Errorf("expected headBranch = %q, got %q", testBranchPR, call.HeadBranch)
 	}
 	if call.BaseBranch != "develop" {
 		t.Errorf("expected baseBranch = %q, got %q", "develop", call.BaseBranch)
@@ -208,7 +260,7 @@ func TestGitPRAction_Execute_HappyPath(t *testing.T) {
 
 func TestGitPRAction_Execute_DefaultTargetBranch(t *testing.T) {
 	gitProvider := &prMockGitProvider{
-		createPRFn: func(_ context.Context, _, _, _, _ string) (string, error) {
+		createRemotePRFn: func(_ context.Context, _, _, _, _, _ string) (string, error) {
 			return testPRURLAlt, nil
 		},
 	}
@@ -220,11 +272,11 @@ func TestGitPRAction_Execute_DefaultTargetBranch(t *testing.T) {
 			return newTestStory(storyID), nil
 		},
 	}
+	projectRepo := prDefaultProjectRepo()
 
-	a := action.NewGitPRAction(factory, storyRepo, testLogger())
+	a := action.NewGitPRAction(factory, storyRepo, projectRepo, testLogger())
 	runCtx := buildPRRunCtx(map[string]any{
 		"branch_name": testBranchPR,
-		"work_dir":    testWorkDir,
 		// No target_branch — should default to "main"
 	})
 	runCtx.StoryID = storyID
@@ -235,7 +287,7 @@ func TestGitPRAction_Execute_DefaultTargetBranch(t *testing.T) {
 	}
 
 	if len(gitProvider.calls) != 1 {
-		t.Fatalf("expected 1 CreatePR call, got %d", len(gitProvider.calls))
+		t.Fatalf("expected 1 CreateRemotePR call, got %d", len(gitProvider.calls))
 	}
 	if gitProvider.calls[0].BaseBranch != "main" {
 		t.Errorf("expected default baseBranch = %q, got %q", "main", gitProvider.calls[0].BaseBranch)
@@ -244,7 +296,7 @@ func TestGitPRAction_Execute_DefaultTargetBranch(t *testing.T) {
 
 func TestGitPRAction_Execute_DraftFlag(t *testing.T) {
 	gitProvider := &prMockGitProvider{
-		createPRFn: func(_ context.Context, _, _, _, _ string) (string, error) {
+		createRemotePRFn: func(_ context.Context, _, _, _, _, _ string) (string, error) {
 			return testPRURLAlt, nil
 		},
 	}
@@ -256,11 +308,11 @@ func TestGitPRAction_Execute_DraftFlag(t *testing.T) {
 			return newTestStory(storyID), nil
 		},
 	}
+	projectRepo := prDefaultProjectRepo()
 
-	a := action.NewGitPRAction(factory, storyRepo, testLogger())
+	a := action.NewGitPRAction(factory, storyRepo, projectRepo, testLogger())
 	runCtx := buildPRRunCtx(map[string]any{
 		"branch_name": testBranchPR,
-		"work_dir":    testWorkDir,
 		"draft":       "true",
 	})
 	runCtx.StoryID = storyID
@@ -271,7 +323,7 @@ func TestGitPRAction_Execute_DraftFlag(t *testing.T) {
 	}
 
 	if len(gitProvider.calls) != 1 {
-		t.Fatalf("expected 1 CreatePR call, got %d", len(gitProvider.calls))
+		t.Fatalf("expected 1 CreateRemotePR call, got %d", len(gitProvider.calls))
 	}
 	if !strings.HasPrefix(gitProvider.calls[0].Title, "[Draft] ") {
 		t.Errorf("expected title to start with %q, got %q", "[Draft] ", gitProvider.calls[0].Title)
@@ -280,7 +332,7 @@ func TestGitPRAction_Execute_DraftFlag(t *testing.T) {
 
 func TestGitPRAction_Execute_MissingBranchName(t *testing.T) {
 	gitProvider := &prMockGitProvider{
-		createPRFn: func(_ context.Context, _, _, _, _ string) (string, error) {
+		createRemotePRFn: func(_ context.Context, _, _, _, _, _ string) (string, error) {
 			return "", nil
 		},
 	}
@@ -290,10 +342,10 @@ func TestGitPRAction_Execute_MissingBranchName(t *testing.T) {
 			return newTestStory(uuid.New()), nil
 		},
 	}
+	projectRepo := prDefaultProjectRepo()
 
-	a := action.NewGitPRAction(factory, storyRepo, testLogger())
+	a := action.NewGitPRAction(factory, storyRepo, projectRepo, testLogger())
 	runCtx := buildPRRunCtx(map[string]any{
-		"work_dir": testWorkDir,
 		// No branch_name
 	})
 
@@ -305,15 +357,15 @@ func TestGitPRAction_Execute_MissingBranchName(t *testing.T) {
 		t.Fatalf("expected error to mention branch_name, got %q", err.Error())
 	}
 
-	// CreatePR should NOT be called
+	// CreateRemotePR should NOT be called
 	if len(gitProvider.calls) != 0 {
-		t.Fatalf("expected 0 CreatePR calls, got %d", len(gitProvider.calls))
+		t.Fatalf("expected 0 CreateRemotePR calls, got %d", len(gitProvider.calls))
 	}
 }
 
-func TestGitPRAction_Execute_MissingWorkDir(t *testing.T) {
+func TestGitPRAction_Execute_MissingRepoURL(t *testing.T) {
 	gitProvider := &prMockGitProvider{
-		createPRFn: func(_ context.Context, _, _, _, _ string) (string, error) {
+		createRemotePRFn: func(_ context.Context, _, _, _, _, _ string) (string, error) {
 			return "", nil
 		},
 	}
@@ -323,24 +375,29 @@ func TestGitPRAction_Execute_MissingWorkDir(t *testing.T) {
 			return newTestStory(uuid.New()), nil
 		},
 	}
+	// Project has no repo_url
+	projectRepo := &prMockProjectRepo{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Project, error) {
+			return &model.Project{ID: id}, nil
+		},
+	}
 
-	a := action.NewGitPRAction(factory, storyRepo, testLogger())
+	a := action.NewGitPRAction(factory, storyRepo, projectRepo, testLogger())
 	runCtx := buildPRRunCtx(map[string]any{
 		"branch_name": testBranchAlt,
-		// No work_dir
 	})
 
 	err := a.Execute(context.Background(), runCtx)
 	if err == nil {
-		t.Fatal("expected error when work_dir is missing")
+		t.Fatal("expected error when repo_url is missing")
 	}
-	if !strings.Contains(err.Error(), "work_dir") {
-		t.Fatalf("expected error to mention work_dir, got %q", err.Error())
+	if !strings.Contains(err.Error(), "repo_url") {
+		t.Fatalf("expected error to mention repo_url, got %q", err.Error())
 	}
 
-	// CreatePR should NOT be called
+	// CreateRemotePR should NOT be called
 	if len(gitProvider.calls) != 0 {
-		t.Fatalf("expected 0 CreatePR calls, got %d", len(gitProvider.calls))
+		t.Fatalf("expected 0 CreateRemotePR calls, got %d", len(gitProvider.calls))
 	}
 }
 
@@ -380,7 +437,7 @@ func TestGitPRAction_Execute_TitleRendering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gitProvider := &prMockGitProvider{
-				createPRFn: func(_ context.Context, _, _, _, _ string) (string, error) {
+				createRemotePRFn: func(_ context.Context, _, _, _, _, _ string) (string, error) {
 					return testPRURLAlt, nil
 				},
 			}
@@ -394,11 +451,11 @@ func TestGitPRAction_Execute_TitleRendering(t *testing.T) {
 					return story, nil
 				},
 			}
+			projectRepo := prDefaultProjectRepo()
 
-			a := action.NewGitPRAction(factory, storyRepo, testLogger())
+			a := action.NewGitPRAction(factory, storyRepo, projectRepo, testLogger())
 			meta := map[string]any{
 				"branch_name": testBranchAlt,
-				"work_dir":    testWorkDir,
 			}
 			if tt.template != "" {
 				meta["title_template"] = tt.template
@@ -412,7 +469,7 @@ func TestGitPRAction_Execute_TitleRendering(t *testing.T) {
 			}
 
 			if len(gitProvider.calls) != 1 {
-				t.Fatalf("expected 1 CreatePR call, got %d", len(gitProvider.calls))
+				t.Fatalf("expected 1 CreateRemotePR call, got %d", len(gitProvider.calls))
 			}
 			if gitProvider.calls[0].Title != tt.expectedTitle {
 				t.Errorf("expected title = %q, got %q", tt.expectedTitle, gitProvider.calls[0].Title)
@@ -424,7 +481,7 @@ func TestGitPRAction_Execute_TitleRendering(t *testing.T) {
 func TestGitPRAction_Execute_GitProviderFailure(t *testing.T) {
 	gitError := fmt.Errorf("gh CLI: command failed")
 	gitProvider := &prMockGitProvider{
-		createPRFn: func(_ context.Context, _, _, _, _ string) (string, error) {
+		createRemotePRFn: func(_ context.Context, _, _, _, _, _ string) (string, error) {
 			return "", gitError
 		},
 	}
@@ -436,11 +493,11 @@ func TestGitPRAction_Execute_GitProviderFailure(t *testing.T) {
 			return newTestStory(storyID), nil
 		},
 	}
+	projectRepo := prDefaultProjectRepo()
 
-	a := action.NewGitPRAction(factory, storyRepo, testLogger())
+	a := action.NewGitPRAction(factory, storyRepo, projectRepo, testLogger())
 	runCtx := buildPRRunCtx(map[string]any{
 		"branch_name": testBranchAlt,
-		"work_dir":    testWorkDir,
 	})
 	runCtx.StoryID = storyID
 
@@ -463,7 +520,7 @@ func TestGitPRAction_Execute_GitProviderFailure(t *testing.T) {
 
 func TestGitPRAction_Execute_StoryNotFound(t *testing.T) {
 	gitProvider := &prMockGitProvider{
-		createPRFn: func(_ context.Context, _, _, _, _ string) (string, error) {
+		createRemotePRFn: func(_ context.Context, _, _, _, _, _ string) (string, error) {
 			return "", nil
 		},
 	}
@@ -475,11 +532,11 @@ func TestGitPRAction_Execute_StoryNotFound(t *testing.T) {
 			return nil, storyError
 		},
 	}
+	projectRepo := prDefaultProjectRepo()
 
-	a := action.NewGitPRAction(factory, storyRepo, testLogger())
+	a := action.NewGitPRAction(factory, storyRepo, projectRepo, testLogger())
 	runCtx := buildPRRunCtx(map[string]any{
 		"branch_name": testBranchAlt,
-		"work_dir":    testWorkDir,
 	})
 
 	err := a.Execute(context.Background(), runCtx)
@@ -490,16 +547,16 @@ func TestGitPRAction_Execute_StoryNotFound(t *testing.T) {
 		t.Errorf("expected error to contain %q, got %q", "fetch story", err.Error())
 	}
 
-	// CreatePR should NOT be called
+	// CreateRemotePR should NOT be called
 	if len(gitProvider.calls) != 0 {
-		t.Fatalf("expected 0 CreatePR calls, got %d", len(gitProvider.calls))
+		t.Fatalf("expected 0 CreateRemotePR calls, got %d", len(gitProvider.calls))
 	}
 }
 
 func TestGitPRAction_Execute_ObjectiveTruncation(t *testing.T) {
 	longObjective := strings.Repeat("A", 600)
 	gitProvider := &prMockGitProvider{
-		createPRFn: func(_ context.Context, _, _, _, _ string) (string, error) {
+		createRemotePRFn: func(_ context.Context, _, _, _, _, _ string) (string, error) {
 			return testPRURLAlt, nil
 		},
 	}
@@ -513,11 +570,11 @@ func TestGitPRAction_Execute_ObjectiveTruncation(t *testing.T) {
 			return story, nil
 		},
 	}
+	projectRepo := prDefaultProjectRepo()
 
-	a := action.NewGitPRAction(factory, storyRepo, testLogger())
+	a := action.NewGitPRAction(factory, storyRepo, projectRepo, testLogger())
 	runCtx := buildPRRunCtx(map[string]any{
 		"branch_name": testBranchAlt,
-		"work_dir":    testWorkDir,
 	})
 	runCtx.StoryID = storyID
 
@@ -531,7 +588,7 @@ func TestGitPRAction_Execute_ObjectiveTruncation(t *testing.T) {
 	if strings.Contains(body, longObjective) {
 		t.Error("expected objective to be truncated")
 	}
-	if !strings.Contains(body, "…") {
+	if !strings.Contains(body, "\u2026") {
 		t.Error("expected truncated objective to end with ellipsis")
 	}
 }

--- a/backend/internal/adapter/action/hitl_gate_test.go
+++ b/backend/internal/adapter/action/hitl_gate_test.go
@@ -152,13 +152,22 @@ func (m *hitlMockGitProvider) CloneRepo(_ context.Context, _ string, _ string) e
 func (m *hitlMockGitProvider) CreateBranch(_ context.Context, _ string, _ string) error {
 	return nil
 }
+func (m *hitlMockGitProvider) CreateRemoteBranch(_ context.Context, _ string, _ string, _ string) error {
+	return nil
+}
 func (m *hitlMockGitProvider) Push(_ context.Context, _ string, _ string) error { return nil }
 func (m *hitlMockGitProvider) CreatePR(_ context.Context, _ string, _ string, _ string, _ string) (string, error) {
 	return "", nil
 }
+func (m *hitlMockGitProvider) CreateRemotePR(_ context.Context, _ string, _ string, _ string, _ string, _ string) (string, error) {
+	return "", nil
+}
 func (m *hitlMockGitProvider) MergePR(_ context.Context, _ string, _ string) error { return nil }
 func (m *hitlMockGitProvider) GetCIStatus(_ context.Context, _ string) (string, error) {
-	return "pass", nil
+	return ciStatusPass, nil
+}
+func (m *hitlMockGitProvider) GetRemoteCIStatus(_ context.Context, _ string) (string, error) {
+	return ciStatusPass, nil
 }
 func (m *hitlMockGitProvider) GetPRDiff(ctx context.Context, prURL string) (string, error) {
 	m.mu.Lock()

--- a/backend/internal/adapter/git/gh_cli_adapter.go
+++ b/backend/internal/adapter/git/gh_cli_adapter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/zakari/hopeitworks/backend/internal/domain/port"
@@ -17,6 +18,9 @@ import (
 const (
 	ciStatusPending = CIStatusPending
 	ciStatusFail    = CIStatusFail
+
+	// conclusionFailure is the GitHub check conclusion for a failed check.
+	conclusionFailure = "failure"
 )
 
 // branchNamePattern validates conventional branch naming: feat/{key}-{slug} or fix/{key}-{slug}.
@@ -246,7 +250,7 @@ func (a *GhCliAdapter) GetCIStatus(ctx context.Context, workDir string) (string,
 			continue
 		}
 
-		if check.Conclusion == "failure" || check.Conclusion == "timed_out" || check.Conclusion == "action_required" {
+		if check.Conclusion == conclusionFailure || check.Conclusion == "timed_out" || check.Conclusion == "action_required" {
 			return ciStatusFail, nil
 		}
 	}
@@ -273,4 +277,207 @@ func (a *GhCliAdapter) GetPRDiff(ctx context.Context, prURL string) (string, err
 		)
 	}
 	return out, nil
+}
+
+// githubRepoPattern matches GitHub repo URLs like:
+// https://github.com/owner/repo
+// https://github.com/owner/repo.git
+var githubRepoPattern = regexp.MustCompile(`^https?://[^/]+/([^/]+)/([^/]+?)(?:\.git)?$`)
+
+// githubPRPattern matches GitHub PR URLs like:
+// https://github.com/owner/repo/pull/123
+var githubPRPattern = regexp.MustCompile(`^https?://[^/]+/([^/]+)/([^/]+)/pull/(\d+)$`)
+
+// parseGitHubOwnerRepo extracts owner and repo from a GitHub repository URL.
+func parseGitHubOwnerRepo(repoURL string) (owner, repo string, err error) {
+	matches := githubRepoPattern.FindStringSubmatch(repoURL)
+	if matches == nil {
+		return "", "", fmt.Errorf("cannot parse GitHub repo URL: %s", repoURL)
+	}
+	return matches[1], matches[2], nil
+}
+
+// parseGitHubPR extracts owner, repo, and PR number from a GitHub PR URL.
+func parseGitHubPR(prURL string) (owner, repo string, number int, err error) {
+	matches := githubPRPattern.FindStringSubmatch(prURL)
+	if matches == nil {
+		return "", "", 0, fmt.Errorf("cannot parse GitHub PR URL: %s", prURL)
+	}
+	n, err := strconv.Atoi(matches[3])
+	if err != nil {
+		return "", "", 0, fmt.Errorf("invalid PR number in URL %s: %w", prURL, err)
+	}
+	return matches[1], matches[2], n, nil
+}
+
+// CreateRemoteBranch creates a new branch on the remote repository via the GitHub API.
+func (a *GhCliAdapter) CreateRemoteBranch(ctx context.Context, repoURL string, branchName string, baseBranch string) error {
+	owner, repo, err := parseGitHubOwnerRepo(repoURL)
+	if err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeInvalidInput,
+			fmt.Sprintf("failed to parse repo URL: %v", err),
+			map[string]any{"repo_url": repoURL},
+		)
+	}
+
+	a.logger.DebugContext(ctx, "creating remote branch via API",
+		"owner", owner, "repo", repo,
+		"branch_name", branchName, "base_branch", baseBranch,
+	)
+
+	// Get the SHA of the base branch
+	apiPath := fmt.Sprintf("repos/%s/%s/git/ref/heads/%s", owner, repo, baseBranch)
+	sha, err := a.runner.Run(ctx, ".", "gh", "api", apiPath, "--jq", ".object.sha")
+	if err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to get base branch %q SHA: %v", baseBranch, err),
+			map[string]any{"owner": owner, "repo": repo, "base_branch": baseBranch},
+		)
+	}
+
+	// Create the new branch ref
+	sha = strings.TrimSpace(sha)
+	refPath := fmt.Sprintf("repos/%s/%s/git/refs", owner, repo)
+	ref := fmt.Sprintf("refs/heads/%s", branchName)
+	_, err = a.runner.Run(ctx, ".", "gh", "api", refPath,
+		"-f", fmt.Sprintf("ref=%s", ref),
+		"-f", fmt.Sprintf("sha=%s", sha),
+	)
+	if err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to create remote branch %q: %v", branchName, err),
+			map[string]any{"owner": owner, "repo": repo, "branch_name": branchName, "sha": sha},
+		)
+	}
+
+	return nil
+}
+
+// CreateRemotePR creates a pull request via the GitHub API and returns the PR URL.
+func (a *GhCliAdapter) CreateRemotePR(ctx context.Context, repoURL string, title string, body string, headBranch string, baseBranch string) (string, error) {
+	owner, repo, err := parseGitHubOwnerRepo(repoURL)
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeInvalidInput,
+			fmt.Sprintf("failed to parse repo URL: %v", err),
+			map[string]any{"repo_url": repoURL},
+		)
+	}
+
+	a.logger.DebugContext(ctx, "creating remote PR via API",
+		"owner", owner, "repo", repo,
+		"head", headBranch, "base", baseBranch,
+	)
+
+	apiPath := fmt.Sprintf("repos/%s/%s/pulls", owner, repo)
+	stdout, err := a.runner.Run(ctx, ".", "gh", "api", apiPath,
+		"-f", fmt.Sprintf("title=%s", title),
+		"-f", fmt.Sprintf("body=%s", body),
+		"-f", fmt.Sprintf("head=%s", headBranch),
+		"-f", fmt.Sprintf("base=%s", baseBranch),
+		"--jq", ".html_url",
+	)
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to create remote PR: %v", err),
+			map[string]any{"owner": owner, "repo": repo, "head": headBranch, "base": baseBranch},
+		)
+	}
+
+	prURL := strings.TrimSpace(stdout)
+	if !strings.HasPrefix(prURL, "http") {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			"failed to parse PR URL from GitHub API response",
+			map[string]any{"output": stdout},
+		)
+	}
+
+	return prURL, nil
+}
+
+// ghCheckRun represents a single check run from the GitHub API.
+type ghCheckRun struct {
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+// ghCheckRunsResponse is the API response for listing check runs.
+type ghCheckRunsResponse struct {
+	TotalCount int          `json:"total_count"`
+	CheckRuns  []ghCheckRun `json:"check_runs"`
+}
+
+// GetRemoteCIStatus returns CI status for a PR identified by its URL via the GitHub API.
+func (a *GhCliAdapter) GetRemoteCIStatus(ctx context.Context, prURL string) (string, error) {
+	owner, repo, prNumber, err := parseGitHubPR(prURL)
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeInvalidInput,
+			fmt.Sprintf("failed to parse PR URL: %v", err),
+			map[string]any{"pr_url": prURL},
+		)
+	}
+
+	a.logger.DebugContext(ctx, "getting remote CI status via API",
+		"owner", owner, "repo", repo, "pr_number", prNumber,
+	)
+
+	// Get the PR head SHA
+	prPath := fmt.Sprintf("repos/%s/%s/pulls/%d", owner, repo, prNumber)
+	sha, err := a.runner.Run(ctx, ".", "gh", "api", prPath, "--jq", ".head.sha")
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to get PR head SHA: %v", err),
+			map[string]any{"pr_url": prURL},
+		)
+	}
+	sha = strings.TrimSpace(sha)
+
+	// Get check runs for that SHA
+	checksPath := fmt.Sprintf("repos/%s/%s/commits/%s/check-runs", owner, repo, sha)
+	stdout, err := a.runner.Run(ctx, ".", "gh", "api", checksPath)
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to get check runs: %v", err),
+			map[string]any{"pr_url": prURL, "sha": sha},
+		)
+	}
+
+	var checksResp ghCheckRunsResponse
+	if err := json.Unmarshal([]byte(stdout), &checksResp); err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to parse check runs JSON: %v", err),
+			map[string]any{"output": stdout},
+		)
+	}
+
+	if checksResp.TotalCount == 0 {
+		return CIStatusNoChecks, nil
+	}
+
+	hasPending := false
+	for _, check := range checksResp.CheckRuns {
+		if check.Status == "queued" || check.Status == "in_progress" {
+			hasPending = true
+			continue
+		}
+		if check.Conclusion == conclusionFailure || check.Conclusion == "timed_out" || check.Conclusion == "action_required" {
+			return CIStatusFail, nil
+		}
+	}
+
+	if hasPending {
+		return CIStatusPending, nil
+	}
+
+	return CIStatusPass, nil
 }

--- a/backend/internal/adapter/git/gitea_api_adapter.go
+++ b/backend/internal/adapter/git/gitea_api_adapter.go
@@ -352,6 +352,180 @@ func (a *GiteaAPIAdapter) GetPRDiff(ctx context.Context, prURL string) (string, 
 	return string(respBody), nil
 }
 
+// giteaCreateBranchRequest is the JSON body for creating a Gitea branch via API.
+type giteaCreateBranchRequest struct {
+	NewBranchName string `json:"new_branch_name"`
+	OldBranchName string `json:"old_branch_name"`
+}
+
+// CreateRemoteBranch creates a new branch on the remote Gitea repository via API.
+func (a *GiteaAPIAdapter) CreateRemoteBranch(ctx context.Context, repoURL string, branchName string, baseBranch string) error {
+	owner, repo, err := parseGiteaRepoOwnerAndName(repoURL)
+	if err != nil {
+		return fmt.Errorf("parse repo URL: %w", err)
+	}
+
+	a.logger.DebugContext(ctx, "creating remote branch via gitea API",
+		"owner", owner, "repo", repo,
+		"branch_name", branchName, "base_branch", baseBranch,
+	)
+
+	reqBody := giteaCreateBranchRequest{
+		NewBranchName: branchName,
+		OldBranchName: baseBranch,
+	}
+
+	endpoint := fmt.Sprintf("%s/api/v1/repos/%s/%s/branches", a.baseURL, owner, repo)
+	_, err = a.doJSON(ctx, http.MethodPost, endpoint, reqBody)
+	if err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to create remote branch %q: %v", branchName, err),
+			map[string]any{"owner": owner, "repo": repo, "branch_name": branchName, "base_branch": baseBranch},
+		)
+	}
+
+	return nil
+}
+
+// CreateRemotePR creates a pull request via the Gitea API and returns the PR URL.
+func (a *GiteaAPIAdapter) CreateRemotePR(ctx context.Context, repoURL string, title string, body string, headBranch string, baseBranch string) (string, error) {
+	owner, repo, err := parseGiteaRepoOwnerAndName(repoURL)
+	if err != nil {
+		return "", fmt.Errorf("parse repo URL: %w", err)
+	}
+
+	a.logger.DebugContext(ctx, "creating remote PR via gitea API",
+		"owner", owner, "repo", repo,
+		"head", headBranch, "base", baseBranch,
+	)
+
+	reqBody := giteaPRRequest{
+		Title: title,
+		Body:  body,
+		Head:  headBranch,
+		Base:  baseBranch,
+	}
+
+	endpoint := fmt.Sprintf("%s/api/v1/repos/%s/%s/pulls", a.baseURL, owner, repo)
+	respBody, err := a.doJSON(ctx, http.MethodPost, endpoint, reqBody)
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to create remote PR via Gitea API: %v", err),
+			map[string]any{"owner": owner, "repo": repo, "head": headBranch, "base": baseBranch},
+		)
+	}
+
+	var pr giteaPRResponse
+	if err := json.Unmarshal(respBody, &pr); err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to parse PR response: %v", err),
+			map[string]any{"response": string(respBody)},
+		)
+	}
+
+	prURL := pr.HTMLURL
+	if prURL == "" {
+		prURL = fmt.Sprintf("%s/%s/%s/pulls/%d", a.baseURL, owner, repo, pr.Number)
+	}
+
+	return prURL, nil
+}
+
+// giteaPRDetailResponse represents the relevant fields of a Gitea PR detail response.
+type giteaPRDetailResponse struct {
+	Head struct {
+		Sha string `json:"sha"`
+	} `json:"head"`
+}
+
+// GetRemoteCIStatus returns CI status for a PR identified by its URL via the Gitea API.
+func (a *GiteaAPIAdapter) GetRemoteCIStatus(ctx context.Context, prURL string) (string, error) {
+	owner, repo, index, err := parseGiteaPRIndex(prURL)
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeInvalidInput,
+			fmt.Sprintf("failed to parse PR URL %s: %v", prURL, err),
+			map[string]any{"pr_url": prURL},
+		)
+	}
+
+	a.logger.DebugContext(ctx, "getting remote CI status via gitea API",
+		"owner", owner, "repo", repo, "pr_index", index,
+	)
+
+	// Get PR details to find head SHA
+	prEndpoint := fmt.Sprintf("%s/api/v1/repos/%s/%s/pulls/%d", a.baseURL, owner, repo, index)
+	prBody, err := a.doGet(ctx, prEndpoint, "application/json")
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to get PR details: %v", err),
+			map[string]any{"pr_url": prURL},
+		)
+	}
+
+	var prDetail giteaPRDetailResponse
+	if err := json.Unmarshal(prBody, &prDetail); err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to parse PR response: %v", err),
+			map[string]any{"response": string(prBody)},
+		)
+	}
+
+	sha := prDetail.Head.Sha
+	if sha == "" {
+		return CIStatusNoChecks, nil
+	}
+
+	// Get commit statuses
+	statusEndpoint := fmt.Sprintf("%s/api/v1/repos/%s/%s/commits/%s/statuses", a.baseURL, owner, repo, sha)
+	respBody, err := a.doGet(ctx, statusEndpoint, "application/json")
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to get CI status: %v", err),
+			map[string]any{"owner": owner, "repo": repo, "sha": sha},
+		)
+	}
+
+	var statuses []giteaCommitStatus
+	if err := json.Unmarshal(respBody, &statuses); err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to parse commit statuses: %v", err),
+			map[string]any{"response": string(respBody)},
+		)
+	}
+
+	if len(statuses) == 0 {
+		return CIStatusNoChecks, nil
+	}
+
+	hasPending := false
+	for _, s := range statuses {
+		state := s.Status
+		if state == "" {
+			state = s.State
+		}
+		switch state {
+		case "failure", "error":
+			return CIStatusFail, nil
+		case "pending", "running":
+			hasPending = true
+		}
+	}
+
+	if hasPending {
+		return CIStatusPending, nil
+	}
+
+	return CIStatusPass, nil
+}
+
 // --- Helpers ---
 
 // doJSON makes an HTTP request with a JSON body and returns the response body.

--- a/backend/internal/adapter/git/gitea_api_adapter_test.go
+++ b/backend/internal/adapter/git/gitea_api_adapter_test.go
@@ -396,3 +396,152 @@ func TestStripCredentials(t *testing.T) {
 		t.Errorf("expected path preserved, got %q", got)
 	}
 }
+
+func TestGiteaAPIAdapter_CreateRemoteBranch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/api/v1/repos/myorg/myrepo/branches") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body giteaCreateBranchRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.NewBranchName != "feat/S-01-my-feature" {
+			t.Errorf("expected new_branch_name %q, got %q", "feat/S-01-my-feature", body.NewBranchName)
+		}
+		if body.OldBranchName != "main" {
+			t.Errorf("expected old_branch_name %q, got %q", "main", body.OldBranchName)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"name":"feat/S-01-my-feature"}`))
+	}))
+	defer srv.Close()
+
+	adapter := NewGiteaAPIAdapter(srv.URL, "test-token", nil, testLogger())
+
+	repoURL := fmt.Sprintf("%s/myorg/myrepo", srv.URL)
+	err := adapter.CreateRemoteBranch(context.Background(), repoURL, "feat/S-01-my-feature", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGiteaAPIAdapter_CreateRemotePR(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/api/v1/repos/myorg/myrepo/pulls") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body giteaPRRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Head != "feat/S-01-test" {
+			t.Errorf("expected head %q, got %q", "feat/S-01-test", body.Head)
+		}
+		if body.Base != "main" {
+			t.Errorf("expected base %q, got %q", "main", body.Base)
+		}
+
+		resp := giteaPRResponse{
+			Number:  42,
+			HTMLURL: fmt.Sprintf("%s/myorg/myrepo/pulls/42", srv.URL),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	adapter := NewGiteaAPIAdapter(srv.URL, "test-token", nil, testLogger())
+
+	repoURL := fmt.Sprintf("%s/myorg/myrepo", srv.URL)
+	prURL, err := adapter.CreateRemotePR(context.Background(), repoURL, "test PR", "body text", "feat/S-01-test", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(prURL, "/pulls/42") {
+		t.Errorf("expected PR URL with /pulls/42, got %q", prURL)
+	}
+}
+
+func TestGiteaAPIAdapter_GetRemoteCIStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		statuses   []giteaCommitStatus
+		wantStatus string
+	}{
+		{
+			name:       "no statuses",
+			statuses:   []giteaCommitStatus{},
+			wantStatus: "no_checks",
+		},
+		{
+			name:       "all success",
+			statuses:   []giteaCommitStatus{{Status: "success"}, {Status: "success"}},
+			wantStatus: "pass",
+		},
+		{
+			name:       "one failure",
+			statuses:   []giteaCommitStatus{{Status: "success"}, {Status: "failure"}},
+			wantStatus: "fail",
+		},
+		{
+			name:       "one pending",
+			statuses:   []giteaCommitStatus{{Status: "success"}, {Status: "pending"}},
+			wantStatus: "pending",
+		},
+		{
+			name:       "error state",
+			statuses:   []giteaCommitStatus{{Status: "error"}},
+			wantStatus: "fail",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				if strings.Contains(r.URL.Path, "/pulls/") && !strings.Contains(r.URL.Path, "/statuses") {
+					// PR details endpoint
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"head": map[string]string{"sha": "abc123def"},
+					})
+					return
+				}
+				if strings.Contains(r.URL.Path, "/statuses") {
+					// Commit statuses endpoint
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(tt.statuses)
+					return
+				}
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			})
+
+			srv := httptest.NewServer(mux)
+			defer srv.Close()
+
+			adapter := NewGiteaAPIAdapter(srv.URL, "test-token", nil, testLogger())
+
+			prURL := fmt.Sprintf("%s/owner/repo/pulls/10", srv.URL)
+			status, err := adapter.GetRemoteCIStatus(context.Background(), prURL)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if status != tt.wantStatus {
+				t.Errorf("got status %q, want %q", status, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/backend/internal/domain/port/git_provider.go
+++ b/backend/internal/domain/port/git_provider.go
@@ -37,4 +37,23 @@ type GitProvider interface {
 	// GetPRDiff returns the diff content for the given pull request URL.
 	// prURL: full PR URL (e.g., "https://github.com/owner/repo/pull/123").
 	GetPRDiff(ctx context.Context, prURL string) (string, error)
+
+	// CreateRemoteBranch creates a new branch on the remote repository via API.
+	// repoURL: full HTTPS URL of the repository.
+	// branchName: name of the new branch to create.
+	// baseBranch: name of the existing branch to branch from (e.g., "main").
+	CreateRemoteBranch(ctx context.Context, repoURL string, branchName string, baseBranch string) error
+
+	// CreateRemotePR creates a pull request via API and returns the PR URL.
+	// repoURL: full HTTPS URL of the repository.
+	// title: PR title.
+	// body: PR description.
+	// headBranch: source branch name.
+	// baseBranch: target branch name.
+	CreateRemotePR(ctx context.Context, repoURL string, title string, body string, headBranch string, baseBranch string) (prURL string, err error)
+
+	// GetRemoteCIStatus returns CI status for a PR identified by its URL.
+	// prURL: full PR URL.
+	// Returns: "pass", "fail", "pending", "no_checks".
+	GetRemoteCIStatus(ctx context.Context, prURL string) (status string, err error)
 }


### PR DESCRIPTION
## Summary
- Actions `git_branch`, `git_pr`, `ci_poll` no longer need `work_dir` — they work via remote API
- Added `CreateRemoteBranch`, `CreateRemotePR`, `GetRemoteCIStatus` to `GitProvider` interface
- Implemented for both GitHub (gh CLI) and Gitea (REST API) adapters
- `projectRepo` injected into `git_branch` and `git_pr` to resolve repo URL

## Test plan
- [x] `go build` + `go vet` pass
- [x] All unit tests pass (`go test ./... -short`)
- [ ] Launch pipeline run — verify Create Branch step succeeds via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)