### PR TITLE
feat(agent): agent runtime overhaul — Wave 2 (container images, callbacks, frontend API keys)

### DIFF
--- a/agent-images/.dockerignore
+++ b/agent-images/.dockerignore
@@ -1,0 +1,3 @@
+README.md
+*.md
+.git

--- a/agent-images/Makefile
+++ b/agent-images/Makefile
@@ -1,0 +1,22 @@
+REGISTRY ?= hopeitworks
+BASE_TAG ?= latest
+
+.PHONY: base stacks all clean
+
+base:
+	docker build -t $(REGISTRY)/agent-base:$(BASE_TAG) -f base/Dockerfile ..
+
+stacks: base
+	docker build -t $(REGISTRY)/agent-go-node:$(BASE_TAG) -f stacks/go-node/Dockerfile .
+	docker build -t $(REGISTRY)/agent-node:$(BASE_TAG) -f stacks/node/Dockerfile .
+	docker build -t $(REGISTRY)/agent-go:$(BASE_TAG) -f stacks/go/Dockerfile .
+	docker build -t $(REGISTRY)/agent-python:$(BASE_TAG) -f stacks/python/Dockerfile .
+
+all: base stacks
+
+clean:
+	docker rmi $(REGISTRY)/agent-base:$(BASE_TAG) || true
+	docker rmi $(REGISTRY)/agent-go-node:$(BASE_TAG) || true
+	docker rmi $(REGISTRY)/agent-node:$(BASE_TAG) || true
+	docker rmi $(REGISTRY)/agent-go:$(BASE_TAG) || true
+	docker rmi $(REGISTRY)/agent-python:$(BASE_TAG) || true

--- a/agent-images/base/Dockerfile
+++ b/agent-images/base/Dockerfile
@@ -1,0 +1,29 @@
+FROM golang:1.23-bookworm AS builder
+WORKDIR /build
+COPY agent-runtime/ ./
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /agent-runtime .
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl jq ca-certificates openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node 22 for Claude Code CLI and OpenCode CLI
+COPY --from=node:22-slim /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:22-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+# Install Claude Code CLI and OpenCode CLI
+RUN npm install -g @anthropic-ai/claude-code opencode-ai
+
+# Agent runtime binary
+COPY --from=builder /agent-runtime /usr/local/bin/agent-runtime
+
+# Non-root user
+RUN useradd -m -s /bin/bash agent
+USER agent
+WORKDIR /workspace
+
+ENTRYPOINT ["agent-runtime"]

--- a/agent-images/stacks/go-node/Dockerfile
+++ b/agent-images/stacks/go-node/Dockerfile
@@ -1,0 +1,22 @@
+FROM hopeitworks/agent-base:latest
+
+USER root
+
+# Go 1.23
+COPY --from=golang:1.23-bookworm /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:/home/agent/go/bin:${PATH}"
+ENV GOPATH="/home/agent/go"
+
+# Go dev tools
+RUN go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest \
+    && go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest \
+    && go install github.com/google/wire/cmd/wire@latest \
+    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b /usr/local/bin
+
+# GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+USER agent

--- a/agent-images/stacks/go/Dockerfile
+++ b/agent-images/stacks/go/Dockerfile
@@ -1,0 +1,22 @@
+FROM hopeitworks/agent-base:latest
+
+USER root
+
+# Go 1.23
+COPY --from=golang:1.23-bookworm /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:/home/agent/go/bin:${PATH}"
+ENV GOPATH="/home/agent/go"
+
+# Go dev tools
+RUN go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest \
+    && go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest \
+    && go install github.com/google/wire/cmd/wire@latest \
+    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b /usr/local/bin
+
+# GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+USER agent

--- a/agent-images/stacks/node/Dockerfile
+++ b/agent-images/stacks/node/Dockerfile
@@ -1,0 +1,14 @@
+FROM hopeitworks/agent-base:latest
+
+USER root
+
+# Node.js is already in base, just add common dev tools
+RUN npm install -g typescript prettier eslint
+
+# GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+USER agent

--- a/agent-images/stacks/python/Dockerfile
+++ b/agent-images/stacks/python/Dockerfile
@@ -1,0 +1,17 @@
+FROM hopeitworks/agent-base:latest
+
+USER root
+
+# Python 3.12
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-pip python3-venv \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3 /usr/bin/python
+
+# GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+USER agent

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -18,6 +18,7 @@ import (
 	dockeradapter "github.com/zakari/hopeitworks/backend/internal/adapter/docker"
 	gitadapter "github.com/zakari/hopeitworks/backend/internal/adapter/git"
 	hbadapter "github.com/zakari/hopeitworks/backend/internal/adapter/handlebars"
+	memoryadapter "github.com/zakari/hopeitworks/backend/internal/adapter/memory"
 	pgadapter "github.com/zakari/hopeitworks/backend/internal/adapter/postgres"
 	riveradapter "github.com/zakari/hopeitworks/backend/internal/adapter/river"
 	smtpadapter "github.com/zakari/hopeitworks/backend/internal/adapter/smtp"
@@ -230,6 +231,10 @@ func run() error {
 	// Cost tracking (for agent_run action)
 	costSvc := costService
 
+	// In-memory stores for agent container callback mode
+	containerTokenStore := memoryadapter.NewContainerTokenStore(appCtx)
+	callbackStatusStore := memoryadapter.NewCallbackStatusStore()
+
 	// Agent run action (requires Docker)
 	if containerMgr != nil {
 		logStreamer, logErr := dockeradapter.NewDockerLogStreamerFromHost(cfg.Docker.Host, logger)
@@ -246,6 +251,8 @@ func run() error {
 				containerMgr, logStreamer, eventRepo,
 				storyRepo, projectRepo, runRepo,
 				handlebarsRenderer, costSvc, agentCfg, logger,
+				apiKeySvc, containerTokenStore, callbackStatusStore,
+				cfg.Docker.CallbackBaseURL,
 			)
 			actionReg.Register(agentRunAction)
 			logger.Info("agent_run action registered")
@@ -379,6 +386,16 @@ func run() error {
 		r.Get("/", apiKeyHandler.ListMyAPIKeys)
 		r.Post("/", apiKeyHandler.CreateMyAPIKey)
 		r.Delete("/{keyId}", apiKeyHandler.DeleteMyAPIKey)
+	})
+
+	// Mount internal callback routes for agent containers (container token auth, NOT JWT).
+	// These routes are excluded from JWT auth via the isPublicPath check in auth middleware.
+	agentCallbackHandler := handler.NewAgentCallbackHandler(eventRepo, costSvc, callbackStatusStore, runRepo)
+	r.Route("/internal/agent/callback", func(r chi.Router) {
+		r.Use(authmw.InternalAuth(containerTokenStore))
+		r.Post("/runs/{runId}/steps/{stepId}/logs", agentCallbackHandler.HandleLogs)
+		r.Post("/runs/{runId}/steps/{stepId}/cost", agentCallbackHandler.HandleCost)
+		r.Post("/runs/{runId}/steps/{stepId}/status", agentCallbackHandler.HandleStatus)
 	})
 
 	// Create HTTP server

--- a/backend/internal/adapter/action/agent_run.go
+++ b/backend/internal/adapter/action/agent_run.go
@@ -34,7 +34,7 @@ type AgentConfig struct {
 //   - Legacy mode: for other images, uses Docker log streaming and exit code detection
 type AgentRunAction struct {
 	containerMgr port.ContainerManager
-	logStreamer   port.LogStreamer
+	logStreamer  port.LogStreamer
 	eventPub     port.EventPublisher
 	storyRepo    port.StoryRepository
 	projectRepo  port.ProjectRepository
@@ -70,7 +70,7 @@ func NewAgentRunAction(
 ) *AgentRunAction {
 	return &AgentRunAction{
 		containerMgr: containerMgr,
-		logStreamer:   logStreamer,
+		logStreamer:  logStreamer,
 		eventPub:     eventPub,
 		storyRepo:    storyRepo,
 		projectRepo:  projectRepo,

--- a/backend/internal/adapter/action/agent_run.go
+++ b/backend/internal/adapter/action/agent_run.go
@@ -29,9 +29,12 @@ type AgentConfig struct {
 }
 
 // AgentRunAction implements model.Action for running Claude Code agents in containers.
+// It supports two execution modes:
+//   - Callback mode: for hopeitworks/agent-* images, uses HTTP callbacks for logs/cost/status
+//   - Legacy mode: for other images, uses Docker log streaming and exit code detection
 type AgentRunAction struct {
 	containerMgr port.ContainerManager
-	logStreamer  port.LogStreamer
+	logStreamer   port.LogStreamer
 	eventPub     port.EventPublisher
 	storyRepo    port.StoryRepository
 	projectRepo  port.ProjectRepository
@@ -40,9 +43,15 @@ type AgentRunAction struct {
 	costSvc      *service.CostService
 	config       AgentConfig
 	logger       *slog.Logger
+	apiKeySvc    *service.APIKeyService
+	tokenStore   port.ContainerTokenStore
+	statusStore  port.CallbackStatusStore
+	callbackURL  string
 }
 
 // NewAgentRunAction creates a new agent run action.
+// The apiKeySvc, tokenStore, statusStore, and callbackURL parameters enable callback mode
+// for hopeitworks/agent-* container images. Pass nil/empty to disable callback mode.
 func NewAgentRunAction(
 	containerMgr port.ContainerManager,
 	logStreamer port.LogStreamer,
@@ -54,10 +63,14 @@ func NewAgentRunAction(
 	costSvc *service.CostService,
 	config AgentConfig,
 	logger *slog.Logger,
+	apiKeySvc *service.APIKeyService,
+	tokenStore port.ContainerTokenStore,
+	statusStore port.CallbackStatusStore,
+	callbackURL string,
 ) *AgentRunAction {
 	return &AgentRunAction{
 		containerMgr: containerMgr,
-		logStreamer:  logStreamer,
+		logStreamer:   logStreamer,
 		eventPub:     eventPub,
 		storyRepo:    storyRepo,
 		projectRepo:  projectRepo,
@@ -66,6 +79,10 @@ func NewAgentRunAction(
 		costSvc:      costSvc,
 		config:       config,
 		logger:       logger,
+		apiKeySvc:    apiKeySvc,
+		tokenStore:   tokenStore,
+		statusStore:  statusStore,
+		callbackURL:  callbackURL,
 	}
 }
 
@@ -130,28 +147,36 @@ func (a *AgentRunAction) Execute(ctx context.Context, runCtx *model.RunContext) 
 		return fmt.Errorf("agent_image is required in run metadata but was not set")
 	}
 
-	// 5. Create container
+	// 5. Detect execution mode: callback for hopeitworks/agent-* images, legacy otherwise
+	isCallbackMode := a.isCallbackMode(agentImage)
+
+	// 6. Create container
 	containerID, err := a.createContainer(ctx, runCtx, project, story, agentImage, prompt, branchName)
 	if err != nil {
 		return fmt.Errorf("create container: %w", err)
 	}
 	defer a.cleanupContainer(containerID)
 
-	// 6. Start container
+	// 7. Start container
 	if err := a.containerMgr.Start(ctx, containerID); err != nil {
 		return fmt.Errorf("start container: %w", err)
 	}
 
-	// 7. Persist container ID to run step
+	// 8. Persist container ID to run step
 	a.persistContainerID(ctx, runCtx.RunStep.ID, containerID)
 
-	// 8. Stream logs + wait for exit
-	exitCode, err := a.streamAndWait(ctx, containerID, runCtx)
+	// 9. Wait for completion using the appropriate mode
+	var exitCode int
+	if isCallbackMode {
+		exitCode, err = a.waitForCallback(ctx, runCtx)
+	} else {
+		exitCode, err = a.streamAndWait(ctx, containerID, runCtx)
+	}
 	if err != nil {
 		return fmt.Errorf("stream/wait: %w", err)
 	}
 
-	// 9. Check exit code
+	// 10. Check exit code
 	if exitCode != 0 {
 		return fmt.Errorf("agent exited with code %d", exitCode)
 	}
@@ -160,6 +185,8 @@ func (a *AgentRunAction) Execute(ctx context.Context, runCtx *model.RunContext) 
 }
 
 // createContainer builds ContainerOpts and creates the container.
+// For callback mode (hopeitworks/agent-* images), it injects CALLBACK_URL, AUTH_TOKEN,
+// API_KEY, PROVIDER, MODEL, RUN_ID, and STEP_ID env vars instead of CLAUDE_CODE_OAUTH_TOKEN.
 func (a *AgentRunAction) createContainer(
 	ctx context.Context,
 	runCtx *model.RunContext,
@@ -187,12 +214,53 @@ func (a *AgentRunAction) createContainer(
 		"GIT_TOKEN=" + gitToken,
 		"GIT_PROVIDER=" + project.GitProvider,
 		"GITHUB_TOKEN=" + gitToken,
-		"CLAUDE_CODE_OAUTH_TOKEN=" + os.Getenv("CLAUDE_CODE_OAUTH_TOKEN"),
 	}
 
-	// Inject per-step model when configured in pipeline YAML.
-	if modelVal, ok := runCtx.Metadata["model"].(string); ok && modelVal != "" {
-		env = append(env, "MODEL="+modelVal)
+	isCallback := a.isCallbackMode(agentImage)
+
+	if isCallback {
+		// Callback mode: use per-user API key and container token auth
+		provider := resolveProvider(runCtx)
+
+		// Resolve the user's API key for the provider
+		if a.apiKeySvc != nil && runCtx.UserID != uuid.Nil {
+			apiKey, keyErr := a.apiKeySvc.DecryptKeyForUserProvider(ctx, runCtx.UserID, provider)
+			if keyErr != nil {
+				a.logger.Warn("failed to resolve API key for user/provider, container may fail auth",
+					"user_id", runCtx.UserID, "provider", provider, "error", keyErr)
+			} else {
+				env = append(env, "API_KEY="+apiKey)
+			}
+		}
+
+		// Generate a short-lived container token for callback auth
+		if a.tokenStore != nil {
+			token, tokenErr := a.tokenStore.Create(ctx, runCtx.Run.ID, runCtx.RunStep.ID, 2*time.Hour)
+			if tokenErr != nil {
+				return "", fmt.Errorf("create container token: %w", tokenErr)
+			}
+			env = append(env, "AUTH_TOKEN="+token)
+		}
+
+		env = append(env,
+			"CALLBACK_URL="+a.callbackURL,
+			"PROVIDER="+provider,
+			"RUN_ID="+runCtx.Run.ID.String(),
+			"STEP_ID="+runCtx.RunStep.ID.String(),
+		)
+
+		// Inject model (prefer per-step, then provider-default)
+		if modelVal, ok := runCtx.Metadata["model"].(string); ok && modelVal != "" {
+			env = append(env, "MODEL="+modelVal)
+		}
+	} else {
+		// Legacy mode: use shared OAuth token
+		env = append(env, "CLAUDE_CODE_OAUTH_TOKEN="+os.Getenv("CLAUDE_CODE_OAUTH_TOKEN"))
+
+		// Inject per-step model when configured in pipeline YAML
+		if modelVal, ok := runCtx.Metadata["model"].(string); ok && modelVal != "" {
+			env = append(env, "MODEL="+modelVal)
+		}
 	}
 
 	opts := model.ContainerOpts{
@@ -376,6 +444,61 @@ func extractAgentID(runCtx *model.RunContext) *uuid.UUID {
 	}
 
 	return nil
+}
+
+// isCallbackMode returns true if the agent image is a hopeitworks/agent-* image
+// that supports HTTP callback mode for logs, cost, and status reporting.
+func (a *AgentRunAction) isCallbackMode(agentImage string) bool {
+	return a.statusStore != nil && strings.Contains(agentImage, "hopeitworks/agent-")
+}
+
+// waitForCallback waits for the agent container to report its exit status via
+// the HTTP callback endpoint. Logs and cost events arrive asynchronously via
+// separate callback endpoints and do not flow through this method.
+func (a *AgentRunAction) waitForCallback(ctx context.Context, runCtx *model.RunContext) (int, error) {
+	stepID := runCtx.RunStep.ID
+
+	exitCode, errMsg, err := a.statusStore.WaitForStatus(ctx, stepID, 2*time.Hour)
+	if err != nil {
+		return -1, err
+	}
+
+	// Revoke the container token after completion
+	if a.tokenStore != nil {
+		revokeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if tokenStr, ok := a.findContainerToken(runCtx); ok {
+			if revokeErr := a.tokenStore.Revoke(revokeCtx, tokenStr); revokeErr != nil {
+				a.logger.Warn("failed to revoke container token",
+					"step_id", stepID, "error", revokeErr)
+			}
+		}
+	}
+
+	if errMsg != "" {
+		a.logger.Warn("agent container reported error",
+			"step_id", stepID, "exit_code", exitCode, "error", errMsg)
+	}
+
+	return exitCode, nil
+}
+
+// findContainerToken looks for the AUTH_TOKEN in the run context metadata.
+// This is a best-effort lookup used to revoke tokens after completion.
+func (a *AgentRunAction) findContainerToken(_ *model.RunContext) (string, bool) {
+	// The token is not stored in metadata; revocation is handled by TTL expiry.
+	// This method exists as a hook for future token tracking if needed.
+	return "", false
+}
+
+// resolveProvider resolves the AI provider for the current step from run context metadata.
+// It checks step-specific provider metadata first, then falls back to "claude".
+func resolveProvider(runCtx *model.RunContext) string {
+	stepOrder := runCtx.RunStep.StepOrder
+	if p, ok := runCtx.Metadata[fmt.Sprintf("step_%d_provider", stepOrder)].(string); ok && p != "" {
+		return p
+	}
+	return "claude"
 }
 
 // derefString safely dereferences a string pointer, returning empty string if nil.

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -506,6 +506,10 @@ func newAgentRunFixture(t *testing.T) *agentRunFixture {
 		f.costSvc,
 		agentCfg,
 		testLogger(),
+		nil, // apiKeySvc - not needed for legacy mode tests
+		nil, // tokenStore - not needed for legacy mode tests
+		nil, // statusStore - not needed for legacy mode tests
+		"",  // callbackURL - not needed for legacy mode tests
 	)
 
 	return f

--- a/backend/internal/adapter/memory/callback_status_store.go
+++ b/backend/internal/adapter/memory/callback_status_store.go
@@ -1,0 +1,88 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// statusResult holds the final exit status for an agent container step.
+type statusResult struct {
+	ExitCode int
+	ErrMsg   string
+}
+
+// CallbackStatusStore is an in-memory implementation of port.CallbackStatusStore.
+// It uses buffered channels per step to coordinate between the HTTP callback handler
+// (which calls SetStatus) and the pipeline executor (which calls WaitForStatus).
+type CallbackStatusStore struct {
+	mu       sync.Mutex
+	channels map[uuid.UUID]chan statusResult
+}
+
+// NewCallbackStatusStore creates a new in-memory callback status store.
+func NewCallbackStatusStore() *CallbackStatusStore {
+	return &CallbackStatusStore{
+		channels: make(map[uuid.UUID]chan statusResult),
+	}
+}
+
+// WaitForStatus blocks until a status is set for the given step, the context is
+// cancelled, or the timeout elapses. Returns the exit code and an optional error message.
+func (s *CallbackStatusStore) WaitForStatus(ctx context.Context, stepID uuid.UUID, timeout time.Duration) (int, string, error) {
+	ch := s.getOrCreateChannel(stepID)
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case result := <-ch:
+		s.removeChannel(stepID)
+		return result.ExitCode, result.ErrMsg, nil
+	case <-ctx.Done():
+		s.removeChannel(stepID)
+		return -1, "", ctx.Err()
+	case <-timer.C:
+		s.removeChannel(stepID)
+		return -1, "", fmt.Errorf("timeout waiting for status callback for step %s", stepID)
+	}
+}
+
+// SetStatus sets the final status for a step, unblocking any WaitForStatus call.
+// If nobody is waiting yet, the result is buffered in the channel (size 1).
+func (s *CallbackStatusStore) SetStatus(_ context.Context, stepID uuid.UUID, exitCode int, errMsg string) error {
+	ch := s.getOrCreateChannel(stepID)
+
+	result := statusResult{ExitCode: exitCode, ErrMsg: errMsg}
+	select {
+	case ch <- result:
+		// Sent successfully
+	default:
+		// Channel already has a value (duplicate callback); ignore
+	}
+
+	return nil
+}
+
+// getOrCreateChannel returns the existing channel for a step or creates a new buffered one.
+func (s *CallbackStatusStore) getOrCreateChannel(stepID uuid.UUID) chan statusResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ch, ok := s.channels[stepID]
+	if !ok {
+		ch = make(chan statusResult, 1)
+		s.channels[stepID] = ch
+	}
+	return ch
+}
+
+// removeChannel cleans up the channel for a step after it has been consumed.
+func (s *CallbackStatusStore) removeChannel(stepID uuid.UUID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.channels, stepID)
+}

--- a/backend/internal/adapter/memory/container_token_store.go
+++ b/backend/internal/adapter/memory/container_token_store.go
@@ -1,0 +1,87 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+)
+
+// ContainerTokenStore is an in-memory implementation of port.ContainerTokenStore.
+// It uses a sync.Map for concurrent-safe token storage with TTL-based expiry.
+type ContainerTokenStore struct {
+	tokens sync.Map // map[string]*model.ContainerToken
+}
+
+// NewContainerTokenStore creates a new in-memory container token store and starts
+// a background goroutine that cleans up expired tokens every 60 seconds.
+// The cleanup goroutine stops when the context is cancelled.
+func NewContainerTokenStore(ctx context.Context) *ContainerTokenStore {
+	s := &ContainerTokenStore{}
+
+	go s.cleanupLoop(ctx)
+
+	return s
+}
+
+// Create generates and stores a new token for a run step.
+// Returns the token string.
+func (s *ContainerTokenStore) Create(_ context.Context, runID, stepID uuid.UUID, ttl time.Duration) (string, error) {
+	token := uuid.New().String()
+	ct := &model.ContainerToken{
+		Token:     token,
+		RunID:     runID,
+		StepID:    stepID,
+		ExpiresAt: time.Now().Add(ttl),
+	}
+	s.tokens.Store(token, ct)
+	return token, nil
+}
+
+// Validate checks if a token is valid and returns the associated container token.
+// Returns an error if the token is invalid or expired.
+func (s *ContainerTokenStore) Validate(_ context.Context, token string) (*model.ContainerToken, error) {
+	val, ok := s.tokens.Load(token)
+	if !ok {
+		return nil, fmt.Errorf("token not found")
+	}
+
+	ct := val.(*model.ContainerToken)
+	if time.Now().After(ct.ExpiresAt) {
+		s.tokens.Delete(token)
+		return nil, fmt.Errorf("token expired")
+	}
+
+	return ct, nil
+}
+
+// Revoke invalidates a token by removing it from the store.
+func (s *ContainerTokenStore) Revoke(_ context.Context, token string) error {
+	s.tokens.Delete(token)
+	return nil
+}
+
+// cleanupLoop periodically removes expired tokens from the store.
+func (s *ContainerTokenStore) cleanupLoop(ctx context.Context) {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			now := time.Now()
+			s.tokens.Range(func(key, value any) bool {
+				ct := value.(*model.ContainerToken)
+				if now.After(ct.ExpiresAt) {
+					s.tokens.Delete(key)
+				}
+				return true
+			})
+		}
+	}
+}

--- a/backend/internal/api/handler/agent_callback_handler.go
+++ b/backend/internal/api/handler/agent_callback_handler.go
@@ -1,0 +1,179 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+)
+
+// LogCallbackRequest is the request body for the log callback endpoint.
+type LogCallbackRequest struct {
+	Lines []string `json:"lines"`
+}
+
+// CostCallbackRequest is the request body for the cost callback endpoint.
+type CostCallbackRequest struct {
+	InputTokens  int    `json:"input_tokens"`
+	OutputTokens int    `json:"output_tokens"`
+	Model        string `json:"model"`
+}
+
+// StatusCallbackRequest is the request body for the status callback endpoint.
+type StatusCallbackRequest struct {
+	ExitCode int    `json:"exit_code"`
+	Error    string `json:"error,omitempty"`
+}
+
+// AgentCallbackHandler handles HTTP callbacks from agent containers.
+type AgentCallbackHandler struct {
+	eventPub    port.EventPublisher
+	costSvc     *service.CostService
+	statusStore port.CallbackStatusStore
+	runRepo     port.RunRepository
+}
+
+// NewAgentCallbackHandler creates a new handler for agent container callbacks.
+func NewAgentCallbackHandler(
+	eventPub port.EventPublisher,
+	costSvc *service.CostService,
+	statusStore port.CallbackStatusStore,
+	runRepo port.RunRepository,
+) *AgentCallbackHandler {
+	return &AgentCallbackHandler{
+		eventPub:    eventPub,
+		costSvc:     costSvc,
+		statusStore: statusStore,
+		runRepo:     runRepo,
+	}
+}
+
+// HandleLogs receives log lines from an agent container and publishes them to the event system.
+// POST /internal/agent/callback/runs/{runId}/steps/{stepId}/logs
+func (h *AgentCallbackHandler) HandleLogs(w http.ResponseWriter, r *http.Request) {
+	runID, stepID, ok := h.parseRunStepIDs(w, r)
+	if !ok {
+		return
+	}
+
+	var req LogCallbackRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":{"code":"INVALID_BODY","message":"invalid JSON body"}}`, http.StatusBadRequest)
+		return
+	}
+
+	// Look up the run to get the project ID for the event
+	run, err := h.runRepo.GetRun(r.Context(), runID)
+	if err != nil {
+		http.Error(w, `{"error":{"code":"RUN_NOT_FOUND","message":"run not found"}}`, http.StatusNotFound)
+		return
+	}
+
+	for _, line := range req.Lines {
+		logEvent := model.LogEvent{Message: line, Type: "stdout"}
+		payload, marshalErr := json.Marshal(logEvent)
+		if marshalErr != nil {
+			continue
+		}
+
+		event := model.Event{
+			ID:         uuid.New(),
+			ProjectID:  run.ProjectID,
+			EntityType: "log",
+			EntityID:   stepID,
+			Action:     "emitted",
+			Payload:    payload,
+		}
+		_ = h.eventPub.Publish(r.Context(), event)
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// HandleCost receives a cost event from an agent container and records it.
+// POST /internal/agent/callback/runs/{runId}/steps/{stepId}/cost
+func (h *AgentCallbackHandler) HandleCost(w http.ResponseWriter, r *http.Request) {
+	_, stepID, ok := h.parseRunStepIDs(w, r)
+	if !ok {
+		return
+	}
+
+	var req CostCallbackRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":{"code":"INVALID_BODY","message":"invalid JSON body"}}`, http.StatusBadRequest)
+		return
+	}
+
+	// Look up the step to get the run, then the run to get the project ID
+	step, err := h.runRepo.GetRunStep(r.Context(), stepID)
+	if err != nil {
+		http.Error(w, `{"error":{"code":"STEP_NOT_FOUND","message":"step not found"}}`, http.StatusNotFound)
+		return
+	}
+
+	run, err := h.runRepo.GetRun(r.Context(), step.RunID)
+	if err != nil {
+		http.Error(w, `{"error":{"code":"RUN_NOT_FOUND","message":"run not found"}}`, http.StatusNotFound)
+		return
+	}
+
+	costEvents := []model.CostEvent{
+		{
+			InputTokens:  int64(req.InputTokens),
+			OutputTokens: int64(req.OutputTokens),
+			Model:        req.Model,
+		},
+	}
+
+	// Cost recording failure is non-fatal — log but continue
+	_ = h.costSvc.RecordStepCost(r.Context(), stepID, run.ProjectID, costEvents, nil)
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// HandleStatus receives the final exit status from an agent container.
+// POST /internal/agent/callback/runs/{runId}/steps/{stepId}/status
+func (h *AgentCallbackHandler) HandleStatus(w http.ResponseWriter, r *http.Request) {
+	_, stepID, ok := h.parseRunStepIDs(w, r)
+	if !ok {
+		return
+	}
+
+	var req StatusCallbackRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":{"code":"INVALID_BODY","message":"invalid JSON body"}}`, http.StatusBadRequest)
+		return
+	}
+
+	if err := h.statusStore.SetStatus(r.Context(), stepID, req.ExitCode, req.Error); err != nil {
+		http.Error(w, `{"error":{"code":"INTERNAL","message":"failed to set status"}}`, http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// parseRunStepIDs extracts and validates runId and stepId from URL parameters.
+func (h *AgentCallbackHandler) parseRunStepIDs(w http.ResponseWriter, r *http.Request) (uuid.UUID, uuid.UUID, bool) {
+	runIDStr := chi.URLParam(r, "runId")
+	stepIDStr := chi.URLParam(r, "stepId")
+
+	runID, err := uuid.Parse(runIDStr)
+	if err != nil {
+		http.Error(w, `{"error":{"code":"INVALID_RUN_ID","message":"invalid run ID"}}`, http.StatusBadRequest)
+		return uuid.Nil, uuid.Nil, false
+	}
+
+	stepID, err := uuid.Parse(stepIDStr)
+	if err != nil {
+		http.Error(w, `{"error":{"code":"INVALID_STEP_ID","message":"invalid step ID"}}`, http.StatusBadRequest)
+		return uuid.Nil, uuid.Nil, false
+	}
+
+	return runID, stepID, true
+}

--- a/backend/internal/api/handler/run_handler.go
+++ b/backend/internal/api/handler/run_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/zakari/hopeitworks/backend/internal/api/middleware"
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
 	"github.com/zakari/hopeitworks/backend/internal/domain/service"
 	"github.com/zakari/hopeitworks/backend/pkg/errors"
@@ -99,7 +100,8 @@ func (h *RunHandler) ListRunsByStory(w http.ResponseWriter, r *http.Request, sto
 
 // LaunchRun handles POST /projects/{projectId}/stories/{storyId}/runs.
 func (h *RunHandler) LaunchRun(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, storyID StoryIdPath) {
-	run, err := h.service.LaunchRun(r.Context(), projectID, storyID)
+	userID, _ := middleware.UserIDFromContext(r.Context())
+	run, err := h.service.LaunchRun(r.Context(), projectID, storyID, userID)
 	if err != nil {
 		writeErrorResponse(w, err)
 		return

--- a/backend/internal/api/middleware/auth.go
+++ b/backend/internal/api/middleware/auth.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
@@ -53,7 +54,12 @@ var publicPaths = []string{
 }
 
 // isPublicPath checks if the request path is a public route.
+// Internal agent callback paths are also excluded from JWT auth
+// because they use container token auth via InternalAuth middleware.
 func isPublicPath(path string) bool {
+	if strings.HasPrefix(path, "/internal/") {
+		return true
+	}
 	for _, p := range publicPaths {
 		if path == p {
 			return true

--- a/backend/internal/api/middleware/internal_auth.go
+++ b/backend/internal/api/middleware/internal_auth.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+)
+
+// ContextKeyContainerToken is the context key for container token data.
+const ContextKeyContainerToken contextKey = "container_token"
+
+// InternalAuth returns middleware that validates container bearer tokens.
+// This is separate from the JWT auth middleware and is used for internal
+// agent callback endpoints.
+func InternalAuth(tokenStore port.ContainerTokenStore) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authHeader := r.Header.Get("Authorization")
+			if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":{"code":"UNAUTHORIZED","message":"Bearer token required"}}`))
+				return
+			}
+
+			token := strings.TrimPrefix(authHeader, "Bearer ")
+			ct, err := tokenStore.Validate(r.Context(), token)
+			if err != nil {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":{"code":"INVALID_TOKEN","message":"Invalid or expired token"}}`))
+				return
+			}
+
+			// Inject the container token info into context for handlers
+			ctx := SetContainerTokenContext(r.Context(), ct)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// SetContainerTokenContext stores a ContainerToken in the request context.
+func SetContainerTokenContext(ctx context.Context, ct *model.ContainerToken) context.Context {
+	return context.WithValue(ctx, ContextKeyContainerToken, ct)
+}
+
+// ContainerTokenFromContext extracts the ContainerToken from the request context.
+func ContainerTokenFromContext(ctx context.Context) (*model.ContainerToken, bool) {
+	ct, ok := ctx.Value(ContextKeyContainerToken).(*model.ContainerToken)
+	return ct, ok
+}

--- a/backend/internal/config/loader.go
+++ b/backend/internal/config/loader.go
@@ -78,6 +78,9 @@ func applyEnvOverrides(cfg *pkgconfig.Config) {
 	if v := os.Getenv("DOCKER_AGENT_NETWORK"); v != "" {
 		cfg.Docker.AgentNetwork = v
 	}
+	if v := os.Getenv("CALLBACK_BASE_URL"); v != "" {
+		cfg.Docker.CallbackBaseURL = v
+	}
 	if v := os.Getenv("SMTP_HOST"); v != "" {
 		cfg.SMTP.Host = v
 	}

--- a/backend/internal/domain/model/container_token.go
+++ b/backend/internal/domain/model/container_token.go
@@ -1,0 +1,16 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ContainerToken is a short-lived bearer token issued to an agent container.
+// It authenticates callback HTTP requests from the container back to the API.
+type ContainerToken struct {
+	Token     string
+	RunID     uuid.UUID
+	StepID    uuid.UUID
+	ExpiresAt time.Time
+}

--- a/backend/internal/domain/model/run_context.go
+++ b/backend/internal/domain/model/run_context.go
@@ -17,6 +17,10 @@ type RunContext struct {
 	// StoryID is the ID of the story being processed.
 	StoryID uuid.UUID
 
+	// UserID is the ID of the user who launched the run.
+	// Used to resolve user-specific API keys for agent containers.
+	UserID uuid.UUID
+
 	// Metadata holds inter-step data (e.g., branch name, PR URL).
 	// Previous steps can write to this map, later steps can read from it.
 	Metadata map[string]any

--- a/backend/internal/domain/port/callback_status_store.go
+++ b/backend/internal/domain/port/callback_status_store.go
@@ -1,0 +1,18 @@
+package port
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CallbackStatusStore manages status channels for waiting on agent container results.
+type CallbackStatusStore interface {
+	// WaitForStatus blocks until a status is set for the given step or the context is cancelled.
+	// Returns the exit code and an optional error message.
+	WaitForStatus(ctx context.Context, stepID uuid.UUID, timeout time.Duration) (exitCode int, errMsg string, err error)
+
+	// SetStatus sets the final status for a step, unblocking any WaitForStatus call.
+	SetStatus(ctx context.Context, stepID uuid.UUID, exitCode int, errMsg string) error
+}

--- a/backend/internal/domain/port/container_token_store.go
+++ b/backend/internal/domain/port/container_token_store.go
@@ -1,0 +1,23 @@
+package port
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+)
+
+// ContainerTokenStore manages short-lived bearer tokens for agent containers.
+type ContainerTokenStore interface {
+	// Create generates and stores a new token for a run step.
+	// Returns the token string.
+	Create(ctx context.Context, runID, stepID uuid.UUID, ttl time.Duration) (string, error)
+
+	// Validate checks if a token is valid and returns the associated container token.
+	// Returns an error if the token is invalid or expired.
+	Validate(ctx context.Context, token string) (*model.ContainerToken, error)
+
+	// Revoke invalidates a token.
+	Revoke(ctx context.Context, token string) error
+}

--- a/backend/internal/domain/service/parallel_group_executor.go
+++ b/backend/internal/domain/service/parallel_group_executor.go
@@ -107,8 +107,9 @@ func (e *ParallelGroupExecutor) Execute(ctx context.Context, epicRun *model.Epic
 func (e *ParallelGroupExecutor) runStory(ctx context.Context, epicRun *model.EpicRun, story model.Story, groupIndex int) error {
 	storyID := story.ID
 
-	// Create a run for this story via LaunchRun (which creates run + steps + enqueues job)
-	run, err := e.runSvc.LaunchRun(ctx, epicRun.ProjectID, storyID)
+	// Create a run for this story via LaunchRun (which creates run + steps + enqueues job).
+	// Epic runs do not yet track a launching user, so uuid.Nil is passed as userID.
+	run, err := e.runSvc.LaunchRun(ctx, epicRun.ProjectID, storyID, uuid.Nil)
 	if err != nil {
 		e.logger.Error("failed to create run for story",
 			"epic_run_id", epicRun.ID,

--- a/backend/internal/domain/service/pipeline_executor.go
+++ b/backend/internal/domain/service/pipeline_executor.go
@@ -223,6 +223,14 @@ func (e *PipelineExecutor) executeStep(ctx context.Context, run *model.Run, step
 		Metadata:  metadata,
 	}
 
+	// Extract the launching user ID from run metadata so actions can resolve
+	// user-specific API keys for agent containers.
+	if userIDStr, ok := metadata["launched_by_user_id"].(string); ok && userIDStr != "" {
+		if parsedID, parseErr := uuid.Parse(userIDStr); parseErr == nil {
+			runCtx.UserID = parsedID
+		}
+	}
+
 	// Inject per-step template_content from run metadata (set by LaunchRun as step_<order>_template_content).
 	templateContentKey := fmt.Sprintf("step_%d_template_content", step.StepOrder)
 	if tc, ok := runCtx.Metadata[templateContentKey].(string); ok && tc != "" {

--- a/backend/internal/domain/service/run_service.go
+++ b/backend/internal/domain/service/run_service.go
@@ -330,8 +330,8 @@ func (s *RunService) LaunchRun(ctx context.Context, projectID, storyID, userID u
 	// 7. Compute run metadata
 	branchName := "feat/" + story.Key
 	runMetadata := map[string]interface{}{
-		"branch_name":          branchName,
-		"launched_by_user_id":  userID.String(),
+		"branch_name":         branchName,
+		"launched_by_user_id": userID.String(),
 	}
 
 	// Build per-step metadata from pipeline config (keyed by step order).

--- a/backend/internal/domain/service/run_service.go
+++ b/backend/internal/domain/service/run_service.go
@@ -260,8 +260,9 @@ func (s *RunService) TransitionRun(ctx context.Context, runID uuid.UUID, newStat
 }
 
 // LaunchRun validates the story, creates a pending run with steps, and enqueues
-// a River job for async execution.
-func (s *RunService) LaunchRun(ctx context.Context, projectID, storyID uuid.UUID) (*model.Run, error) {
+// a River job for async execution. The userID identifies the launching user so
+// that user-specific API keys can be resolved for agent containers.
+func (s *RunService) LaunchRun(ctx context.Context, projectID, storyID, userID uuid.UUID) (*model.Run, error) {
 	// 1. Verify story exists and belongs to project
 	story, err := s.storyRepo.GetByID(ctx, storyID)
 	if err != nil {
@@ -329,7 +330,8 @@ func (s *RunService) LaunchRun(ctx context.Context, projectID, storyID uuid.UUID
 	// 7. Compute run metadata
 	branchName := "feat/" + story.Key
 	runMetadata := map[string]interface{}{
-		"branch_name": branchName,
+		"branch_name":          branchName,
+		"launched_by_user_id":  userID.String(),
 	}
 
 	// Build per-step metadata from pipeline config (keyed by step order).
@@ -358,6 +360,9 @@ func (s *RunService) LaunchRun(ctx context.Context, projectID, storyID uuid.UUID
 			}
 			runMetadata[fmt.Sprintf("step_%d_agent_id", i)] = agent.ID.String()
 			runMetadata[fmt.Sprintf("step_%d_model", i)] = agent.Model
+			if agent.Provider != "" {
+				runMetadata[fmt.Sprintf("step_%d_provider", i)] = agent.Provider
+			}
 			if agent.Image != "" {
 				runMetadata[fmt.Sprintf("step_%d_agent_image", i)] = agent.Image
 			}

--- a/backend/internal/domain/service/run_service_test.go
+++ b/backend/internal/domain/service/run_service_test.go
@@ -612,7 +612,7 @@ func TestLaunchRun_Success(t *testing.T) {
 
 	svc := NewRunService(runRepo, newMockProjectRepoForService(), storyRepo, pipelineConfigRepo, jobQueue)
 	svc.SetAgentRepo(newTestAgentRepo())
-	run, err := svc.LaunchRun(context.Background(), projectID, storyID)
+	run, err := svc.LaunchRun(context.Background(), projectID, storyID, uuid.Nil)
 
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -694,7 +694,7 @@ func TestLaunchRun_BranchNameInMetadata(t *testing.T) {
 
 	svc := NewRunService(runRepo, newMockProjectRepoForService(), storyRepo, pipelineConfigRepo, &mockJobQueue{})
 	svc.SetAgentRepo(newTestAgentRepo())
-	run, err := svc.LaunchRun(context.Background(), projectID, storyID)
+	run, err := svc.LaunchRun(context.Background(), projectID, storyID, uuid.Nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -758,7 +758,7 @@ func TestLaunchRun_ModelInMetadata(t *testing.T) {
 
 	svc := NewRunService(runRepo, newMockProjectRepoForService(), storyRepo, pipelineConfigRepo, &mockJobQueue{})
 	svc.SetAgentRepo(newTestAgentRepo())
-	_, err := svc.LaunchRun(context.Background(), projectID, storyID)
+	_, err := svc.LaunchRun(context.Background(), projectID, storyID, uuid.Nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -833,7 +833,7 @@ func TestLaunchRun_NoModelWhenEmpty(t *testing.T) {
 	}
 
 	svc := NewRunService(runRepo, newMockProjectRepoForService(), storyRepo, pipelineConfigRepo, &mockJobQueue{})
-	_, err := svc.LaunchRun(context.Background(), projectID, storyID)
+	_, err := svc.LaunchRun(context.Background(), projectID, storyID, uuid.Nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -856,7 +856,7 @@ func TestLaunchRun_StoryNotFound(t *testing.T) {
 		&mockJobQueue{},
 	)
 
-	_, err := svc.LaunchRun(context.Background(), projectID, storyID)
+	_, err := svc.LaunchRun(context.Background(), projectID, storyID, uuid.Nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -893,7 +893,7 @@ func TestLaunchRun_StoryWrongProject(t *testing.T) {
 		&mockJobQueue{},
 	)
 
-	_, err := svc.LaunchRun(context.Background(), projectID, storyID)
+	_, err := svc.LaunchRun(context.Background(), projectID, storyID, uuid.Nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -929,7 +929,7 @@ func TestLaunchRun_StoryAlreadyCompleted(t *testing.T) {
 		&mockJobQueue{},
 	)
 
-	_, err := svc.LaunchRun(context.Background(), projectID, storyID)
+	_, err := svc.LaunchRun(context.Background(), projectID, storyID, uuid.Nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -978,7 +978,7 @@ func TestLaunchRun_StoryAlreadyRunning(t *testing.T) {
 		&mockJobQueue{},
 	)
 
-	_, err := svc.LaunchRun(context.Background(), projectID, storyID)
+	_, err := svc.LaunchRun(context.Background(), projectID, storyID, uuid.Nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -1017,7 +1017,7 @@ func TestLaunchRun_NoPipelineConfig(t *testing.T) {
 		&mockJobQueue{},
 	)
 
-	_, err := svc.LaunchRun(context.Background(), projectID, storyID)
+	_, err := svc.LaunchRun(context.Background(), projectID, storyID, uuid.Nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -1081,7 +1081,7 @@ func TestLaunchRun_JobEnqueueFails(t *testing.T) {
 
 	svc := NewRunService(runRepo, newMockProjectRepoForService(), storyRepo, pipelineConfigRepo, jobQueue)
 	svc.SetAgentRepo(newTestAgentRepo())
-	_, err := svc.LaunchRun(context.Background(), projectID, storyID)
+	_, err := svc.LaunchRun(context.Background(), projectID, storyID, uuid.Nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/backend/internal/integration/pipeline_validation_test.go
+++ b/backend/internal/integration/pipeline_validation_test.go
@@ -264,7 +264,7 @@ func TestIntegration_PipelineValidation_RunCreation(t *testing.T) {
 	runSvc.SetAgentRepo(agentRepo)
 
 	// Launch run
-	run, err := runSvc.LaunchRun(ctx, projectID, story.ID)
+	run, err := runSvc.LaunchRun(ctx, projectID, story.ID, uuid.Nil)
 	if err != nil {
 		t.Fatalf("LaunchRun() error = %v", err)
 	}
@@ -341,7 +341,7 @@ func TestIntegration_PipelineValidation_RunCreation(t *testing.T) {
 	})
 
 	t.Run("duplicate launch blocked for active run", func(t *testing.T) {
-		_, err := runSvc.LaunchRun(ctx, projectID, story.ID)
+		_, err := runSvc.LaunchRun(ctx, projectID, story.ID, uuid.Nil)
 		if err == nil {
 			t.Fatal("expected error for duplicate launch, got nil")
 		}
@@ -422,7 +422,7 @@ func TestIntegration_PipelineValidation_Execution(t *testing.T) {
 	runSvc := service.NewRunService(runRepo, projectRepo, storyRepo, pipelineConfigRepo, mockQueue)
 	runSvc.SetAgentRepo(agentRepo)
 
-	run, err := runSvc.LaunchRun(ctx, projectID, story.ID)
+	run, err := runSvc.LaunchRun(ctx, projectID, story.ID, uuid.Nil)
 	if err != nil {
 		t.Fatalf("LaunchRun() error = %v", err)
 	}
@@ -631,7 +631,7 @@ func TestIntegration_PipelineValidation_FullFlow(t *testing.T) {
 	runSvc := service.NewRunService(runRepo, projectRepo, storyRepo, pipelineConfigRepo, mockQueue)
 	runSvc.SetAgentRepo(agentRepo)
 
-	run, err := runSvc.LaunchRun(ctx, projectID, story1.ID)
+	run, err := runSvc.LaunchRun(ctx, projectID, story1.ID, uuid.Nil)
 	if err != nil {
 		t.Fatalf("LaunchRun() error = %v", err)
 	}

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -51,6 +51,9 @@ type DockerConfig struct {
 	Host string `yaml:"host"`
 	// AgentNetwork is the Docker network for agent containers.
 	AgentNetwork string `yaml:"agent_network"`
+	// CallbackBaseURL is the base URL agent containers use to call back to the API
+	// (e.g., "http://api:8080"). Set via CALLBACK_BASE_URL env var.
+	CallbackBaseURL string `yaml:"callback_base_url"`
 }
 
 // LogConfig holds logging settings.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -62,11 +62,15 @@ services:
       # --- docker / agent runtime ---
       DOCKER_HOST: tcp://socket-proxy:2375
       DOCKER_AGENT_NETWORK: ${DOCKER_AGENT_NETWORK:-deploy_hopeitworks_agent-network}
-      AGENT_IMAGE: ${AGENT_IMAGE:-hopeitworks/agent:latest}
+      AGENT_IMAGE: ${AGENT_IMAGE:-hopeitworks/agent-go-node:latest}
       CLAUDE_MD_PATH: ${CLAUDE_MD_PATH:-agent/claude-md}
       # --- agent tokens (required for pipeline execution) ---
       GITHUB_TOKEN: ${GITHUB_TOKEN}
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN}
+      # --- callback ---
+      CALLBACK_BASE_URL: http://api:8080
+      # --- encryption ---
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-dev-encryption-key-32bytes!!}
       # --- smtp ---
       SMTP_HOST: mailhog
       SMTP_PORT: 1025
@@ -86,6 +90,7 @@ services:
     restart: on-failure
     networks:
       - hopeitworks
+      - agent-network
 
   mailhog:
     image: mailhog/mailhog:v1.0.1

--- a/frontend/src/composables/__tests__/useAPIKeys.spec.ts
+++ b/frontend/src/composables/__tests__/useAPIKeys.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useAPIKeys } from '../useAPIKeys'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockDelete = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+    POST: (...args: unknown[]) => mockPost(...args),
+    DELETE: (...args: unknown[]) => mockDelete(...args),
+  },
+}))
+
+const sampleKey = {
+  id: 'key-1',
+  provider: 'claude',
+  key_name: 'default',
+  key_hint: 'abcd',
+  created_at: '2026-01-15T10:00:00Z',
+}
+
+describe('useAPIKeys', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockDelete.mockReset()
+  })
+
+  it('starts with empty keys and no error', () => {
+    const { keys, isLoading, error } = useAPIKeys()
+    expect(keys.value).toEqual([])
+    expect(isLoading.value).toBe(false)
+    expect(error.value).toBeNull()
+  })
+
+  describe('fetchKeys', () => {
+    it('populates keys on success', async () => {
+      mockGet.mockResolvedValue({ data: [sampleKey], error: undefined })
+
+      const { keys, fetchKeys } = useAPIKeys()
+      await fetchKeys()
+
+      expect(mockGet).toHaveBeenCalledWith('/users/me/api-keys')
+      expect(keys.value).toEqual([sampleKey])
+    })
+
+    it('sets error when API returns error', async () => {
+      mockGet.mockResolvedValue({ data: undefined, error: { message: 'fail' } })
+
+      const { keys, error, fetchKeys } = useAPIKeys()
+      await fetchKeys()
+
+      expect(keys.value).toEqual([])
+      expect(error.value).toBe('Failed to load API keys')
+    })
+
+    it('sets error on network failure', async () => {
+      mockGet.mockRejectedValue(new Error('Network error'))
+
+      const { error, fetchKeys } = useAPIKeys()
+      await fetchKeys()
+
+      expect(error.value).toBe('Network error')
+    })
+
+    it('sets fallback error for non-Error thrown value', async () => {
+      mockGet.mockRejectedValue('unexpected')
+
+      const { error, fetchKeys } = useAPIKeys()
+      await fetchKeys()
+
+      expect(error.value).toBe('Failed to load API keys')
+    })
+  })
+
+  describe('createKey', () => {
+    it('creates a key and refreshes the list on success', async () => {
+      mockPost.mockResolvedValue({ data: sampleKey, error: undefined })
+      mockGet.mockResolvedValue({ data: [sampleKey], error: undefined })
+
+      const { keys, createKey } = useAPIKeys()
+      const result = await createKey('claude', 'default', 'sk-ant-abc123')
+
+      expect(result).toBe(true)
+      expect(mockPost).toHaveBeenCalledWith('/users/me/api-keys', {
+        body: { provider: 'claude', key_name: 'default', api_key: 'sk-ant-abc123' },
+      })
+      expect(keys.value).toEqual([sampleKey])
+    })
+
+    it('returns false when API returns error', async () => {
+      mockPost.mockResolvedValue({ data: undefined, error: { message: 'conflict' } })
+
+      const { error, createKey } = useAPIKeys()
+      const result = await createKey('claude', 'default', 'sk-ant-abc')
+
+      expect(result).toBe(false)
+      expect(error.value).toBe('Failed to create API key')
+    })
+
+    it('returns false on network failure', async () => {
+      mockPost.mockRejectedValue(new Error('Network error'))
+
+      const { error, createKey } = useAPIKeys()
+      const result = await createKey('claude', 'default', 'sk-ant-abc')
+
+      expect(result).toBe(false)
+      expect(error.value).toBe('Network error')
+    })
+  })
+
+  describe('deleteKey', () => {
+    it('removes the key from the list on success', async () => {
+      mockGet.mockResolvedValue({ data: [sampleKey], error: undefined })
+      mockDelete.mockResolvedValue({ error: undefined })
+
+      const { keys, fetchKeys, deleteKey } = useAPIKeys()
+      await fetchKeys()
+      expect(keys.value).toHaveLength(1)
+
+      const result = await deleteKey('key-1')
+
+      expect(result).toBe(true)
+      expect(mockDelete).toHaveBeenCalledWith('/users/me/api-keys/{keyId}', {
+        params: { path: { keyId: 'key-1' } },
+      })
+      expect(keys.value).toHaveLength(0)
+    })
+
+    it('returns false when API returns error', async () => {
+      mockDelete.mockResolvedValue({ error: { message: 'not found' } })
+
+      const { error, deleteKey } = useAPIKeys()
+      const result = await deleteKey('key-missing')
+
+      expect(result).toBe(false)
+      expect(error.value).toBe('Failed to delete API key')
+    })
+
+    it('returns false on network failure', async () => {
+      mockDelete.mockRejectedValue(new Error('Network error'))
+
+      const { error, deleteKey } = useAPIKeys()
+      const result = await deleteKey('key-1')
+
+      expect(result).toBe(false)
+      expect(error.value).toBe('Network error')
+    })
+  })
+})

--- a/frontend/src/composables/useAPIKeys.ts
+++ b/frontend/src/composables/useAPIKeys.ts
@@ -1,0 +1,79 @@
+import { ref } from 'vue'
+import { apiClient } from '@/api/client'
+
+/** A user API key (hint only — never the raw key) */
+export interface APIKey {
+  id: string
+  provider: string
+  key_name: string
+  key_hint: string
+  created_at: string
+}
+
+/**
+ * Composable for managing the current user's API keys.
+ * Provides fetch, create, and delete operations.
+ */
+export function useAPIKeys() {
+  const keys = ref<APIKey[]>([])
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+
+  /** Fetch the current user's API keys */
+  async function fetchKeys() {
+    isLoading.value = true
+    error.value = null
+    try {
+      const { data, error: apiError } = await apiClient.GET('/users/me/api-keys')
+      if (apiError) {
+        error.value = 'Failed to load API keys'
+        return
+      }
+      keys.value = (data as APIKey[]) ?? []
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load API keys'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  /** Create a new API key for the given provider */
+  async function createKey(provider: string, keyName: string, apiKey: string): Promise<boolean> {
+    error.value = null
+    try {
+      const { error: apiError } = await apiClient.POST('/users/me/api-keys', {
+        body: { provider, key_name: keyName, api_key: apiKey },
+      })
+      if (apiError) {
+        error.value = 'Failed to create API key'
+        return false
+      }
+      await fetchKeys()
+      return true
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to create API key'
+      return false
+    }
+  }
+
+  /** Delete an API key by ID */
+  async function deleteKey(keyId: string): Promise<boolean> {
+    error.value = null
+    try {
+      const { error: apiError } = await apiClient.DELETE('/users/me/api-keys/{keyId}', {
+        params: { path: { keyId } },
+      })
+      if (apiError) {
+        error.value = 'Failed to delete API key'
+        return false
+      }
+      keys.value = keys.value.filter((k) => k.id !== keyId)
+      return true
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to delete API key'
+      return false
+    }
+  }
+
+  return { keys, isLoading, error, fetchKeys, createKey, deleteKey }
+}

--- a/frontend/src/composables/useAgentEditor.ts
+++ b/frontend/src/composables/useAgentEditor.ts
@@ -32,6 +32,7 @@ export function useAgentEditor(projectId: string, agentId: string) {
   const model = ref('claude-sonnet-4-6')
   const image = ref('')
   const scope = ref<AgentScope>('project')
+  const provider = ref('claude')
   const loading = ref(false)
   const saving = ref(false)
   const error = ref<string | null>(null)
@@ -73,6 +74,7 @@ export function useAgentEditor(projectId: string, agentId: string) {
       model.value = a.model
       image.value = a.image
       scope.value = a.scope
+      provider.value = a.provider ?? 'claude'
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to load agent'
     } finally {
@@ -86,6 +88,7 @@ export function useAgentEditor(projectId: string, agentId: string) {
     agentModel?: string,
     agentImage?: string,
     agentScope?: AgentScope,
+    agentProvider?: string,
   ) {
     saving.value = true
     error.value = null
@@ -101,7 +104,7 @@ export function useAgentEditor(projectId: string, agentId: string) {
               image: agentImage ?? image.value,
               template_content: content.value,
               scope: agentScope ?? scope.value,
-              provider: 'claude',
+              provider: (agentProvider ?? provider.value) as 'claude' | 'opencode',
             },
           },
         )
@@ -119,6 +122,7 @@ export function useAgentEditor(projectId: string, agentId: string) {
               name: name.value,
               model: model.value,
               image: image.value,
+              provider: (agentProvider ?? provider.value) as 'claude' | 'opencode',
             },
           },
         )
@@ -164,6 +168,7 @@ export function useAgentEditor(projectId: string, agentId: string) {
     model,
     image,
     scope,
+    provider,
     loading,
     saving,
     error,

--- a/frontend/src/features/agents/AgentEditorLayout.vue
+++ b/frontend/src/features/agents/AgentEditorLayout.vue
@@ -22,6 +22,7 @@ interface Props {
   agentModel: string
   agentImage: string
   agentScope: AgentScope
+  agentProvider: string
   previewVisible: boolean
   previewContent: string
   previewLoading: boolean
@@ -36,6 +37,7 @@ const emit = defineEmits<{
   'update:agentModel': [model: string]
   'update:agentImage': [image: string]
   'update:agentScope': [scope: AgentScope]
+  'update:agentProvider': [provider: string]
   'update:previewVisible': [visible: boolean]
   save: []
   cancel: []
@@ -45,6 +47,11 @@ const emit = defineEmits<{
 const scopeOptions = [
   { label: 'Project', value: 'project' },
   { label: 'Global', value: 'global' },
+]
+
+const providerOptions = [
+  { label: 'Claude', value: 'claude' },
+  { label: 'OpenCode', value: 'opencode' },
 ]
 
 const editorRef = ref<InstanceType<typeof MonacoEditorWrapper> | null>(null)
@@ -98,6 +105,19 @@ const editorRef = ref<InstanceType<typeof MonacoEditorWrapper> | null>(null)
           class="w-64"
           :disabled="isReadOnly"
           @update:model-value="emit('update:agentModel', $event)"
+        />
+      </div>
+      <div class="flex flex-col gap-1">
+        <label class="text-xs font-medium text-surface-500">Provider</label>
+        <Select
+          :model-value="agentProvider"
+          :options="providerOptions"
+          option-label="label"
+          option-value="value"
+          size="small"
+          class="w-40"
+          :disabled="isReadOnly"
+          @update:model-value="emit('update:agentProvider', $event)"
         />
       </div>
       <div class="flex min-w-[200px] flex-1 flex-col gap-1">

--- a/frontend/src/features/profile/APIKeyDialog.vue
+++ b/frontend/src/features/profile/APIKeyDialog.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import Dialog from 'primevue/dialog'
+import Select from 'primevue/select'
+import InputText from 'primevue/inputtext'
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import { useAPIKeys } from '@/composables/useAPIKeys'
+
+interface Props {
+  visible: boolean
+}
+
+defineProps<Props>()
+
+const emit = defineEmits<{
+  'update:visible': [visible: boolean]
+  created: []
+}>()
+
+const { createKey, error } = useAPIKeys()
+
+const providerOptions = [
+  { label: 'Claude', value: 'claude' },
+  { label: 'OpenCode', value: 'opencode' },
+]
+
+const provider = ref('claude')
+const keyName = ref('')
+const apiKey = ref('')
+const isSaving = ref(false)
+const localError = ref<string | null>(null)
+
+function resetForm() {
+  provider.value = 'claude'
+  keyName.value = ''
+  apiKey.value = ''
+  localError.value = null
+}
+
+function handleClose() {
+  resetForm()
+  emit('update:visible', false)
+}
+
+async function handleSubmit() {
+  if (!provider.value || !keyName.value.trim() || !apiKey.value.trim()) {
+    localError.value = 'All fields are required'
+    return
+  }
+  isSaving.value = true
+  localError.value = null
+  const success = await createKey(provider.value, keyName.value.trim(), apiKey.value.trim())
+  isSaving.value = false
+  if (success) {
+    emit('created')
+    handleClose()
+  } else {
+    localError.value = error.value ?? 'Failed to create API key'
+  }
+}
+</script>
+
+<template>
+  <Dialog
+    :visible="visible"
+    header="Add API Key"
+    :modal="true"
+    :closable="true"
+    :style="{ width: '28rem' }"
+    @update:visible="handleClose"
+  >
+    <div class="flex flex-col gap-4">
+      <Message v-if="localError" severity="error" :closable="false">
+        {{ localError }}
+      </Message>
+
+      <div class="flex flex-col gap-1">
+        <label class="text-sm font-medium">Provider</label>
+        <Select
+          v-model="provider"
+          :options="providerOptions"
+          option-label="label"
+          option-value="value"
+          class="w-full"
+          placeholder="Select provider"
+        />
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label class="text-sm font-medium">Key Name</label>
+        <InputText
+          v-model="keyName"
+          placeholder="e.g. default, work"
+          class="w-full"
+        />
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label class="text-sm font-medium">API Key</label>
+        <InputText
+          v-model="apiKey"
+          type="password"
+          placeholder="sk-ant-..."
+          class="w-full"
+        />
+      </div>
+    </div>
+
+    <template #footer>
+      <div class="flex justify-end gap-2">
+        <Button label="Cancel" severity="secondary" text @click="handleClose" />
+        <Button
+          label="Save"
+          :loading="isSaving"
+          :disabled="isSaving"
+          @click="handleSubmit"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>

--- a/frontend/src/features/profile/APIKeyList.vue
+++ b/frontend/src/features/profile/APIKeyList.vue
@@ -28,7 +28,7 @@ function handleDelete(keyId: string, keyName: string) {
     message: `Delete API key "${keyName}"? This cannot be undone.`,
     header: 'Delete API Key',
     icon: 'pi pi-exclamation-triangle',
-    acceptSeverity: 'danger',
+    acceptClass: 'p-button-danger',
     accept: async () => {
       await deleteKey(keyId)
     },

--- a/frontend/src/features/profile/APIKeyList.vue
+++ b/frontend/src/features/profile/APIKeyList.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import DataTable from 'primevue/datatable'
+import Column from 'primevue/column'
+import Button from 'primevue/button'
+import Tag from 'primevue/tag'
+import Message from 'primevue/message'
+import ConfirmDialog from 'primevue/confirmdialog'
+import { useConfirm } from 'primevue/useconfirm'
+import { useAPIKeys } from '@/composables/useAPIKeys'
+import APIKeyDialog from './APIKeyDialog.vue'
+
+const confirm = useConfirm()
+const { keys, isLoading, error, fetchKeys, deleteKey } = useAPIKeys()
+
+const dialogVisible = ref(false)
+
+onMounted(() => {
+  fetchKeys()
+})
+
+function providerSeverity(provider: string): 'info' | 'secondary' {
+  return provider === 'claude' ? 'info' : 'secondary'
+}
+
+function handleDelete(keyId: string, keyName: string) {
+  confirm.require({
+    message: `Delete API key "${keyName}"? This cannot be undone.`,
+    header: 'Delete API Key',
+    icon: 'pi pi-exclamation-triangle',
+    acceptSeverity: 'danger',
+    accept: async () => {
+      await deleteKey(keyId)
+    },
+  })
+}
+</script>
+
+<template>
+  <ConfirmDialog />
+
+  <div class="flex flex-col gap-4">
+    <div class="flex items-center justify-between">
+      <span class="text-sm text-surface-500">
+        API keys are stored encrypted. Only the last 4 characters are shown.
+      </span>
+      <Button
+        label="Add API Key"
+        icon="pi pi-plus"
+        size="small"
+        @click="dialogVisible = true"
+      />
+    </div>
+
+    <Message v-if="error" severity="error" :closable="false">{{ error }}</Message>
+
+    <DataTable
+      :value="keys"
+      :loading="isLoading"
+      size="small"
+      :rows="20"
+    >
+      <template #empty>
+        <div class="p-4 text-center text-surface-400">No API keys configured yet.</div>
+      </template>
+
+      <Column field="provider" header="Provider">
+        <template #body="{ data }">
+          <Tag :value="data.provider" :severity="providerSeverity(data.provider)" />
+        </template>
+      </Column>
+
+      <Column field="key_name" header="Key Name" />
+
+      <Column field="key_hint" header="Key Hint">
+        <template #body="{ data }">
+          <code class="text-xs">...{{ data.key_hint }}</code>
+        </template>
+      </Column>
+
+      <Column field="created_at" header="Created">
+        <template #body="{ data }">
+          {{ new Date(data.created_at).toLocaleDateString() }}
+        </template>
+      </Column>
+
+      <Column header="Actions">
+        <template #body="{ data }">
+          <Button
+            icon="pi pi-trash"
+            severity="danger"
+            text
+            size="small"
+            aria-label="Delete API key"
+            @click="handleDelete(data.id, data.key_name)"
+          />
+        </template>
+      </Column>
+    </DataTable>
+
+    <APIKeyDialog
+      v-model:visible="dialogVisible"
+      @created="fetchKeys"
+    />
+  </div>
+</template>

--- a/frontend/src/stores/__tests__/agents.spec.ts
+++ b/frontend/src/stores/__tests__/agents.spec.ts
@@ -23,6 +23,7 @@ const sampleAgent = {
   image: 'ghcr.io/org/agent:latest',
   template_content: 'You are a developer...',
   scope: 'project' as const,
+  provider: 'claude',
   project_id: 'p1',
   created_at: '2026-01-15T10:00:00Z',
   updated_at: '2026-01-15T10:00:00Z',

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -16,6 +16,7 @@ export interface Agent {
   image: string
   template_content: string
   scope: AgentScope
+  provider?: string | null
   project_id?: string | null
   created_at: string
   updated_at: string
@@ -43,6 +44,7 @@ export interface UpdateAgentParams {
   model?: string
   image?: string
   template_content?: string
+  provider?: 'claude' | 'opencode'
 }
 
 /**

--- a/frontend/src/views/AgentEditorView.vue
+++ b/frontend/src/views/AgentEditorView.vue
@@ -27,6 +27,7 @@ const {
   model,
   image,
   scope,
+  provider,
   loading,
   saving,
   error,
@@ -111,6 +112,7 @@ async function handlePreview() {
     :agent-model="model"
     :agent-image="image"
     :agent-scope="scope"
+    :agent-provider="provider"
     :preview-visible="previewVisible"
     :preview-content="previewContent"
     :preview-loading="previewLoading"
@@ -120,6 +122,7 @@ async function handlePreview() {
     @update:agent-model="model = $event"
     @update:agent-image="image = $event"
     @update:agent-scope="scope = $event"
+    @update:agent-provider="provider = $event"
     @update:preview-visible="previewVisible = $event"
     @save="handleSave"
     @cancel="handleCancel"

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -8,6 +8,7 @@ import Toast from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
 import ProfileInfoForm from '@/features/profile/ProfileInfoForm.vue'
 import ChangePasswordForm from '@/features/profile/ChangePasswordForm.vue'
+import APIKeyList from '@/features/profile/APIKeyList.vue'
 import { useProfile } from '@/composables/useProfile'
 
 const toast = useToast()
@@ -76,26 +77,35 @@ async function handlePasswordSave(payload: {
     </div>
 
     <!-- Profile content -->
-    <div v-else-if="user" class="grid grid-cols-1 gap-6 md:grid-cols-2">
-      <Card>
-        <template #title>Profile Information</template>
-        <template #content>
-          <ProfileInfoForm
-            :user="user"
-            :is-saving="updateMe.isLoading.value"
-            @save="handleProfileSave"
-          />
-        </template>
-      </Card>
+    <div v-else-if="user" class="flex flex-col gap-6">
+      <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <Card>
+          <template #title>Profile Information</template>
+          <template #content>
+            <ProfileInfoForm
+              :user="user"
+              :is-saving="updateMe.isLoading.value"
+              @save="handleProfileSave"
+            />
+          </template>
+        </Card>
 
-      <Card>
-        <template #title>Change Password</template>
+        <Card>
+          <template #title>Change Password</template>
+          <template #content>
+            <ChangePasswordForm
+              :is-saving="changePassword.isLoading.value"
+              :reset-key="passwordResetKey"
+              @save="handlePasswordSave"
+            />
+          </template>
+        </Card>
+      </div>
+
+      <Card class="col-span-full">
+        <template #title>API Keys</template>
         <template #content>
-          <ChangePasswordForm
-            :is-saving="changePassword.isLoading.value"
-            :reset-key="passwordResetKey"
-            @save="handlePasswordSave"
-          />
+          <APIKeyList />
         </template>
       </Card>
     </div>


### PR DESCRIPTION
## Summary

Agent Runtime Overhaul — Wave 2: Phases 4, 5, and 6 completing the full agent container lifecycle.

- **Phase 4 — Container Images**: Multi-stage Dockerfiles for agent containers (`agent-images/base` + 4 stacks: go-node, node, go, python). Updated `docker-compose.yml` with dual network, `CALLBACK_BASE_URL`, `ENCRYPTION_KEY`.
- **Phase 5 — Backend Callbacks** (the big one): HTTP callback mode for agent containers. Container tokens, callback status stores (in-memory), 3 internal callback endpoints (`/internal/agent/callback/...`), internal auth middleware, major refactor of `agent_run.go` with dual-mode execution (callback vs legacy). User API keys resolved per-run for provider auth.
- **Phase 6 — Frontend API Keys UI + Provider**: `useAPIKeys` composable, `APIKeyList`/`APIKeyDialog` on ProfileView, Provider dropdown in Agent Editor.

## Key Changes

### Phase 4 — Container Images
- `agent-images/base/Dockerfile` — multi-stage: Go builder → debian-slim + Claude CLI + OpenCode CLI
- `agent-images/stacks/{go-node,node,go,python}/Dockerfile` — stack-specific tooling
- `agent-images/Makefile` — `make base`, `make stacks`, `make all`
- `deploy/docker-compose.yml` — API on dual network (hopeitworks + agent-network)

### Phase 5 — Backend Callbacks (13 files modified, 7 new)
- `backend/internal/domain/model/container_token.go` — ContainerToken model
- `backend/internal/domain/port/{container_token_store,callback_status_store}.go` — interfaces
- `backend/internal/adapter/memory/` — in-memory implementations (sync.Map + channels)
- `backend/internal/api/handler/agent_callback_handler.go` — 3 endpoints (logs, cost, status)
- `backend/internal/api/middleware/internal_auth.go` — bearer token auth for containers
- `backend/internal/adapter/action/agent_run.go` — **dual-mode**: callback (new images) vs legacy (stdout)
- `backend/internal/domain/service/run_service.go` — UserID propagation + provider metadata
- `backend/cmd/api/main.go` — full wiring of new components

### Phase 6 — Frontend
- `frontend/src/composables/useAPIKeys.ts` — CRUD composable
- `frontend/src/features/profile/{APIKeyList,APIKeyDialog}.vue` — UI components
- `frontend/src/views/ProfileView.vue` — API Keys section
- Agent Editor — Provider dropdown (claude/opencode)

## Test plan
- [x] Backend builds (`go build ./...`)
- [x] Backend unit tests pass (`go test ./... -short`)
- [x] Frontend unit tests pass (688/688)
- [x] ESLint + TypeScript type check pass
- [ ] `docker build` for agent images
- [ ] E2E: API key CRUD on profile page
- [ ] E2E: Agent launch with callback mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)