### PR TITLE
chore(ci): build & push agent images to ghcr.io

### DIFF
--- a/.github/workflows/agent-images.yml
+++ b/.github/workflows/agent-images.yml
@@ -1,0 +1,105 @@
+name: Agent Images
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/zkarahacane/hopeitworks
+
+jobs:
+  build-base:
+    name: Build agent-base
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata for agent-base
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/agent-base
+          tags: |
+            type=raw,value=latest
+            type=ref,event=tag
+
+      - name: Build and push agent-base
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: agent-images/base/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=agent-base
+          cache-to: type=gha,mode=max,scope=agent-base
+
+  build-stacks:
+    name: Build agent-${{ matrix.stack }}
+    needs: build-base
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    strategy:
+      matrix:
+        stack: [go, node, go-node, python]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata for agent-${{ matrix.stack }}
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/agent-${{ matrix.stack }}
+          tags: |
+            type=raw,value=latest
+            type=ref,event=tag
+
+      - name: Build and push agent-${{ matrix.stack }}
+        uses: docker/build-push-action@v6
+        with:
+          context: agent-images
+          file: agent-images/stacks/${{ matrix.stack }}/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-contexts: |
+            hopeitworks/agent-base=docker-image://${{ env.IMAGE_PREFIX }}/agent-base:latest
+          cache-from: type=gha,scope=agent-${{ matrix.stack }}
+          cache-to: type=gha,mode=max,scope=agent-${{ matrix.stack }}


### PR DESCRIPTION
## Summary

- Ajoute `.github/workflows/agent-images.yml` : build et push des 5 images Docker des agents vers `ghcr.io/zkarahacane/hopeitworks/`
- Gère la dépendance base→stacks : `build-base` s'exécute en premier, `build-stacks` attend via `needs: build-base`
- Cache GHA par scope pour optimiser les rebuilds

## Déclenchement

- **`workflow_dispatch`** : lancement manuel depuis l'UI GitHub Actions
- **`push` sur tag `v*`** : déclenché automatiquement à chaque release taguée (ex. `v1.0.0`)

## Convention de nommage des images

Alignée sur le `Makefile` (préfixe `agent-`), poussée vers ghcr.io :

| Image | Tag(s) |
|-------|--------|
| `ghcr.io/zkarahacane/hopeitworks/agent-base` | `latest` + tag git |
| `ghcr.io/zkarahacane/hopeitworks/agent-go` | `latest` + tag git |
| `ghcr.io/zkarahacane/hopeitworks/agent-node` | `latest` + tag git |
| `ghcr.io/zkarahacane/hopeitworks/agent-go-node` | `latest` + tag git |
| `ghcr.io/zkarahacane/hopeitworks/agent-python` | `latest` + tag git |

## Gestion base→stacks

Le job `build-base` build l'image `agent-base` avec **contexte = racine du repo** (identique au Makefile : `docker build ... -f base/Dockerfile ..`) car le Dockerfile embarque `agent-runtime/` via un COPY multi-stage.

Le job `build-stacks` (matrix sur `[go, node, go-node, python]`) attend `build-base` via `needs`, puis référence l'image base déjà pushée sur ghcr.io via `build-contexts: hopeitworks/agent-base=docker-image://ghcr.io/...` — ce qui satisfait le `FROM hopeitworks/agent-base:latest` des Dockerfiles stacks sans modifier ces fichiers.

Le contexte des stacks est `agent-images/` (équivalent au `.` du Makefile exécuté depuis `agent-images/`).

## Auth ghcr.io

Login avec `GITHUB_TOKEN` (secret automatique), permissions `packages: write` + `contents: read` déclarées par job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)