### PR TITLE
fix(config): replace pgcrypto crypt() with pre-computed Go bcrypt hashes in seed data

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -70,9 +70,9 @@ seed: ## Seed the local database with dev fixtures
 	@echo "Seeding dev data..."
 	@PGPASSWORD="$(DB_PASS)" psql -h $(DB_HOST) -p $(DB_PORT) -U $(DB_USER) -d $(DB_NAME) -f testdata/seed.sql
 	@echo "Seed complete. Credentials:"
-	@echo "  admin@hopeitworks.dev / admin123 (admin)"
-	@echo "  dev@hopeitworks.dev   / dev123   (user)"
-	@echo "  alice@hopeitworks.dev / alice123  (user)"
+	@echo "  admin@hopeitworks.dev / admin1234 (admin)"
+	@echo "  dev@hopeitworks.dev   / user1234  (user)"
+	@echo "  alice@hopeitworks.dev / user1234  (user)"
 
 reset-db: ## Drop and recreate dev database, run migrations, and seed
 	@echo "Dropping database $(DB_NAME)..."

--- a/backend/testdata/seed.sql
+++ b/backend/testdata/seed.sql
@@ -6,12 +6,12 @@
 -- Reset:   cd backend && make reset-db
 --
 -- Credentials:
---   admin@hopeitworks.dev  / admin123  (admin)
---   sarah@hopeitworks.dev  / sarah123  (admin)
---   marc@hopeitworks.dev   / marc123   (admin)
---   dev@hopeitworks.dev    / dev123    (user)
---   alice@hopeitworks.dev  / alice123  (user)
---   bob@hopeitworks.dev    / bob123    (user)
+--   admin@hopeitworks.dev  / admin1234  (admin)
+--   sarah@hopeitworks.dev  / admin1234  (admin)
+--   marc@hopeitworks.dev   / admin1234  (admin)
+--   dev@hopeitworks.dev    / user1234   (user)
+--   alice@hopeitworks.dev  / user1234   (user)
+--   bob@hopeitworks.dev    / user1234   (user)
 --
 -- Idempotent: safe to run multiple times (uses ON CONFLICT).
 -- =============================================================================
@@ -23,12 +23,12 @@ BEGIN;
 -- ---------------------------------------------------------------------------
 
 INSERT INTO users (id, email, password_hash, name, role) VALUES
-('00000000-0000-0000-0000-000000000001', 'admin@hopeitworks.dev', crypt('admin123', gen_salt('bf', 10)), 'Admin User', 'admin'),
-('00000000-0000-0000-0000-000000000002', 'sarah@hopeitworks.dev', crypt('sarah123', gen_salt('bf', 10)), 'Sarah Chen', 'admin'),
-('00000000-0000-0000-0000-000000000003', 'marc@hopeitworks.dev',  crypt('marc123',  gen_salt('bf', 10)), 'Marc Dupont', 'admin'),
-('00000000-0000-0000-0000-000000000011', 'dev@hopeitworks.dev',   crypt('dev123',   gen_salt('bf', 10)), 'Dev User', 'user'),
-('00000000-0000-0000-0000-000000000012', 'alice@hopeitworks.dev', crypt('alice123', gen_salt('bf', 10)), 'Alice Martin', 'user'),
-('00000000-0000-0000-0000-000000000013', 'bob@hopeitworks.dev',   crypt('bob123',   gen_salt('bf', 10)), 'Bob Nguyen', 'user')
+('00000000-0000-0000-0000-000000000001', 'admin@hopeitworks.dev', '$2a$10$OxGZnxAwWA6XQt45Z5RUxOcKuknitNZFYNTDYGl.52yR35cBPdN/C', 'Admin User', 'admin'),
+('00000000-0000-0000-0000-000000000002', 'sarah@hopeitworks.dev', '$2a$10$OxGZnxAwWA6XQt45Z5RUxOcKuknitNZFYNTDYGl.52yR35cBPdN/C', 'Sarah Chen', 'admin'),
+('00000000-0000-0000-0000-000000000003', 'marc@hopeitworks.dev',  '$2a$10$OxGZnxAwWA6XQt45Z5RUxOcKuknitNZFYNTDYGl.52yR35cBPdN/C', 'Marc Dupont', 'admin'),
+('00000000-0000-0000-0000-000000000011', 'dev@hopeitworks.dev',   '$2a$10$WrlGk50pss6bpaGdnA1HjO1qXqs5/DdbFMX2L9Uq.Z4IXtiaECaou', 'Dev User', 'user'),
+('00000000-0000-0000-0000-000000000012', 'alice@hopeitworks.dev', '$2a$10$WrlGk50pss6bpaGdnA1HjO1qXqs5/DdbFMX2L9Uq.Z4IXtiaECaou', 'Alice Martin', 'user'),
+('00000000-0000-0000-0000-000000000013', 'bob@hopeitworks.dev',   '$2a$10$WrlGk50pss6bpaGdnA1HjO1qXqs5/DdbFMX2L9Uq.Z4IXtiaECaou', 'Bob Nguyen', 'user')
 ON CONFLICT (email) DO UPDATE SET
     password_hash = EXCLUDED.password_hash,
     name = EXCLUDED.name,

--- a/frontend/e2e/real-tests/helpers/auth.ts
+++ b/frontend/e2e/real-tests/helpers/auth.ts
@@ -10,19 +10,19 @@ export interface SeedUser {
 export const SEED_USERS = {
   admin: {
     email: 'admin@hopeitworks.dev',
-    password: 'admin123',
+    password: 'admin1234',
     name: 'Admin User',
     role: 'admin' as const,
   },
   dev: {
     email: 'dev@hopeitworks.dev',
-    password: 'dev123',
+    password: 'user1234',
     name: 'Dev User',
     role: 'user' as const,
   },
   alice: {
     email: 'alice@hopeitworks.dev',
-    password: 'alice123',
+    password: 'user1234',
     name: 'Alice Developer',
     role: 'user' as const,
   },

--- a/scripts/e2e-stack.sh
+++ b/scripts/e2e-stack.sh
@@ -147,7 +147,7 @@ cmd_reset() {
     < "${PROJECT_ROOT}/backend/testdata/seed.sql"
 
   log_success "Database reset complete."
-  log_info "Credentials: admin@hopeitworks.dev/admin123, dev@hopeitworks.dev/dev123, alice@hopeitworks.dev/alice123"
+  log_info "Credentials: admin@hopeitworks.dev/admin1234, dev@hopeitworks.dev/user1234, alice@hopeitworks.dev/user1234"
 }
 
 cmd_up() {

--- a/scripts/reset-dev.sh
+++ b/scripts/reset-dev.sh
@@ -11,11 +11,11 @@
 #
 # Credentials after reset:
 #   admin@hopeitworks.dev  / admin1234  (admin)
-#   sarah@hopeitworks.dev  / sarah1234  (admin)
-#   marc@hopeitworks.dev   / marc12345  (admin)
-#   dev@hopeitworks.dev    / dev123456  (user)
-#   alice@hopeitworks.dev  / alice1234  (user)
-#   bob@hopeitworks.dev    / bob123456  (user)
+#   sarah@hopeitworks.dev  / admin1234  (admin)
+#   marc@hopeitworks.dev   / admin1234  (admin)
+#   dev@hopeitworks.dev    / user1234   (user)
+#   alice@hopeitworks.dev  / user1234   (user)
+#   bob@hopeitworks.dev    / user1234   (user)
 # =============================================================================
 
 set -euo pipefail
@@ -92,11 +92,11 @@ register_user() {
 }
 
 register_user "admin@hopeitworks.dev" "admin1234" "Admin User"
-register_user "sarah@hopeitworks.dev" "sarah1234" "Sarah Chen"
-register_user "marc@hopeitworks.dev"  "marc12345"  "Marc Dupont"
-register_user "dev@hopeitworks.dev"   "dev123456"   "Dev User"
-register_user "alice@hopeitworks.dev" "alice1234" "Alice Martin"
-register_user "bob@hopeitworks.dev"   "bob123456"   "Bob Nguyen"
+register_user "sarah@hopeitworks.dev" "admin1234" "Sarah Chen"
+register_user "marc@hopeitworks.dev"  "admin1234"  "Marc Dupont"
+register_user "dev@hopeitworks.dev"   "user1234"   "Dev User"
+register_user "alice@hopeitworks.dev" "user1234" "Alice Martin"
+register_user "bob@hopeitworks.dev"   "user1234"   "Bob Nguyen"
 
 log "6 users registered"
 


### PR DESCRIPTION
## Summary
- Replaced `crypt()/gen_salt()` calls in `backend/testdata/seed.sql` with pre-computed Go-compatible `$2a$` bcrypt hash literals
- Standardized seed passwords: `admin1234` for admin-role users, `user1234` for user-role users (all ≥8 chars)
- Updated credential references in `backend/Makefile`, `scripts/e2e-stack.sh`, `scripts/reset-dev.sh`, and `frontend/e2e/real-tests/helpers/auth.ts`
- Verified hashes with `bcrypt.CompareHashAndPassword` in Go — both correct password and wrong password cases pass

## Root Cause
pgcrypto's `crypt()` produces hashes with an internal byte layout that differs from Go's `golang.org/x/crypto/bcrypt`, making them mutually incompatible. Seed users could not authenticate via the Go backend.

## Test plan
- [ ] Apply seed SQL to a fresh database (`cd backend && make seed`)
- [ ] Login with `admin@hopeitworks.dev` / `admin1234` — should return 200 with JWT cookie
- [ ] Login with `dev@hopeitworks.dev` / `user1234` — should return 200
- [ ] Verify wrong password (`admin123`) is rejected with 401

Refs: F-1-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)