### PR TITLE
fix(auth): prevent redirect cascade on public pages and SSE reconnect

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,13 +2,24 @@ import createClient, { type Middleware } from 'openapi-fetch'
 import type { paths } from './schema'
 import router from '@/router'
 
+let redirecting = false
+
+router.afterEach(() => {
+  redirecting = false
+})
+
 const authMiddleware: Middleware = {
   async onResponse({ request, response }) {
     if (response.status === 401) {
       const url = new URL(request.url, window.location.origin)
       // Skip redirect for auth endpoints — those 401s are handled by callers
       if (!url.pathname.startsWith('/api/v1/auth/')) {
-        await router.push({ name: 'login' })
+        const currentRoute = router.currentRoute.value
+        const isPublic = currentRoute.meta.requiresAuth === false
+        if (!isPublic && !redirecting) {
+          redirecting = true
+          await router.push({ name: 'login' })
+        }
       }
     }
     return response

--- a/frontend/src/composables/__tests__/useSSE.spec.ts
+++ b/frontend/src/composables/__tests__/useSSE.spec.ts
@@ -39,6 +39,12 @@ vi.mock('vue', async () => {
   }
 })
 
+const mockAuthStore = { isAuthenticated: true }
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => mockAuthStore,
+}))
+
 vi.stubGlobal('EventSource', MockEventSource)
 
 describe('useSSE', () => {
@@ -46,6 +52,7 @@ describe('useSSE', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
+    mockAuthStore.isAuthenticated = true
     const mod = await import('../useSSE')
     useSSE = mod.useSSE
   })
@@ -76,13 +83,25 @@ describe('useSSE', () => {
     expect(status.value).toBe('open')
   })
 
-  it('sets status to error when onerror fires', () => {
+  it('sets status to error when onerror fires and user is authenticated', () => {
     const onEvent = vi.fn()
     const { status } = useSSE('proj-123', onEvent)
 
     mockInstance.onerror!(new Event('error'))
 
     expect(status.value).toBe('error')
+    expect(mockInstance.close).not.toHaveBeenCalled()
+  })
+
+  it('closes EventSource on error when user is not authenticated', () => {
+    mockAuthStore.isAuthenticated = false
+    const onEvent = vi.fn()
+    const { status } = useSSE('proj-123', onEvent)
+
+    mockInstance.onerror!(new Event('error'))
+
+    expect(status.value).toBe('closed')
+    expect(mockInstance.close).toHaveBeenCalledTimes(1)
   })
 
   it('dispatches parsed JSON on message event', () => {

--- a/frontend/src/composables/useSSE.ts
+++ b/frontend/src/composables/useSSE.ts
@@ -1,4 +1,5 @@
 import { ref, onBeforeUnmount } from 'vue'
+import { useAuthStore } from '@/stores/auth'
 
 export type SSEStatus = 'connecting' | 'open' | 'closed' | 'error'
 
@@ -18,7 +19,13 @@ export function useSSE(
     status.value = 'open'
   }
   es.onerror = () => {
-    status.value = 'error'
+    const auth = useAuthStore()
+    if (!auth.isAuthenticated) {
+      es.close()
+      status.value = 'closed'
+    } else {
+      status.value = 'error'
+    }
   }
   es.onmessage = (e) => {
     try {

--- a/frontend/src/router/guards.ts
+++ b/frontend/src/router/guards.ts
@@ -8,17 +8,17 @@ declare module 'vue-router' {
   }
 }
 
-let authChecked = false
+let authCheckPromise: Promise<void> | null = null
 
 export function setupAuthGuard(router: Router) {
   router.beforeEach(async (to) => {
     const auth = useAuthStore()
 
-    // One-time session restore on first navigation
-    if (!authChecked) {
-      authChecked = true
-      await auth.checkAuth()
+    // One-time session restore on first navigation — concurrent guards share the same promise
+    if (!authCheckPromise) {
+      authCheckPromise = auth.checkAuth()
     }
+    await authCheckPromise
 
     const requiresAuth = to.meta.requiresAuth !== false
 


### PR DESCRIPTION
## Summary

- **Fix auth middleware redirect cascade**: Skip 401 redirects when the current route is public (`requiresAuth: false`) and deduplicate concurrent redirects via a module-level `redirecting` flag reset by `router.afterEach`
- **Fix auth guard race condition**: Replace boolean `authChecked` with a shared `Promise<void>` so concurrent `beforeEach` guard invocations wait on the same `checkAuth()` call instead of triggering it multiple times
- **Fix SSE reconnect loop**: Close `EventSource` on error when the user is unauthenticated, preventing the browser's automatic retry from generating repeated 401 requests

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/api/client.ts` | Add public-route check + redirect deduplication flag |
| `frontend/src/router/guards.ts` | Replace `authChecked` boolean with shared promise pattern |
| `frontend/src/composables/useSSE.ts` | Close EventSource on error when unauthenticated |
| `frontend/src/composables/__tests__/useSSE.spec.ts` | Add auth mock + test for close-on-unauth behavior |

## Test plan

- [x] `npm run lint` passes
- [x] useSSE unit tests pass (13/13 including 2 new auth-aware tests)
- [ ] Manual: navigate to `/login` directly — no flicker or redirect
- [ ] Manual: let session expire on a protected page — single redirect to `/login`
- [ ] Manual: verify SSE connection closes on logout, no reconnect loop

Refs: F-1-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)