### PR TITLE
chore(deploy): add agent test stack and slim devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,10 @@
     "HOPEITWORKS_ENV": "devcontainer",
     "CLAUDE_CODE_OAUTH_TOKEN": "${localEnv:CLAUDE_CODE_OAUTH_TOKEN_PERSO}",
     "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}",
-    "CLAUDE_MODEL": "${localEnv:CLAUDE_MODEL:opus}"
+    "CLAUDE_MODEL": "${localEnv:CLAUDE_MODEL:opus}",
+    "TEST_API_PORT": "8081",
+    "TEST_POSTGRES_PORT": "5433",
+    "TEST_MAILHOG_PORT": "8026"
   },
 
   // ─── Docker socket from host ─────────────────────────────────
@@ -23,11 +26,13 @@
   // ─── Ports ───────────────────────────────────────────────────
   // Only forward frontend dev server — docker-compose stack runs on the host
   "forwardPorts": [
-    5173   // frontend vite dev
+    5173,  // frontend vite dev
+    8081,  // API test stack
+    8026   // MailHog test stack
   ],
 
   // ─── Post-create: install deps ───────────────────────────────
-  "postCreateCommand": "cd frontend && npm install && npx playwright install chromium",
+  "postCreateCommand": "cd frontend && pnpm install && npx playwright install chromium",
 
   // ─── VS Code settings ────────────────────────────────────────
   "customizations": {
@@ -54,16 +59,8 @@
         "esbenp.prettier-vscode",
         // Tailwind
         "bradlc.vscode-tailwindcss",
-        // Docker
-        "ms-azuretools.vscode-docker",
-        // DB
-        "ckolkman.vscode-postgres",
-        // Git
-        "eamodio.gitlens",
         // API
-        "42Crunch.vscode-openapi",
-        // Claude Code
-        "anthropic.claude-code"
+        "42Crunch.vscode-openapi"
       ]
     }
   },

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .env
 .env.local
 .env.*.local
-
+.pnpm-store
 # OS
 .DS_Store
 Thumbs.db

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,11 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+      "args": ["@playwright/mcp@latest", "--headless", "--browser", "chromium"]
+    },
+    "playwright-chrome-local": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest", "--cdp-endpoint", "http://host.docker.internal:9222"]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,16 +96,28 @@ Specified   Architected    In Progress  Review      Testing       → Done
 
 ## Development Environment
 
-Devcontainer = code-only. Docker stack runs on host.
+Devcontainer = code-only. Deux Docker stacks sur le même daemon :
 
+### Stack stable (host, branch develop)
 ```bash
-# Safe in devcontainer
 ./scripts/update-stack.sh              # rebuild + restart
 ./scripts/update-stack.sh --reset      # rebuild + reseed
+# Ports : API 8080, Postgres 5432, MailHog 8025
+```
 
-# Blocked in devcontainer (use host)
-./scripts/reset-dev.sh
-./scripts/e2e-stack.sh up
+### Stack de test agents (safe depuis devcontainer)
+```bash
+./scripts/agent-stack.sh up            # start stack test isolé
+./scripts/agent-stack.sh down          # stop
+./scripts/agent-stack.sh reset         # reset DB test uniquement
+./scripts/agent-stack.sh status        # health check
+# Ports : API 8081, Postgres 5433, MailHog 8026
+```
+
+### Bloqué en devcontainer (protège le stack stable)
+```bash
+./scripts/reset-dev.sh                 # → utiliser le host
+./scripts/e2e-stack.sh up              # → utiliser le host
 ```
 
 Seed credentials: `admin@hopeitworks.dev` / `admin1234`

--- a/deploy/docker-compose.agent-test.yml
+++ b/deploy/docker-compose.agent-test.yml
@@ -1,0 +1,85 @@
+# ─── Agent Test Stack ─────────────────────────────────────────────────────────
+# Isolated stack for agent-driven tests. Runs in parallel with the main dev
+# stack on different ports. No socket-proxy, no agent-network — agents do NOT
+# spawn sub-containers from inside this stack.
+#
+# Ports:
+#   Postgres  → 5433 (host)
+#   API       → 8081 (host)
+#   MailHog   → 1026 SMTP / 8026 UI (host)
+# ──────────────────────────────────────────────────────────────────────────────
+
+services:
+  test-postgres:
+    image: postgres:16-alpine
+    container_name: hopeitworks-test-postgres
+    environment:
+      POSTGRES_DB: hopeitworks_test
+      POSTGRES_USER: ${POSTGRES_USER:-hopeitworks}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-hopeitworks_dev_password}
+    ports:
+      - "5433:5432"
+    volumes:
+      - test_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-hopeitworks} -d hopeitworks_test"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - hopeitworks-test
+
+  test-mailhog:
+    image: mailhog/mailhog:v1.0.1
+    container_name: hopeitworks-test-mailhog
+    ports:
+      - "1026:1025"
+      - "8026:8025"
+    networks:
+      - hopeitworks-test
+    restart: unless-stopped
+
+  api:
+    build:
+      context: ../backend
+      dockerfile: Dockerfile
+    container_name: hopeitworks-test-api
+    environment:
+      APP_ENV: ${APP_ENV:-development}
+      LOG_LEVEL: ${LOG_LEVEL:-debug}
+      SERVER_PORT: 8081
+      DB_HOST: test-postgres
+      DB_PORT: 5432
+      DB_NAME: hopeitworks_test
+      DB_USER: ${POSTGRES_USER:-hopeitworks}
+      DB_PASSWORD: ${POSTGRES_PASSWORD:-hopeitworks_dev_password}
+      DB_SSLMODE: disable
+      JWT_SECRET: ${JWT_SECRET:-dev-secret-key-change-in-production}
+      AGENT_IMAGE: ${AGENT_IMAGE:-hopeitworks/agent-go-node:latest}
+      CLAUDE_MD_PATH: ${CLAUDE_MD_PATH:-agent/claude-md}
+      GITHUB_TOKEN: ${GITHUB_TOKEN}
+      CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN}
+      CALLBACK_BASE_URL: http://api:8081
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-dev-encryption-key-32bytes!!}
+      SMTP_HOST: test-mailhog
+      SMTP_PORT: 1025
+      SMTP_FROM: ${SMTP_FROM:-noreply@hopeitworks.local}
+      FRONTEND_URL: ${FRONTEND_URL:-http://localhost:5173}
+    ports:
+      - "8081:8081"
+    depends_on:
+      test-postgres:
+        condition: service_healthy
+      test-mailhog:
+        condition: service_started
+    restart: unless-stopped
+    networks:
+      - hopeitworks-test
+
+volumes:
+  test_postgres_data:
+
+networks:
+  hopeitworks-test:
+    driver: bridge

--- a/scripts/agent-stack.sh
+++ b/scripts/agent-stack.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ─── Agent Test Stack ─────────────────────────────────────────────────────────
+# Manages the isolated agent test stack (hopeitworks-test project).
+# Designed to run from INSIDE the devcontainer — no devcontainer guard.
+#
+# Ports: API=8081, Postgres=5433, MailHog SMTP=1026 / UI=8026
+# ──────────────────────────────────────────────────────────────────────────────
+
+# ─── Colors ────────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# ─── Project root detection ─────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+COMPOSE_FILE="${PROJECT_ROOT}/deploy/docker-compose.agent-test.yml"
+COMPOSE_PROJECT="hopeitworks-test"
+
+BACKEND_URL="http://localhost:8081"
+POSTGRES_HOST="localhost"
+POSTGRES_PORT="5433"
+MAILHOG_UI_URL="http://localhost:8026"
+
+DB_CONTAINER="hopeitworks-test-postgres"
+DB_USER="${POSTGRES_USER:-hopeitworks}"
+DB_NAME="hopeitworks_test"
+API_CONTAINER="hopeitworks-test-api"
+
+HEALTH_TIMEOUT=120
+
+# ─── Helpers ───────────────────────────────────────────────────────────────────
+log_info()    { echo -e "${BLUE}[agent-stack]${NC} $*"; }
+log_success() { echo -e "${GREEN}[agent-stack]${NC} $*"; }
+log_warn()    { echo -e "${YELLOW}[agent-stack]${NC} $*"; }
+log_error()   { echo -e "${RED}[agent-stack]${NC} $*" >&2; }
+
+check_backend() {
+  curl -sf "${BACKEND_URL}/healthz" > /dev/null 2>&1 || \
+  curl -sf "${BACKEND_URL}/health" > /dev/null 2>&1
+}
+
+check_postgres() {
+  nc -z "${POSTGRES_HOST}" "${POSTGRES_PORT}" > /dev/null 2>&1
+}
+
+check_mailhog() {
+  curl -sf "${MAILHOG_UI_URL}" > /dev/null 2>&1
+}
+
+# ─── Subcommands ───────────────────────────────────────────────────────────────
+
+cmd_wait() {
+  local timeout="${HEALTH_TIMEOUT}"
+  local elapsed=0
+  local interval=2
+
+  log_info "Waiting for all services to be healthy (timeout: ${timeout}s)..."
+
+  while [ "${elapsed}" -lt "${timeout}" ]; do
+    local backend_ok=false
+    local postgres_ok=false
+    local mailhog_ok=false
+
+    check_backend  && backend_ok=true
+    check_postgres && postgres_ok=true
+    check_mailhog  && mailhog_ok=true
+
+    if "${backend_ok}" && "${postgres_ok}" && "${mailhog_ok}"; then
+      log_success "All services are healthy."
+      return 0
+    fi
+
+    local status=""
+    "${backend_ok}"  || status+=" api"
+    "${postgres_ok}" || status+=" postgres"
+    "${mailhog_ok}"  || status+=" mailhog"
+
+    log_info "Waiting for:${status} (${elapsed}s elapsed)..."
+    sleep "${interval}"
+    elapsed=$((elapsed + interval))
+  done
+
+  log_error "Timeout reached (${timeout}s). Some services are still not healthy."
+  return 1
+}
+
+cmd_status() {
+  echo -e "${CYAN}─── Agent Test Stack Status ────────────────────────────${NC}"
+
+  if check_backend; then
+    echo -e "  API       ${BACKEND_URL}   ${GREEN}UP${NC}"
+  else
+    echo -e "  API       ${BACKEND_URL}   ${RED}DOWN${NC}"
+  fi
+
+  if check_postgres; then
+    echo -e "  Postgres  ${POSTGRES_HOST}:${POSTGRES_PORT}              ${GREEN}UP${NC}"
+  else
+    echo -e "  Postgres  ${POSTGRES_HOST}:${POSTGRES_PORT}              ${RED}DOWN${NC}"
+  fi
+
+  if check_mailhog; then
+    echo -e "  MailHog   ${MAILHOG_UI_URL}    ${GREEN}UP${NC}"
+  else
+    echo -e "  MailHog   ${MAILHOG_UI_URL}    ${RED}DOWN${NC}"
+  fi
+
+  echo -e "${CYAN}────────────────────────────────────────────────────────${NC}"
+
+  check_backend && check_postgres && check_mailhog
+}
+
+cmd_reset() {
+  log_info "Resetting database via docker exec (no local psql tools required)..."
+
+  # Verify the postgres container is running
+  if ! docker exec "${DB_CONTAINER}" pg_isready -U "${DB_USER}" > /dev/null 2>&1; then
+    log_error "Postgres container '${DB_CONTAINER}' is not running or not ready."
+    return 1
+  fi
+
+  # Terminate active connections and drop/recreate database
+  log_info "Dropping database ${DB_NAME}..."
+  docker exec "${DB_CONTAINER}" psql -U "${DB_USER}" -d postgres \
+    -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${DB_NAME}' AND pid <> pg_backend_pid();" \
+    > /dev/null 2>&1 || true
+  docker exec "${DB_CONTAINER}" psql -U "${DB_USER}" -d postgres \
+    -c "DROP DATABASE IF EXISTS ${DB_NAME};"
+
+  log_info "Creating database ${DB_NAME}..."
+  docker exec "${DB_CONTAINER}" psql -U "${DB_USER}" -d postgres \
+    -c "CREATE DATABASE ${DB_NAME} OWNER ${DB_USER};"
+
+  # Run migrations (sorted order)
+  log_info "Running migrations..."
+  local migration_dir="${PROJECT_ROOT}/backend/migrations"
+  local migration_count=0
+  for f in "${migration_dir}"/*.up.sql; do
+    [ -f "$f" ] || continue
+    docker exec -i "${DB_CONTAINER}" psql -U "${DB_USER}" -d "${DB_NAME}" --set ON_ERROR_STOP=1 < "$f"
+    migration_count=$((migration_count + 1))
+  done
+  log_info "Applied ${migration_count} migrations."
+
+  # Seed test data
+  log_info "Seeding test data..."
+  docker exec -i "${DB_CONTAINER}" psql -U "${DB_USER}" -d "${DB_NAME}" --set ON_ERROR_STOP=1 \
+    < "${PROJECT_ROOT}/backend/testdata/seed.sql"
+
+  log_success "Database reset complete."
+  log_info "Credentials: admin@hopeitworks.dev/admin1234"
+
+  # Restart API to pick up fresh DB state
+  log_info "Restarting API container..."
+  docker restart "${API_CONTAINER}"
+
+  log_info "Waiting for API to be healthy after restart..."
+  local elapsed=0
+  local interval=2
+  while [ "${elapsed}" -lt "${HEALTH_TIMEOUT}" ]; do
+    if check_backend; then
+      log_success "API is healthy."
+      return 0
+    fi
+    sleep "${interval}"
+    elapsed=$((elapsed + interval))
+  done
+
+  log_error "API did not recover within ${HEALTH_TIMEOUT}s after restart."
+  return 1
+}
+
+cmd_up() {
+  log_info "Starting agent test stack (project: ${COMPOSE_PROJECT})..."
+  docker compose -p "${COMPOSE_PROJECT}" -f "${COMPOSE_FILE}" up -d --build
+
+  log_info "Waiting for API to be healthy..."
+  local elapsed=0
+  local interval=2
+  while [ "${elapsed}" -lt "${HEALTH_TIMEOUT}" ]; do
+    if check_backend; then
+      log_success "API is healthy."
+      break
+    fi
+    log_info "API not ready yet (${elapsed}s)..."
+    sleep "${interval}"
+    elapsed=$((elapsed + interval))
+    if [ "${elapsed}" -ge "${HEALTH_TIMEOUT}" ]; then
+      log_error "API health timeout reached (${HEALTH_TIMEOUT}s)."
+      exit 1
+    fi
+  done
+
+  log_info "Seeding database..."
+  cmd_reset
+
+  log_success "Agent test stack is up and ready."
+  cmd_status
+}
+
+cmd_down() {
+  log_info "Stopping agent test stack (project: ${COMPOSE_PROJECT})..."
+  docker compose -p "${COMPOSE_PROJECT}" -f "${COMPOSE_FILE}" down
+  log_success "Agent test stack is down."
+}
+
+# ─── Entrypoint ────────────────────────────────────────────────────────────────
+usage() {
+  echo -e "${CYAN}Usage:${NC} $(basename "$0") <subcommand>"
+  echo ""
+  echo -e "  ${GREEN}up${NC}      Start agent test stack + reset DB + seed"
+  echo -e "  ${GREEN}down${NC}    Stop agent test stack"
+  echo -e "  ${GREEN}reset${NC}   Reset the database (drop, recreate, migrate, seed) + restart API"
+  echo -e "  ${GREEN}status${NC}  Check health of API, postgres, and mailhog"
+  echo -e "  ${GREEN}wait${NC}    Block until all services are healthy (timeout: ${HEALTH_TIMEOUT}s)"
+  echo ""
+  echo -e "${CYAN}Ports:${NC}"
+  echo -e "  API       → 8081"
+  echo -e "  Postgres  → 5433"
+  echo -e "  MailHog   → 1026 (SMTP) / 8026 (UI)"
+  echo ""
+}
+
+if [ $# -lt 1 ]; then
+  usage
+  exit 1
+fi
+
+case "$1" in
+  up)     cmd_up     ;;
+  down)   cmd_down   ;;
+  reset)  cmd_reset  ;;
+  status) cmd_status ;;
+  wait)   cmd_wait   ;;
+  *)
+    log_error "Unknown subcommand: $1"
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Remove 4 RAM-heavy VSCode extensions (claude-code, docker, postgres, gitlens) — saves 6-11 GB
- Fix `npm install` → `pnpm install` in postCreateCommand
- Add isolated agent test stack (`docker-compose.agent-test.yml` + `agent-stack.sh`)
- Add Playwright headless MCP + Chrome CDP for local browser access from devcontainer
- Update CLAUDE.md with dual-stack documentation

## Test plan
- [ ] Rebuild devcontainer → verify RAM stays under ~2 GB
- [ ] `./scripts/agent-stack.sh up` → all 3 services UP on ports 8081/5433/8026
- [ ] Stable stack (8080) and test stack (8081) run simultaneously without conflict
- [ ] `./scripts/agent-stack.sh reset` resets only test DB
- [ ] `./scripts/reset-dev.sh` remains blocked in devcontainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)