### PR TITLE
fix(auth): prevent white page on app load

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,12 @@
     <title>hopeitworks</title>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app">
+      <div style="display:flex;align-items:center;justify-content:center;height:100vh;">
+        <div style="width:40px;height:40px;border:3px solid #e5e7eb;border-top-color:#6366f1;border-radius:50%;animation:spin 0.6s linear infinite;"></div>
+      </div>
+      <style>@keyframes spin{to{transform:rotate(360deg)}}</style>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,13 +5,13 @@
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>hopeitworks</title>
+    <style>@keyframes spin{to{transform:rotate(360deg)}}</style>
   </head>
   <body>
     <div id="app">
       <div style="display:flex;align-items:center;justify-content:center;height:100vh;">
         <div style="width:40px;height:40px;border:3px solid #e5e7eb;border-top-color:#6366f1;border-radius:50%;animation:spin 0.6s linear infinite;"></div>
       </div>
-      <style>@keyframes spin{to{transform:rotate(360deg)}}</style>
     </div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -32,4 +32,8 @@ app.use(PrimeVue, {
 
 router.isReady().then(() => {
   app.mount('#app')
+}).catch((err) => {
+  console.error('[router] Initial navigation failed:', err)
+  // Mount anyway — the app can handle its own error states
+  app.mount('#app')
 })

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -30,4 +30,6 @@ app.use(PrimeVue, {
   },
 })
 
-app.mount('#app')
+router.isReady().then(() => {
+  app.mount('#app')
+})

--- a/frontend/src/ui/layout/AppShell.vue
+++ b/frontend/src/ui/layout/AppShell.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref, computed, watch } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import Button from 'primevue/button'
+import ProgressSpinner from 'primevue/progressspinner'
 import Toast from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
 import AppHeader from './AppHeader.vue'
@@ -17,7 +18,9 @@ const layoutStore = useLayoutStore()
 const hitlStore = useHITLStore()
 const toast = useToast()
 const { isMobile } = useBreakpoint()
-const { isAuthenticated } = useAuth()
+const { isAuthenticated, loading: authLoading } = useAuth()
+const route = useRoute()
+const routeResolved = computed(() => route.matched.length > 0)
 const mobileSidebarOpen = ref(false)
 const router = useRouter()
 
@@ -92,7 +95,12 @@ function toggleMobileSidebar() {
 
 <template>
   <div class="flex h-screen flex-col overflow-hidden">
-    <template v-if="isAuthenticated">
+    <!-- Loading initial (premier check auth) -->
+    <div v-if="authLoading && !routeResolved" class="flex h-full items-center justify-center">
+      <ProgressSpinner />
+    </div>
+
+    <template v-else-if="isAuthenticated">
       <!-- Skip navigation link -->
       <a
         href="#main-content"

--- a/frontend/src/ui/layout/AppShell.vue
+++ b/frontend/src/ui/layout/AppShell.vue
@@ -20,6 +20,9 @@ const toast = useToast()
 const { isMobile } = useBreakpoint()
 const { isAuthenticated, loading: authLoading } = useAuth()
 const route = useRoute()
+// NOTE: With router.isReady() in main.ts, routeResolved is always true at mount time.
+// This computed is kept as a safety net for future programmatic navigations where
+// matched routes could momentarily be empty (e.g. dynamic route additions).
 const routeResolved = computed(() => route.matched.length > 0)
 const mobileSidebarOpen = ref(false)
 const router = useRouter()

--- a/frontend/src/ui/layout/__tests__/AppShell.spec.ts
+++ b/frontend/src/ui/layout/__tests__/AppShell.spec.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { ref, computed } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import PrimeVue from 'primevue/config'
+import ToastService from 'primevue/toastservice'
+
+// --- Mock dependencies before importing AppShell ---
+
+const mockIsAuthenticated = ref(false)
+const mockAuthLoading = ref(false)
+
+vi.mock('@/composables/useAuth', () => ({
+  useAuth: () => ({
+    isAuthenticated: computed(() => mockIsAuthenticated.value),
+    loading: computed(() => mockAuthLoading.value),
+  }),
+}))
+
+const mockRoute = ref({ matched: [{}] })
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return {
+    ...actual,
+    useRouter: () => ({ push: vi.fn() }),
+    useRoute: () => computed(() => mockRoute.value).value,
+  }
+})
+
+vi.mock('@/stores/layout', () => ({
+  useLayoutStore: () => ({
+    sidebarCollapsed: false,
+    toggleSidebar: vi.fn(),
+  }),
+}))
+
+vi.mock('@/stores/hitl', () => ({
+  useHITLStore: () => ({
+    pendingCount: 0,
+    pendingItems: [],
+    handleResolvedEvent: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useKeyboard', () => ({
+  useKeyboard: vi.fn(),
+}))
+
+vi.mock('@/composables/useBreakpoint', () => ({
+  useBreakpoint: () => ({ isMobile: ref(false) }),
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: vi.fn() }),
+}))
+
+import AppShell from '../AppShell.vue'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function mountShell() {
+  wrapper = mount(AppShell, {
+    global: {
+      plugins: [PrimeVue, ToastService, createPinia()],
+      stubs: {
+        AppHeader: true,
+        AppSidebar: true,
+        AppStatusBar: true,
+        ProgressSpinner: { template: '<div data-testid="progress-spinner" />' },
+        Toast: true,
+        RouterView: { template: '<div data-testid="router-view" />' },
+      },
+    },
+  })
+  return wrapper
+}
+
+describe('AppShell loading guard', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockIsAuthenticated.value = false
+    mockAuthLoading.value = false
+    mockRoute.value = { matched: [{}] }
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('shows ProgressSpinner when authLoading=true and routeResolved=false', async () => {
+    mockAuthLoading.value = true
+    mockRoute.value = { matched: [] } // route not yet resolved
+
+    mountShell()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="progress-spinner"]').exists()).toBe(true)
+  })
+
+  it('does not show ProgressSpinner when authLoading=false (normal post-mount state)', async () => {
+    mockAuthLoading.value = false
+    mockIsAuthenticated.value = false
+    mockRoute.value = { matched: [{}] }
+
+    mountShell()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="progress-spinner"]').exists()).toBe(false)
+  })
+
+  it('does not show ProgressSpinner when authLoading=true but route is already resolved', async () => {
+    // This is the normal case post router.isReady() fix — route is always resolved at mount
+    mockAuthLoading.value = true
+    mockRoute.value = { matched: [{}] } // route resolved
+
+    mountShell()
+    await wrapper.vm.$nextTick()
+
+    // authLoading && !routeResolved → false → spinner not shown
+    expect(wrapper.find('[data-testid="progress-spinner"]').exists()).toBe(false)
+  })
+
+  it('renders app chrome (authenticated layout) when isAuthenticated=true', async () => {
+    mockAuthLoading.value = false
+    mockIsAuthenticated.value = true
+    mockRoute.value = { matched: [{}] }
+
+    mountShell()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="progress-spinner"]').exists()).toBe(false)
+    // AppHeader stub is rendered in authenticated layout
+    expect(wrapper.findComponent({ name: 'AppHeader' }).exists()).toBe(true)
+  })
+
+  it('renders unauthenticated router-view when isAuthenticated=false and not loading', async () => {
+    mockAuthLoading.value = false
+    mockIsAuthenticated.value = false
+    mockRoute.value = { matched: [{}] }
+
+    mountShell()
+    await wrapper.vm.$nextTick()
+
+    // Unauthenticated branch shows router-view directly (login page)
+    expect(wrapper.find('[data-testid="router-view"]').exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'AppHeader' }).exists()).toBe(false)
+  })
+})
+
+describe('AppShell router.isReady() error resilience', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockIsAuthenticated.value = false
+    mockAuthLoading.value = false
+    mockRoute.value = { matched: [{}] }
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('mounts and renders without throwing when route has no matched entries', () => {
+    // Simulates the edge case where router.isReady() .catch() mounted the app
+    // before navigation completed — AppShell must not crash
+    mockRoute.value = { matched: [] }
+    mockAuthLoading.value = false
+    mockIsAuthenticated.value = false
+
+    expect(() => mountShell()).not.toThrow()
+  })
+
+  it('shows spinner when both authLoading and unresolved route occur together', async () => {
+    // This is exactly the scenario that .catch() in main.ts can produce:
+    // app mounts (due to error recovery), auth is still loading, route not matched
+    mockAuthLoading.value = true
+    mockRoute.value = { matched: [] }
+
+    mountShell()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="progress-spinner"]').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Scope

Implémente #215 — fix white page au chargement causée par le mount avant `router.isReady()`

## Changements

- **`main.ts`** : `router.isReady().then(() => app.mount('#app'))` — attend que la navigation initiale (guard auth `checkAuth()`) se résolve avant de monter l'app
- **`index.html`** : spinner CSS-only dans `<div id="app">` comme indicateur de chargement pendant l'init Vue (remplacé automatiquement au mount)
- **`AppShell.vue`** : guard loading initial avec `ProgressSpinner` — safety net si l'auth check est encore en cours quand le composant se monte

## Tests

- [x] Type-check clean (`vue-tsc --build`)
- [x] Lint clean (`eslint`)
- [x] Tests unitaires passent (72 fichiers, 682 tests)
- [ ] Smoke test navigateur — ouvrir sans token → login visible, pas de page blanche

Refs: #215