### PR TITLE
docs(stories): add Phase 13 stabilization stories from functional audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,13 +341,9 @@ hopeitworks/
 │   └── Dockerfile
 ├── api/
 │   └── openapi.yaml            # Single source of truth — API contract
-├── agent/                      # Agent runtime
-│   ├── Dockerfile              # Project-specific agent image
-│   ├── Dockerfile.base         # Base image: Claude Code + git + gh CLI
-│   ├── entrypoint.sh           # Container entry script
-│   ├── scripts/                # Runtime scripts (clone, inject CLAUDE.md, run agent, extract results)
-│   ├── claude-md/              # CLAUDE.md templates (this directory)
-│   └── prompts/                # Handlebars prompt templates
+├── agent/                      # Agent runtime (reference scripts only — no embedded image)
+│   ├── entrypoint.sh           # Container entry script (CLAUDE_MD_CONTENT optional)
+│   └── scripts/                # Runtime scripts (clone, run agent, extract results)
 ├── deploy/                     # Infrastructure
 │   ├── docker-compose.yml      # Dev local stack
 │   └── postgres/               # DB setup
@@ -380,7 +376,6 @@ hopeitworks/
 | Frontend E2E tests | `frontend/e2e/tests/` |
 | Docker Compose (dev) | `deploy/docker-compose.yml` |
 | Agent scripts | `agent/scripts/` |
-| Agent prompts | `agent/prompts/` |
 | Architecture doc | `_bmad-output/planning-artifacts/architecture.md` |
 
 ## Shared API Contract
@@ -404,7 +399,7 @@ Both sides generate types and clients from the same OpenAPI spec. Never manually
 | Epic 4 | Agent runtime & container management | IN PROGRESS |
 | Epic 5 | DAG scheduler & epic runs | NOT STARTED |
 | Epic 6 | HITL gates & approval workflow | NOT STARTED |
-| Epic 7 | Pipeline configuration & templates | NOT STARTED |
+| Epic 7 | Pipeline configuration & templates | IN PROGRESS |
 | Epic 8 | Real-time monitoring & SSE | IN PROGRESS |
 | Epic 9 | Cost tracking & observability | IN PROGRESS |
 | Epic 10 | Reference project & validation | NOT STARTED |
@@ -427,6 +422,11 @@ Both sides generate types and clients from the same OpenAPI spec. Never manually
 - Admin: User management CRUD
 - Pipeline runtime fixes: River timeout, OAuth auth, healthcheck, template mount
 - Pipeline wiring: story_key in Run API, story status transitions on run complete
+- Agent entity as source of truth: removed embedded Dockerfile/CLAUDE.md templates, TemplateService, CLAUDEMDComposer — Agent.Image/Model/TemplateContent are now authoritative
+- Agent CRUD API: create/update/delete agents with image, model, template_content, scope (global/project)
+- Cost tracking: per-step cost recording from agent container cost events
+- Pipeline config: agent_id required per agent_run step, validated at launch time
+- Git providers: GitHub + Gitea support via configurable git_provider/git_token_env per project
 
 ## Known Constraints
 

--- a/_bmad-output/implementation-artifacts/F-1-1-fix-auth-redirect-cascade.md
+++ b/_bmad-output/implementation-artifacts/F-1-1-fix-auth-redirect-cascade.md
@@ -1,0 +1,148 @@
+# Story F-1.1: [FRONT] Fix auth redirect cascade on public pages
+
+Status: ready-for-dev
+
+## Story
+
+As a user,
+I want the app to not redirect me chaotically between pages,
+so that I can actually use the application without being interrupted after a few seconds.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Public pages stay stable**
+- **Given** user is on `/login`, `/forgot-password`, or `/reset-password`
+- **When** an API call returns 401
+- **Then** no redirect occurs — the page remains stable
+
+**AC2: Protected pages redirect once**
+- **Given** user session expires while on a protected route
+- **When** an API call returns 401
+- **Then** user is redirected to `/login` exactly once (no bounce loop)
+
+**AC3: SSE reconnection does not trigger redirect**
+- **Given** user is authenticated and SSE connection drops
+- **When** SSE reconnects and gets a 401
+- **Then** only a single redirect to `/login` happens, not a cascade
+
+**AC4: No redirect on initial page load of public routes**
+- **Given** user navigates directly to `/login` via URL bar
+- **When** the page loads
+- **Then** the login form renders immediately, no flicker or redirect
+
+## Tasks / Subtasks
+
+### Task 1 — Fix `authMiddleware` in `frontend/src/api/client.ts`
+
+The middleware at lines 5-16 redirects on any 401 regardless of the current route. Two problems:
+
+1. **No public-route check:** `router.push({ name: 'login' })` is called unconditionally.
+2. **No deduplication:** multiple concurrent 401 responses each fire `router.push`, causing a cascade.
+
+**Changes:**
+
+- Import a `PUBLIC_ROUTE_NAMES` constant (defined in `frontend/src/router/index.ts` or a new `frontend/src/router/constants.ts`) containing `['login', 'forgot-password', 'reset-password', 'not-found']`.
+- Before calling `router.push`, check `router.currentRoute.value.meta.requiresAuth !== false`. If the current route is already public, skip the redirect entirely.
+- Add a module-level `let redirecting = false` flag. Set it to `true` before calling `router.push`, reset it to `false` inside a `router.afterEach` hook (registered once at module load) so that only one redirect fires even when multiple 401s arrive in the same tick.
+
+Resulting logic in `onResponse`:
+
+```ts
+if (response.status === 401) {
+  const url = new URL(request.url, window.location.origin)
+  if (!url.pathname.startsWith('/api/v1/auth/')) {
+    const currentRoute = router.currentRoute.value
+    const isPublic = currentRoute.meta.requiresAuth === false
+    if (!isPublic && !redirecting) {
+      redirecting = true
+      await router.push({ name: 'login' })
+    }
+  }
+}
+```
+
+Reset `redirecting` inside a one-time `router.afterEach` registered at module init:
+
+```ts
+router.afterEach(() => {
+  redirecting = false
+})
+```
+
+### Task 2 — Fix race condition in `frontend/src/router/guards.ts`
+
+The `authChecked` flag at line 11 is module-level. On fast navigation, `checkAuth()` is awaited correctly; however if `checkAuth()` itself triggers a redirect (e.g. via the `authMiddleware` above), the guard fires again before `authChecked` is set, causing double evaluation.
+
+**Changes:**
+
+- Replace the boolean `authChecked` with a `Promise<void> | null` pattern so concurrent guard invocations wait on the same in-flight promise rather than calling `checkAuth()` multiple times:
+
+```ts
+let authCheckPromise: Promise<void> | null = null
+
+export function setupAuthGuard(router: Router) {
+  router.beforeEach(async (to) => {
+    const auth = useAuthStore()
+
+    if (!authCheckPromise) {
+      authCheckPromise = auth.checkAuth()
+    }
+    await authCheckPromise
+
+    const requiresAuth = to.meta.requiresAuth !== false
+
+    if (requiresAuth && !auth.isAuthenticated) {
+      return { path: '/login', query: { redirect: to.fullPath } }
+    }
+    if (to.path === '/login' && auth.isAuthenticated) {
+      const redirect = to.query.redirect as string
+      return { path: redirect || '/' }
+    }
+  })
+}
+```
+
+This ensures `checkAuth()` runs exactly once regardless of how many guard invocations are triggered concurrently during initial page load.
+
+### Task 3 — Suppress SSE connection when auth state is invalid (`frontend/src/composables/useSSE.ts`)
+
+Currently `useSSE` (line 15) opens `EventSource` immediately and its `onerror` handler (lines 20-22) only sets `status.value = 'error'` — it never closes the connection. The browser auto-retries `EventSource` on error, firing repeated reconnects that may each produce a 401.
+
+**Changes:**
+
+- On `onerror`, call `es.close()` and set `status.value = 'closed'` if the auth store reports the user is unauthenticated. Import `useAuthStore` from `@/stores/auth`.
+- Expose a `reconnect()` function that the caller can invoke after auth is restored (useful for future re-auth flow).
+
+```ts
+es.onerror = () => {
+  const auth = useAuthStore()
+  if (!auth.isAuthenticated) {
+    es.close()
+    status.value = 'closed'
+  } else {
+    status.value = 'error'
+  }
+}
+```
+
+This stops the reconnect loop that generates repeated 401 SSE requests while the user is logged out.
+
+### Task 4 — Export public route names constant from router (`frontend/src/router/index.ts` or new `frontend/src/router/constants.ts`)
+
+To avoid duplicating the list of public routes between the middleware and the guard, extract them as a single exported constant. Add to `frontend/src/router/index.ts` (or a new `frontend/src/router/constants.ts` if preferred):
+
+```ts
+export const PUBLIC_ROUTE_NAMES = new Set(['login', 'forgot-password', 'reset-password', 'not-found'])
+```
+
+This constant is used by `authMiddleware` in Task 1 and can be referenced by future auth-aware composables.
+
+## Dev Notes
+
+- Priority: P0 — this blocks testing of all other features
+- The fix must NOT break the normal auth flow (redirect to login when session expires on protected pages)
+- The `redirecting` flag in `client.ts` must be reset via `router.afterEach`, not via `setTimeout`, to avoid timing-dependent behaviour
+- `authCheckPromise` in `guards.ts` is intentionally never reset to `null` after resolution — the session check is a one-time startup operation; the Pinia store handles auth state updates from that point on
+- SSE `EventSource` does not go through `openapi-fetch`, so the `authMiddleware` does not cover it — the `onerror` fix in `useSSE.ts` is the only guard for SSE-triggered redirect loops
+- No new dependencies required — all changes are within existing files
+- After implementing, run `npm run type-check` and `npm run lint` to verify no regressions

--- a/_bmad-output/implementation-artifacts/F-1-2-fix-seed-sql-bcrypt-hashes.md
+++ b/_bmad-output/implementation-artifacts/F-1-2-fix-seed-sql-bcrypt-hashes.md
@@ -1,0 +1,61 @@
+# Story F-1.2: [BACK] Fix seed SQL to use Go-compatible bcrypt hashes
+
+Status: ready-for-dev
+
+## Story
+
+As a developer,
+I want seed data users to have passwords that work with the backend auth system,
+so that I can log in with documented credentials after a fresh database setup.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Seed users can log in**
+- **Given** a fresh database seeded with `backend/testdata/seed.sql`
+- **When** I try to log in with `admin@hopeitworks.dev` / `admin1234`
+- **Then** login succeeds with 200 and JWT cookie is set
+
+**AC2: All seed passwords are Go bcrypt compatible**
+- **Given** seed SQL has been applied
+- **When** the Go backend calls `bcrypt.CompareHashAndPassword(hash, password)`
+- **Then** it returns nil (success) for all seeded seed users (admin, sarah, marc, dev, alice, bob)
+
+**AC3: Documented passwords are correct**
+- **Given** the seed.sql file
+- **When** a developer reads the credentials comment block at the top of the file
+- **Then** documented passwords match actual hash values and meet the minimum 8-character requirement
+
+**AC4: No pgcrypto dependency for password hashing**
+- **Given** the seed.sql file
+- **When** executing the seed against a fresh database
+- **Then** no `crypt()` or `gen_salt()` calls are used for password fields — pre-computed `$2a$` bcrypt hashes are used as string literals instead
+
+## Tasks / Subtasks
+
+- [ ] Read `backend/testdata/seed.sql` to confirm current state: 6 users (admin, sarah, marc, dev, alice, bob) all using `crypt(password, gen_salt('bf', 10))` with sub-8-char passwords (admin123, sarah123, etc.)
+- [ ] Decide on standard seed passwords — use `admin1234` for admin-role users, `user1234` for user-role users (all meet the 8-char minimum enforced by the backend)
+- [ ] Generate Go-compatible bcrypt hashes for each seed user using a Go one-liner, for example:
+  ```bash
+  go run -e 'package main; import ("fmt"; "golang.org/x/crypto/bcrypt"); func main() { h, _ := bcrypt.GenerateFromPassword([]byte("admin1234"), bcrypt.DefaultCost); fmt.Println(string(h)) }'
+  ```
+  Or write a small `backend/testdata/genhash/main.go` script, run it, then delete it.
+- [ ] Replace all 6 `crypt(..., gen_salt('bf', 10))` expressions in the `INSERT INTO users` block with the corresponding pre-computed `$2a$...` string literals
+- [ ] Update the credentials comment block at the top of the file to reflect the new passwords:
+  - `admin@hopeitworks.dev  / admin1234  (admin)`
+  - `sarah@hopeitworks.dev  / admin1234  (admin)`
+  - `marc@hopeitworks.dev   / admin1234  (admin)`
+  - `dev@hopeitworks.dev    / user1234   (user)`
+  - `alice@hopeitworks.dev  / user1234   (user)`
+  - `bob@hopeitworks.dev    / user1234   (user)`
+- [ ] Check whether `pgcrypto` is used anywhere else in the seed file or in migrations — if it is not used for anything other than password hashing, remove the `CREATE EXTENSION IF NOT EXISTS pgcrypto` line if present; otherwise leave it
+- [ ] Manually verify one hash by running a quick Go snippet calling `bcrypt.CompareHashAndPassword` against the inserted hash and the plain-text password
+
+## Dev Notes
+
+- Priority: P0 — developers cannot use seed data for local development; only users registered via the API can currently authenticate
+- Root cause: `pgcrypto`'s `crypt()` uses the OpenBSD blowfish variant (`$2a$`) but the internal byte layout differs from Go's `golang.org/x/crypto/bcrypt`, making the hashes mutually incompatible
+- Go bcrypt produces `$2a$10$...` hashes — embed these directly as SQL string literals; no runtime function call needed
+- The seed file is idempotent (`ON CONFLICT (email) DO UPDATE SET password_hash = EXCLUDED.password_hash`) so re-running the seed after this fix will overwrite stale hashes
+- All current seed passwords (admin123, sarah123, etc.) are only 8 characters if you count carefully — they are actually 8 chars but the backend minimum is 8, so they technically pass; however the documented password `admin123` is 8 chars and the context note says the known-working API-registered password is `admin1234` (9 chars) — use `admin1234` / `user1234` to match documented working credentials and avoid any edge-case ambiguity
+- File to modify: `backend/testdata/seed.sql` (lines 9–14 for the comment block, lines 26–31 for the INSERT values)
+- No migrations, no Go source changes, no OpenAPI changes required — this is a pure SQL data fix

--- a/_bmad-output/implementation-artifacts/F-1-3-secure-users-endpoint-admin-only.md
+++ b/_bmad-output/implementation-artifacts/F-1-3-secure-users-endpoint-admin-only.md
@@ -1,0 +1,196 @@
+# Story F-1.3: [BACK] Secure /api/v1/users endpoint to admin-only access
+
+Status: ready-for-dev
+
+## Story
+
+As an admin,
+I want user management endpoints to be restricted to admin users only,
+so that regular users cannot view, edit, or delete other user accounts.
+
+## Context
+
+The user management handlers (`ListUsers`, `GetUser`, `UpdateUser`, `DeleteUser`) in
+`backend/internal/api/handler/user_handler.go` already call the `requireAdmin(w, r)` helper
+as their first action. This helper calls `middleware.IsAdmin(r.Context())`, which checks the
+role injected by the global JWT auth middleware.
+
+The vulnerability is one of **missing defense-in-depth**: the admin enforcement relies solely
+on per-handler checks with no route-group-level middleware enforcing it. There is no
+`RequireAdmin` chi middleware in `backend/internal/api/middleware/rbac.go`. If a handler
+inadvertently omits the `requireAdmin` call (e.g. a future handler added to the same domain),
+there is no safety net at the router level.
+
+Additionally, the routes are registered through `handler.HandlerFromMuxWithBaseURL(server, r, "/api/v1")`
+in `backend/cmd/api/main.go` (line 358), which mounts all oapi-codegen routes flat on the same
+router with no sub-group applying admin-specific middleware to `/api/v1/users/*`.
+
+The fix is to:
+1. Add a `RequireAdmin` chi middleware to `backend/internal/api/middleware/rbac.go`
+2. Register the `/api/v1/users` route group manually with that middleware applied, instead of
+   relying on oapi-codegen's flat `HandlerFromMuxWithBaseURL` registration for those routes
+
+## Acceptance Criteria (BDD)
+
+**AC1: Non-admin GET /api/v1/users returns 403**
+- **Given** a user with role "user" is authenticated (valid JWT cookie, role=user)
+- **When** GET /api/v1/users is called
+- **Then** response is 403 Forbidden with error code `FORBIDDEN`
+
+**AC2: Admin GET /api/v1/users returns 200**
+- **Given** a user with role "admin" is authenticated (valid JWT cookie, role=admin)
+- **When** GET /api/v1/users is called
+- **Then** response is 200 with a `UserList` payload
+
+**AC3: Non-admin cannot modify users**
+- **Given** a user with role "user" is authenticated
+- **When** PUT /api/v1/users/{id} or DELETE /api/v1/users/{id} is called
+- **Then** response is 403 Forbidden with error code `FORBIDDEN`
+
+**AC4: Admin can modify users**
+- **Given** a user with role "admin" is authenticated
+- **When** PUT /api/v1/users/{id} or DELETE /api/v1/users/{id} is called
+- **Then** operation succeeds (200 or 204)
+
+**AC5: GET /api/v1/users/{id} for a non-admin returns 403**
+- **Given** a user with role "user" is authenticated
+- **When** GET /api/v1/users/{id} is called
+- **Then** response is 403 Forbidden with error code `FORBIDDEN`
+
+## Tasks / Subtasks
+
+### Task 1 — Add `RequireAdmin` middleware to `backend/internal/api/middleware/rbac.go`
+
+Add a new exported middleware function after `RequireProjectAccess`:
+
+```go
+// RequireAdmin returns chi middleware that allows only users with role "admin".
+// Returns 403 Forbidden for any authenticated user without the admin role.
+func RequireAdmin() func(http.Handler) http.Handler {
+    return func(next http.Handler) http.Handler {
+        return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            if !IsAdmin(r.Context()) {
+                writeForbidden(w, "Admin access required")
+                return
+            }
+            next.ServeHTTP(w, r)
+        })
+    }
+}
+```
+
+No new imports are needed — `IsAdmin`, `writeForbidden`, and `http` are already available in the package.
+
+### Task 2 — Apply `RequireAdmin` middleware at the route group level in `backend/cmd/api/main.go`
+
+The oapi-codegen call `handler.HandlerFromMuxWithBaseURL(server, r, "/api/v1")` registers all routes
+on the flat router `r`. The `/api/v1/users` routes must be registered on a sub-router that has
+`authmw.RequireAdmin()` applied.
+
+The oapi-codegen generated router (`HandlerFromMuxWithBaseURL`) does not support per-group
+middleware injection. The solution is to mount the user management routes manually on a dedicated
+chi sub-router **before** the `HandlerFromMuxWithBaseURL` call, and to ensure the `Server` methods
+still delegate to `UserHandler` as they do today.
+
+In `main.go`, after building `server` (line 338) and `r := chi.NewRouter()` with global middleware,
+add a manually registered sub-router for user routes:
+
+```go
+// Admin-only: user management routes
+r.Route("/api/v1/users", func(r chi.Router) {
+    r.Use(authmw.RequireAdmin())
+    r.Get("/", func(w http.ResponseWriter, req *http.Request) {
+        server.ListUsers(w, req, handler.ListUsersParams{
+            Page:    pageIntPtr(req.URL.Query().Get("page")),
+            PerPage: pageIntPtr(req.URL.Query().Get("per_page")),
+        })
+    })
+    r.Route("/{id}", func(r chi.Router) {
+        r.Get("/", func(w http.ResponseWriter, req *http.Request) {
+            server.GetUser(w, req, handler.IdPath(chi.URLParam(req, "id")))
+        })
+        r.Put("/", func(w http.ResponseWriter, req *http.Request) {
+            server.UpdateUser(w, req, handler.IdPath(chi.URLParam(req, "id")))
+        })
+        r.Delete("/", func(w http.ResponseWriter, req *http.Request) {
+            server.DeleteUser(w, req, handler.IdPath(chi.URLParam(req, "id")))
+        })
+    })
+})
+```
+
+**Important:** Chi resolves routes in registration order. The manual `/api/v1/users` sub-router
+must be registered **before** `handler.HandlerFromMuxWithBaseURL(server, r, "/api/v1")` so that
+chi matches the more-specific admin-guarded route first. Verify the `IdPath` type — in the
+generated code it is `type IdPath = uuid.UUID`, so the correct conversion is
+`uuid.MustParse(chi.URLParam(req, "id"))` (with proper error handling for invalid UUIDs, returning
+400 before calling the handler).
+
+Alternatively, if the generated `HandlerFromMuxWithBaseURL` allows per-route override via chi's
+route conflict resolution, confirm that behavior in `gen_server.go` before choosing the approach.
+
+### Task 3 — Add `RequireAdmin` middleware unit tests to `backend/internal/api/middleware/rbac_test.go`
+
+Add a `TestRequireAdmin` test following the same pattern as `TestRequireProjectAccess`:
+
+```go
+func TestRequireAdmin(t *testing.T) {
+    mw := RequireAdmin()
+    nextCalled := false
+    next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+        nextCalled = true
+        w.WriteHeader(http.StatusOK)
+    })
+
+    tests := []struct {
+        name       string
+        role       model.Role
+        hasAuth    bool
+        wantStatus int
+        wantNext   bool
+    }{
+        {name: "admin is allowed", role: model.RoleAdmin, hasAuth: true, wantStatus: http.StatusOK, wantNext: true},
+        {name: "user role gets 403", role: model.RoleUser, hasAuth: true, wantStatus: http.StatusForbidden, wantNext: false},
+        {name: "no context gets 403", hasAuth: false, wantStatus: http.StatusForbidden, wantNext: false},
+    }
+    // table-driven test body — follow TestRequireProjectAccess pattern
+}
+```
+
+### Task 4 — Remove redundant `requireAdmin` calls from user handler methods (optional cleanup)
+
+Once the route-group middleware enforces admin access at the router level, the `requireAdmin(w, r)`
+calls at the top of each handler method in `backend/internal/api/handler/user_handler.go` are
+redundant. They can be removed to avoid duplicated logic.
+
+**This task is optional for the P0 fix** — keeping the in-handler checks is a valid defense-in-depth
+posture. Remove them only if the team prefers a single enforcement point. If removed, verify that
+existing unit tests in `user_handler_test.go` still pass (they inject context directly without
+going through the middleware stack, so the 403 assertions would need to be updated to expect
+200/204 from the handler in isolation — the middleware test covers the 403 path).
+
+### Task 5 — Verify with `golangci-lint`
+
+```bash
+cd backend && golangci-lint run ./...
+```
+
+The `errcheck` linter requires `_ = json.NewEncoder(w).Encode(...)` pattern for ignored return
+values (already used consistently in the middleware package). Ensure `RequireAdmin` follows the
+same pattern if it uses `json.NewEncoder`.
+
+## Dev Notes
+
+- Priority: P0 — security vulnerability (defense-in-depth gap, in-handler check exists but has no router-level backstop)
+- `RequireAdmin` middleware lives in `backend/internal/api/middleware/rbac.go` alongside `RequireProjectAccess`
+- `IsAdmin` helper is already in `backend/internal/api/middleware/auth.go` — no new role-check logic needed
+- `writeForbidden` helper is already in `backend/internal/api/middleware/rbac.go` — reuse it
+- The `profile` endpoints (`GET/PUT /api/v1/profile`, `POST /api/v1/profile/password`) must NOT
+  be included in the admin-only group — they are for any authenticated user
+- The `GET /api/v1/auth/me` endpoint is also not admin-only
+- Chi route registration order matters: manually registered routes take precedence over
+  `HandlerFromMuxWithBaseURL` when registered first on the same router
+- `IdPath` in the generated types resolves to `uuid.UUID` — parse with proper error handling
+- No database migrations required
+- No OpenAPI spec changes required
+- No frontend changes required

--- a/_bmad-output/implementation-artifacts/F-1-4-fix-forgot-reset-password-flow.md
+++ b/_bmad-output/implementation-artifacts/F-1-4-fix-forgot-reset-password-flow.md
@@ -1,0 +1,165 @@
+# Story F-1.4: [SHARED] Fix forgot/reset password end-to-end flow
+
+Status: ready-for-dev
+
+## Story
+
+As a user who forgot their password,
+I want to reset it via email and then log in with the new password,
+so that I can regain access to my account.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Forgot password page loads without redirect**
+- **Given** user is not authenticated
+- **When** navigating to `/forgot-password`
+- **Then** the page renders with email input form, no redirect to `/login`
+
+**AC2: Reset password page loads with token**
+- **Given** user has a valid reset token
+- **When** navigating to `/reset-password?token=xxx`
+- **Then** the page renders with new password form, no redirect to `/login`
+
+**AC3: Password reset stores correct hash**
+- **Given** user submits a new password via the reset form
+- **When** the backend processes the reset
+- **Then** the `password_hash` column in the `users` table is updated with a valid bcrypt hash of the new password
+
+**AC4: Login works after reset**
+- **Given** user has successfully reset their password (API returned 200)
+- **When** they attempt to log in with the new password
+- **Then** login succeeds with HTTP 200 and a valid session cookie is set
+
+**AC5: Reset token expires**
+- **Given** a reset token older than 1 hour (or a manually expired token)
+- **When** user submits the reset form with that token
+- **Then** the API returns 400 with error code `RESET_TOKEN_EXPIRED`
+
+## Root Cause Analysis
+
+### Backend — critical bug (causes AC4 failure)
+
+`auth_service.go` `ResetPassword()` (line 240) calls `s.repo.Update(ctx, user)` after computing the new bcrypt hash. The underlying `UpdateUser` SQL query uses `COALESCE(sqlc.narg(...))` only for `name`, `email`, and `role` columns — **`password_hash` is not in that query**. The new hash is silently discarded, leaving the old password in the database.
+
+The fix is one line: replace the `GetByID` + `Update` pattern with a direct call to `s.repo.UpdatePasswordHash(ctx, prt.UserID, string(hash))`.
+
+The `UpdatePasswordHash` port method (`port/user_repository.go` line 18), the SQL query (`queries/users.sql` lines 27-31: `UpdateUserPasswordHash`), and the adapter implementation (`adapter/postgres/user_repository.go` lines 85-89) all exist and are correct. Only the service call is wrong.
+
+Note: the existing unit test `TestResetPassword_ValidToken` passes because the mock's `Update()` simulates `password_hash` propagation (mock lines 80-81), masking the real-DB bug.
+
+### Frontend — routes are already correct, guard logic is correct
+
+`router/index.ts` lines 29-38: both `/forgot-password` and `/reset-password` already carry `meta: { requiresAuth: false }`.
+
+`router/guards.ts` line 22: `const requiresAuth = to.meta.requiresAuth !== false` — routes explicitly set to `false` are treated as public.
+
+`api/client.ts` lines 9-13: the `authMiddleware` skips the redirect-to-login for any path starting with `/api/v1/auth/`. The `checkAuth()` call (`GET /auth/me` → `/api/v1/auth/me`) on first navigation returns 401 for unauthenticated users but does not trigger a redirect, so the guard correctly reaches the unauthenticated state and allows the public route.
+
+**Frontend task**: add unit tests confirming the guard allows unauthenticated access to these routes, and add an E2E smoke test covering the full reset flow.
+
+## Tasks / Subtasks
+
+### Task 1 — Backend: fix `ResetPassword` to call `UpdatePasswordHash` (CRITICAL)
+
+File: `backend/internal/domain/service/auth_service.go`
+
+Current code (lines 234-244):
+```go
+hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+if err != nil {
+    return err
+}
+
+user, err := s.repo.GetByID(ctx, prt.UserID)
+if err != nil {
+    return err
+}
+user.PasswordHash = string(hash)
+if _, err := s.repo.Update(ctx, user); err != nil {
+    return err
+}
+
+return s.tokenRepo.MarkUsed(ctx, prt.ID)
+```
+
+Replace with:
+```go
+hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+if err != nil {
+    return err
+}
+
+if err := s.repo.UpdatePasswordHash(ctx, prt.UserID, string(hash)); err != nil {
+    return err
+}
+
+return s.tokenRepo.MarkUsed(ctx, prt.ID)
+```
+
+This removes the unnecessary `GetByID` call and uses the dedicated `UpdateUserPasswordHash` SQL query which correctly updates the `password_hash` column.
+
+### Task 2 — Backend: fix `TestResetPassword_ValidToken` to catch the real-DB path
+
+File: `backend/internal/domain/service/auth_service_test.go`
+
+The mock `Update()` currently simulates password propagation (lines 80-81), masking the bug. After the fix in Task 1, the test still passes because `UpdatePasswordHash` is now called instead. However, add a new test that verifies `Update()` is NOT called during reset (i.e., ensure the mock's `Update` is never invoked in the reset flow), so any future regression where someone switches back to `Update` is caught.
+
+Add a test case:
+```go
+func TestResetPassword_UsesUpdatePasswordHash_NotUpdate(t *testing.T) {
+    repo := newMockRepo()
+    // Track whether Update() is called
+    updateCalled := false
+    // Wrap mock to detect Update() calls
+    // ...register user, trigger forgot password, call ResetPassword...
+    // Assert updateCalled == false
+}
+```
+
+### Task 3 — Backend: add integration test for full reset flow against real DB
+
+File: `backend/internal/domain/service/auth_service_test.go` or a new `backend/internal/adapter/postgres/auth_integration_test.go`
+
+Tag with `Integration` in test name. Use `testutil.NewTestDB(t)` (testcontainers). Steps:
+1. Create user via `UserRepository.Create`
+2. Create a valid reset token via `PasswordResetTokenRepository.Create`
+3. Call `AuthService.ResetPassword` with the token and new password
+4. Query the `users` table directly and verify `password_hash` is a valid bcrypt hash of the new password
+5. Call `AuthService.Login` with the new password — assert no error
+6. Call `AuthService.Login` with the old password — assert `ErrInvalidCredentials`
+
+### Task 4 — Frontend: add router guard unit test for public auth routes
+
+File: `frontend/src/router/__tests__/guards.spec.ts` (create if it does not exist)
+
+Using Vitest + `@vue/test-utils`, test that:
+- Navigating to `/forgot-password` when `isAuthenticated === false` does NOT redirect
+- Navigating to `/reset-password?token=abc` when `isAuthenticated === false` does NOT redirect
+- Navigating to `/` when `isAuthenticated === false` redirects to `/login`
+
+Mock `useAuthStore` to control `isAuthenticated` state.
+
+### Task 5 — Frontend: E2E smoke test for reset password flow
+
+File: `frontend/e2e/tests/auth.spec.ts` (add to existing file or create)
+
+Using Playwright against the local dev stack (MailHog at `http://localhost:8025`):
+1. Navigate to `/forgot-password`, enter a known test user email, submit
+2. Poll MailHog API (`GET http://localhost:8025/api/v2/messages`) to retrieve the reset email
+3. Extract the `?token=` value from the reset link in the email body
+4. Navigate to `/reset-password?token=<extracted_token>`
+5. Enter a new password (min 8 chars), submit
+6. Assert redirect to `/login?reset=success`
+7. Log in with the new password, assert redirect to `/` (dashboard)
+8. Log out, attempt login with old password, assert error message is shown
+
+## Dev Notes
+
+- Priority: P1 — users are completely blocked from recovering accounts
+- The backend fix (Task 1) is a one-line change; Tasks 2-3 add regression coverage
+- Depends on F-1-1 (auth redirect fix in `client.ts`) if that story changes the 401 middleware behaviour — verify no conflict before merging
+- Frontend routes `/forgot-password` and `/reset-password` already have `meta: { requiresAuth: false }` — no route config change needed
+- Backend `UpdatePasswordHash` port, query, and adapter are all correctly implemented — only the service call is wrong
+- Test with MailHog at `http://localhost:8025` for the reset email in dev/E2E environments
+- The `base64.URLEncoding` tokens generated by `generateSecureToken()` contain `=` padding characters; confirm the URL is not double-encoded in the frontend when building the reset link
+- After fix: run `go test ./internal/domain/service/... -run TestResetPassword` and `golangci-lint run ./...` before committing

--- a/_bmad-output/implementation-artifacts/F-2-1-fix-seed-runs-project-uuid.md
+++ b/_bmad-output/implementation-artifacts/F-2-1-fix-seed-runs-project-uuid.md
@@ -1,0 +1,129 @@
+# Story F-2.1: [BACK] Fix seed runs to reference correct project UUID
+
+Status: ready-for-dev
+
+## Story
+
+As a developer,
+I want seed run data to be correctly linked to the seeded project,
+so that the Runs page and Cost Dashboard display sample data after a fresh setup.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Seeded runs appear in project runs list**
+- **Given** a fresh database seeded with seed.sql
+- **When** navigating to the Todo App project's Runs tab
+- **Then** seeded runs are visible (3 runs: 1 completed, 1 running, 1 pending)
+
+**AC2: Seeded costs appear in cost dashboard**
+- **Given** a fresh database seeded with seed.sql
+- **When** navigating to the Todo App project's Costs tab
+- **Then** cost data from seeded runs is displayed (2 cost records totalling ~$0.81)
+
+**AC3: All FK references are consistent**
+- **Given** seed.sql has been executed
+- **When** querying runs, run_steps, step_costs
+- **Then** all foreign key references (project_id, story_id, run_id, run_step_id) point to existing records
+
+**AC4: Seed is idempotent**
+- **Given** seed.sql has already been executed once
+- **When** seed.sql is executed a second time
+- **Then** no errors occur and no duplicate rows are created
+
+## Tasks / Subtasks
+
+### Task 1: Fix project INSERT to use id-based conflict resolution
+
+The current `ON CONFLICT (name)` clause on the `projects` insert is the root cause.
+If a project named "Todo App" already exists with a *different* UUID, the `id` column is
+never updated, causing all subsequent inserts that reference
+`00000000-0000-0000-0000-000000000101` to violate FK constraints silently
+(thanks to `ON CONFLICT DO NOTHING` on the dependent tables).
+
+- Change the conflict target on the `projects` INSERT from `ON CONFLICT (name)` to
+  `ON CONFLICT (id)`, so that a re-run always upserts the row at the known UUID:
+
+```sql
+INSERT INTO projects (id, name, description, owner_id, repo_url, git_provider, git_token_env, default_model)
+VALUES (
+    '00000000-0000-0000-0000-000000000101',
+    ...
+) ON CONFLICT (id) DO UPDATE SET
+    name          = EXCLUDED.name,
+    description   = EXCLUDED.description,
+    owner_id      = EXCLUDED.owner_id,
+    repo_url      = EXCLUDED.repo_url,
+    git_provider  = EXCLUDED.git_provider,
+    git_token_env = EXCLUDED.git_token_env,
+    default_model = EXCLUDED.default_model;
+```
+
+  Verify that `projects` has a unique constraint or primary key on `id` (it does — uuid PK).
+
+### Task 2: Apply the same id-based conflict resolution to epics and stories
+
+The epic INSERT uses `ON CONFLICT (project_id, name)` and story INSERTs use
+`ON CONFLICT (project_id, key)`. These are semantically correct for uniqueness but
+they do NOT guarantee the well-known UUIDs are preserved on re-seed.
+Change all three to `ON CONFLICT (id) DO UPDATE SET ...` to ensure downstream FK
+references always resolve to the fixed UUIDs:
+
+- Epic `00000000-0000-0000-0000-000000000201` — change conflict target to `(id)`
+- Story `00000000-0000-0000-0000-000000000301` — change conflict target to `(id)`
+- Story `00000000-0000-0000-0000-000000000302` — change conflict target to `(id)`
+- Story `00000000-0000-0000-0000-000000000303` — change conflict target to `(id)`
+
+### Task 3: Verify run_steps and cost_records insert correctly after the fix
+
+The run INSERTs already use `ON CONFLICT DO NOTHING` keyed on the primary key UUID,
+so they are structurally correct once the upstream project/story UUIDs are stable.
+Trace and confirm:
+
+- `runs` (`00000000-...-000000000501/502/503`) → `project_id` and `story_id` resolve
+- `run_steps` (`00000000-...-000000000601..612`) → `run_id` resolves
+- `hitl_requests` (`00000000-...-000000000701`) → `run_step_id` resolves
+- `cost_records` (`00000000-...-000000001001/1002`) → `run_step_id` and `project_id` resolve
+- `events` (`00000000-...-000000000801..804`) → `project_id` and `entity_id` resolve
+
+No structural changes should be needed for these tables once Tasks 1 and 2 are applied.
+
+### Task 4: Manual verification after fix
+
+Run the seed on a clean DB and confirm:
+
+```bash
+cd backend && make reset-db && make seed
+```
+
+Then execute these spot-check queries:
+
+```sql
+-- Confirm project UUID is stable
+SELECT id, name FROM projects WHERE name = 'Todo App';
+-- Expected: 00000000-0000-0000-0000-000000000101
+
+-- Confirm runs are visible
+SELECT id, status FROM runs WHERE project_id = '00000000-0000-0000-0000-000000000101';
+-- Expected: 3 rows
+
+-- Confirm cost records are linked
+SELECT cr.id, cr.cost_usd FROM cost_records cr
+JOIN run_steps rs ON rs.id = cr.run_step_id
+JOIN runs r ON r.id = rs.run_id
+WHERE r.project_id = '00000000-0000-0000-0000-000000000101';
+-- Expected: 2 rows (0.6315, 0.183)
+```
+
+## Dev Notes
+
+- **Priority:** P1
+- **File to modify:** `backend/testdata/seed.sql` only — no Go code changes required
+- **Depends on:** F-1-2 (seed bcrypt fix) — both touch `seed.sql`; merge F-1-2 first to avoid conflicts
+- **Root cause summary:** `ON CONFLICT (name)` on the `projects` table does not guarantee
+  the row's `id` matches the hardcoded UUID used in all downstream inserts. On a DB where
+  "Todo App" already exists under a different UUID, the `id` field is never reconciled, and
+  `ON CONFLICT DO NOTHING` on the runs/steps silently swallows the FK violations.
+- **Preferred fix:** `ON CONFLICT (id)` for all seed entities that have downstream FK references,
+  ensuring the well-known UUIDs are always authoritative.
+- **Alternative (not preferred):** Replace hardcoded UUIDs with `INSERT ... SELECT` subqueries
+  that look up by name. This is more resilient but significantly more verbose and harder to read.

--- a/_bmad-output/implementation-artifacts/F-2-2-fix-board-epic-story-counts.md
+++ b/_bmad-output/implementation-artifacts/F-2-2-fix-board-epic-story-counts.md
@@ -1,0 +1,156 @@
+# Story F-2.2: [FRONT] Fix board epic story counts display
+
+Status: ready-for-dev
+
+## Story
+
+As a user viewing the story board,
+I want to see accurate story counts per status on each epic card,
+so that I can quickly understand the progress of each epic.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Backlog count matches**
+- **Given** an epic has 3 stories in "backlog" status
+- **When** viewing the Board page
+- **Then** the epic card shows "3 Backlog"
+
+**AC2: All status counts display**
+- **Given** an epic has stories in various statuses
+- **When** viewing the Board page
+- **Then** each status count (Backlog, Running, Done, Failed) reflects actual story counts
+
+**AC3: Counts update after story status change**
+- **Given** a story changes status
+- **When** the Board page is refreshed or updated via SSE
+- **Then** the epic card counts reflect the new status
+
+## Root Cause Analysis
+
+The bug is a full-stack gap. The frontend (`EpicCard.vue`) correctly reads `epic.story_counts` from the
+API response and the generated TypeScript types (`schema.d.ts`) correctly define `StoryCounts` as a
+required field on `Epic`. However, the backend never populates this field:
+
+1. `backend/internal/domain/model/epic.go` — `model.Epic` has no `StoryCounts` field.
+2. `backend/queries/epics.sql` — `ListEpicsByProject` does a plain `SELECT *` with no story count
+   aggregation join.
+3. `backend/internal/api/handler/epic_handler.go` — `toAPIEpic()` constructs the API `Epic` struct
+   but never sets `StoryCounts`, so it is serialized as `{"backlog":0,"running":0,"done":0,"failed":0}`.
+4. The frontend receives zero counts and displays them faithfully — the frontend code is correct.
+
+## Tasks / Subtasks
+
+### Task 1 — Add `StoryCounts` to domain model
+File: `backend/internal/domain/model/epic.go`
+
+Add the `StoryCounts` struct and embed it in `Epic`:
+
+```go
+// StoryCounts holds the count of stories per status for an epic.
+type StoryCounts struct {
+    Backlog int
+    Running int
+    Done    int
+    Failed  int
+}
+
+type Epic struct {
+    // ... existing fields ...
+    StoryCounts StoryCounts
+}
+```
+
+### Task 2 — Add a SQL query that returns story counts per epic
+File: `backend/queries/epics.sql`
+
+Add a new query `ListEpicsByProjectWithCounts` that LEFT JOINs stories and aggregates by status. It must
+return all existing epic columns plus four count columns (`backlog_count`, `running_count`, `done_count`,
+`failed_count`).
+
+```sql
+-- name: ListEpicsByProjectWithCounts :many
+SELECT
+    e.*,
+    COUNT(s.id) FILTER (WHERE s.status = 'backlog')  AS backlog_count,
+    COUNT(s.id) FILTER (WHERE s.status = 'running')  AS running_count,
+    COUNT(s.id) FILTER (WHERE s.status = 'done')     AS done_count,
+    COUNT(s.id) FILTER (WHERE s.status = 'failed')   AS failed_count
+FROM epics e
+LEFT JOIN stories s ON s.epic_id = e.id
+WHERE e.project_id = $1
+GROUP BY e.id
+ORDER BY e.created_at DESC
+LIMIT $2 OFFSET $3;
+```
+
+Regenerate sqlc after adding this query:
+```bash
+cd backend && sqlc generate
+```
+
+### Task 3 — Update `EpicRepo.ListByProject` to use the new query
+File: `backend/internal/adapter/postgres/epic_repo.go`
+
+Replace the call to `r.queries.ListEpicsByProject` with the new
+`r.queries.ListEpicsByProjectWithCounts`. Update `toDomainEpic` (or add a separate mapper) to
+map the four count columns onto `model.StoryCounts`.
+
+The new mapper should read the count columns from the sqlc-generated row struct and set them on
+`model.Epic.StoryCounts`.
+
+### Task 4 — Populate `StoryCounts` in `toAPIEpic`
+File: `backend/internal/api/handler/epic_handler.go`
+
+Update `toAPIEpic` to set the `StoryCounts` field on the API `Epic` response type:
+
+```go
+func toAPIEpic(e *model.Epic) Epic {
+    epic := Epic{
+        // ... existing fields ...
+        StoryCounts: StoryCounts{
+            Backlog: e.StoryCounts.Backlog,
+            Running: e.StoryCounts.Running,
+            Done:    e.StoryCounts.Done,
+            Failed:  e.StoryCounts.Failed,
+        },
+    }
+    // ...
+    return epic
+}
+```
+
+### Task 5 — Add/update unit test for `toAPIEpic`
+File: `backend/internal/api/handler/epic_handler_test.go`
+
+Add a test case asserting that `toAPIEpic` propagates `StoryCounts` correctly from domain to API type.
+
+### Task 6 — Add integration test for `ListByProject` story counts
+File: `backend/internal/adapter/postgres/epic_repo.go` (test file alongside)
+
+Add an integration test that:
+1. Creates an epic
+2. Creates stories in different statuses under that epic
+3. Calls `ListByProject`
+4. Asserts that the returned `model.Epic.StoryCounts` matches the expected values
+
+### Task 7 — Verify frontend renders correctly (no frontend code change expected)
+Files: `frontend/src/features/board/EpicCard.vue`, `frontend/src/stores/epics.ts`
+
+Confirm no frontend changes are needed:
+- `EpicCard.vue` already reads `epic.story_counts[status.key]` for all four statuses.
+- `useEpicsStore.fetchEpics` already stores the full `Epic` object from the API response.
+- The generated `schema.d.ts` already types `story_counts` as a required `StoryCounts` object.
+
+If a visual regression test exists in `frontend/e2e/tests/`, add a scenario asserting non-zero counts
+appear on epic cards when stories exist.
+
+## Dev Notes
+
+- Priority: P2
+- Scope: primarily backend (Tasks 1-6); frontend requires no code changes (Task 7 is verification only)
+- The `CountEpicsByProject` query in `epics.sql` is unrelated — it counts epics, not stories
+- The existing `GetEpic` (single epic by ID) handler has the same missing `StoryCounts` issue and
+  should be fixed as part of this story for consistency
+- `golangci-lint run ./...` must pass after changes — run before committing
+- No OpenAPI spec change is needed — `story_counts` is already defined as required in `api/openapi.yaml`
+  and the generated `schema.d.ts` is already correct

--- a/_bmad-output/implementation-artifacts/F-2-3-add-role-selector-edit-user.md
+++ b/_bmad-output/implementation-artifacts/F-2-3-add-role-selector-edit-user.md
@@ -1,0 +1,72 @@
+# Story F-2.3: [FRONT] Add role selector to Edit User dialog
+
+Status: ready-for-dev
+
+## Story
+
+As an admin,
+I want to change a user's role from the edit dialog,
+so that I can promote users to admin or demote them.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Role dropdown present in edit dialog**
+- **Given** admin opens the Edit User dialog
+- **When** the dialog renders
+- **Then** a Select dropdown for Role is visible with options "Member" (value: `user`) and "Admin" (value: `admin`)
+
+**AC2: Current role pre-selected**
+- **Given** admin edits a user with role "admin"
+- **When** the dialog opens
+- **Then** "Admin" is pre-selected in the Role dropdown
+
+**AC3: Role change persists**
+- **Given** admin changes role from "user" to "admin"
+- **When** they save the edit
+- **Then** the API is called with the new role, and the user list reflects the change
+
+**AC4: Cannot change own role**
+- **Given** admin is editing their own account
+- **When** the dialog renders
+- **Then** the Role dropdown is disabled (prevent self-demotion)
+
+## Tasks / Subtasks
+
+### Task 1 — Extend the Zod schema in `EditUserDialog.vue` to include `role`
+
+File: `frontend/src/features/admin/EditUserDialog.vue`
+
+- Add `role: z.enum(['admin', 'user'])` to the `editUserSchema` object (currently only has `name` and `email`)
+- Add a `useField<string>('role')` call alongside the existing `name` and `email` field extractions
+- Update the `watch` on `props.user` to also set `role: user.role` in the `resetForm` values
+- Update `onSubmit` to pass `role` in the `values` object forwarded to `updateUser.execute`
+
+### Task 2 — Replace the read-only `Tag` with a `Select` dropdown in `EditUserDialog.vue`
+
+File: `frontend/src/features/admin/EditUserDialog.vue`
+
+- Import `Select` from `primevue/select` (remove the `Tag` import — it is no longer needed in the role field)
+- Define a `roleOptions` constant: `[{ label: 'Member', value: 'user' }, { label: 'Admin', value: 'admin' }]`
+- Import `useAuthStore` from `@/stores/auth` and derive `isSelf = computed(() => authStore.user?.id === props.user?.id)`
+- Replace the `<Tag>` block with a PrimeVue `<Select>` bound to the `role` vee-validate field (`v-model="role"`), using `option-label="label"` / `option-value="value"`, `:disabled="isSelf"`, and a helper text rendered conditionally when `isSelf` is true (e.g. "You cannot change your own role")
+
+### Task 3 — Extend `updateUser` in the users store to accept `role`
+
+File: `frontend/src/stores/users.ts`
+
+- Widen the `payload` type of `updateUser` from `{ name?: string; email?: string }` to `{ name?: string; email?: string; role?: 'admin' | 'user' }` so the `role` field is passed through to `PUT /users/{id}`
+- The `UpdateUserRequest` schema in `api/openapi.yaml` already includes an optional `role: enum [admin, user]` field, so no spec change is required — the generated type already covers this
+
+### Task 4 — Refresh the user list after a role update
+
+No additional changes required: `updateUser` in the store already calls `fetchUsers()` after a successful PUT, so the updated role will be reflected immediately in the `UserTable`.
+
+## Dev Notes
+
+- Priority: P2
+- Use PrimeVue `Select` component for the role dropdown
+- Role options: `[{ label: 'Member', value: 'user' }, { label: 'Admin', value: 'admin' }]`
+- The PUT `/api/v1/users/{id}` endpoint already accepts `role` in the request body (`UpdateUserRequest` schema at line 2070 of `api/openapi.yaml`) — no backend or spec changes needed
+- Self-detection: compare `props.user.id` with `useAuthStore().user?.id`
+- The `User` interface in `frontend/src/stores/auth.ts` already types `role` as `'admin' | 'user'`
+- No API regeneration needed: the generated client already exposes `role` on `UpdateUserRequest`

--- a/_bmad-output/implementation-artifacts/F-2-4-fix-cost-dashboard-project-id.md
+++ b/_bmad-output/implementation-artifacts/F-2-4-fix-cost-dashboard-project-id.md
@@ -1,0 +1,121 @@
+# Story F-2.4: [FRONT] Fix cost dashboard API call with empty project ID
+
+Status: ready-for-dev
+
+## Story
+
+As a user viewing the cost dashboard,
+I want to see accurate cost data for my project,
+so that I can track spending on pipeline runs.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Cost API called with correct project ID**
+- **Given** user navigates to `/projects/{id}/costs`
+- **When** the cost dashboard loads
+- **Then** API calls to `/projects/{projectId}/costs/*` include the correct project ID from the route params (`:id`)
+
+**AC2: Run cost API called with correct project ID**
+- **Given** user navigates to `/runs/{id}` (from any navigation path)
+- **When** the run detail page loads
+- **Then** the API call to `/projects/{projectId}/runs/{runId}/costs` includes the correct project ID
+- **And** the URL does not contain an empty segment (e.g. `/projects//runs/...`)
+
+**AC3: Cost data displays when available**
+- **Given** the project has runs with cost data
+- **When** the cost dashboard loads
+- **Then** total cost, average cost per story, and cost over time are displayed
+
+**AC4: Empty state when no costs**
+- **Given** the project has no runs with cost data
+- **When** the cost dashboard loads
+- **Then** a friendly "No cost data yet" message is shown (not an error)
+
+**AC5: Period filters work**
+- **Given** cost data exists
+- **When** user toggles between 7d and 30d period
+- **Then** displayed costs reflect the selected time range
+
+**AC6: Run detail navigation from cost dashboard passes project ID**
+- **Given** user is on the cost dashboard
+- **When** user clicks a run row to navigate to run detail
+- **Then** the run detail page receives the project ID and loads cost data correctly
+
+## Tasks / Subtasks
+
+### Task 1 — Fix `RunDetailView.vue`: make `projectId` reactive and source it from the run data
+
+**File:** `frontend/src/views/RunDetailView.vue`
+
+**Root cause:** `projectId` is sourced from `route.query.projectId` (line 22), which is empty when navigating without a query param. It is then passed as a static `.value` snapshot to `useRunDetail` and `useRunCosts` (lines 27, 31–35), so even if the value were fixed reactively, the composables would not update.
+
+**Sub-tasks:**
+- 1a. Change `projectId` to be derived from the loaded `run` object once it resolves: `computed(() => run.value?.project_id ?? '')`. The `Run` API response includes `project_id`.
+- 1b. Update `useRunDetail` call: since `runId` is already a `computed`, also make `projectId` a `Ref<string>` or pass the computed directly. Check `useRunDetail` signature to confirm it accepts a reactive value or plain string. Adjust the call so `projectId` is not snapshotted at call time.
+- 1c. Update `useRunCosts` call: `useRunCosts` in `frontend/src/features/runs/composables/useRunCosts.ts` currently accepts plain `string` args. Change signature to accept `Ref<string>` or use a `watch`-based approach so it re-fetches when `projectId` becomes available (after run loads). Alternatively, trigger `fetchCosts` imperatively once `run.value?.project_id` is known.
+- 1d. Update `handlePause`, `handleResume`, `handleCancelConfirm` to use the reactive computed `projectId` (they already call `.value` so this should be transparent once the computed is fixed).
+
+### Task 2 — Fix `CostDashboardView.vue`: guard against empty project ID before calling `useCosts`
+
+**File:** `frontend/src/views/CostDashboardView.vue`
+
+**Current code (line 22):**
+```typescript
+const projectId = route.params.id as string
+```
+
+**Issue:** `route.params.id` is read synchronously at setup time. For a lazy-loaded child route, it should already be available, but the cast to `string` hides an `undefined` or empty string edge case if the route param is missing.
+
+**Sub-tasks:**
+- 2a. Add a guard: if `!projectId`, log a warning and avoid calling `useCosts` — or pass a default that prevents the API call from firing (e.g. skip `onMounted` fetch when `projectId` is falsy inside the composable).
+- 2b. In `useCosts` composable (`frontend/src/composables/useCosts.ts`), add a guard at the top of `fetchAll` and `fetchAgentCosts`: if `projectId` is empty/falsy, set an error message `'No project ID available'` and return early without calling the API.
+
+### Task 3 — Fix `CostDashboardView.vue`: pass `projectId` when navigating to run detail
+
+**File:** `frontend/src/views/CostDashboardView.vue`
+
+**Current code (line 50):**
+```typescript
+function onRunNavigate(runId: string) {
+  router.push({ name: 'run-detail', params: { id: runId } })
+}
+```
+
+**Issue:** No `projectId` is forwarded. `RunDetailView` previously relied on `route.query.projectId` to get the project ID for the cost API call.
+
+**Sub-tasks:**
+- 3a. Pass `projectId` as a query param when navigating:
+  ```typescript
+  function onRunNavigate(runId: string) {
+    router.push({ name: 'run-detail', params: { id: runId }, query: { projectId } })
+  }
+  ```
+  **Note:** This is a stopgap fix. Task 1 (deriving `projectId` from `run.project_id`) is the proper long-term fix. Both fixes are complementary — Task 1 handles direct navigation; Task 3 handles navigation from the cost dashboard.
+
+### Task 4 — Update unit tests for `useCosts` composable
+
+**File:** `frontend/src/composables/__tests__/useCosts.spec.ts`
+
+**Sub-tasks:**
+- 4a. Add a test: `fetchAll does not call the API when projectId is empty string`.
+- 4b. Add a test: `fetchAll sets error to "No project ID available" when projectId is empty`.
+- 4c. Add a test: `fetchAgentCosts does not call the API when projectId is empty`.
+
+### Task 5 — Update unit tests for `useRunCosts` composable
+
+**File:** `frontend/src/features/runs/__tests__/useRunCosts.spec.ts`
+
+**Sub-tasks:**
+- 5a. If `useRunCosts` signature is changed to accept `Ref<string>`, update existing test calls to pass `ref('proj-1')` instead of `'proj-1'`.
+- 5b. Add a test: `does not call the API when projectId ref is empty, and calls it once projectId becomes available`.
+
+## Dev Notes
+
+- Priority: P2
+- **Root cause summary:**
+  - `RunDetailView.vue` reads `projectId` from `route.query.projectId` (a query param), but nothing passes this query param when navigating to `/runs/:id`. Result: `projectId` is always `''`, producing `/projects//runs/.../costs` in the API URL.
+  - `CostDashboardView.vue` reads `route.params.id` correctly (the route param is `:id` per `router/index.ts` line 52), so `useCosts` itself is not the primary broken path — but it lacks a guard against an empty `projectId`.
+- **Route param name:** The project route is `/projects/:id` (not `:projectId`). The `CostDashboardView` correctly reads `route.params.id`. No rename needed.
+- **`useRunCosts` signature change:** The composable currently accepts `projectId: string` and `runId: string` as plain strings. To support reactive late-binding (project ID known only after run loads), consider changing to `projectId: Ref<string> | string` using `toRef`/`toValue` (Vue 3.3+).
+- **Also related to F-2-1** — even after fixing the API call, seed data needs correct UUIDs to show cost data. Fix this story independently of seed data concerns.
+- **No OpenAPI spec changes needed** — this is a pure frontend wiring fix.

--- a/_bmad-output/implementation-artifacts/F-3-1-add-dark-mode-toggle.md
+++ b/_bmad-output/implementation-artifacts/F-3-1-add-dark-mode-toggle.md
@@ -1,0 +1,94 @@
+# Story F-3.1: [FRONT] Add dark mode toggle to app header
+
+Status: ready-for-dev
+
+## Story
+
+As a user,
+I want to toggle between light and dark mode,
+so that I can use the app comfortably in different lighting conditions.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Toggle button visible in header**
+- **Given** user is authenticated
+- **When** viewing any page
+- **Then** a dark/light mode toggle button is visible in the app header (right side, before the user menu button)
+
+**AC2: Clicking toggle switches theme**
+- **Given** app is in light mode
+- **When** user clicks the toggle
+- **Then** `.dark` class is added to `<html>`, PrimeVue switches to dark palette (Aura dark surface tokens activate)
+
+**AC3: Preference persisted**
+- **Given** user has selected dark mode
+- **When** they refresh the page or return later
+- **Then** dark mode is still active (preference key `hope-theme` persisted in localStorage)
+
+**AC4: System preference respected as default**
+- **Given** user has not set a preference in localStorage
+- **When** they load the app for the first time
+- **Then** the theme matches their OS preference (`prefers-color-scheme: dark`)
+
+## Tasks / Subtasks
+
+### Task 1: Create `useTheme` composable
+
+File to create: `frontend/src/composables/useTheme.ts`
+
+- Use `@vueuse/core` `usePreferredDark` and `useLocalStorage` (both already available — see `frontend/package.json`)
+- localStorage key: `hope-theme`, values: `'light' | 'dark' | null` (null = unset, fall back to OS preference)
+- Expose:
+  - `isDark: ComputedRef<boolean>` — derived from stored preference or OS fallback
+  - `toggle(): void` — flips the stored preference between `'light'` and `'dark'`
+- On composable init (and on `isDark` change), sync the `.dark` class on `document.documentElement`:
+  - `isDark` is `true` → add class `dark`
+  - `isDark` is `false` → remove class `dark`
+- Use `watchEffect` or `watch` with `immediate: true` to apply the class on every change
+- The composable is stateless (no Pinia store needed — localStorage is the source of truth)
+
+### Task 2: Add toggle button to `AppHeader.vue`
+
+File to modify: `frontend/src/ui/layout/AppHeader.vue`
+
+- Import and call `useTheme()` in `<script setup>`
+- Add a PrimeVue `Button` component in the right section of the header (between the left logo area and the existing user menu button), using:
+  - `:icon="isDark ? 'pi pi-sun' : 'pi pi-moon'"`
+  - `text` + `rounded` props (matches the existing hamburger and user-menu button style)
+  - `aria-label` toggling between `'Switch to light mode'` and `'Switch to dark mode'`
+  - `data-testid="theme-toggle-button"`
+  - `@click="toggle"`
+- No new imports beyond `useTheme` and `Button` (already imported)
+
+### Task 3: Apply dark class on app init
+
+File to modify: `frontend/src/main.ts`
+
+- Import `useTheme` and call it once before `app.mount('#app')` so the `.dark` class is applied immediately on page load (before first render), preventing a flash of wrong theme
+- Note: composables normally require an active Vue instance; use `app.runWithContext(() => useTheme())` or restructure as a plain function call that reads localStorage + `window.matchMedia` directly at module level if the composable pattern is incompatible outside a component
+
+  **Preferred alternative (avoids complexity):** extract the "apply class on load" logic into a small standalone function `applyInitialTheme()` exported from `useTheme.ts`, callable outside Vue context, and call it at the top of `main.ts` before `createApp`.
+
+### Task 4: Write unit tests for `useTheme`
+
+File to create: `frontend/src/composables/__tests__/useTheme.spec.ts`
+
+- Use Vitest + `@vueuse/core` test utilities
+- Test cases:
+  - No localStorage entry + OS dark preference → `isDark` is `true`, `.dark` on `<html>`
+  - No localStorage entry + OS light preference → `isDark` is `false`, no `.dark` on `<html>`
+  - localStorage `'dark'` overrides OS light preference → `isDark` is `true`
+  - localStorage `'light'` overrides OS dark preference → `isDark` is `false`
+  - `toggle()` from light → sets localStorage to `'dark'`, adds `.dark` to `<html>`
+  - `toggle()` from dark → sets localStorage to `'light'`, removes `.dark` from `<html>`
+
+## Dev Notes
+
+- Priority: P2
+- `@vueuse/core` is already a dependency — use `usePreferredDark` and `useLocalStorage`
+- PrimeVue 4 Aura preset handles dark palette automatically via the `.dark` selector on `<html>` — no PrimeVue API calls needed, just DOM class manipulation
+- `darkModeSelector: '.dark'` is already configured in `frontend/src/main.ts` (line 24)
+- Dark surface tokens are already defined in `frontend/src/theme/tokens.ts` — no theme changes needed
+- `main.css` has no dark-mode CSS to add — PrimeVue CSS layers handle it
+- The `AppHeader.vue` right-side section currently only has a `Button` + `Menu` for user menu; add the toggle button before it in the same `div.flex.items-center.gap-2`
+- No backend changes, no API spec changes, no Pinia store changes required

--- a/_bmad-output/implementation-artifacts/F-3-2-improve-auth-error-messages.md
+++ b/_bmad-output/implementation-artifacts/F-3-2-improve-auth-error-messages.md
@@ -1,0 +1,92 @@
+# Story F-3.2: [FRONT] Improve auth error messages and user feedback
+
+Status: ready-for-dev
+
+## Story
+
+As a user,
+I want clear feedback when authentication errors occur,
+so that I understand why I was redirected or why an action failed.
+
+## Acceptance Criteria (BDD)
+
+**AC1: Session expired toast**
+- **Given** user's session expires mid-session (a non-auth API call returns 401)
+- **When** `authMiddleware` in `api/client.ts` intercepts the response and redirects to `/login`
+- **Then** a Toast notification says "Session expired. Please log in again." before or during the redirect
+
+**AC2: Login redirect reason displayed**
+- **Given** user was redirected to `/login` with `?reason=session_expired` in the query string
+- **When** `LoginView.vue` renders
+- **Then** a `Message` component above the form says "Your session has expired. Please sign in again." (similar to the existing `?reset=success` message pattern)
+
+**AC3: 403 Forbidden shows meaningful message**
+- **Given** user tries to access a resource they don't have permission for
+- **When** any API call returns 403
+- **Then** `authMiddleware` (or a dedicated 403 handler in `api/client.ts`) triggers a Toast notification saying "Access denied. You don't have permission to perform this action."
+
+**AC4: Network error feedback**
+- **Given** the API is unreachable (fetch throws a network-level error, not an HTTP error)
+- **When** any API call in `authMiddleware.onRequest` or a global fetch wrapper fails with a `TypeError`
+- **Then** a Toast notification says "Unable to connect to the server. Please check your connection."
+
+## Tasks / Subtasks
+
+### Task 1 — Extend `authMiddleware` in `frontend/src/api/client.ts`
+
+The current middleware only handles 401 with a silent redirect. Extend `onResponse` to:
+
+1. On **401** (non-auth endpoint): push to `/login` with query `{ reason: 'session_expired' }` instead of bare `{ name: 'login' }`. Fire a Toast *before* the redirect using the PrimeVue `useToast()` service. Because `useToast` is a composable tied to the Vue app context, inject the toast instance at client initialisation time (export a `setToastService(toast: ToastServiceMethods)` function called from `AppShell.vue` or `main.ts`, then call it inside the middleware).
+
+2. On **403**: fire a Toast with `severity: 'error'`, `summary: 'Access Denied'`, `detail: "You don't have permission to perform this action."`, `life: 5000`. Do NOT redirect.
+
+3. Add an `onRequest` error hook (or wrap `fetch` globally) to catch `TypeError` (network failure) and fire a Toast with `severity: 'error'`, `summary: 'Connection Error'`, `detail: 'Unable to connect to the server. Please check your connection.'`, `life: 5000`.
+
+File to edit: `frontend/src/api/client.ts`
+
+### Task 2 — Wire Toast service into `client.ts` from `AppShell.vue`
+
+`AppShell.vue` already imports `useToast` and holds the `<Toast>` component. It is the earliest authenticated component that has access to the Vue app context.
+
+1. In `AppShell.vue` (`frontend/src/ui/layout/AppShell.vue`), on `onMounted`, call the `setToastService(toast)` function exported by `client.ts`.
+2. Add a second `<Toast position="top-right" group="auth" />` element inside the `<template v-if="isAuthenticated">` block alongside the existing HITL Toast, so auth error toasts render independently from HITL toasts.
+3. For the unauthenticated layout (`<template v-else>`), add a standalone `<Toast position="top-right" group="auth" />` so the session-expired toast fires even before the shell is fully shown.
+
+File to edit: `frontend/src/ui/layout/AppShell.vue`
+
+### Task 3 — Display redirect reason on `LoginView.vue`
+
+`LoginView.vue` (`frontend/src/views/LoginView.vue`) already reads `route.query.reset` to show a success `Message`. Apply the same pattern for the new `reason` query param:
+
+1. Read `route.query.reason` (type: `string | undefined`).
+2. Define a computed `redirectMessage` that maps known reason values to human-readable strings:
+   - `'session_expired'` → `"Your session has expired. Please sign in again."`
+   - Any other non-empty value → `"Please sign in to continue."`
+3. Render a `<Message severity="warn" :closable="false">{{ redirectMessage }}</Message>` above the form, conditionally on `redirectMessage` being non-null (same position as the existing `reset=success` Message).
+
+File to edit: `frontend/src/views/LoginView.vue`
+
+### Task 4 — Add unit tests
+
+Add/extend tests for the changed modules:
+
+1. `frontend/src/api/__tests__/client.spec.ts` (create if absent):
+   - Mock `router.push` and the toast service.
+   - Assert 401 on a non-auth URL → `router.push` called with `{ path: '/login', query: { reason: 'session_expired' } }` and toast fired.
+   - Assert 401 on `/api/v1/auth/*` → neither redirect nor toast.
+   - Assert 403 → toast fired with correct severity/summary, no redirect.
+
+2. `frontend/src/views/__tests__/LoginView.spec.ts` (create if absent):
+   - Mount `LoginView` with `route.query.reason = 'session_expired'`.
+   - Assert the `Message` with `"Your session has expired"` is rendered.
+   - Mount with no query params → assert Message is absent.
+
+## Dev Notes
+
+- Priority: P2
+- Use PrimeVue Toast service (`useToast` / `ToastServiceMethods`) for all transient notifications; `life: 5000` for errors, `life: 0` (sticky) only for HITL.
+- The `?reason=session_expired` query param on login redirect is the canonical mechanism for passing redirect context — keep it extensible for future reasons (e.g. `reason=forbidden`, `reason=logout`).
+- `authMiddleware` in `client.ts` runs outside Vue component context so `useToast()` cannot be called directly there. Use the exported `setToastService()` initialisation pattern (module-level variable, set once from `AppShell.vue` on mount).
+- The existing HITL Toast uses `group="hitl"` — use `group="auth"` for auth-related toasts to keep them separate and independently dismissible.
+- Do not show raw HTTP status codes or internal error objects to users — map to plain English as specified above.
+- The `guards.ts` redirect at line 26 (`{ path: '/login', query: { redirect: to.fullPath } }`) already preserves the intended destination via `?redirect=`. The new `?reason=` param is additive: both query params can coexist on the login URL.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,4 +1,4 @@
-# generated: 2026-02-22
+# generated: 2026-02-24
 # project: hopeitworks
 # project_key: NOKEY
 # tracking_system: file-system
@@ -33,7 +33,7 @@
 # - SM typically creates next story after previous one is 'done' to incorporate learnings
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
-generated: 2026-02-22
+generated: 2026-02-24
 project: hopeitworks
 project_key: NOKEY
 tracking_system: file-system
@@ -177,6 +177,30 @@ development_status:
   refactor-2-migrate-consumers-to-runner: done
   refactor-3-db-migration-workload-handle-cleanup: done
 
+  # Post-MVP: Agent Entity Source of Truth
+  post-mvp-agent-source-of-truth: done
+  refactor-remove-embedded-agent-env: done
+
+  # Phase 13: Stabilization — Functional Test Audit (2026-02-24)
+  # Epic F-1: Auth & Security Stabilization (P0)
+  epic-F-1-auth-security-stabilization: backlog
+  F-1-1-fix-auth-redirect-cascade: backlog
+  F-1-2-fix-seed-sql-bcrypt-hashes: backlog
+  F-1-3-secure-users-endpoint-admin-only: backlog
+  F-1-4-fix-forgot-reset-password-flow: backlog
+
+  # Epic F-2: Data & Display Fixes (P1-P2)
+  epic-F-2-data-display-fixes: backlog
+  F-2-1-fix-seed-runs-project-uuid: backlog
+  F-2-2-fix-board-epic-story-counts: backlog
+  F-2-3-add-role-selector-edit-user: backlog
+  F-2-4-fix-cost-dashboard-project-id: backlog
+
+  # Epic F-3: Polish & UX (P2)
+  epic-F-3-polish-ux: backlog
+  F-3-1-add-dark-mode-toggle: backlog
+  F-3-2-improve-auth-error-messages: backlog
+
   # Post-MVP: Smoke Tests & Monaco Fix
   post-mvp-smoke-monaco: done
   fix-smoke-tests-green: done
@@ -253,6 +277,7 @@ development_status:
 #   Phase 2 (Waves 5-9):  Core Platform - Epics 2, 3, 6 in parallel
 #   Phase 3 (Waves 10-12): Extensions - Epics 4, 5, 7, 8, 9
 #   Phase 11 (Waves 31-35): Pipeline Refonte — Groups, Agents, Runs UI, Costs
+#   Phase 12 (Wave 36):    Agent Entity Source of Truth
 #   Phase 4 (Waves 13-15): Validation - Epic 10
 #   Phase 5 (Waves 16-19): Post-MVP Bug Fixes
 #   Phase 6 (Waves 20-21): Auth Enhancements
@@ -1074,3 +1099,85 @@ parallel_waves:
     container_count: 2
     depends_on: [wave-34]
     notes: "Final: agent cost tab + E2E agents CRUD — Phase 11 COMPLETE"
+
+  # =====================================================
+  # PHASE 12: AGENT ENTITY SOURCE OF TRUTH
+  # =====================================================
+
+  wave-36:
+    phase: 12-agent-source-of-truth
+    stories:
+      - key: refactor-remove-embedded-agent-env
+        domain: back
+        status: done
+    container_count: 1
+    depends_on: [wave-35]
+    notes: "Remove embedded Dockerfile/CLAUDE.md/TemplateService/CLAUDEMDComposer — Agent.Image/Model/TemplateContent are now authoritative, agent_id required per step — Phase 12 COMPLETE"
+
+  # =====================================================
+  # PHASE 13: STABILIZATION — Functional Test Audit Fixes
+  # Bugs and gaps discovered via Playwright E2E audit (2026-02-24)
+  # =====================================================
+
+  wave-37:
+    phase: 13-stabilization
+    stories:
+      - key: F-1-1-fix-auth-redirect-cascade
+        domain: front
+        status: backlog
+        cross_epic_deps: [1-9-login-page-auth-guard]
+      - key: F-1-2-fix-seed-sql-bcrypt-hashes
+        domain: back
+        status: backlog
+        cross_epic_deps: [1-18-dev-seed-data-fixtures]
+      - key: F-1-3-secure-users-endpoint-admin-only
+        domain: back
+        status: backlog
+        cross_epic_deps: [1-4-user-management-api-admin-crud]
+    container_count: 3
+    depends_on: [wave-36]
+    notes: "P0 fixes: auth redirect cascade (front), seed bcrypt hashes (back), admin-only users endpoint (back) — all parallel, independent"
+
+  wave-38:
+    phase: 13-stabilization
+    stories:
+      - key: F-1-4-fix-forgot-reset-password-flow
+        domain: shared
+        status: backlog
+        explicit_deps: [F-1-1-fix-auth-redirect-cascade]
+    container_count: 1
+    depends_on: [wave-37]
+    notes: "P1: forgot/reset password flow depends on auth redirect fix being in place first"
+
+  wave-39:
+    phase: 13-stabilization
+    stories:
+      - key: F-2-1-fix-seed-runs-project-uuid
+        domain: back
+        status: backlog
+        explicit_deps: [F-1-2-fix-seed-sql-bcrypt-hashes]
+      - key: F-2-2-fix-board-epic-story-counts
+        domain: front
+        status: backlog
+      - key: F-2-3-add-role-selector-edit-user
+        domain: front
+        status: backlog
+      - key: F-2-4-fix-cost-dashboard-project-id
+        domain: front
+        status: backlog
+    container_count: 4
+    depends_on: [wave-38]
+    notes: "P1-P2 data/display fixes: seed runs UUID, board counts, edit user role, cost dashboard — all parallel"
+
+  wave-40:
+    phase: 13-stabilization
+    stories:
+      - key: F-3-1-add-dark-mode-toggle
+        domain: front
+        status: backlog
+      - key: F-3-2-improve-auth-error-messages
+        domain: front
+        status: backlog
+    container_count: 2
+    depends_on: [wave-39]
+    notes: "P2 polish: dark mode toggle, auth error UX — all parallel"


### PR DESCRIPTION
## Summary
- 10 user stories (F-1-1 to F-3-2) from Playwright E2E functional audit
- Sprint status updated with Phase 13 (waves 37-40)
- CLAUDE.md updated with agent entity refactor context

### Epic F-1: Auth & Security (P0)
- F-1-1: Fix auth redirect cascade on public pages
- F-1-2: Fix seed SQL bcrypt hashes
- F-1-3: Secure /api/v1/users endpoint admin-only
- F-1-4: Fix forgot/reset password flow

### Epic F-2: Data & Display (P1-P2)
- F-2-1: Fix seed runs project UUID
- F-2-2: Fix board epic story counts
- F-2-3: Add role selector to edit user
- F-2-4: Fix cost dashboard project ID

### Epic F-3: Polish & UX (P2)
- F-3-1: Add dark mode toggle
- F-3-2: Improve auth error messages

## Test plan
- [ ] Docs-only change — no code changes, CI should pass
- [ ] Verify all 10 story files are present in `_bmad-output/implementation-artifacts/`
- [ ] Verify sprint-status.yaml has waves 37-40 with correct dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)