### PR TITLE
feat(agents): replace Select with AutoComplete for free-text model input

### DIFF
--- a/frontend/src/features/agents/AgentEditorLayout.vue
+++ b/frontend/src/features/agents/AgentEditorLayout.vue
@@ -2,13 +2,15 @@
 import { ref } from 'vue'
 import InputText from 'primevue/inputtext'
 import Select from 'primevue/select'
+import AutoComplete from 'primevue/autocomplete'
+import type { AutoCompleteCompleteEvent } from 'primevue/autocomplete'
 import Message from 'primevue/message'
 import MonacoEditorWrapper from './MonacoEditorWrapper.vue'
 import AgentVariableSidebar from './AgentVariableSidebar.vue'
 import AgentEditorToolbar from './AgentEditorToolbar.vue'
 import AgentPreviewDialog from './AgentPreviewDialog.vue'
 import type { AgentScope } from '@/stores/agents'
-import { LLM_MODEL_OPTIONS } from '@/utils/models'
+import { DEFAULT_MODEL_SUGGESTIONS } from '@/utils/models'
 
 interface Props {
   content: string
@@ -54,6 +56,15 @@ const providerOptions = [
   { label: 'OpenCode', value: 'opencode' },
 ]
 
+const filteredModels = ref<string[]>([])
+
+function searchModels(event: AutoCompleteCompleteEvent) {
+  const query = event.query.toLowerCase()
+  filteredModels.value = query
+    ? DEFAULT_MODEL_SUGGESTIONS.filter((m) => m.toLowerCase().includes(query))
+    : [...DEFAULT_MODEL_SUGGESTIONS]
+}
+
 const editorRef = ref<InstanceType<typeof MonacoEditorWrapper> | null>(null)
 </script>
 
@@ -96,14 +107,14 @@ const editorRef = ref<InstanceType<typeof MonacoEditorWrapper> | null>(null)
       </div>
       <div class="flex flex-col gap-1">
         <label class="text-xs font-medium text-surface-500">Model</label>
-        <Select
+        <AutoComplete
           :model-value="agentModel"
-          :options="LLM_MODEL_OPTIONS"
-          option-label="label"
-          option-value="value"
-          size="small"
-          class="w-64"
+          :suggestions="filteredModels"
+          dropdown
           :disabled="isReadOnly"
+          placeholder="Type or select a model..."
+          class="w-64"
+          @complete="searchModels"
           @update:model-value="emit('update:agentModel', $event)"
         />
       </div>

--- a/frontend/src/features/agents/__tests__/AgentEditorLayout.spec.ts
+++ b/frontend/src/features/agents/__tests__/AgentEditorLayout.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { DEFAULT_MODEL_SUGGESTIONS } from '@/utils/models'
+
+// Test the searchModels filtering logic extracted as a pure function
+// (mirrors the component's searchModels implementation)
+function searchModels(query: string): string[] {
+  const q = query.toLowerCase()
+  return q
+    ? DEFAULT_MODEL_SUGGESTIONS.filter((m) => m.toLowerCase().includes(q))
+    : [...DEFAULT_MODEL_SUGGESTIONS]
+}
+
+describe('AgentEditorLayout — searchModels', () => {
+  it('returns all suggestions when query is empty', () => {
+    const result = searchModels('')
+    expect(result).toEqual(DEFAULT_MODEL_SUGGESTIONS)
+    expect(result).not.toBe(DEFAULT_MODEL_SUGGESTIONS) // must be a copy
+  })
+
+  it('filters suggestions by partial query (case-insensitive)', () => {
+    const result = searchModels('opus')
+    expect(result).toEqual(['claude-opus-4-6'])
+  })
+
+  it('filters suggestions matching multiple models', () => {
+    const result = searchModels('claude')
+    expect(result).toEqual(DEFAULT_MODEL_SUGGESTIONS)
+  })
+
+  it('returns empty array when query matches nothing', () => {
+    const result = searchModels('gpt-4')
+    expect(result).toEqual([])
+  })
+
+  it('is case-insensitive', () => {
+    const lower = searchModels('sonnet')
+    const upper = searchModels('SONNET')
+    expect(lower).toEqual(upper)
+    expect(lower).toEqual(['claude-sonnet-4-6'])
+  })
+})

--- a/frontend/src/utils/models.ts
+++ b/frontend/src/utils/models.ts
@@ -1,6 +1,6 @@
-/** Available LLM model options for agent configuration */
-export const LLM_MODEL_OPTIONS = [
-  { label: 'Claude Opus 4 (claude-opus-4-6)', value: 'claude-opus-4-6' },
-  { label: 'Claude Sonnet 4 (claude-sonnet-4-6)', value: 'claude-sonnet-4-6' },
-  { label: 'Claude Haiku 3.5 (claude-haiku-3-5)', value: 'claude-haiku-3-5' },
+/** Default LLM model suggestions for AutoComplete */
+export const DEFAULT_MODEL_SUGGESTIONS: string[] = [
+  'claude-opus-4-6',
+  'claude-sonnet-4-6',
+  'claude-haiku-3-5',
 ]


### PR DESCRIPTION
## Scope

Implements #228 et #229 (parent #226)

## Changements

- **`frontend/src/utils/models.ts`** : remplace `LLM_MODEL_OPTIONS` (tableau d'objets `{label, value}`) par `DEFAULT_MODEL_SUGGESTIONS` (`string[]`) — les IDs de modèle sont déjà lisibles et cohérents avec le type `model: string` de l'API
- **`frontend/src/features/agents/AgentEditorLayout.vue`** : remplace le `Select` PrimeVue par un `AutoComplete` pour le champ modèle, avec `searchModels` pour filtrer les suggestions, sans `forceSelection` (saisie libre de modèles custom)
- **`frontend/src/features/agents/__tests__/AgentEditorLayout.spec.ts`** : tests unitaires pour la logique de filtrage `searchModels` (query vide → toutes, query partielle → filtrées, insensible à la casse, no-match → vide)

## Tests

- [x] Type-check clean
- [x] Lint clean
- [x] Tests unitaires passent (708 tests, 76 fichiers)
- [ ] Smoke test navigateur

Refs: #228, #229