### PR TITLE
chore(deploy): decouple API host port from app port

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -79,7 +79,9 @@ services:
     #volumes:
     #  - ../agent/claude-md:/app/agent/claude-md:ro
     ports:
-      - "${SERVER_PORT:-8080}:8080"
+      # Host port decoupled from the app port (SERVER_PORT) so the stack can run
+      # alongside other local stacks without port collisions. App still listens on 8080.
+      - "${API_HOST_PORT:-8080}:8080"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Permet de publier l'API sur un port hôte alternatif (`API_HOST_PORT`) sans collision avec d'autres stacks locaux (cas multi-clients). L'app écoute toujours sur 8080 dans le container, callbacks inchangés. Validé E2E : stack up sur 8090/5434/8027, login + seed OK.