### PR TITLE
feat(board): live kanban API — latest_run, story_counts, story_id in events

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2693,6 +2693,10 @@ components:
           $ref: "#/components/schemas/StoryStatus"
         acceptance_criteria:
           type: string
+        latest_run:
+          $ref: "#/components/schemas/LatestRun"
+          nullable: true
+          description: Most recent run for the story with its current pipeline step, for the live board. Null when the story has never been run.
         created_at:
           type: string
           format: date-time
@@ -2704,6 +2708,57 @@ components:
       type: string
       enum: [backlog, running, done, failed]
       default: backlog
+
+    LatestRun:
+      type: object
+      description: Lightweight projection of a story's most recent run for the live kanban.
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          description: Run status (pending, running, paused, completed, failed, cancelled)
+          example: running
+        current_step:
+          $ref: "#/components/schemas/LatestRunStep"
+          nullable: true
+          description: Step currently running or waiting for approval. Null when no step is in progress.
+
+    LatestRunStep:
+      type: object
+      description: The currently active step of a run and its position in the pipeline.
+      required:
+        - id
+        - name
+        - action_type
+        - status
+        - index
+        - total
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: implement
+        action_type:
+          type: string
+          example: agent_run
+        status:
+          type: string
+          example: running
+        index:
+          type: integer
+          description: Zero-based position (step_order) of the current step
+          example: 1
+        total:
+          type: integer
+          description: Total number of steps in the run
+          example: 4
 
     StoryList:
       type: object

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -128,6 +128,10 @@ func run() error {
 
 	projectHandler := handler.NewProjectHandler(projectService, projectUserService, circuitBreakerService)
 
+	// Run repository (shared by run service, pipeline executor, story/epic handlers,
+	// and other components).
+	runRepo := pgadapter.NewRunRepo(queries)
+
 	// Epic service
 	epicRepo := pgadapter.NewEpicRepo(queries)
 	epicService := service.NewEpicService(epicRepo)
@@ -135,7 +139,7 @@ func run() error {
 	// Story service
 	storyRepo := pgadapter.NewStoryRepo(queries)
 	storyService := service.NewStoryService(storyRepo)
-	storyHandler := handler.NewStoryHandler(storyService)
+	storyHandler := handler.NewStoryHandler(storyService, runRepo)
 
 	// Scheduler service (DAG computation, pure domain service)
 	schedulerService := service.NewSchedulerService()
@@ -169,9 +173,6 @@ func run() error {
 
 	// Background cleanup of expired revoked tokens
 	startTokenCleanup(appCtx, authService, logger)
-
-	// Run repository (shared by run service, pipeline executor, and other components)
-	runRepo := pgadapter.NewRunRepo(queries)
 
 	// Cost service
 	costRepo := pgadapter.NewCostRepo(queries)

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -975,3 +975,15 @@ func TestAgentRunAction_ModelFallback(t *testing.T) {
 		}
 	}
 }
+
+func (m *mockStoryRepo) CountByEpicGroupedByStatus(_ context.Context, _ uuid.UUID) (model.StoryCounts, error) {
+	return model.StoryCounts{}, nil
+}
+
+func (m *mockRunRepo) GetLatestRunByStory(_ context.Context, _ uuid.UUID) (*model.LatestRun, error) {
+	return nil, nil
+}
+
+func (m *mockRunRepo) GetLatestRunsByStories(_ context.Context, _ []uuid.UUID) (map[uuid.UUID]*model.LatestRun, error) {
+	return map[uuid.UUID]*model.LatestRun{}, nil
+}

--- a/backend/internal/adapter/action/git_branch_test.go
+++ b/backend/internal/adapter/action/git_branch_test.go
@@ -504,3 +504,7 @@ func TestGitBranchAction_Execute_NilConfig(t *testing.T) {
 		t.Fatalf("expected branch to use default pattern, got %q", calls[0].BranchName)
 	}
 }
+
+func (m *gbMockStoryRepo) CountByEpicGroupedByStatus(_ context.Context, _ uuid.UUID) (model.StoryCounts, error) {
+	return model.StoryCounts{}, nil
+}

--- a/backend/internal/adapter/action/git_pr_test.go
+++ b/backend/internal/adapter/action/git_pr_test.go
@@ -592,3 +592,7 @@ func TestGitPRAction_Execute_ObjectiveTruncation(t *testing.T) {
 		t.Error("expected truncated objective to end with ellipsis")
 	}
 }
+
+func (m *prMockStoryRepo) CountByEpicGroupedByStatus(_ context.Context, _ uuid.UUID) (model.StoryCounts, error) {
+	return model.StoryCounts{}, nil
+}

--- a/backend/internal/adapter/action/hitl_gate_test.go
+++ b/backend/internal/adapter/action/hitl_gate_test.go
@@ -547,3 +547,15 @@ func TestHITLGateAction_Execute_StoryFetchFails(t *testing.T) {
 		t.Fatalf("expected error containing %q, got %q", "fetch story", err.Error())
 	}
 }
+
+func (m *hitlMockStoryRepo) CountByEpicGroupedByStatus(_ context.Context, _ uuid.UUID) (model.StoryCounts, error) {
+	return model.StoryCounts{}, nil
+}
+
+func (m *hitlMockRunRepo) GetLatestRunByStory(_ context.Context, _ uuid.UUID) (*model.LatestRun, error) {
+	return nil, nil
+}
+
+func (m *hitlMockRunRepo) GetLatestRunsByStories(_ context.Context, _ []uuid.UUID) (map[uuid.UUID]*model.LatestRun, error) {
+	return map[uuid.UUID]*model.LatestRun{}, nil
+}

--- a/backend/internal/adapter/action/human_test.go
+++ b/backend/internal/adapter/action/human_test.go
@@ -494,3 +494,15 @@ func TestHumanAction_Execute_StoryFetchFails(t *testing.T) {
 		t.Fatalf("expected no status updates when story fetch fails, got %d", len(runRepo.statusCalls))
 	}
 }
+
+func (m *humanMockStoryRepo) CountByEpicGroupedByStatus(_ context.Context, _ uuid.UUID) (model.StoryCounts, error) {
+	return model.StoryCounts{}, nil
+}
+
+func (m *humanMockRunRepo) GetLatestRunByStory(_ context.Context, _ uuid.UUID) (*model.LatestRun, error) {
+	return nil, nil
+}
+
+func (m *humanMockRunRepo) GetLatestRunsByStories(_ context.Context, _ []uuid.UUID) (map[uuid.UUID]*model.LatestRun, error) {
+	return map[uuid.UUID]*model.LatestRun{}, nil
+}

--- a/backend/internal/adapter/action/incremental_retry_test.go
+++ b/backend/internal/adapter/action/incremental_retry_test.go
@@ -361,3 +361,11 @@ func TestIncrementalRetryAction_CustomRetryPolicy(t *testing.T) {
 		t.Error("expected error_context to be cleared for full retry")
 	}
 }
+
+func (m *retryMockRunRepo) GetLatestRunByStory(_ context.Context, _ uuid.UUID) (*model.LatestRun, error) {
+	return nil, nil
+}
+
+func (m *retryMockRunRepo) GetLatestRunsByStories(_ context.Context, _ []uuid.UUID) (map[uuid.UUID]*model.LatestRun, error) {
+	return map[uuid.UUID]*model.LatestRun{}, nil
+}

--- a/backend/internal/adapter/action/notification_test.go
+++ b/backend/internal/adapter/action/notification_test.go
@@ -384,3 +384,7 @@ func TestNotificationAction_Execute_StoryLookupFailure(t *testing.T) {
 		t.Errorf("payload[message] = %q, want %q", payload["message"], expectedMessage)
 	}
 }
+
+func (m *notificationMockStoryRepo) CountByEpicGroupedByStatus(_ context.Context, _ uuid.UUID) (model.StoryCounts, error) {
+	return model.StoryCounts{}, nil
+}

--- a/backend/internal/adapter/postgres/live_kanban_integration_test.go
+++ b/backend/internal/adapter/postgres/live_kanban_integration_test.go
@@ -1,0 +1,221 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/zakari/hopeitworks/backend/internal/adapter/postgres"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+)
+
+func createTestEpic(t *testing.T, pool *pgxpool.Pool, projectID uuid.UUID) uuid.UUID {
+	t.Helper()
+	epicID := uuid.New()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO epics (id, project_id, name, status) VALUES ($1, $2, $3, $4)`,
+		epicID, projectID, "Epic-"+epicID.String()[:8], "backlog",
+	)
+	if err != nil {
+		t.Fatalf("failed to create test epic: %v", err)
+	}
+	return epicID
+}
+
+func createTestStoryWithEpic(t *testing.T, pool *pgxpool.Pool, projectID, epicID uuid.UUID, status string) uuid.UUID {
+	t.Helper()
+	storyID := uuid.New()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO stories (id, project_id, epic_id, key, title, status)
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		storyID, projectID, epicID, "S-"+storyID.String()[:6], "Story", status,
+	)
+	if err != nil {
+		t.Fatalf("failed to create test story: %v", err)
+	}
+	return storyID
+}
+
+// TestIntegration_GetLatestRunByStory exercises the latest-run projection against
+// a real Postgres, including the NULL current_step case (no step in progress).
+func TestIntegration_GetLatestRunByStory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db := setupTestDB(t)
+	defer db.cleanup()
+
+	ctx := context.Background()
+	queries := postgres.New(db.pool)
+	runRepo := postgres.NewRunRepo(queries)
+
+	projectID := createTestProject(t, db.pool)
+	storyID := createTestStory(t, db.pool, projectID)
+
+	// No run yet -> nil.
+	latest, err := runRepo.GetLatestRunByStory(ctx, storyID)
+	if err != nil {
+		t.Fatalf("GetLatestRunByStory() error = %v", err)
+	}
+	if latest != nil {
+		t.Fatalf("expected nil latest run, got %+v", latest)
+	}
+
+	// Create a run with 3 steps: completed, running, pending.
+	run, err := runRepo.CreateRun(ctx, &model.Run{
+		ProjectID: projectID,
+		StoryID:   storyID,
+		Status:    model.RunStatusRunning,
+	})
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	s0, _ := runRepo.CreateRunStep(ctx, &model.RunStep{RunID: run.ID, StepName: "branch", StepOrder: 0, Action: "git_branch", Status: model.StepStatusPending})
+	s1, _ := runRepo.CreateRunStep(ctx, &model.RunStep{RunID: run.ID, StepName: "implement", StepOrder: 1, Action: "agent_run", Status: model.StepStatusPending})
+	_, _ = runRepo.CreateRunStep(ctx, &model.RunStep{RunID: run.ID, StepName: "review", StepOrder: 2, Action: "agent_run", Status: model.StepStatusPending})
+
+	if _, err := runRepo.UpdateRunStepStatus(ctx, s0.ID, model.StepStatusCompleted, nil, nil, nil); err != nil {
+		t.Fatalf("UpdateRunStepStatus(s0) error = %v", err)
+	}
+	if _, err := runRepo.UpdateRunStepStatus(ctx, s1.ID, model.StepStatusRunning, nil, nil, nil); err != nil {
+		t.Fatalf("UpdateRunStepStatus(s1) error = %v", err)
+	}
+
+	latest, err = runRepo.GetLatestRunByStory(ctx, storyID)
+	if err != nil {
+		t.Fatalf("GetLatestRunByStory() error = %v", err)
+	}
+	if latest == nil {
+		t.Fatal("expected latest run, got nil")
+	}
+	if latest.ID != run.ID {
+		t.Errorf("expected run %s, got %s", run.ID, latest.ID)
+	}
+	if latest.CurrentStep == nil {
+		t.Fatal("expected current step (running), got nil")
+	}
+	if latest.CurrentStep.ID != s1.ID {
+		t.Errorf("expected current step %s, got %s", s1.ID, latest.CurrentStep.ID)
+	}
+	if latest.CurrentStep.Name != "implement" || latest.CurrentStep.ActionType != "agent_run" {
+		t.Errorf("unexpected current step fields: %+v", latest.CurrentStep)
+	}
+	if latest.CurrentStep.Index != 1 {
+		t.Errorf("expected current step index 1, got %d", latest.CurrentStep.Index)
+	}
+	if latest.CurrentStep.Total != 3 {
+		t.Errorf("expected total 3, got %d", latest.CurrentStep.Total)
+	}
+
+	// Complete the running step -> no step in progress -> current_step NULL.
+	if _, err := runRepo.UpdateRunStepStatus(ctx, s1.ID, model.StepStatusCompleted, nil, nil, nil); err != nil {
+		t.Fatalf("UpdateRunStepStatus(s1 complete) error = %v", err)
+	}
+	latest, err = runRepo.GetLatestRunByStory(ctx, storyID)
+	if err != nil {
+		t.Fatalf("GetLatestRunByStory() error = %v", err)
+	}
+	if latest == nil {
+		t.Fatal("expected latest run, got nil")
+	}
+	if latest.CurrentStep != nil {
+		t.Errorf("expected nil current step when none in progress, got %+v", latest.CurrentStep)
+	}
+}
+
+// TestIntegration_GetLatestRunsByStories verifies the batch latest-run query
+// returns the most recent run per story and skips stories without runs.
+func TestIntegration_GetLatestRunsByStories(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db := setupTestDB(t)
+	defer db.cleanup()
+
+	ctx := context.Background()
+	queries := postgres.New(db.pool)
+	runRepo := postgres.NewRunRepo(queries)
+
+	projectID := createTestProject(t, db.pool)
+	storyA := createTestStory(t, db.pool, projectID)
+	storyB := createTestStory(t, db.pool, projectID)
+	storyNoRun := createTestStory(t, db.pool, projectID)
+
+	// storyA: two runs; the latest should win.
+	_, _ = runRepo.CreateRun(ctx, &model.Run{ProjectID: projectID, StoryID: storyA, Status: model.RunStatusFailed})
+	runA2, _ := runRepo.CreateRun(ctx, &model.Run{ProjectID: projectID, StoryID: storyA, Status: model.RunStatusRunning})
+	sA, _ := runRepo.CreateRunStep(ctx, &model.RunStep{RunID: runA2.ID, StepName: "impl", StepOrder: 0, Action: "agent_run", Status: model.StepStatusPending})
+	_, _ = runRepo.UpdateRunStepStatus(ctx, sA.ID, model.StepStatusWaitingApproval, nil, nil, nil)
+
+	// storyB: one run, no step in progress.
+	runB, _ := runRepo.CreateRun(ctx, &model.Run{ProjectID: projectID, StoryID: storyB, Status: model.RunStatusCompleted})
+
+	got, err := runRepo.GetLatestRunsByStories(ctx, []uuid.UUID{storyA, storyB, storyNoRun})
+	if err != nil {
+		t.Fatalf("GetLatestRunsByStories() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries (storyNoRun absent), got %d", len(got))
+	}
+	if got[storyA] == nil || got[storyA].ID != runA2.ID {
+		t.Errorf("storyA: expected latest run %s, got %+v", runA2.ID, got[storyA])
+	}
+	if got[storyA].CurrentStep == nil || got[storyA].CurrentStep.Status != string(model.StepStatusWaitingApproval) {
+		t.Errorf("storyA: expected waiting_approval current step, got %+v", got[storyA].CurrentStep)
+	}
+	if got[storyB] == nil || got[storyB].ID != runB.ID {
+		t.Errorf("storyB: expected latest run %s, got %+v", runB.ID, got[storyB])
+	}
+	if got[storyB].CurrentStep != nil {
+		t.Errorf("storyB: expected nil current step, got %+v", got[storyB].CurrentStep)
+	}
+	if _, ok := got[storyNoRun]; ok {
+		t.Errorf("storyNoRun should be absent from result map")
+	}
+}
+
+// TestIntegration_CountStoriesByEpicGroupedByStatus verifies the grouped count
+// query aggregates story statuses for an epic in a single query.
+func TestIntegration_CountStoriesByEpicGroupedByStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db := setupTestDB(t)
+	defer db.cleanup()
+
+	ctx := context.Background()
+	queries := postgres.New(db.pool)
+	storyRepo := postgres.NewStoryRepo(queries)
+
+	projectID := createTestProject(t, db.pool)
+	epicID := createTestEpic(t, db.pool, projectID)
+
+	createTestStoryWithEpic(t, db.pool, projectID, epicID, model.StoryStatusBacklog)
+	createTestStoryWithEpic(t, db.pool, projectID, epicID, model.StoryStatusBacklog)
+	createTestStoryWithEpic(t, db.pool, projectID, epicID, model.StoryStatusRunning)
+	createTestStoryWithEpic(t, db.pool, projectID, epicID, model.StoryStatusDone)
+	createTestStoryWithEpic(t, db.pool, projectID, epicID, model.StoryStatusDone)
+	createTestStoryWithEpic(t, db.pool, projectID, epicID, model.StoryStatusFailed)
+
+	counts, err := storyRepo.CountByEpicGroupedByStatus(ctx, epicID)
+	if err != nil {
+		t.Fatalf("CountByEpicGroupedByStatus() error = %v", err)
+	}
+	if counts.Backlog != 2 || counts.Running != 1 || counts.Done != 2 || counts.Failed != 1 {
+		t.Errorf("unexpected counts: %+v", counts)
+	}
+
+	// Empty epic -> all zeros.
+	emptyEpic := createTestEpic(t, db.pool, projectID)
+	empty, err := storyRepo.CountByEpicGroupedByStatus(ctx, emptyEpic)
+	if err != nil {
+		t.Fatalf("CountByEpicGroupedByStatus(empty) error = %v", err)
+	}
+	if empty.Backlog != 0 || empty.Running != 0 || empty.Done != 0 || empty.Failed != 0 {
+		t.Errorf("expected zero counts for empty epic, got %+v", empty)
+	}
+}

--- a/backend/internal/adapter/postgres/run_repo.go
+++ b/backend/internal/adapter/postgres/run_repo.go
@@ -79,6 +79,70 @@ func (r *RunRepo) GetActiveRunByStory(ctx context.Context, storyID uuid.UUID) (*
 	return toDomainRun(row), nil
 }
 
+func (r *RunRepo) GetLatestRunByStory(ctx context.Context, storyID uuid.UUID) (*model.LatestRun, error) {
+	row, err := r.queries.GetLatestRunByStory(ctx, storyID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, apperrors.NewInternal("failed to get latest run by story", err)
+	}
+	return toDomainLatestRun(row.RunID, row.RunStatus, row.CurrentStep, row.TotalSteps)
+}
+
+func (r *RunRepo) GetLatestRunsByStories(ctx context.Context, storyIDs []uuid.UUID) (map[uuid.UUID]*model.LatestRun, error) {
+	result := make(map[uuid.UUID]*model.LatestRun, len(storyIDs))
+	if len(storyIDs) == 0 {
+		return result, nil
+	}
+	rows, err := r.queries.GetLatestRunsByStories(ctx, storyIDs)
+	if err != nil {
+		return nil, apperrors.NewInternal("failed to get latest runs by stories", err)
+	}
+	for _, row := range rows {
+		latest, err := toDomainLatestRun(row.RunID, row.RunStatus, row.CurrentStep, row.TotalSteps)
+		if err != nil {
+			return nil, err
+		}
+		result[row.StoryID] = latest
+	}
+	return result, nil
+}
+
+// currentStepJSON mirrors the JSON object produced by to_jsonb in the
+// GetLatestRun* queries.
+type currentStepJSON struct {
+	ID         uuid.UUID `json:"id"`
+	Name       string    `json:"name"`
+	ActionType string    `json:"action_type"`
+	Status     string    `json:"status"`
+	Index      int       `json:"index"`
+}
+
+// toDomainLatestRun maps the latest-run query columns into a domain LatestRun,
+// decoding the optional current-step JSON blob (NULL when no step is in progress).
+func toDomainLatestRun(runID uuid.UUID, runStatus string, currentStep []byte, totalSteps int32) (*model.LatestRun, error) {
+	latest := &model.LatestRun{
+		ID:     runID,
+		Status: runStatus,
+	}
+	if len(currentStep) > 0 {
+		var cs currentStepJSON
+		if err := json.Unmarshal(currentStep, &cs); err != nil {
+			return nil, apperrors.NewInternal("failed to unmarshal current step", err)
+		}
+		latest.CurrentStep = &model.LatestRunStep{
+			ID:         cs.ID,
+			Name:       cs.Name,
+			ActionType: cs.ActionType,
+			Status:     cs.Status,
+			Index:      cs.Index,
+			Total:      int(totalSteps),
+		}
+	}
+	return latest, nil
+}
+
 func (r *RunRepo) ListRunsByProject(ctx context.Context, projectID uuid.UUID, limit, offset int32) ([]*model.Run, error) {
 	rows, err := r.queries.ListRunsByProjectWithStoryKey(ctx, ListRunsByProjectWithStoryKeyParams{
 		ProjectID: projectID,

--- a/backend/internal/adapter/postgres/runs.sql.go
+++ b/backend/internal/adapter/postgres/runs.sql.go
@@ -102,6 +102,108 @@ func (q *Queries) GetActiveRunByStory(ctx context.Context, storyID uuid.UUID) (R
 	return i, err
 }
 
+const getLatestRunByStory = `-- name: GetLatestRunByStory :one
+SELECT
+    r.id AS run_id,
+    r.status AS run_status,
+    (
+        SELECT to_jsonb(cs)
+        FROM (
+            SELECT s.id, s.step_name AS name, s.action AS action_type, s.status, s.step_order AS index
+            FROM run_steps s
+            WHERE s.run_id = r.id AND s.status IN ('running', 'waiting_approval')
+            ORDER BY s.step_order ASC
+            LIMIT 1
+        ) cs
+    ) AS current_step,
+    (SELECT COUNT(*) FROM run_steps s WHERE s.run_id = r.id)::int AS total_steps
+FROM runs r
+WHERE r.story_id = $1
+ORDER BY r.created_at DESC
+LIMIT 1
+`
+
+type GetLatestRunByStoryRow struct {
+	RunID       uuid.UUID `json:"run_id"`
+	RunStatus   string    `json:"run_status"`
+	CurrentStep []byte    `json:"current_step"`
+	TotalSteps  int32     `json:"total_steps"`
+}
+
+// Returns the most recent run for a story along with its current in-progress step
+// (running or waiting_approval, lowest step_order) and the total step count.
+// current_step is a JSON object (NULL when no step is in progress) carrying
+// id, name, action_type, status and index (step_order).
+func (q *Queries) GetLatestRunByStory(ctx context.Context, storyID uuid.UUID) (GetLatestRunByStoryRow, error) {
+	row := q.db.QueryRow(ctx, getLatestRunByStory, storyID)
+	var i GetLatestRunByStoryRow
+	err := row.Scan(
+		&i.RunID,
+		&i.RunStatus,
+		&i.CurrentStep,
+		&i.TotalSteps,
+	)
+	return i, err
+}
+
+const getLatestRunsByStories = `-- name: GetLatestRunsByStories :many
+SELECT DISTINCT ON (r.story_id)
+    r.story_id AS story_id,
+    r.id AS run_id,
+    r.status AS run_status,
+    (
+        SELECT to_jsonb(cs)
+        FROM (
+            SELECT s.id, s.step_name AS name, s.action AS action_type, s.status, s.step_order AS index
+            FROM run_steps s
+            WHERE s.run_id = r.id AND s.status IN ('running', 'waiting_approval')
+            ORDER BY s.step_order ASC
+            LIMIT 1
+        ) cs
+    ) AS current_step,
+    (SELECT COUNT(*) FROM run_steps s WHERE s.run_id = r.id)::int AS total_steps
+FROM runs r
+WHERE r.story_id = ANY($1::uuid[])
+ORDER BY r.story_id, r.created_at DESC
+`
+
+type GetLatestRunsByStoriesRow struct {
+	StoryID     uuid.UUID `json:"story_id"`
+	RunID       uuid.UUID `json:"run_id"`
+	RunStatus   string    `json:"run_status"`
+	CurrentStep []byte    `json:"current_step"`
+	TotalSteps  int32     `json:"total_steps"`
+}
+
+// Batch version of GetLatestRunByStory: returns the most recent run per story
+// for the given story IDs, with current step (JSON) and total step count.
+// Avoids N+1 when listing stories of an epic.
+func (q *Queries) GetLatestRunsByStories(ctx context.Context, dollar_1 []uuid.UUID) ([]GetLatestRunsByStoriesRow, error) {
+	rows, err := q.db.Query(ctx, getLatestRunsByStories, dollar_1)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetLatestRunsByStoriesRow{}
+	for rows.Next() {
+		var i GetLatestRunsByStoriesRow
+		if err := rows.Scan(
+			&i.StoryID,
+			&i.RunID,
+			&i.RunStatus,
+			&i.CurrentStep,
+			&i.TotalSteps,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getRun = `-- name: GetRun :one
 SELECT id, project_id, story_id, status, pipeline_config_snapshot, started_at, completed_at, error_message, created_at, updated_at, paused_at, metadata FROM runs WHERE id = $1
 `

--- a/backend/internal/adapter/postgres/stories.sql.go
+++ b/backend/internal/adapter/postgres/stories.sql.go
@@ -12,6 +12,38 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const countStoriesByEpicGroupedByStatus = `-- name: CountStoriesByEpicGroupedByStatus :many
+SELECT status, COUNT(*) AS count
+FROM stories
+WHERE epic_id = $1
+GROUP BY status
+`
+
+type CountStoriesByEpicGroupedByStatusRow struct {
+	Status string `json:"status"`
+	Count  int64  `json:"count"`
+}
+
+func (q *Queries) CountStoriesByEpicGroupedByStatus(ctx context.Context, epicID pgtype.UUID) ([]CountStoriesByEpicGroupedByStatusRow, error) {
+	rows, err := q.db.Query(ctx, countStoriesByEpicGroupedByStatus, epicID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CountStoriesByEpicGroupedByStatusRow{}
+	for rows.Next() {
+		var i CountStoriesByEpicGroupedByStatusRow
+		if err := rows.Scan(&i.Status, &i.Count); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const countStoriesByProject = `-- name: CountStoriesByProject :one
 SELECT COUNT(*) FROM stories WHERE project_id = $1
 `

--- a/backend/internal/adapter/postgres/story_repo.go
+++ b/backend/internal/adapter/postgres/story_repo.go
@@ -163,6 +163,27 @@ func (r *StoryRepo) CountByStatus(ctx context.Context, projectID uuid.UUID, stat
 	return count, nil
 }
 
+func (r *StoryRepo) CountByEpicGroupedByStatus(ctx context.Context, epicID uuid.UUID) (model.StoryCounts, error) {
+	rows, err := r.queries.CountStoriesByEpicGroupedByStatus(ctx, pgtype.UUID{Bytes: epicID, Valid: true})
+	if err != nil {
+		return model.StoryCounts{}, apperrors.NewInternal("failed to count stories by epic grouped by status", err)
+	}
+	var counts model.StoryCounts
+	for _, row := range rows {
+		switch row.Status {
+		case model.StoryStatusBacklog:
+			counts.Backlog = int(row.Count)
+		case model.StoryStatusRunning:
+			counts.Running = int(row.Count)
+		case model.StoryStatusDone:
+			counts.Done = int(row.Count)
+		case model.StoryStatusFailed:
+			counts.Failed = int(row.Count)
+		}
+	}
+	return counts, nil
+}
+
 func (r *StoryRepo) Update(ctx context.Context, story *model.Story) (*model.Story, error) {
 	targetFiles, err := marshalJSONB(story.TargetFiles)
 	if err != nil {

--- a/backend/internal/api/handler/epic_handler.go
+++ b/backend/internal/api/handler/epic_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
@@ -39,7 +40,7 @@ func (h *EpicHandler) ListEpics(w http.ResponseWriter, r *http.Request, projectI
 		},
 	}
 	for i, e := range result.Epics {
-		resp.Data[i] = toAPIEpic(e)
+		resp.Data[i] = h.toAPIEpic(r.Context(), e)
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -72,7 +73,7 @@ func (h *EpicHandler) CreateEpic(w http.ResponseWriter, r *http.Request, project
 		return
 	}
 
-	writeJSON(w, http.StatusCreated, toAPIEpic(epic))
+	writeJSON(w, http.StatusCreated, h.toAPIEpic(r.Context(), epic))
 }
 
 // GetEpic handles GET /projects/{projectId}/epics/{epicId}.
@@ -83,7 +84,7 @@ func (h *EpicHandler) GetEpic(w http.ResponseWriter, r *http.Request, _ ProjectI
 		return
 	}
 
-	writeJSON(w, http.StatusOK, toAPIEpic(epic))
+	writeJSON(w, http.StatusOK, h.toAPIEpic(r.Context(), epic))
 }
 
 // UpdateEpic handles PUT /projects/{projectId}/epics/{epicId}.
@@ -114,7 +115,7 @@ func (h *EpicHandler) UpdateEpic(w http.ResponseWriter, r *http.Request, _ Proje
 		return
 	}
 
-	writeJSON(w, http.StatusOK, toAPIEpic(epic))
+	writeJSON(w, http.StatusOK, h.toAPIEpic(r.Context(), epic))
 }
 
 // DeleteEpic handles DELETE /projects/{projectId}/epics/{epicId}.
@@ -177,8 +178,19 @@ func toEpicDAGResponse(dag model.DAGResult) EpicDAGResponse {
 	return EpicDAGResponse{Nodes: nodes, Edges: edges}
 }
 
-// toAPIEpic converts a domain Epic to the API Epic type.
-func toAPIEpic(e *model.Epic) Epic {
+// toAPIEpic converts a domain Epic to the API Epic type, populating story_counts
+// (per story.status) via a single grouped query. Count errors are non-fatal:
+// the epic is still returned with zeroed counts.
+func (h *EpicHandler) toAPIEpic(ctx context.Context, e *model.Epic) Epic {
+	counts, err := h.storyRepo.CountByEpicGroupedByStatus(ctx, e.ID)
+	if err != nil {
+		counts = model.StoryCounts{}
+	}
+	return buildAPIEpic(e, counts)
+}
+
+// buildAPIEpic converts a domain Epic plus its story counts to the API Epic type.
+func buildAPIEpic(e *model.Epic, counts model.StoryCounts) Epic {
 	epic := Epic{
 		Id:        e.ID,
 		ProjectId: e.ProjectID,
@@ -186,6 +198,12 @@ func toAPIEpic(e *model.Epic) Epic {
 		Status:    EpicStatus(e.Status),
 		CreatedAt: e.CreatedAt,
 		UpdatedAt: e.UpdatedAt,
+		StoryCounts: StoryCounts{
+			Backlog: counts.Backlog,
+			Running: counts.Running,
+			Done:    counts.Done,
+			Failed:  counts.Failed,
+		},
 	}
 	if e.Description != nil {
 		epic.Description = e.Description

--- a/backend/internal/api/handler/epic_handler_test.go
+++ b/backend/internal/api/handler/epic_handler_test.go
@@ -615,3 +615,86 @@ func TestGetEpicDAG_StoryRepoError(t *testing.T) {
 		t.Errorf("expected 404, got %d. Body: %s", rec.Code, rec.Body.String())
 	}
 }
+
+// countsStoryRepo is a story repo mock returning configurable per-epic counts.
+type countsStoryRepo struct {
+	mockStoryRepo
+	counts model.StoryCounts
+}
+
+func (m *countsStoryRepo) CountByEpicGroupedByStatus(_ context.Context, _ uuid.UUID) (model.StoryCounts, error) {
+	return m.counts, nil
+}
+
+func TestGetEpic_PopulatesStoryCounts(t *testing.T) {
+	storyRepo := &countsStoryRepo{
+		mockStoryRepo: *newMockStoryRepo(),
+		counts:        model.StoryCounts{Backlog: 3, Running: 1, Done: 5, Failed: 2},
+	}
+	h, epicRepo := setupEpicHandlerWithStoryRepo(storyRepo)
+
+	projectID := uuid.New()
+	epicID := uuid.New()
+	epicRepo.epics[epicID] = &model.Epic{
+		ID:        epicID,
+		ProjectID: projectID,
+		Name:      "Auth",
+		Status:    model.EpicStatusBacklog,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+projectID.String()+"/epics/"+epicID.String(), nil)
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleUser)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.GetEpic(rec, req, projectID, epicID)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+	var resp Epic
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if resp.StoryCounts.Backlog != 3 || resp.StoryCounts.Running != 1 ||
+		resp.StoryCounts.Done != 5 || resp.StoryCounts.Failed != 2 {
+		t.Errorf("unexpected story_counts: %+v", resp.StoryCounts)
+	}
+}
+
+func TestListEpics_PopulatesStoryCounts(t *testing.T) {
+	storyRepo := &countsStoryRepo{
+		mockStoryRepo: *newMockStoryRepo(),
+		counts:        model.StoryCounts{Backlog: 1, Running: 2, Done: 0, Failed: 0},
+	}
+	h, epicRepo := setupEpicHandlerWithStoryRepo(storyRepo)
+
+	projectID := uuid.New()
+	for i := 0; i < 2; i++ {
+		id := uuid.New()
+		epicRepo.epics[id] = &model.Epic{ID: id, ProjectID: projectID, Name: "E", Status: model.EpicStatusBacklog}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+projectID.String()+"/epics", nil)
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleUser)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.ListEpics(rec, req, projectID, ListEpicsParams{})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp EpicList
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 epics, got %d", len(resp.Data))
+	}
+	for _, e := range resp.Data {
+		if e.StoryCounts.Running != 2 || e.StoryCounts.Backlog != 1 {
+			t.Errorf("unexpected story_counts: %+v", e.StoryCounts)
+		}
+	}
+}

--- a/backend/internal/api/handler/gen_server.go
+++ b/backend/internal/api/handler/gen_server.go
@@ -384,6 +384,18 @@ type CostSummary struct {
 	TotalTokensOutput *int64 `json:"total_tokens_output,omitempty"`
 }
 
+// CreateAPIKeyRequest defines model for CreateAPIKeyRequest.
+type CreateAPIKeyRequest struct {
+	// ApiKey The raw API key (will be encrypted at rest)
+	ApiKey string `json:"api_key"`
+
+	// KeyName User-defined name for the key
+	KeyName string `json:"key_name"`
+
+	// Provider LLM provider name
+	Provider string `json:"provider"`
+}
+
 // CreateAgentRequest defines model for CreateAgentRequest.
 type CreateAgentRequest struct {
 	Image string `json:"image"`
@@ -644,6 +656,30 @@ type ImportStoryError struct {
 
 	// Message Human-readable error description
 	Message string `json:"message"`
+}
+
+// LatestRun Lightweight projection of a story's most recent run for the live kanban.
+type LatestRun struct {
+	// CurrentStep The currently active step of a run and its position in the pipeline.
+	CurrentStep *LatestRunStep     `json:"current_step,omitempty"`
+	Id          openapi_types.UUID `json:"id"`
+
+	// Status Run status (pending, running, paused, completed, failed, cancelled)
+	Status string `json:"status"`
+}
+
+// LatestRunStep The currently active step of a run and its position in the pipeline.
+type LatestRunStep struct {
+	ActionType string             `json:"action_type"`
+	Id         openapi_types.UUID `json:"id"`
+
+	// Index Zero-based position (step_order) of the current step
+	Index  int    `json:"index"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+
+	// Total Total number of steps in the run
+	Total int `json:"total"`
 }
 
 // LoginRequest defines model for LoginRequest.
@@ -1012,7 +1048,10 @@ type Story struct {
 	Id                 openapi_types.UUID  `json:"id"`
 
 	// Key Unique story identifier within project (e.g., S-01)
-	Key         string             `json:"key"`
+	Key string `json:"key"`
+
+	// LatestRun Lightweight projection of a story's most recent run for the live kanban.
+	LatestRun   *LatestRun         `json:"latest_run,omitempty"`
 	Objective   *string            `json:"objective,omitempty"`
 	ProjectId   openapi_types.UUID `json:"project_id"`
 	Scope       *StoryScope        `json:"scope,omitempty"`
@@ -1188,6 +1227,21 @@ type User struct {
 // UserRole defines model for User.Role.
 type UserRole string
 
+// UserAPIKey defines model for UserAPIKey.
+type UserAPIKey struct {
+	CreatedAt time.Time          `json:"created_at"`
+	Id        openapi_types.UUID `json:"id"`
+
+	// KeyHint Last 4 characters of the key, prefixed with "..."
+	KeyHint string `json:"key_hint"`
+
+	// KeyName User-defined name for the key (e.g. default, work)
+	KeyName string `json:"key_name"`
+
+	// Provider LLM provider name (e.g. claude, openai)
+	Provider string `json:"provider"`
+}
+
 // UserList defines model for UserList.
 type UserList struct {
 	Data       []User     `json:"data"`
@@ -1208,6 +1262,9 @@ type HITLRequestIdPath = openapi_types.UUID
 
 // IdPath defines model for IdPath.
 type IdPath = openapi_types.UUID
+
+// KeyIdPath defines model for KeyIdPath.
+type KeyIdPath = openapi_types.UUID
 
 // NotificationIdPath defines model for NotificationIdPath.
 type NotificationIdPath = openapi_types.UUID
@@ -1469,6 +1526,9 @@ type UpdatePromptTemplateJSONRequestBody = UpdatePromptTemplateRequest
 
 // UpdateMyProfileJSONRequestBody defines body for UpdateMyProfile for application/json ContentType.
 type UpdateMyProfileJSONRequestBody = UpdateMyProfileRequest
+
+// CreateMyAPIKeyJSONRequestBody defines body for CreateMyAPIKey for application/json ContentType.
+type CreateMyAPIKeyJSONRequestBody = CreateAPIKeyRequest
 
 // ChangeMyPasswordJSONRequestBody defines body for ChangeMyPassword for application/json ContentType.
 type ChangeMyPasswordJSONRequestBody = ChangePasswordRequest
@@ -1756,6 +1816,15 @@ type ServerInterface interface {
 	// Update the current user's profile (name and/or email)
 	// (PUT /users/me)
 	UpdateMyProfile(w http.ResponseWriter, r *http.Request)
+	// List the current user's API keys (hint only, never decrypted)
+	// (GET /users/me/api-keys)
+	ListMyAPIKeys(w http.ResponseWriter, r *http.Request)
+	// Store an encrypted API key for the current user
+	// (POST /users/me/api-keys)
+	CreateMyAPIKey(w http.ResponseWriter, r *http.Request)
+	// Delete an API key
+	// (DELETE /users/me/api-keys/{keyId})
+	DeleteMyAPIKey(w http.ResponseWriter, r *http.Request, keyId KeyIdPath)
 	// Change the current user's password
 	// (PUT /users/me/password)
 	ChangeMyPassword(w http.ResponseWriter, r *http.Request)
@@ -2203,6 +2272,24 @@ func (_ Unimplemented) GetMyProfile(w http.ResponseWriter, r *http.Request) {
 // Update the current user's profile (name and/or email)
 // (PUT /users/me)
 func (_ Unimplemented) UpdateMyProfile(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List the current user's API keys (hint only, never decrypted)
+// (GET /users/me/api-keys)
+func (_ Unimplemented) ListMyAPIKeys(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Store an encrypted API key for the current user
+// (POST /users/me/api-keys)
+func (_ Unimplemented) CreateMyAPIKey(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Delete an API key
+// (DELETE /users/me/api-keys/{keyId})
+func (_ Unimplemented) DeleteMyAPIKey(w http.ResponseWriter, r *http.Request, keyId KeyIdPath) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -4889,6 +4976,77 @@ func (siw *ServerInterfaceWrapper) UpdateMyProfile(w http.ResponseWriter, r *htt
 	handler.ServeHTTP(w, r)
 }
 
+// ListMyAPIKeys operation middleware
+func (siw *ServerInterfaceWrapper) ListMyAPIKeys(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListMyAPIKeys(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateMyAPIKey operation middleware
+func (siw *ServerInterfaceWrapper) CreateMyAPIKey(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateMyAPIKey(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteMyAPIKey operation middleware
+func (siw *ServerInterfaceWrapper) DeleteMyAPIKey(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "keyId" -------------
+	var keyId KeyIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "keyId", chi.URLParam(r, "keyId"), &keyId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "keyId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteMyAPIKey(w, r, keyId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ChangeMyPassword operation middleware
 func (siw *ServerInterfaceWrapper) ChangeMyPassword(w http.ResponseWriter, r *http.Request) {
 
@@ -5332,6 +5490,15 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Put(options.BaseURL+"/users/me", wrapper.UpdateMyProfile)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/users/me/api-keys", wrapper.ListMyAPIKeys)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/users/me/api-keys", wrapper.CreateMyAPIKey)
+	})
+	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/users/me/api-keys/{keyId}", wrapper.DeleteMyAPIKey)
+	})
+	r.Group(func(r chi.Router) {
 		r.Put(options.BaseURL+"/users/me/password", wrapper.ChangeMyPassword)
 	})
 	r.Group(func(r chi.Router) {
@@ -5350,179 +5517,189 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x9i27cOLbgrxDaBSbBVpXLjtOPDAa4jpPO+E7S7bWd6Z3pDgyWxKriWCLVJGWnxghw",
-	"/2H3C++XLPiQREmkHuV6OI+Li+m4xMfhOYeHh+fF+yCkSUoJIoIHL+6DFDKYIIGY+utkgYg4i86hWMo/",
-	"I8RDhlOBKQle6I/g/fuzV8EowPKXVLYbBQQmKHgRQN05GAUM/ZFhhqLghWAZGgU8XKIEyhHnlCVQBC+C",
-	"LMOypVilsisXDJNF8OnTKHid4tAHgfzWAgBSXTcw/0VGWkFgGekAQ43wQEj+enb19gL9kSHuJYlsAphu",
-	"0wLREou4GOmBUPlAuUCcZixELWDgh879MxV4jkMop/TBYbcBISVzvGgBiVRGfCB453CBzuV+akIlPwGS",
-	"JTPEckD+yBBblZCkcIECe74IzWEWi+DF4ShIMMFJlqh/m3kxEWiBmJ4YsZa5zwRKOEgRA2YO5/SIXftB",
-	"OJqOggR+NDBMp90QMfovFHr51nxuIUyaD/BAmrRs5YvWXcw2sIMvKRMvVx6y/IRRHAFBAadMgNnKQxj5",
-	"9Vp9ddAlCBmCAkXXULgBEChtWz4XKG3BAVfdH4oEQdnKB4T62AqB6vxAEK5QksZQoBZ2TFIBhGnWAo8o",
-	"RnoQSJ9kZ55SwpE6d1/CyMhn+VdIiUBE/ROmaWzE08G/uAT23prmfzI0D14E/+OgPNMP9Fd+8JoxyvRU",
-	"1cW+hFF+ZASfRsEpJfMYhzuYuDghQjMleIImiwmIMj0VAiiBOH4qofqJshmOIkS2D1YxFRgDGCWYABiG",
-	"iHNQkFefPD/RjEQ7xBKhAszVnJ9GwXsCM7GkDP8b7QCGymxq9pRRiRM4i9FrIrBYbR+Iv8MYR/oYR6ZN",
-	"vsVKXVWpsIymiAmst5IlEe2NGEGBxgInqLkbR1Ix6d60owAn8oBsSI9XNLxBDKivgKE5YoiECMwpA2KJ",
-	"gFKLpcooZ5e8LyAmSg1oTJDQCMXNCd6+fQfUJ4AjRKTCgpjZO78HYQyzCI1pmvHx8fi734NR+SOnhCCh",
-	"f37qmlBLtXt5tr9FZCFl49Hz5+p0z/8+dHQzh/O1xludf/WuAXdLRAAPaYoA5uD3vNPvwZ8ByeJY4WcR",
-	"0xmMNYp4MGqQQDaUPJdLWBcktzhCrHYqquUHdY46OQN5e5BxpA5fqcqLJeYahmAUICK1mt/KMWiKSEgj",
-	"FHxwzK/W10TC74Fe2e+BWRuADAF4C7FaDoAho5wDGMfAoIX/2UaR3UtNoWCFgGOyiFHeZ/I7sQDWMwYF",
-	"dZzw5ufXtbV3a1cKSKIYzSDjcprKsZj3cYybpdHAXffJPj9/03cDxY75Nsj3mwPoHO8W/UdVVciCp0QD",
-	"nSm8fBpp2XFKuXjJELyJ6B1pChJFguueokE3zrcT+giTVHJtEKHbsdJhXJ1CysV1xqNKl8OjyXNrI0Q0",
-	"k/xf9DZ3CIm9jPDrkGaaiEV/uzMm4tlR0FTQR4GgN4jwa0zSrNZ9Kv+vOsZ3x21j0EzUBznsO0iNCQqU",
-	"VxBag7Y+sYXHClJcdD9dQiLvSZzfUWarXLUzJGNMTp+ahkpEtotEgu58zX/o4v3GdLXhnCuhXLyCAp5T",
-	"7DoFJfdXOfFoevTdeHo0Ppzacla1c8kJKmB87WTQ6eTw6NlxDxatrTKfqjqyb22XWZJAtnJsy9uF7i1v",
-	"rGprrQ/hKJhl0QKJ6xgn2LEVp73GSBHDNLpGJPJg/Pur6fSF+v9/1nHvVUnMoFxAJnyEXGNYC/sJJWLZ",
-	"WPOzyfHz777vte4WHjmcHD07fj50lDuEbhzEfP7d9z8MGKou2qrH25VsA9RHoFvKY41nCYoAJkph06iX",
-	"J+taQtGCoRSNLiD01/5Q/LCeUK2RqcZaFfYd+XaXc5eq81adpF5BWmjMflV3gzrpY9EE88lzRWwDOlr7",
-	"AdJXb/KTUVm9fVSs4M4WRcoYLvV4eV2UNxNjdp0jKDKGpEZvU1Gxr5fe5bDvOWLgpDJkbaQe/MAFFBmv",
-	"EmQGw5uYLiyClL9gcp0yumCIS7AjSlxkduHdj1TbFH2qLNF+jWMJCUHxtR7pvoAvwjzUGsEdmi0pvZHT",
-	"Wepl8dmhXMoJ1YkZRViCAOPzypyNLsW490HG4uBFsBQi5S8ODsw0k5AmBzDFBwYWfjCZTBTH1tePiLzm",
-	"RBXs6xtcMUflQjejNEaQqK638uZzPcex0Ju56PGb1O4kDGmMBDLa3mQOsZzpwyjAAiXuhZkfIGNw1dS+",
-	"bNQXeKsD4qeysWV7Sas1WXP/b54Fp7lBoDAR5AIJfURhJnIDAhco5eCJQSeXDf4UKcvDnwCeA5pgIVD0",
-	"1OJt/TUYBTfZDDGCBOI17skbNBBmZrn2GCRe6c/gVElGY5ugt4gxHGnDhw0zNnLVEocFCDXrRZ8rv1ca",
-	"nQCu/mlNZMmMQ7f0WWBxXT067IW+waI8KLRBp1xIjRgLLJbZzEcM/TVQE8ZQ/mOGxSwLb5DQPyJYJU7R",
-	"wQmyUhquEbl1OMBgggCdKyUCkVvMKEkkMW4hw8r4sKRxhMlCNVhgo4CAJ4QK9ZP+EwuO4vnTCrHenF39",
-	"9f3L66tf/vb65z6Uakr2dytw7iJOH4HOUEqvlVyqr/j9xdt8wYY0f+JqZbILx+b6XUKRizWNYiXVKFsc",
-	"JKtxyTkdixt2EGj/Qu6F8EqKJr7yjXYm/1ZU1EMNx55LqSjn+QfNlK0J5/NI/lDqH7i/12rgDVp9+iTl",
-	"ffdUtTOsGFS5TIQiBkO3GN3JsRBTukqYcUGT6hawO/ZSgByGItXPT5mLjHjJkeIUxZio0cxRWm2gxJtS",
-	"c/OTpyb5w1xIebdGr2WZcVyraD3ZNHyubpqkvWxbjTFNz1EDP34sKy+f/4AMQ5QKSEJ0HTIsEMPQibMI",
-	"pYhE/FqjtO9pP1LxGH3teDdoVd0Zl+PpYXW3PXcdI3rF+NZ92SnuBrbaqS9cc6ZYVf6TLyFDkftyUSiz",
-	"ba4UheZL3VTiAbIFElKBQXwYxgQWcU0SlRIopgtM8lCCuhRqZx6J3Xx0F7fI+0SXR6duCDkcHz6/Opy+",
-	"eDbMEPKQO43Hf1SO8f33U/TD8XQ6Rkc/zsbHh9HxGH5/+N34+Pi7754/Pz6WF3mHt2Ptq1GHg6bs/t13",
-	"mwGs5Me+F6kShrKlY1gpXJT5th+zn+qmDQfERpjE5aGwEFu4KwwyauAPc0hIrnt18uZ1pM0ltXNGOYQd",
-	"wRPaUazP6Ru0kgqpFJGIhKuq5makWHPjKxHhMFCp310ji8bAR91nhoa/mK4FAT/TyIGABwrvRsMYrlza",
-	"/j8Ro+MZlNcvffeS+161BZhE6KO98qnL+Gdtiz7s3l/M9uBMW7ZaPKmX2oLxCxOH0sQ6iha1g6PVj29x",
-	"sONIITQaPpjihi4tR488MuD6VvoWc7ebBA4CyrW0FC4wgflJ0jbCednS4R2BQWUs30ouMnKiNCZtX6nR",
-	"TOo6LCMNyf/jj9uS/HJxURbL7xU5b/3uEfUYeRyYHRZte5E18VsO2YK+V0hAHDsUjdy01ObG7rz1rhOA",
-	"MkRF7dmsqgKsQVcp7zXxWEaI/pdtfDOGN8mzGdd6a0n8srOP8oO23UVG1HnfKQyah3SOWotRKgdzDk4L",
-	"v+ipG+yyYDRLr/XJsPmzpNzEg4NiXMdQB0FW/fnEGAMcZhiC/8hydcSKVLrDYimPstxqhiaLyQjIs7mP",
-	"kuK/f9r4LxbtJKMKH2vKSvfPoVFBLKX78vXF9c+/XF3/9Mv7n1+5bxNSonC/tb1CqRKyBHFuPGQ1HV8i",
-	"DZy9AnAWHh49s4IBO4MJqPJV5SM38VEXpgoLLrT9RNmCis5gCRW0WV1BxhH7D/PnJKSJfbDo5l2r0K1c",
-	"UFlZEZsJ/ovwfO4Ph3pPJBNHQLbKA6DAnNGkGtvXZ1suoEClg6dAFkxTRm9hvDtZz5AyVlByzRA0wZqd",
-	"0DPEaXz7wLNRm/02MwhbVzz6JauzKRco3cQpqums/VaKAIPOzCEwWBK6+y6km3fYr1SbjV5XbMyW67Oh",
-	"r05rbx/3Ud4hLDZwAbBFz37vAWdJSpm41KqLXxr6hNoFvAMJZCrwsRBq6sT5x8m7t0DZJBMoBGLmNJ/F",
-	"NLzhPc4ef5xBDWSufMLOI7m/aliOuTJh5E2qGDW16SZTYUOAzoHRAIFYQgF0cyAowGpwZ5CP/tQ+KkF3",
-	"8QoY/szncI5mTENtg5kmBahPbtAKwJghGK0A+oi58TZ2XJwKuMtJLT3eIL+deKvX7VpTdQXvYLjEBI0l",
-	"oMr3qOYARkfxGXBcKULKCJXAFZghgJJUrACeqx9DmsWR0o/kl4+CwbCKDCvmqNS2ajHPWQJJHUi7ST/D",
-	"dj7+KKhFCZWIfCvF5JZVKSk9ykBU60KOwoyh8//g/NAexYo67aOTWaO7FvhO48BvVXKqvGdz7VlXUwDM",
-	"AUMLydQMRSMAAUMcCRBjcgOWkIMZQgTwPn5BvxY8Ct7RCMUdMeBF/ENbxIIjyNITXP1sE8HVzwfGIoaU",
-	"i+FhrXVEmtAya8iOsGwXypsBUV98JNRWnFdWeNUjiKfanv9r226sfTiN+oWblTQe5kdq7rAN6L2Obdtl",
-	"h1PjuwA8ryjJtYCL+rlw6JJqRaa63fJo6hWAlXbHR/3ipbUKjgJrOudq9JXNrtQgULJBu4Q33klQIG/B",
-	"ygqhbBNP8BycX2hlkD/1GxNaCkiopOded+LeV9EtXVt9N8qWy2THTbFJyQ1sHA97uCIuGpz6rJNRzVVR",
-	"d3WuyQTo+I5aZUBtRngHv7BIal4gxlzoCxJKgW48AW/Uf1W0mAlQjQCXiyMCwzhe/dlEfRqrL9Qd/e0n",
-	"wagnMs1qFADO+/deT4ujDZwWlYPCUKdT5Ffx4vGdOy31lo2+iG3V1DLEUxGVZnhQnFTeMJXWS5VsVORE",
-	"61nyFOZLJLJUJy6/QrcopmmCiPCkLDeD7vowzaVAaT/nURHU4YudqwzpiflraK9FELgO9r2eMUjCZZDH",
-	"H8t5rUM2GAVLiT0ptvB1SmN5Hi2xiK8XUNTCaeyRPWmpLhY4e5WHzGobtqAg46jkA7n+CbjQRl+uQ7xH",
-	"Osd9BCCJyqxgKHTqDE7QpOLP2ZTLGWaCXhvraWXnzWHMnTrvGhp/TQKmuhNIERtrko5lF7MJMqZjwm7Q",
-	"anwL4wyBFGJmWXdKbqkLox9+2AxSrMj8lKFQG5D0HaAeq59/f6EonLMEwIQLBKMJ+BtKhSL8DIY3d5BF",
-	"QG4kKPAMx1isJh0B+z2i1loCeU1IsGRyHK66tvOFbHuum7btXnsX1hioNqFzh5so8K2mcmwmUSPELMyU",
-	"PEHwBrFrWBjxq6D9ukRiibTwNX2A6QMwByYDOV4BwXCaokreoX+b1SYvYjl8ZsyQEq584bfWuSIvnCaw",
-	"0vaIFwWmnJp9feoEOnzwV0uG+JLGkeJue/J8TjBDc8qQXrX2vdgKWFuRq9G24lK/jMybTSbafOVpNNvS",
-	"ZxP48Vrnv7sM96rYG9DfC70tj+HABLy/fAWeYKJn0YclJXE17vRw6jQ1elZcJnJ3JA41o+/vSOEOLvs8",
-	"f74ZPD2qxKOdGa3MSVqg1ifuvWeQW0gPM2cZmrcWhJitSmHZ607gMPw7bpOzlVKq+w56kZE+Q/I8lKzX",
-	"oCbGvWPYtn2cF1o0+1jVudj27q26HVyVD+S3HIpCtDTqHfSuhKMn7F/wwT/l4EIPQyo8tKx0+tDSDkEV",
-	"CzXwLNYrGHtUbpyWnbcJI5gRbfuNmKimYO4oyWhbl79BiaI796psMtV0L8mle80m8uWwDj44LXbfzC62",
-	"989+N/OFiQ7YeiBFc6P9JyQIvKJoeAb2ukEZQyqJNUI0Rv7U9AsVhNgaTluGh9ZrPMrf1YFmYknNPch2",
-	"J9USxaddsJvJ3KBy1B2IbCO4bghAgKA7kLcAT8zNHvwAwiVUIUOMV29pBN1datpAzg+PnnVRwsQ/uCfX",
-	"ASz6SshQiPAtisBsBXJ6WaaeN3//d3R6OJ0diXiGD5PZszMRJn//9z//z//+S6dQ0RB0ROjYNrRmwAv8",
-	"eC3FaL6PCv9qpf53l3VGW9jqoppQom4UZGzML8EogPEdXNWsXZUGHfE9FriVaZ0Lz8iaOT+byfFhjLJr",
-	"K/xp7Wjvat79NScw5UsqBmcfFGm6zWsDYiEiAi6QNtsZHOVFaKb//V//93A6fTpSn5RLDwqgCpcXfgBP",
-	"uXgnvwzPVWJDsd8vv8mkMnkSnUJIQhTHA3OdNpFa8ze0Ktw1nNMQF9GgK+NFU+k0fwY0d1xADjhNEEDR",
-	"AoEQcsRBAldgCW8RIFR3nfTKEd5MadeKqmMl8RSR3FbO+BBFp3Hv3kjsxaAYh2aylc09D43P9wTxPZsc",
-	"Ph8exmfFSNhh9oYEletkR7yEwbsvlXJgkAgfYBJBaadF5GE4W7uQpFXVuXDxrBX6uWYJybb5n69nYSgY",
-	"psIbfue4YYsLevdAnrAlvLP26fDb+PZ36kB+Kfwc2h4z3BzkCBPua4Zqznq0Rlyxo1rrdL3qwO2SyeKH",
-	"XhWELzKygTuvVBj3fNHNSFuYiVOLXFOjzX3XZos+LpU3povr/KBxXKxV9Wwr2NAX6kIZlujW4lFvAsxV",
-	"foFgUsGyXiZglJaO+uEphuom4vGH/7rE4dLMCYVAqsa+geXJoU4af+oDxTO19/JVv7jLSblgUKDFSocn",
-	"FPLAwOKbubC4kZApw5mKkp1nsTIgbzLrcnv6fYdaPwruIBaYLK6LpNxBGZqeqm7mK2XG9d2VpdWMZrWC",
-	"0swwRVW4/smQFxn5FYvlZa5vwTj+ZR68+K2PEOwufdcxRq8APJ9e8cE8ZdWl6btOpGe9NL71En22pKYM",
-	"CZq2uK6nbdubnXS4ieyk/WoRtYziWl3svs9IuDaPpwZI39qFayUA7KDe4bDKWruo99FVS3GorehrLb24",
-	"FcONp8jYEIONI6bBUVh1XbPZ2vaU55Oj5+vIG8uQVd5brDlaUeCNaZGnf2c0ZYS5wCRU4dcmex0TFckZ",
-	"qQgLXotmdNWrG4DnhyGuEaVRPTHWi7ko07rWs25Y5OsfSlHSpoW2eQXLWqiSqQXYkedjqmZ2FEWzSxt0",
-	"lpJS+m9Hal0NOWXhwlJ/jrQLp8wRda9/A3dvT7mvnd6+i7X8wi7Vw2vOC1XGCAdFU3VvUolTf2SIYcRH",
-	"gLL83TZdykC2uEErEFN6k6XKI4Z6KOIlZqU63gN3H/IlXA58CqOb3qVUeK+k/SN9BWbLT770e6ilwVYa",
-	"Zeu9uPLeFAKpFqdY65EVM5Kqd/yzUZTXfWJl/edUPNh5tzpnVKpPFooSTGyn5uHIF/TRP65j0IL90H57",
-	"6OVxVCJY62WXchEfvASuZtJ6ibtOQu2G0l9rSzeQtKxoh6/WfMVv0nTK680/S/OVZ8t8TlktOXfkUfrr",
-	"HcOP7WEcv8RZ7xEcC0tJui6S2oOS8ynqTx3v4r2b3gj8fF5R+UJfQ+l+7MRDufd8WKwyQXdj9fOmApYv",
-	"EyyWa0gWGlerGEQJludXxitvCrQigCO2o2yLTQV9byuPsDWYfDDuq4vcYxJDjkfjbFFwDzMJSx7ZgMlI",
-	"sdo+LUZSNKEwY1isLuWIuVeS3mB0kslNVj+g//PXK6P6cKktQQ4gAfIU/oXEK6BzA4AeQN2pVcSS+Uuz",
-	"UxHzna86xX9D8j4gGZnMaV4HFup6BqbTX2mKzsSvlN1wcIVg0qyA8VLLZHByflboSXavXGdKIIEL7Z2Q",
-	"J6dkosnv5MqEM8hexvalH4FR6gjLxLIYVE4gAWQwFJPf5UpiHCJTOtKA++7sSnJR5apKU0T0mBOpo5hO",
-	"/EC2LYV2ZaUn52fBKLhFjOs1TieHk6k6r1JEYIqDF8GzyXTyTNFZLBX1DtStQd/utEop+VNxwFkUvAgk",
-	"375Rr/qe6IYqHgUmSCDGvTa9sonkOXQu//Sa9ezGiFntP6iq3KrOpgLwaDqtlf2FaRobu8TBv0wqh2b2",
-	"B+41tdiNbrb6Xmpw5FtzedZvKANDl0+j4Hh66JurQM/BewIzsaQM/xtFeqfmvhc9MIzj6sjgidJTwF/M",
-	"z6oYEVzwopoPDz7IcQ7kuAdzVSt/bKegpMZTUuWXalH9QAsZxMVLGq0GEa8Nte7K/Z+qMk2q758aHHS0",
-	"MSDqlWAdJFV5Paboa4R5CkW4RBF4orNCAFPGdRSB//6v/wdSps02prk8Fg1en2ommHYzwUtoIaMU1sGL",
-	"3z7YDGHaAFgmDFkVaG8xLPJ2CoaQ0t1iB+Wo9TOBqgL8Xh/b26B/pcpwL7JPNza3PoUd21f5rnkWhojz",
-	"eaYqWiEYIV3u+xKJ8ak+2RqHZHEeytOyOP5KaOo6yqf1ZYKHId7SBcBEns2qvCImC5ArXX4GoNpH6eUA",
-	"momCBSq0OG6i4C1dLFAEaCYsDMarjUg/ulDjqspAugxQ1+K0Gus8Dt8gcaoHca9t+3x2aq0B5O+ybABP",
-	"b1AFR/HKfiASRV04ywta+1kiT2rdolyo5832Eg2HWyeZevCmrPhdZfEti4mBp4bs8mN3l1NK5jEOu44Z",
-	"vWIAVXJqJwNx1EfBqOTKbo2PHPm4Oz5neqgXOYTl8wkN2bk5peESCUPIQmnI5NWnKF9fXNSaBF5iEY8N",
-	"odqvGla6tuOqUV3+T8q/BWarSlo2KKK21HVSJW2Wt8ky46IgQu+XbBq2gsd89+n5zouOt3Cxlrq8WD49",
-	"G8ebu5ZURgXaY6lTx8usPcNPkolc/HQwW425QOnBvfzfs+hT2+FtLf3lSsVsD73PXqpJzqFY7oxILgJV",
-	"WP5haoDsdNzd6WcqflIvtLn1hgpAyh2pwk+4xnEnEe/ln3kR6d40HEw9u1T1NyJWiAirJJytdL30oZQ7",
-	"sCrZuk/wE93gCyVjcXisq35tn/RrKXkFrxjy1fhlHU7Rh2ubqlev4LIpPtmGyliHdcf64hAeLbSaL5VH",
-	"NTV6sagx9Lerped5ox1av7vbX1ImXq52oDDaxfJ6KYsFUjdpvk5LIuR0LH768GnkESKnylFXFlfdxuav",
-	"zLEn40NRhtBBH+PLMj7L3e36Ch01kvI7ZFnstklKe1se3GOtDUYoRrqwYZW+r9TvJX2H7U+/9nDsLzaq",
-	"QYn2oqnp5QLYjsGRV3nePKKmu2Th/SvJuWO4rh9XRVHmwH4lMPVhBNi8CHNGze5YhelB//xZz8eruFRY",
-	"RmO1a7c25N2BqSw9NpWltXHUVpQdfkbufPyACwnAE5XQ9ZfpCOji1X9Rbx48BZzqvLrisQKVahdCAmYo",
-	"r5eAIgAXEJMJOIkSTMaUxCuASJRSTExEg8NCe6rheKnB2K5cPq2tWdsjN+BIkp2edXf6ibIZjiJEHsou",
-	"2l/sIqM2qAzgIvMvdSHvjvAw22vdEI98Lk2z0beYkE3HhGw6GERHgMBbiFWsc5W9wBPzj7GKEInA/2oL",
-	"EWnXu09M4tmDGOrDNrX2SmrfjnV2w1FNuqsPVX19HeF1dNSnU8qoFJSSEV4TgcWqh+Kes0aeWOiMHGqR",
-	"Rgf36r9nfXT7jfBQt5w50QANOHc0lR7DbYD4CeG/CjwOvE53tZvmpWFpLxcHEyeqs7TqtwdbnPrvDnuj",
-	"2LbuG8OF787YpXLT2NO1gawhX3VljFLZc+fzw8WCoYWy2anHSqQiVIQs8xSFeI5RVGgE9FaFcahESP28",
-	"x0iVwdH6aUTvCNc+W8pWI3mJ0G8oqiTFCXhpPc6iX1bFJIyzyBRnq6ajRZinMVwBGFOy4DhCIONwgVwX",
-	"jdKccUr5RvTWWnXJcrkmwVIjTSc5usILiqdPShYsSxJ8H1mpi+qPZ1P5vz9OneEFO7C02DVanBuhYJKc",
-	"EQpm2Z8g9XGu63qkN0PXbum6IdX47OVqc1rtA+jb/87SUU/Yq35K9M7sfnsheBUMm/6zlTlNH0j+cAmZ",
-	"6En9U9V225JGrVmBBUxizoakzRbkTC8+VLW0oYDnFLvu0E0WfAVxvLJ2uLI27c/uGznB0bRSZGKIRIiZ",
-	"4pnD2I9lpK/suZBNt818LCOWnN8m632pliKrSvhe8/V6eGoLYjN6t7/txTIyjtEtiuvS/oGSnZcF6Hrs",
-	"rlwV+qZH9jahfYYKpILA/LQ+f6EUh2MpuQ/u5T8vMtIRtfhat9r+7f11Ds72LS5mKvNIhoMBVPEtKWKM",
-	"31ZfGlPExrqqKi/KF+znLkEAyiFUFhkPfCVfyOadfNHua3mtWjxmH8sjijySyOofdqSQr2mo6RfqQpWb",
-	"8pvo8avOkuZsTW5p95HINT5qF4ldym/HHhKFG59g2Xk803r+4PXDGCueFyWpMHEeV/3Ekj6qevlcNsGT",
-	"/Y6qQR4XRfaHO1x26dMvXTRI47QpHNpUhn0TYbqbrbz3uC6jCdT9MpYE97tl9kSnbTllBov7HfHIXmK/",
-	"tiwqHnY+lH4ij2zpeR4cRHDRdXd5dfLmy5JFr07etCXXvjp5o3U7QiPElTsLRQvEd5gAcbS5YiWvGaPu",
-	"cgKrMEZS/KqEEKlfaF1Wl9FDJMRyyc6Mv6LJCiwYTJfgyauTN0+1evxgjsyNop7yEjAj4XKnV2o/Wx5t",
-	"+j59okodqiuI/0Yt+0RZrDKwi/ZfO2tqvgAQzKAIlwpPih3Vi5GUYcTzOicSjU8gX5Hw6QO59OCeKePP",
-	"gX5nyx+le6q+6zDdwuwg5YoET8flgnCJ40hF4U5AUYOY52Z5IqmtC/xCpl6mSVMUTUDu1T+e/giwrocq",
-	"x8YcwJghGK30vUEglpjn4aBwetQ1iHvZV92td2TUUg+CtWy84jm1TUUY71Bh0PSVV0hd7GCUc5V6xUG/",
-	"Dl3wprUvlDRec1uoUf274lx+5rYpbgJOi12gw9PNq86qtgNTAekMgSWKoxG4W+LYLlqT75JyI6nqe5hk",
-	"CAiaP/WNKXHummJbYq7m09dtmKngSP+2UWv4tmvado3hrc9vyyjaSvbEZJy/+LDpLcIQzxLUmt+RJXKT",
-	"1LfoBJzrHyx2l3tDDxhprVUVrMeUFBvBmEglwxP0UVQVOZqlfbdGTlPfttBgf9sXbfsip9TntzE0dZs8",
-	"OWBPLLGID/K6O50hi3Fc5ilpJagU++ZdU6UoLbMEEpC/cDoBrxDHC2KCDcOMxfoJWnD69gzcUXYzj+kd",
-	"VzUY7Ypneo9Aq9qW2k2hBEM9R5CnQMljhSME7uRJRRCKONDV0F1bQiXb6AW3lzrabSxZaxBCA1yfQybP",
-	"VjEU3UjJoOE2mKbbpgJPzhdW1SGPD9hRJKDCvcR6Fafd5dd8P+dRU7wJbhfFbVSA0KxwH7ZcBZALGi+V",
-	"q1Ts8tU1UfOoPXf+h5t27Mdz4M3BTj83CbcfJ9/6DFi67Bxr6cuD/UTOwb39Zy+33ubZt1vR+rkC5ABn",
-	"n4sbHkXpBQdp2wWK33X0qAiyLYfSA6XQ9BFIoc+17sAwVl1T7hyI/OEX58l5hVwa0CMWPBLgKua4yfze",
-	"OSEvEYmU5bYG0TpEzC9PrdGwlYcAH/W1pAqpKz4svyxqvs+YiaTeY5HM1AmSv7qDaT7OVequ2jKbp97W",
-	"Ks04X5zcdcGZNXnoiwxFcB0gm+FZr0RqzXyRV7mLjPCXq3VLJn1OdUk6bIj9Y2AVTjcV8KoMyj5KG+te",
-	"+4V5A5bfrd6QLzKypyuxxzJ8kZHP986L7iqlpLpYp1Uw9ParXzFIuHoYmheub0FtP62K4p+As9I1voQc",
-	"QP1OcWlENp4Soh9DUe4S5X8f6ZJMxZPAmJeud2MdtbzyCWQ3KAKQlxCs6aEHT4ono0dAvxat/LTFuE/9",
-	"PvydeFz260O5+Bqc8TrkZZhbpbp7KG9PbTfJivxLYheVbuzNSrooElxVEzvpB6WPIONdUAF1JiS3Kun7",
-	"oByQtDYkLuMyryioq/hLCSqlqmbLCbiqPBVUSk4tUgtHcyXkYgRmmbzGqnOiFJixCtpql5KeYAzwJMm4",
-	"ADOUb52n3vCMr0Qgfu5xFlaY2wMFX9+gijI+gs5Lb7bSXhhNFBPGkAtQnMWKdXswa7/wiK+EL7+cOId1",
-	"GNMEn7bedS9Nm0eeGVqLaaVJAsccyR72LVQfGPoAmBfvND1Bk8VkBGYwvInpYpTL7P5vNTkKSNROLUWc",
-	"G7SSE8eU3oAsBU+Y2ar5U72ykW/WG7RqnXKb+0dBL3nhF3apQO135c9DmymrrFBiXK5mb374HC5HwixN",
-	"Tbkvo1loHqmWT8k3TZeJQWHtURsZFIR7MjNo7Dj4SG+VryuHVu8LTxJtyW9dcvwAJyllLS6vM/V9QxJ9",
-	"S6xZgXFPBvgaDDyLnVZO3UzpELFo1GjQGoWOdWVMVc8qs/4fJ0tXOPRlFt8AzVGlyJSqZwKZroKjVvyP",
-	"k3dv5e9EJFCIyluaAzj3XiGtV7DIRuRqj1oSGqAB/tlLkwb0OaaBaxHkOeV8JprHQYnprs6k/T/yUehP",
-	"lWTwikLi98LujVrb8tUOV192xirfcsJ9OeEtgqb/IdFtPVZk2JH9eLfyqaO2mVGfrWJij8herOUXDBnl",
-	"OnGC6cKRvS3FTU6oJ2TX7ABKy+alM6M0WWtDb4QYvkVRaVMzk/2J1wMMtCJH/shQJgfkKxKWNjqn2c2s",
-	"1jjSlGuP5Am1qhb18XRabWv53SJKkGxxXG1BWQMuY9lTdeSduR3Kjr0Te17HTtiok/pXLJaXkoYd3upa",
-	"spmh4DfR7MhOd/jIbcPNAMOiQEkay51XSZ9KGQrVsaiO55H7wZ8kFVdF7681tKaKh0EPXCapACX6NxVx",
-	"Ux+47eWnJBXjEgLbTNbFAsWDldbiH7UFrQrq/p7YtPHlfqbOpt5XZl2r8a7Pzubg3G75dnCf/7Nhu+hi",
-	"9uKF0A0ye7cMuyrAHfbCaAWDn6mNo8YIXVKr57mlizU/MiJO9yhdHsVjqBWIHI+iOg6prBe5ixdJ90/x",
-	"LT63uu6ptk+++2Z0ES3vvPaXfPLUs0NWOqL0BjP/7qI+Ou+IlfrfXLfcm9SqlfvGghuQnPeuSlCRandw",
-	"L/+jY4yEfl3AF5mMFwvEuJxTttQRRjqS18TVoXQCSuOJ1KJ0SxVHp4KUdWkXqo0Tpq/+attJ5EdMQoYS",
-	"RISqbiCUBajI1bBMKFdlqJIoYqdRpOIygKBFCBaeAyzAHVRF04qZoUAeKwxKregnuz2gDCTwowIKq5Cr",
-	"EKEIRe6oKMFWP6nOkqMewvR97CiSjo9giyhqYYIFhiraO49YMaK2Zk37XAKnFAvW+d29y/wGx47koPW8",
-	"LRUD2rfEoIckBrWYrDKuyNFCw/eqxWCt7ot420CuvT/5NC73V0QHxrGBoSS1/tui9UHSml38bnXO6BzH",
-	"Ui/aKlqd5UR1tLpahNTTFBwb2A95bm9ojf8nXszQxFar87iKom1dPIpZ9nTn8NHovTnumjTa1TXjwXcA",
-	"PyuAJwQmqorYgdTHEogrL6q7NtNBCjm/oyxSOqaLa06XkCwkPfOGW7LCqmnySQZxjcvMZcYBoRrWFRW+",
-	"C3pXLZkKFCf5StT6aXWP+4RUKb4fetoNsiDKGT5Xs2HGK1Ftpbz0nScbRucO5JumzkPNdrukjr4yK4Fc",
-	"t+71OtAeTqNtHYISssd2/kk0fy3FJbwbXrVGYcawWClu0fU3TzKxDF789kFyBUfsNuel2puD52fg9hDM",
-	"IEcglUw0CjIWBy+CA5jig9tDxVRmxkbfsv6nDmGIzLOzRXaIRJsjDUbRLYEELpT9xdUz198dLh+VFtHe",
-	"O3eOOQZQpWTbe+uy9o657TiE9iHM7bHLYdW5iqoN1JfA0z5MHsnWsqBqrRIXKPUyJc3B/polkIwxGYsl",
-	"GseUpmXtUMeAqlpocxBHMbEWqKq1nJqj6Ye527FjHjN35WpxAQSD4Y16NIJEgM7kPoIzHGOxco2l48Q+",
-	"ffj0/wMAAP//HewTb1c7AQA=",
+	"H4sIAAAAAAAC/+x9i24bObbgrxDaBdrBSrLsOP3IYIDrOOmMbyfdXjuZ3plOYFBVRxLHJbKaZNnRBAHu",
+	"P+x+4f2SBR9VxapivWQ9nMdicadjscjDcw4Pz5sfBwFbxowClWLw9OMgxhwvQQLX/zqdA5Xn4QWWC/XP",
+	"EETASSwJo4On5kf09u3588FwQNRfYjVuOKB4CYOnA2w+HgwHHP5MCIdw8FTyBIYDESxgidWMM8aXWA6e",
+	"DpKEqJFyFatPheSEzgefPg0HL2IS1EGgfmsAAPSnG1j/MqGNIPCEtoChZ7gnJH87f/PqEv5MQNSSRA1B",
+	"3IxpgGhBZJTNdE+o6kC5BMESHkADGOS+a/8Cq1rmvDhHN7BqWP1GfXxPAH5lksxIgNWidZC4Y1DA6IzM",
+	"G6CihRnvCd4FnsOFOtBVqNRPiCbLKfAUkD8T4KsckhjPYeCuF8IMJ5EcPD0aDpaEkmWy1P9t1yVUwhy4",
+	"WRh4w9rnEpYCxcCRXcO7PPDrehCOJ8PBEn+wMEwm7RBx9i8Iag+O/bmBMHE6wT1p0iBLLhvFCN+ACLli",
+	"XD5b1ZDlZwJRiCRDgnGJpqsawqhfr/WvHroMAg5YQniNpR8ACXHT9oWEuAEHQn9+XyRIxmvlhv6xEQL9",
+	"8T1BeAPLOMISGthxGUsk7bAGeGQ2071A+qQ+FjGjAvTF/wyH9oJQ/woYlUD1f+I4jqx4OvyXUMB+dJb5",
+	"nxxmg6eD/3GYKxWH5ldx+IJzxs1Sxc0+w2F6Zw0+DQdnjM4iEuxg4eyKCuyS6ADG8zEKE7MUIFhiEj1S",
+	"UP3M+JSEIdDtg5UthUYIh0tCEQ4CEAJl5DU3z88soeEOsUSZRDO95qfh4C3FiVwwTv4NO4ChsJpePeZM",
+	"4QRPI3hBJZGr7QPxdxyR0FzjYMekRyxXlrUOzVkMXBJzlByJ6B7EEEsYSbKE6mkcKs2o/dAOB2SpLsiK",
+	"9HjOghvgSP+KOMyAAw0AzRhHcgFI6+VKZ1WrK96XmFCtBlQWWLIQouoCr169RvonREKgSmEBbs/Ou0EQ",
+	"4SSEEYsTMToZff9uMMz/KBilIM2fH/kWNFLto7rbXwGdK9l4/OSJvt3Tfx95PrOX87XBW5l/zalBdwug",
+	"SAQsBkQEepd+9G7wF0STKNL4mUdsiiODIjEYVkigBiqeSyWsD5JbEgIv3Yp6+4MyR52eo3Q8SgToy1fZ",
+	"EnJBhIFhMBwAVVrNH/kcLAYasBAG7z3r6/1VkfBuYHb2bmD3hjAHhG8x0dtBOOBMCISjCFm0iL+4KHK/",
+	"0ktoWDEShM4jSL8Zv6MOwGbFQUYdL7zp/XXtnN2STYNpGMEUc6GWKVyL6TeeeZM47HnqPrn35x/GONHs",
+	"mB6D9Lx5gE7x7tB/WFSFHHhyNLCpxsunoZEdZ0zIZxzwTcjuaFWQaBJcdxQNZnB6nOADXsaKawch3I60",
+	"DuP7KGBCXiciLHxydDx+4hyEkCWK/7OvrQ2hsJdQcR2wxBAx+979mFD5+HhQVdCHA8lugIprQuOk9PlE",
+	"/b/iHN+fNM3BElme5KjrJCUmyFBeQGgJ2vLCDh4LSPHR/WyBqbKThLhj3FW5SndIwrlaPrYDtYhsFokU",
+	"7uqG/9jG+5XlStN5d8KEfI4lvmDEdwsq7i9y4vHk+PvR5Hh0NHHlrB7nkxNM4ujay6CT8dHx45MOLFra",
+	"ZbpUcea6vV0lyyXmK8+xvJ2br5XFqo/W+hAOB9MknIO8jsiSeI7ipNMcMXDCwmugYQ3Gf3gzmTzV//+f",
+	"ZdzXqiR2UiExl3WEXGNaB/tLRuWisufH45Mn3//Qad8NPHI0Pn588qTvLHcANx5iPvn+hx97TFUWbcXr",
+	"7Y0ag/SPyIxU15pIlhAiQrXCZlCvbta1hKIDQy4afUCYX7tD8eN6QrVEphJrFdh3WHe6vKdU37enF+e/",
+	"wKpWkuKYXN/AyoOCBSCO71DqODy4I1GEpoCABnwVSwgRloiDkI9cHAzEzQhTOcIxmTwe4WlwdPz4w+rf",
+	"P/z406BVa72BVXZDl+wdAXwUwoxQCJEakinvCvZh4T43OubQVZlTh1iLyuwoqmXtPlNL7YWXL5ipoc56",
+	"T9qWK3GAoyRlOBhmpGmgrbqDa0mbWUP1ZswG7Y2HouWni6dK9gb072biddWJ68moQyp1VCzgzr1mdKRF",
+	"HQOcyIWyOq1LfQZYJhxEkSWPtWiqpXc+rTpq6LQwZWmmDvwgJJaJKBJkioObiM0dguR/IfQ65mzOQSiw",
+	"Q0Z9ZPbhvR6pbpjhTEcZ6rXJBaYUomsz08cMvpCIwGh7dzBdMHajlnNETfazx3BQC2r5GoZEgYCji8Ka",
+	"lU+yeT8OEh4Nng4WUsbi6eGhXWYcsOUhjsmhhUUcjsdjzbHl/QNVJmxYwL6xzrM1Csb6lLEIMNWf3iqr",
+	"9npGImkOc/bFH0pzVzDEEUiwmvx4hola6f1wQCQs/Ruzf8Cc41VVs3ZRn+GtDEg9lW2cov5601aK9e1U",
+	"RftZ6uzJ3D+pQIIPECQydQ4JCbFABxadQg34LtRepe8QmSG2JFJC+MjhbfOrEujJFDgFCaLEPemACsLs",
+	"Ktc1zqbn5md0piWj9TuxW+CchOZedGEmVq464rB0dWWeqS7unFppdIqE/k9noeIF7JM+cyKv6+/dl0Tm",
+	"F4W57/ONlIgxJ3KRTOuIYX4d6AUjrP5jSuQ0CW5Amj8CLhIn+8ALslYIr4HeeoKbSjdhM62aAL0lnNGl",
+	"IsYt5kQ7lhYsCgmd6wFzYpVLdECZ1H8y/yRSQDQr6lUvz9/87e2z6ze//fLi1y6Uqkr21yt04SNOF4HO",
+	"IWbXWi5VVLPLV+mGLWm+E3pn6hNBrGslhyIVawbFWqoxPj9crkY557Rsrt9FYGJHaYSpVlJU8ZUetHP1",
+	"b01FM1V/7PmUinydf7BE+xFJuo7iD63ao48fjYp/A6tPn5S8b1+qdIdlk+pwmNTE4HBL4E7NBVzrKkEi",
+	"JFsWj4D7YScFyOME1N/VU+YyobXkiEkMEaF6NnuVFgdo8abV3PTmKUn+IBVStUej07bsPL5dNN5sBj7f",
+	"Z4aknfyWlTntl8MKfuqxrCO49RdkEEAsMQ3gOuBEAifYi7MQYqChuDYo7XrbD3WyT1cfrbVDcx68Gk2O",
+	"qpZV5TuzY3LrN3Yy28BVO40xPeOaVdV/igXmEPqNi0yZbQqTaTRfmaEKD5jPQSoFBkQ/jEkio5IkyiVQ",
+	"xOaEpmkiZSnUzDzGUjaz+7hF2RNt0bqyk+todPTkzdHk6eN+Tq772DQ1scF8jh9+mMCPJ5PJCI5/mo5O",
+	"jsKTEf7h6PvRycn33z95cnIymUwmnkjW2qZRS/At//z77zcDWM6PXQ2pHIZ8pGdaJVy0a74bs5+ZoZXg",
+	"0kaYxBd9chCbhaIsMkrg9ws2Ka57fvryRWjcJaV7Rgf7PYkxJgnA3NPaQWZEJNBgVdTcrBSrHnwtIjye",
+	"N/1338yyMvFx+51h4M+Wa0DAryz0IOCewrsyMMIrn7b/T+BsNMXK/DK2lzr3eiwiNIQP7s4nPseucyy6",
+	"sHt3MduBM13Z6vCk2WoDxi9tjlEV6xDOSxdHY46Gw8GeK4WysP9kmhvatBwz89CCW7fTV0T4Q2C4F1C+",
+	"rcV4TihOb5KmGS7ykZ7IFx4U5qrbyWVCT7XGZPwrJZopXYcntCL5f/ppW5JfbS5MIvV7Qc47f68R9QRq",
+	"gtMt0Qp3kyXxm0/ZgL7nIDGJPIpG6lpqSlFotXrXSS7qo6J2HFZUAdagq5L3hng8odT8l+t8s443xbOJ",
+	"MHprTvz84zrK9zp2lwnV932rMKhe0ilqHUYpXMwpOA38YpausMucsyS+NjfD5u+S/BD3TnjyXUMtBFl1",
+	"5xPrDPC4YSj5M0nVEScL7Y7IhbrKUq8ZjOfjIVJ3cxclpd7+dPGfbdpLRp0aWJWV/j8HVgVxlO6rF5fX",
+	"v/725vrn397++txvTSiJIuq97QVK5ZAtQQgbISvp+App6Pw5MuFLJ9GzNVGEmVCgnbmKj7Iw1Vjwoe1n",
+	"xudMtibC6ITc4g4SAfw/7D/HAVu6F4sZ3rYLM8oHlVNys5nEzpDMZvWpbm+pYuIQqVFpchuacbYs5m12",
+	"OZZzLCEP8GTIwnHM2S2OdifrOWhnBaPXHLBNxG2FnoNg0e0970bj9tvMJHxd8VgvWb1DhYR4E7eoobOJ",
+	"W2kC9Loz+8DgSOh2W8gMb/Ff6TEbNVdczOb7c6EvLuseH/9V3iIsNmAAuKJnv3bA+TJmXF4Z1aVeGtYJ",
+	"tUt8h5aY66TWTKjpG+cfp69fIe2TXGIpgdvbfBqx4EZ0uHvq8wxKIAsdE/Zeyd1Vw3zOlS0RqFLFqqnV",
+	"MJlOCUNshqwGiOQCS2SGI8kQ0ZN7E7jMT82zUriLVsjyZ7qGdzbrGmqazA7JQD24gRXCEQccrhB8IMJG",
+	"G1sMpwzufFFHj7fIbybe6kWz1lTcwWscLAiFkQJUxx71GsjqKHUOHF/5l3ZCLfFKp38tY7lCZKb/GLAk",
+	"CrV+pH75IDkOishwco5ybauUz54sMS0D6Q7p5thO5x8OSllCOSJfYQlCXibUk+NF5gt5B+r/prqyshnY",
+	"DGFzCr8TaMmERBwCq3VkKWgRuQV0g+kU07ExgDyZykrItp2oDL4rNbi7BuJm21QLCNVv6MDeb0Nk7ckh",
+	"MpbjEGVm5dCevyEKMA0gimwQPbtwclO0wx3TYBIU9+nNPLRoi1YI65vRFEJqcijUYxoiIgXSEWZFqDQn",
+	"00bFqnQwYTyfBphmiNyn7qjVDM0APdC3LeMh8Edp3NxuVu/RRfiRT2BVwxINkVq/OVpLR5sdW5cPSx2p",
+	"neWWgNXAs+lP2iWh47936eKoFqlhaeDxMpHSebZsFylVIK8YcLxrECQcLv5DiCN3Fqc8oIuB5czu2+Br",
+	"I9DqXcRe+/V8ZtJk9BKICMRhrm4ors41RhwESBQReoMWWKApAEWiS5C/3qQdDl6zEKKWYp0smakp/cjD",
+	"jjVVMI83UQXzpGfSeMCE7F9/UEakzRN1pmypn/GhvJrd+MWnNW4lEu3kSj6A5MjtBbO3HZPeRwS4W+5o",
+	"TuN+QeHqCduAEes5tm1OdT2/D8CLgsVbyp4q3wteVSJrKeKOPJ7UCsDCuJPjboUtxp6GgbOcdzdGP3V7",
+	"+khYbtDJWJu8KBm6JXCnVRntaDwgM3RxaSw78aheLWxoNaS7U3RycHVW8bfkg6pzDzV4hlrcPlVKbuDg",
+	"1LCHL32qwqmPWxnV+n3qlc0La1fUXbU6GuKxwH5Tej6EKCJCpnozMoPH6KX+X536abPNQyTU5qgkOIpW",
+	"f7Fqtg3hYPNh/Xhl9HRDpt2NBsDrTNvrbXG8gduicFFY6rSK/CJeahJhvGE3J+CWJaobalniucYpym6q",
+	"2pyzRg9Jof7NrJL2mrgCmcSmw8RzuIWIxcourOktUc2g7cI0qW+iPRKcZWjVJcIWpqxJ4K1or669Pify",
+	"esoxDRaDtJhAretcsoPhYKGwp8QWuY5ZpO6jBZHR9RzLUm5coyfAbTZQ6t71PLXjTUBKMpQIyPlA7X+M",
+	"Lk0ER5h6jaFpRjLUjoysfQM2fiXF4OOC42VT+SM4kezahkIKJ2+GI+HVedfQ+EsSMDYfoRj4yJB0pD6x",
+	"hyDhJsHzBlajWxwlgGJMuOOqzbmlLIx+/HEzSHHKbGIOgfEGGxugXHiT/v5UUzhlCUSokIDDMfoFYqkJ",
+	"P8XBzR3moXauYUmmJCJyNW6pvumQgtro69H5/YrJSbBqO86XauyFGdrdP1NgoNKC3hNuSzq2Wpe1maqr",
+	"gPAg0fIE8A3wa5xF5Iqg/b4AuQAjfO03yH6DiHAcl5KTOIZCgXj9MSstniVm1cUkAkaFTmy5de4VZXDa",
+	"LGk3vSXrBOjV7MtLL/EHn0uWg1iwKNTc7S6erommMGMczK6Nc9FVwJq6EQ63lWT+ZZTRbbJq7iuviduW",
+	"PrvEH65NoxJfFE535UTm90xvSxOyCEVvr56jA0LNKuayZDQqJpEfTbyuxpod5x03WqoAq6U0dzTL7ci/",
+	"efJkM3h6UFWEO3Na2Zs0Q22duK+9g/xCup87y9K8sXPPdJULy042gcfx77EmpyutVHed9DKhXaYUaV5o",
+	"p0ltwUrLtE3nOO2Ia8+xbki07dNbDDv4QnLqtxSKTLRUGtN0bllmFuzemad+yd4defq04mnY6eS+PXgG",
+	"RSyUwHNYL2PsYX5wGk7eJpxgVrTtN/2pWE+9o4rBbRl/vaq+dx5V2WTd+F4qxfdaGlhXkN774nTYfTOn",
+	"2D0/+z3MlzY7YOuJFNWD9p+YAnrOoH87hXWTMvq0fKykaAzr+0xc6ozixtz4PNe73IxX/V1faDYx3NpB",
+	"bjip1PVh0ga7XcwPqoD2qgIXwdXcLAp3KB2BDqxlj35EwQLr/D8uilYahbsrQxssxNHx4zZK2PyHmpZ0",
+	"OoHFmIQcAiC3EKLpCqX0clw9L//+7/DsaDI9ltGUHC2nj89lsPz7v//5f/73X1uFioGgJUPH9aFVE17w",
+	"h2slRtNzlMVXCw81tHlnjIetLKopo9qioCPrfhkMBzi6w6uSt6swoCW/xwG3sKx34wlds4BvMwV7nDN+",
+	"7aQ/rV26UWyicS0ojsWCyd6lRFnNfdVsAB4AlXgOxm1ncZR2lJr893/936PJ5JFJw0xsV0X9wkQWB6h5",
+	"18PLL/0LD3lf7HcrVrR1iTVVi1mCaa/CxU3Uyf0CqyxcIwQLSJbavbJRNF0b9xfE0sAFFkiwJSAI54AC",
+	"LECgJV6hBb4FRJn5dNyp4H8zPbgLqo5TkZflTjoNIPooOhW7eyO5F71yHKqpqi733LfYpiaJ7/H46En/",
+	"ND4nR8KtmbEkKJiTLfkSFu91ddE9k0RED5cIxK0ekfvhbO2Ov077/SzEs1bq55q9fpvWf7KehyFjmAJv",
+	"1AfHLVtcsrt78oQr4b1Nqvtb49s/qT35JYtzlHLRj+6RJtzVDVVd9XiNvGJPW+3Jem3cmyWTww+dWr1f",
+	"JnQDNq9SGPds6ObVJp37xK2p0aaxa3tEH5bKG7H5dXrReAzrrFapJdWFcaLQbcSjOQRE6PoCyZWC5Twh",
+	"wxnLA/X964W1JVITD/99QYKFXRNLCfoxFAvLwZEpvXlUB0rN0rXGV9lwV4sKybGE+cqkJ2TywMJSt3Lm",
+	"caMB144znSU7SyLtQN5kCfX29PsWtX44uMNEEjq/zirse5Vb17RotL/q8inn58ZCo2I2q5OUZqfJWjx2",
+	"r2y+TOjvRC6uUn0LR9Fvs8HTP7oIwfY+li1zdErAq9Mr3ts3B9s0fd+N9LiTxrdeoc+W1JQ+SdMO13X0",
+	"bddWJx1tojppv1pEqT1Aqcl91/d+fIenpqFP10akaxUA7KB5ab82ebto3jMcRLrQNo2+dyo9bu+n2tfF",
+	"9LW2X92Kv6em0WAfP48nFcLTXHldb9vabpgn4+Mn64gpx/+VmzvOGo0oqE2FUUpDaxJmSIQkNNBZ27aD",
+	"BaE6ATTUiRmilATp61nZA8/3Q1wluaN40ayXqpFXg63nFHHI1z0DI6dNA23TLralDCfbD7SlPMh2zm1p",
+	"jOi2N2ltJ6fV5paKvBJy8ualudodmshPXlrq3/8GTPaaln87NdqzvfzGr/TDml47LOFUoGyoNrd0vdWf",
+	"CXACYogYT9/lNO1M1IgbWKGIsZsk1oE06KC/55hVWnwH3L1Pt3DV8zmcdnrnUuGtlvYP9CWoLT/71O2x",
+	"pgpbGZSt9+rSW9sMqNigZq2HluxMuuf5r1a/XveZpfWfVKrBzuvVBWdKfXJQtCTUjYUeDetyRbqng/Ta",
+	"cD203x57ehgNDNZ63SnfxPtaAhcLcGuJu04d7oaqZktbt5A07GiHL1d9xe9StcrrzT9N9ZUX2XxOxTAp",
+	"d6TJ/etdww/tcax6ibPeQ1gOlpbxukhqzmVOlyg/Zb+LN686I/DzeUnpC30Rqf3BoxrKvRX9Upwp3I30",
+	"nzeV53y1JHKxhmRhUbH5Qbgk6v5KROFdkUYECOA7KtLYVK74tsoPG3PQe+O+uMk91j6keLQxGg13P5ew",
+	"4hHzTvieynkw3gyFb2B1vSA+r+0rLCQ6cXLU03v5BlZDFHOYkQ8Qmj7M7wbj8fjdoHAzj8fjD+YR8009",
+	"W27TTa1WPUR3jN88qnnL/D6vldt1jFI9RCwGiskj/xvm3cIRnrfKM8S3xs4VTjbgntRibZ/eSXUNQpBw",
+	"IldXasY0cM5uCJwmSqCXKfOfv7+xarZQmjkWCFOkNL7faLRCpnwFmQm0/0Yn1dl/Gf7KyhLSXcdEndlP",
+	"n3QP2hlL+45j03LDfvQ3FsO5/J3xG4HeAF5Wm7Q8M/e/fus/5VD3q1Q/X2KK5yYSprQ0dRzH7+gbm3Gj",
+	"vrJ+VvPomD5iPJGLbFK1gAJQncHxO7WTiARgu5tacF+fv1ESq+AWUUxr5hwrfdh+JA7V2FxBKOz09OJ8",
+	"MBzcAhdmj5Px0XiidSN1AGIyeDp4PJ6MH2s6y4Wm3qG2UI0nwZgvij81B5yHuku0kC/1K/KnZqBOmcJL",
+	"UAKl1n+cD1E8Bxfqn7UuZHcwcGf8e/0KhG4FqwE8nkxKbeZxHEfWB3b4L1ttZJj9nmdNb3ajh618lioc",
+	"+co6asyb/cjS5dNwcDI5qlsrQ8/hW4oTuWCc/BtCc1LTOJ+ZGEdRcWZ0oHVi9Ff7Z90vC89F1nBKDN6r",
+	"eQ7VvIcz/TbLyK2Sim1UrsgvxUdcBkbIgJDPWLjqRbwm1PpfivlUlGnKVPxU4aDjjQFRblbsIakuPbN9",
+	"iUMiYiyDBYTowBQuIa4DORCi//6v/6fuY+0itMOVCmbx+sgwwaSdCZ5hBxm5sB48/eO9yxB2DMJ5TZvT",
+	"JPmW4Ky0LGMIJd0ddtBJAfVMoBtVvzUq4jboX2iE3Ynsk42tbW5hz/HVeRIiCQIQYpbopmuAQzDPS1yB",
+	"HJ2Zm61ySWb3obots+svh6asoXxaXybUMMQrNkeEqrtZdwAldI5SBb+eAZiJh9dyAEtkxgIFWpx4NDg2",
+	"n0OIWCIdDEarjUg/Ntfzul3nWzZn9FrvdfgS5JmZxL+37fPZmbMHlL4DtgE8vYQCjqKV+yAxhG04S3uu",
+	"17NEWne9RblQLu3uJBqOtk4y/cBa3pS+yOJbFhM9bw31yU/tn5wxOotI0HbNmB0jrOunWxlIQBcFo1DO",
+	"vTU+8pSM7/ie6aBepBDmz/VUZOfmlIYrkJaQmdKQKNMne2EhM9SqBF4QGY0soZpNDaejgMfUKG7/Zx1L",
+	"RdNVoXMAch7UGDwd6Lri3JrMi4IyInR+Oa3iKXjItk/Hd8VMbo+PtbTx4sSPXRxvziwpzIpMdNx0N8gL",
+	"Sy0/KSby8dPhdDUSEuLDj+r/noefmi5vZ+vPVlfm8Zl+9uyVXuQCy8XOiOQjUIHl76cGqI9O2j/6lcmf",
+	"9Yugfr2hAJAOfetUJ/vATysRP6p/pn3OO9OwN/XcburfiFggIi6ScLoyLf37Uu7Qabbsv8FPzYAvlIzZ",
+	"5bGu+rV90q+l5GW8YslX4pd1OMVcrk2qXrnJ0Kb4ZBsqYxnWHeuLfXg002q+VB411OjEotbR36yWXqSD",
+	"duj9bh9/xbh8ttqBwuj2c+ykLGZI3aT7Os6JkNIx+9P7T8MaIXKmY3N5/99tHP7CGntyPmSdMj30sbEs",
+	"G6bc3akv0NEgKbUh837MVVK6x/LwIzHaYAgRmN6bRfo+13/P6dvvfNZrDyf1/XANKOFeNDWzXYSbMTis",
+	"VZ43j6jJLll4/0pyGhgu68dFUZR4sF9Igr4fATYvwrwZ2jtWYTrQP31G+uEqLgWWMVhtO60VeXdom5+P",
+	"bPNz4xx1FWVPnFF43+cQUgFwoIsH/zoZ2reF/6qf5XiEBDM1nNl7GrqsM8AUTSFt6QEhwnNM6BidhktC",
+	"R4xGKwQ0jBmhNqPB46E9M3A8M2BsVy6flfZs/JEbCCSpjx63f/Qz41MShkDvyy4mXuwjo3Go9OAi+1/a",
+	"IG/P8LDHa90Uj3QtQ7Pht5yQTeeEbDoZxGSA4FtMdF59kb3Qgf2Pkc4QCdH/akoRada7T22R470Y6v02",
+	"tfZCGemOdXbLUVW66x+K+vo6wuv4uMtHMWdKUCpGeEElkasOinvKGmkRqzdzqEEaHX7U/3veRbffCA+1",
+	"y5lTA1CPe8dQ6SFYA7SeEPWmwMPA62RXp2mWO5b2YjjYPFFTEVi2HlxxWm877I1i27I3+gvfnbFLwdLY",
+	"k9lA15CvpgtLruz5e0fg+ZzDXPvs9Hs6ShHKUpZFDAGZEQgzjYDd6jQOXXRrXqAZmrqBadpQR5iYLeOr",
+	"oTIizDOfuiB2jJ457weZx38JDaIktP0Di6WPIRFxhFcIR4zOBQkBJQLPwWdo5O6MMyY2oreWGqDm27XF",
+	"vAZppqDWl16Qvc6Ts2De/uKH0CmT1f94PFH/96eJN71gB54Wtx+Q9yBkTJIyQsYs+xOkdZzrM4/MYWg7",
+	"LW0WUonPnq02p9Xeg77dbZaWlte16qdC79T9bi8EL4Lh0n+6srfpPckfLDCXHal/psduW9LoPWuwkC3M",
+	"2ZC02YKc6cSHut07lviCEZ8NXWXB55hEK+eEa2/T/vy+oRccQytNJg40BG77u/ZjP57QrrLnUg3dNvPx",
+	"hDpyfpus96V6ipxG9nut1+sQqc2Izdnd/o4XT+gogluIytL+npJd5M0OO5yuVBX6pkd2dqF9hgqkhsD+",
+	"aX3+gpgEIyW5Dz+q/7xMaEvW4gszavvW+4sUnO17XOxS9h0XDwPoRm9KxNi4rTEaY+Aj0/hXZK0y9mNL",
+	"UAQphNojUwNfzhdqeCtfNMdaXugRDznG8oAyjxSyuqcdaeQbGhr6BaYp6qbiJmb+YrCkulqVW5pjJGqP",
+	"DzpE4raN3HGEROOmTrDsPJ9pvXjw+mmMhciLllSEeq+rbmLJXFWdYi6b4MluV1WviIsm+/0DLruM6ech",
+	"GjA4rQqHJpVh30SY7OYo7z2vy2oC5biMI8HrwzJ7otO2gjK9xf2OeGQvuV9bFhX3ux/yOFGNbOl4HxyG",
+	"eN5muzw/ffllyaLnpy+bimufn740uh1lIQgdzoJwDmKHBRDHm2tW8oJz5m8nsAoiUOJXF4Qo/cLosqZl",
+	"I9CAqC17K/6yISs05zheoIPnpy8fGfX43hyZOkVr2kvghAaLnZrU9Wx5vGl7+lS31dQmSL1Frb4Jk0hX",
+	"YGfjv3bWNHyBMJpiGSw0njQ76kdNGScg0j4nCo0HWKxo8OieXHr4kWvnz6F5Cq4+S/dM/27SdDO3g5Ir",
+	"CjyTl4uCBYlCnYU7Rlm/a5G65amitmkmjbl+PCmOIRyjNKp/MvkJEdPjT81NBMIRBxyujN0ggS/tC4ZY",
+	"eiPqBsS9nKv20TtyaukXoRoOXvbi36YyjHeoMBj6KhPSNDsYplylXwwxD5hnvOmcCy2N1zwWetb6U3Gh",
+	"fhauK26MzrJTYNLT7cPjurcD1wnpHNAConCI7hYkcpvWpKckP0i6+x6hCSDJ0tfoCaPeU5MdSyL0esbc",
+	"xolOjqw/NnoP305N06mxvPX5HRlNW8WehI7S10U2fUQ4iGQJjfUdyVIdkvIRHaML8weH3dXZMBOGRmvV",
+	"jyMQRrODYF2kiuEpfJBFRY4lcdejkdK07lgYsL+di6ZzkVLq8zsYhrpVnuxxJhZERodp353WlMUoyuuU",
+	"jBKUi3379K5WlBbJElOUPsI7Rs9BkDm1yYZBwiPzSjI6e3WuOxDPInYndA9Gt+OZOSPY6balT1OgwNBP",
+	"X6QlUOpaEQDoTt1UFCAUyHTe9x0JXWxjNtzc6mi3uWSNSQgVcOsCMmm1iqXoRloG9ffBVMM2BXhSvnC6",
+	"DtXEgD1NAgrcS50XmJpDftW3mh40xavgtlHcRQUK7A734cvVAPmgqaVykYptsboqah505K7+kbAdx/E8",
+	"ePOw069Vwu0nyLc+A+YhO89euvJgN5Fz+NH9Z6ew3ubZt13R+rUAZI9gn48bHkTrBQ9pmwVKfejoQRFk",
+	"WwGle0qhyQOQQp9r34F+rLqm3DmU6SND3pvzDfg0oAcseBTARcwJW/m9c0JeAQ2157YE0TpETI2nxmzY",
+	"wqOTD9osKULqyw9LjUXD9wm3mdR7bJIZe0Gq7+5gh49Slbqtt8zmqbe1TjPe10133XBmTR76IlMRfBfI",
+	"Zni2ViI1Vr4oU+4yoeLZat2WSZ9TX5IWH2L3HFiN000lvGqHch2lrXev2WDegOd3qxbyZUL3ZBLXeIYv",
+	"E/r52rxwV2gl1cY6jYKhc1z9DcdU6EfIRRb6lsyN0+os/jE6z0PjCywQNm9i505kGymh5jEUHS7R8feh",
+	"acmUPT9NRB56t95RJyq/xPwGQoRFDsGaEXp0kD1PPkTmZXIdp83mfVQfw99JxGW/MZTLryEYb1Je+oVV",
+	"iqeHiebSdlusKL4kdtHlxrVVSZdZgase4hb9QPwAKt4lk9hUQgqnk34dlD2K1vrkZVylHQVNF38lQZVU",
+	"NWw5Rm8KTwXlktOI1CzQXEi5GKJposxYfU/kAjPSSVvNUrImGQMdLBMh0RTSo/OoNj3jKxGIn3uehZPm",
+	"dk/B1zWpIs+PYLM8mq21F86WmgkjLCTK7mLNuh2YtVt6xFfCl19OnsM6jGmTTxtt3Ss75oFXhpZyWtly",
+	"iUcC1BeuFWouDHMBzLJ3mvSzzEM0xcFNxObDVGZ3f6vJ00CidGtp4tzASi0cMXaDkhgdcHtU06d61aC6",
+	"VW9g1bjkNs+Phl7xwm/8SoPazeRPU5sZL+xQYVztZm9x+BQuT8Esi227L6tZGB4ptk9JD02bi0Fj7UE7",
+	"GTSEe3IzGOx4+Mgcla+rhtaci5oi2pzf2uT4IVnGjDeEvM717xuS6FtizQKMe3LAl2AQSeT1cpphWoeI",
+	"ZKVHg9EoTK4r57p7Vl71/zBZusChz5LoBhmOykWmUj2XmJsuOHrH/zh9/Ur9ncollrLwlmYPzv2okdYp",
+	"WWQjcrVDLwkDUI/47JUtA/ocy8CNCKq55epcNA+DEpNd3Un7f+Qj058KxeAFhaQ+Crs3am0rVttffdkZ",
+	"q3yrCa+rCW8QNN0viXbvsSbDjvzHu5VPLb3NrPrsNBN7QP5iI79wwJkwhRPcNI7s7CmuckK5ILvkB9Ba",
+	"tsiDGbnL2jh6Q+DkFsLcp2YX+06UEwyMIkf/TCBRE4oVDXIfndftZndrA2k6tEfTglrdi/pkMimOdeJu",
+	"IaOgRpwURzBegct69nQfeW9th/Zj78Sf13ISNhqk/p3IxZWiYUu0ulRsZin4TTR7qtM9MXLXcdPDsShh",
+	"GUfq5BXKp2IOgb4W9fU89D/4s4zlm+zrrzW1poiHXg9cLmOJcvRvKuOmPHHTy0/LWI5yCFw3WRsLZA9W",
+	"Opt/0B60Iqj7e2LTxZf/mTqXel+Zd63Eu3V+Ng/ntsu3w4/pf1Z8F23Mnr0QukFmb5dhbzJw+70wWsDg",
+	"Z+rjKDFCm9TqeG+ZZs0PjIiTPUqXB/EYagEiz6Oonksq6UTu7EXS/VN8i8+trnur7ZPvvjldZMM7r90l",
+	"n7r13JSVliy93sy/u6yPVhux0P9bmJF7k1qldt9ECguS1+4qJBXpcYcf1f+YHCNpXheoy0wm8zlwodZU",
+	"I02GkcnktXl1EI9R7jxRWpQZqfPodJKyae3CjHPCfmt+df0k6kdCAw5LoFJ3N5DaA5TVajgulDd5qpLM",
+	"cqch1HkZSLIsBYvMEJHoDuumadnKWEKNFwZiJ/vJHY8YR0v8QQNFdMpVABBC6M+Kknz1s/5YcdR9mL6L",
+	"H0XR8QEcEU0tQokkWGd7pxkrVtSWvGmfS+KUZsEyv/tPWb3DsaU4aL1oS8GB9q0w6D6FQQ0uq0RocjTQ",
+	"8K0e0Vur+yLeNlB7704+g8v9NdHBUWRhyElt/u3Q+nDZWF38enXB2YxESi/aKlq97URNtrrehNLTNBwb",
+	"OA9pbW/gzP+dyFaoYqsxeFxE0bYMj2yVPdkcdTR6a6+7Ko12ZWbc2waoZwV0QPFSdxE7VPrYEpPCi+q+",
+	"w3SIYzK6gVWzEH29Or04/0WN2sVTfop2Zr0u7/ilHaJOL86R2kj2yKyLo41dSx7kZwsfLAiViNFoNUQU",
+	"boGjEAK+iiWEhYftU4y3pZ2mWB9s9XV6vcSe/N0upT2PexnE6vvfm9j/8I+s0gJN+3xqOSFlFz+bernE",
+	"e14PP95Atyw7h436KUG/QL+suXRnD+O9egtNB5TGWIg7xkNtZvsuzrMFpnN1paUDt3Qg9TLpIr2OpM/T",
+	"b+dBgZ52X+enGMzRoHhvsBy19dfVR9KF39+ag9SP13sxulrhc42clMRMrjLWqdQbRucOVDxDnftGLnZJ",
+	"HeM11DppOcDRSae/P422ZQcoyB6aCaDQ/LX016k98Ho0BAkncqW5xbQgPk3kYvD0j/eKKwTw25SXqjf9",
+	"7RGaYgEoVkw0HCQ8GjwdKPXk8PZIM5VdsfJt3gLZZHGF9uXtrEBOoc1TCajptsQUz7UL2vdl6sLwRL11",
+	"ZVjz12l+gGcC3U27+WvzsodnbTcVq3kK60Bri9m37qIYBqqrYWyeJk3mbdhQsV2TD5Ryp6bqZH9LlpiO",
+	"CB3JBYwixuK8fbJnQt0wuTqJp59iA1TFdnbV2U71i//N2MFqjPCWqyojkePgRr+bQ0PEpuoc4SmJiFz5",
+	"5jKpsjX8nurULeCkmu2n95/+fwAAAP//tQrjom1JAQA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/backend/internal/api/handler/hitl_handler_test.go
+++ b/backend/internal/api/handler/hitl_handler_test.go
@@ -455,3 +455,11 @@ func TestHITLHandler_RejectHITLRequest(t *testing.T) {
 		})
 	}
 }
+
+func (m *mockRunRepoForHITLHandler) GetLatestRunByStory(_ context.Context, _ uuid.UUID) (*model.LatestRun, error) {
+	return nil, nil
+}
+
+func (m *mockRunRepoForHITLHandler) GetLatestRunsByStories(_ context.Context, _ []uuid.UUID) (map[uuid.UUID]*model.LatestRun, error) {
+	return map[uuid.UUID]*model.LatestRun{}, nil
+}

--- a/backend/internal/api/handler/run_handler_test.go
+++ b/backend/internal/api/handler/run_handler_test.go
@@ -524,7 +524,7 @@ func TestResumeRunHandler_Success(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
-	if result["status"] != "running" {
+	if result["status"] != string(model.RunStatusRunning) {
 		t.Errorf("expected run status 'running', got %v", result["status"])
 	}
 }
@@ -600,4 +600,16 @@ func TestResumeRunHandler_WrongProject(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected status 404, got %d. Body: %s", rec.Code, rec.Body.String())
 	}
+}
+
+func (m *runHandlerStoryRepo) CountByEpicGroupedByStatus(_ context.Context, _ uuid.UUID) (model.StoryCounts, error) {
+	return model.StoryCounts{}, nil
+}
+
+func (m *runHandlerRunRepo) GetLatestRunByStory(_ context.Context, _ uuid.UUID) (*model.LatestRun, error) {
+	return nil, nil
+}
+
+func (m *runHandlerRunRepo) GetLatestRunsByStories(_ context.Context, _ []uuid.UUID) (map[uuid.UUID]*model.LatestRun, error) {
+	return map[uuid.UUID]*model.LatestRun{}, nil
 }

--- a/backend/internal/api/handler/story_handler.go
+++ b/backend/internal/api/handler/story_handler.go
@@ -1,12 +1,14 @@
 package handler
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
 	"github.com/zakari/hopeitworks/backend/internal/adapter/markdown"
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
 	"github.com/zakari/hopeitworks/backend/internal/domain/service"
 	"github.com/zakari/hopeitworks/backend/pkg/errors"
 )
@@ -14,11 +16,14 @@ import (
 // StoryHandler implements story-related HTTP handlers.
 type StoryHandler struct {
 	service *service.StoryService
+	runRepo port.RunRepository
 }
 
-// NewStoryHandler creates a new StoryHandler.
-func NewStoryHandler(svc *service.StoryService) *StoryHandler {
-	return &StoryHandler{service: svc}
+// NewStoryHandler creates a new StoryHandler. runRepo is used to populate each
+// story's latest_run for the live board; it may be nil in tests that don't
+// exercise that field.
+func NewStoryHandler(svc *service.StoryService, runRepo port.RunRepository) *StoryHandler {
+	return &StoryHandler{service: svc, runRepo: runRepo}
 }
 
 // ListStories handles GET /projects/{projectId}/stories.
@@ -31,7 +36,7 @@ func (h *StoryHandler) ListStories(w http.ResponseWriter, r *http.Request, proje
 			writeErrorResponse(w, err)
 			return
 		}
-		writeJSON(w, http.StatusOK, toAPIStory(story))
+		writeJSON(w, http.StatusOK, toAPIStory(story, h.latestRunFor(r.Context(), story.ID)))
 		return
 	}
 
@@ -45,7 +50,7 @@ func (h *StoryHandler) ListStories(w http.ResponseWriter, r *http.Request, proje
 			writeErrorResponse(w, err)
 			return
 		}
-		writeStoryListResponse(w, result, page, perPage)
+		h.writeStoryListResponse(r.Context(), w, result, page, perPage)
 		return
 	}
 
@@ -55,7 +60,7 @@ func (h *StoryHandler) ListStories(w http.ResponseWriter, r *http.Request, proje
 		writeErrorResponse(w, err)
 		return
 	}
-	writeStoryListResponse(w, result, page, perPage)
+	h.writeStoryListResponse(r.Context(), w, result, page, perPage)
 }
 
 // CreateStory handles POST /projects/{projectId}/stories.
@@ -101,7 +106,8 @@ func (h *StoryHandler) CreateStory(w http.ResponseWriter, r *http.Request, proje
 		return
 	}
 
-	writeJSON(w, http.StatusCreated, toAPIStory(story))
+	// A freshly created story has no run yet, so latest_run is nil.
+	writeJSON(w, http.StatusCreated, toAPIStory(story, nil))
 }
 
 // GetStory handles GET /projects/{projectId}/stories/{storyId}.
@@ -112,7 +118,7 @@ func (h *StoryHandler) GetStory(w http.ResponseWriter, r *http.Request, _ Projec
 		return
 	}
 
-	writeJSON(w, http.StatusOK, toAPIStory(story))
+	writeJSON(w, http.StatusOK, toAPIStory(story, h.latestRunFor(r.Context(), story.ID)))
 }
 
 // UpdateStory handles PUT /projects/{projectId}/stories/{storyId}.
@@ -158,7 +164,7 @@ func (h *StoryHandler) UpdateStory(w http.ResponseWriter, r *http.Request, _ Pro
 		return
 	}
 
-	writeJSON(w, http.StatusOK, toAPIStory(story))
+	writeJSON(w, http.StatusOK, toAPIStory(story, h.latestRunFor(r.Context(), story.ID)))
 }
 
 // DeleteStory handles DELETE /projects/{projectId}/stories/{storyId}.
@@ -233,8 +239,9 @@ func (h *StoryHandler) ImportStories(w http.ResponseWriter, r *http.Request, pro
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// toAPIStory converts a domain Story to the API Story type.
-func toAPIStory(s *model.Story) Story {
+// toAPIStory converts a domain Story to the API Story type. latest may be nil
+// when the story has no run.
+func toAPIStory(s *model.Story, latest *model.LatestRun) Story {
 	story := Story{
 		Id:        s.ID,
 		ProjectId: s.ProjectID,
@@ -263,11 +270,67 @@ func toAPIStory(s *model.Story) Story {
 	if s.DependsOn != nil {
 		story.DependsOn = &s.DependsOn
 	}
+	story.LatestRun = toAPILatestRun(latest)
 	return story
 }
 
-// writeStoryListResponse writes a paginated story list response.
-func writeStoryListResponse(w http.ResponseWriter, result *service.StoryListResult, page, perPage int) {
+// toAPILatestRun maps a domain LatestRun (and its optional current step) to the
+// API type. Returns nil when latest is nil.
+func toAPILatestRun(latest *model.LatestRun) *LatestRun {
+	if latest == nil {
+		return nil
+	}
+	lr := &LatestRun{
+		Id:     latest.ID,
+		Status: latest.Status,
+	}
+	if cs := latest.CurrentStep; cs != nil {
+		lr.CurrentStep = &LatestRunStep{
+			Id:         cs.ID,
+			Name:       cs.Name,
+			ActionType: cs.ActionType,
+			Status:     cs.Status,
+			Index:      cs.Index,
+			Total:      cs.Total,
+		}
+	}
+	return lr
+}
+
+// latestRunFor fetches a single story's latest run, swallowing errors (the field
+// is best-effort enrichment and must not fail the request).
+func (h *StoryHandler) latestRunFor(ctx context.Context, storyID uuid.UUID) *model.LatestRun {
+	if h.runRepo == nil {
+		return nil
+	}
+	latest, err := h.runRepo.GetLatestRunByStory(ctx, storyID)
+	if err != nil {
+		return nil
+	}
+	return latest
+}
+
+// latestRunsFor batch-fetches latest runs for many stories, avoiding N+1.
+// Returns an empty map on error or when no run repo is configured.
+func (h *StoryHandler) latestRunsFor(ctx context.Context, stories []*model.Story) map[uuid.UUID]*model.LatestRun {
+	if h.runRepo == nil || len(stories) == 0 {
+		return map[uuid.UUID]*model.LatestRun{}
+	}
+	ids := make([]uuid.UUID, len(stories))
+	for i, s := range stories {
+		ids[i] = s.ID
+	}
+	runs, err := h.runRepo.GetLatestRunsByStories(ctx, ids)
+	if err != nil {
+		return map[uuid.UUID]*model.LatestRun{}
+	}
+	return runs
+}
+
+// writeStoryListResponse writes a paginated story list response, populating each
+// story's latest_run via a single batch query.
+func (h *StoryHandler) writeStoryListResponse(ctx context.Context, w http.ResponseWriter, result *service.StoryListResult, page, perPage int) {
+	latestRuns := h.latestRunsFor(ctx, result.Stories)
 	resp := StoryList{
 		Data: make([]Story, len(result.Stories)),
 		Pagination: Pagination{
@@ -277,7 +340,7 @@ func writeStoryListResponse(w http.ResponseWriter, result *service.StoryListResu
 		},
 	}
 	for i, s := range result.Stories {
-		resp.Data[i] = toAPIStory(s)
+		resp.Data[i] = toAPIStory(s, latestRuns[s.ID])
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/backend/internal/api/handler/story_handler_test.go
+++ b/backend/internal/api/handler/story_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/zakari/hopeitworks/backend/internal/api/middleware"
@@ -138,10 +139,16 @@ func (m *mockStoryRepo) Delete(_ context.Context, id uuid.UUID) error {
 }
 
 func setupStoryHandler() (*StoryHandler, *mockStoryRepo) {
-	repo := newMockStoryRepo()
-	svc := service.NewStoryService(repo)
-	h := NewStoryHandler(svc)
+	h, repo, _ := setupStoryHandlerWithRuns()
 	return h, repo
+}
+
+func setupStoryHandlerWithRuns() (*StoryHandler, *mockStoryRepo, *storyHandlerRunRepo) {
+	repo := newMockStoryRepo()
+	runRepo := &storyHandlerRunRepo{latestByStory: make(map[uuid.UUID]*model.LatestRun)}
+	svc := service.NewStoryService(repo)
+	h := NewStoryHandler(svc, runRepo)
+	return h, repo, runRepo
 }
 
 func TestCreateStory_AdminOnly(t *testing.T) {
@@ -633,5 +640,209 @@ func TestCreateStory_WithJSONBFields(t *testing.T) {
 	}
 	if resp.DependsOn == nil || len(*resp.DependsOn) != 1 {
 		t.Errorf("expected 1 depends_on, got %v", resp.DependsOn)
+	}
+}
+
+func (m *mockStoryRepo) CountByEpicGroupedByStatus(_ context.Context, _ uuid.UUID) (model.StoryCounts, error) {
+	return model.StoryCounts{}, nil
+}
+
+// storyHandlerRunRepo is a minimal mock of port.RunRepository for story handler
+// tests, supporting only the latest-run lookups used to populate latest_run.
+type storyHandlerRunRepo struct {
+	latestByStory map[uuid.UUID]*model.LatestRun
+}
+
+var _ port.RunRepository = (*storyHandlerRunRepo)(nil)
+
+func (m *storyHandlerRunRepo) GetLatestRunByStory(_ context.Context, storyID uuid.UUID) (*model.LatestRun, error) {
+	return m.latestByStory[storyID], nil
+}
+func (m *storyHandlerRunRepo) GetLatestRunsByStories(_ context.Context, storyIDs []uuid.UUID) (map[uuid.UUID]*model.LatestRun, error) {
+	out := make(map[uuid.UUID]*model.LatestRun)
+	for _, id := range storyIDs {
+		if lr, ok := m.latestByStory[id]; ok {
+			out[id] = lr
+		}
+	}
+	return out, nil
+}
+func (m *storyHandlerRunRepo) CreateRun(_ context.Context, run *model.Run) (*model.Run, error) {
+	return run, nil
+}
+func (m *storyHandlerRunRepo) GetRun(_ context.Context, id uuid.UUID) (*model.Run, error) {
+	return nil, errors.NewNotFound("run", id)
+}
+func (m *storyHandlerRunRepo) GetActiveRunByStory(_ context.Context, _ uuid.UUID) (*model.Run, error) {
+	return nil, nil
+}
+func (m *storyHandlerRunRepo) ListRunsByProject(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *storyHandlerRunRepo) ListRunsByStory(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *storyHandlerRunRepo) UpdateRunStatus(_ context.Context, _ uuid.UUID, _ model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
+	return nil, nil
+}
+func (m *storyHandlerRunRepo) CountRunsByProject(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+func (m *storyHandlerRunRepo) CountRunsByStory(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+func (m *storyHandlerRunRepo) CreateRunStep(_ context.Context, step *model.RunStep) (*model.RunStep, error) {
+	return step, nil
+}
+func (m *storyHandlerRunRepo) GetRunStep(_ context.Context, id uuid.UUID) (*model.RunStep, error) {
+	return nil, errors.NewNotFound("run_step", id)
+}
+func (m *storyHandlerRunRepo) ListRunStepsByRun(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+	return nil, nil
+}
+func (m *storyHandlerRunRepo) UpdateRunStepStatus(_ context.Context, _ uuid.UUID, _ model.StepStatus, _, _ *time.Time, _ *string) (*model.RunStep, error) {
+	return nil, nil
+}
+func (m *storyHandlerRunRepo) UpdateRunStepContainerInfo(_ context.Context, _ uuid.UUID, _ *string, _ *string) (*model.RunStep, error) {
+	return nil, nil
+}
+func (m *storyHandlerRunRepo) CreateRetryRunStep(_ context.Context, step *model.RunStep) (*model.RunStep, error) {
+	return step, nil
+}
+func (m *storyHandlerRunRepo) ListRetryStepsByParent(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+	return nil, nil
+}
+
+func TestGetStory_PopulatesLatestRun(t *testing.T) {
+	h, repo, runRepo := setupStoryHandlerWithRuns()
+	projectID := uuid.New()
+	storyID := uuid.New()
+	repo.stories[storyID] = &model.Story{
+		ID:        storyID,
+		ProjectID: projectID,
+		Key:       "S-01",
+		Title:     "running story",
+		Status:    "running",
+	}
+	runID := uuid.New()
+	stepID := uuid.New()
+	runRepo.latestByStory[storyID] = &model.LatestRun{
+		ID:     runID,
+		Status: "running",
+		CurrentStep: &model.LatestRunStep{
+			ID:         stepID,
+			Name:       "implement",
+			ActionType: "agent_run",
+			Status:     "running",
+			Index:      1,
+			Total:      4,
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+projectID.String()+"/stories/"+storyID.String(), nil)
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleUser)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.GetStory(rec, req, projectID, storyID)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+	var resp Story
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.LatestRun == nil {
+		t.Fatalf("expected latest_run to be populated, got nil")
+	}
+	if resp.LatestRun.Id != runID {
+		t.Errorf("expected latest_run.id %s, got %s", runID, resp.LatestRun.Id)
+	}
+	if resp.LatestRun.Status != "running" {
+		t.Errorf("expected latest_run.status running, got %q", resp.LatestRun.Status)
+	}
+	if resp.LatestRun.CurrentStep == nil {
+		t.Fatalf("expected current_step to be populated, got nil")
+	}
+	cs := resp.LatestRun.CurrentStep
+	if cs.Id != stepID || cs.Name != "implement" || cs.ActionType != "agent_run" {
+		t.Errorf("unexpected current_step: %+v", cs)
+	}
+	if cs.Index != 1 || cs.Total != 4 {
+		t.Errorf("expected index 1/total 4, got %d/%d", cs.Index, cs.Total)
+	}
+}
+
+func TestGetStory_NilLatestRun(t *testing.T) {
+	h, repo, _ := setupStoryHandlerWithRuns()
+	projectID := uuid.New()
+	storyID := uuid.New()
+	repo.stories[storyID] = &model.Story{
+		ID:        storyID,
+		ProjectID: projectID,
+		Key:       "S-02",
+		Title:     "never run",
+		Status:    "backlog",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+projectID.String()+"/stories/"+storyID.String(), nil)
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleUser)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.GetStory(rec, req, projectID, storyID)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp Story
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.LatestRun != nil {
+		t.Errorf("expected latest_run nil for never-run story, got %+v", resp.LatestRun)
+	}
+}
+
+func TestListStories_PopulatesLatestRunBatch(t *testing.T) {
+	h, repo, runRepo := setupStoryHandlerWithRuns()
+	projectID := uuid.New()
+
+	withRun := uuid.New()
+	repo.stories[withRun] = &model.Story{ID: withRun, ProjectID: projectID, Key: "S-01", Title: "a", Status: "running"}
+	runRepo.latestByStory[withRun] = &model.LatestRun{ID: uuid.New(), Status: "running"}
+
+	withoutRun := uuid.New()
+	repo.stories[withoutRun] = &model.Story{ID: withoutRun, ProjectID: projectID, Key: "S-02", Title: "b", Status: "backlog"}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+projectID.String()+"/stories", nil)
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleUser)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.ListStories(rec, req, projectID, ListStoriesParams{})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp StoryList
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 stories, got %d", len(resp.Data))
+	}
+	for _, s := range resp.Data {
+		switch s.Key {
+		case "S-01":
+			if s.LatestRun == nil {
+				t.Errorf("S-01 should have latest_run")
+			}
+		case "S-02":
+			if s.LatestRun != nil {
+				t.Errorf("S-02 should have nil latest_run, got %+v", s.LatestRun)
+			}
+		}
 	}
 }

--- a/backend/internal/domain/model/latest_run.go
+++ b/backend/internal/domain/model/latest_run.go
@@ -1,0 +1,25 @@
+package model
+
+import "github.com/google/uuid"
+
+// LatestRunStep is the currently active step (running or waiting_approval) of a
+// run, with its position within the pipeline. Used by the live kanban to show
+// the current pipeline stage on a story card.
+type LatestRunStep struct {
+	ID         uuid.UUID
+	Name       string
+	ActionType string
+	Status     string
+	// Index is the zero-based step_order of the current step.
+	Index int
+	// Total is the number of steps in the run.
+	Total int
+}
+
+// LatestRun is a lightweight projection of a story's most recent run, carrying
+// the run status and the current in-progress step (nil when no step is active).
+type LatestRun struct {
+	ID          uuid.UUID
+	Status      string
+	CurrentStep *LatestRunStep
+}

--- a/backend/internal/domain/model/story.go
+++ b/backend/internal/domain/model/story.go
@@ -21,6 +21,15 @@ const (
 	StoryScopeShared   = "shared"
 )
 
+// StoryCounts holds the number of stories per lifecycle status. Used to populate
+// an epic's aggregate progress on the board without N per-status queries.
+type StoryCounts struct {
+	Backlog int
+	Running int
+	Done    int
+	Failed  int
+}
+
 // Story represents a user story within a project.
 type Story struct {
 	ID                 uuid.UUID

--- a/backend/internal/domain/port/run_repository.go
+++ b/backend/internal/domain/port/run_repository.go
@@ -14,6 +14,13 @@ type RunRepository interface {
 	GetRun(ctx context.Context, id uuid.UUID) (*model.Run, error)
 	// GetActiveRunByStory returns the most recent pending or running run for a story, or nil if none.
 	GetActiveRunByStory(ctx context.Context, storyID uuid.UUID) (*model.Run, error)
+	// GetLatestRunByStory returns the most recent run for a story (any status) as a
+	// lightweight projection with its current in-progress step, or nil if the story
+	// has no runs.
+	GetLatestRunByStory(ctx context.Context, storyID uuid.UUID) (*model.LatestRun, error)
+	// GetLatestRunsByStories batch-fetches the most recent run per story for the given
+	// story IDs. Returns a map keyed by story ID; stories with no run are absent.
+	GetLatestRunsByStories(ctx context.Context, storyIDs []uuid.UUID) (map[uuid.UUID]*model.LatestRun, error)
 	ListRunsByProject(ctx context.Context, projectID uuid.UUID, limit, offset int32) ([]*model.Run, error)
 	ListRunsByStory(ctx context.Context, storyID uuid.UUID, limit, offset int32) ([]*model.Run, error)
 	UpdateRunStatus(ctx context.Context, id uuid.UUID, status model.RunStatus, startedAt, completedAt, pausedAt *time.Time, errorMsg *string) (*model.Run, error)

--- a/backend/internal/domain/port/story_repository.go
+++ b/backend/internal/domain/port/story_repository.go
@@ -17,6 +17,9 @@ type StoryRepository interface {
 	ListByEpic(ctx context.Context, epicID uuid.UUID, limit, offset int32) ([]*model.Story, error)
 	CountByProject(ctx context.Context, projectID uuid.UUID) (int64, error)
 	CountByStatus(ctx context.Context, projectID uuid.UUID, statuses []string) (int64, error)
+	// CountByEpicGroupedByStatus returns story counts per lifecycle status for an epic
+	// in a single GROUP BY query.
+	CountByEpicGroupedByStatus(ctx context.Context, epicID uuid.UUID) (model.StoryCounts, error)
 	Update(ctx context.Context, story *model.Story) (*model.Story, error)
 	Delete(ctx context.Context, id uuid.UUID) error
 }

--- a/backend/internal/domain/service/cost_service_test.go
+++ b/backend/internal/domain/service/cost_service_test.go
@@ -791,3 +791,15 @@ func TestParsePeriod(t *testing.T) {
 		})
 	}
 }
+
+func (m *mockStoryRepoForCost) CountByEpicGroupedByStatus(_ context.Context, _ uuid.UUID) (model.StoryCounts, error) {
+	return model.StoryCounts{}, nil
+}
+
+func (m *mockRunRepoForCost) GetLatestRunByStory(_ context.Context, _ uuid.UUID) (*model.LatestRun, error) {
+	return nil, nil
+}
+
+func (m *mockRunRepoForCost) GetLatestRunsByStories(_ context.Context, _ []uuid.UUID) (map[uuid.UUID]*model.LatestRun, error) {
+	return map[uuid.UUID]*model.LatestRun{}, nil
+}

--- a/backend/internal/domain/service/epic_run_service_test.go
+++ b/backend/internal/domain/service/epic_run_service_test.go
@@ -427,3 +427,7 @@ func TestGetEpicRun_NotFound(t *testing.T) {
 		t.Fatal("expected error for non-existent epic run")
 	}
 }
+
+func (m *mockStoryRepoForEpicRun) CountByEpicGroupedByStatus(_ context.Context, _ uuid.UUID) (model.StoryCounts, error) {
+	return model.StoryCounts{}, nil
+}

--- a/backend/internal/domain/service/hitl_service_test.go
+++ b/backend/internal/domain/service/hitl_service_test.go
@@ -630,3 +630,11 @@ func TestHITLService_GetByStepID(t *testing.T) {
 		}
 	})
 }
+
+func (m *mockRunRepoForHITL) GetLatestRunByStory(_ context.Context, _ uuid.UUID) (*model.LatestRun, error) {
+	return nil, nil
+}
+
+func (m *mockRunRepoForHITL) GetLatestRunsByStories(_ context.Context, _ []uuid.UUID) (map[uuid.UUID]*model.LatestRun, error) {
+	return map[uuid.UUID]*model.LatestRun{}, nil
+}

--- a/backend/internal/domain/service/pipeline_executor.go
+++ b/backend/internal/domain/service/pipeline_executor.go
@@ -101,6 +101,7 @@ func (e *PipelineExecutor) ExecuteRun(ctx context.Context, runID uuid.UUID) erro
 
 	e.publishEvent(ctx, run.ProjectID, "run", run.ID, "started", map[string]any{
 		"run_id":     runID.String(),
+		"story_id":   run.StoryID.String(),
 		"status":     string(model.RunStatusRunning),
 		"started_at": now.Format(time.RFC3339),
 	})
@@ -165,6 +166,7 @@ func (e *PipelineExecutor) ExecuteRun(ctx context.Context, runID uuid.UUID) erro
 
 	e.publishEvent(ctx, run.ProjectID, "run", run.ID, "completed", map[string]any{
 		"run_id":       runID.String(),
+		"story_id":     run.StoryID.String(),
 		"status":       string(model.RunStatusCompleted),
 		"completed_at": completedAt.Format(time.RFC3339),
 	})
@@ -194,6 +196,7 @@ func (e *PipelineExecutor) executeStep(ctx context.Context, run *model.Run, step
 
 	e.publishEvent(ctx, run.ProjectID, "step", step.ID, "started", map[string]any{
 		"run_id":     run.ID.String(),
+		"story_id":   run.StoryID.String(),
 		"step_id":    step.ID.String(),
 		"step_name":  step.StepName,
 		"action":     step.Action,
@@ -286,6 +289,7 @@ func (e *PipelineExecutor) executeStep(ctx context.Context, run *model.Run, step
 
 	e.publishEvent(ctx, run.ProjectID, "step", step.ID, "completed", map[string]any{
 		"run_id":       run.ID.String(),
+		"story_id":     run.StoryID.String(),
 		"step_id":      step.ID.String(),
 		"step_name":    step.StepName,
 		"status":       string(model.StepStatusCompleted),
@@ -307,6 +311,7 @@ func (e *PipelineExecutor) handleStepFailure(ctx context.Context, run *model.Run
 
 	e.publishEvent(ctx, run.ProjectID, "step", step.ID, "failed", map[string]any{
 		"run_id":        run.ID.String(),
+		"story_id":      run.StoryID.String(),
 		"step_id":       step.ID.String(),
 		"step_name":     step.StepName,
 		"status":        string(model.StepStatusFailed),
@@ -320,6 +325,7 @@ func (e *PipelineExecutor) handleStepFailure(ctx context.Context, run *model.Run
 
 	e.publishEvent(ctx, run.ProjectID, "run", run.ID, "failed", map[string]any{
 		"run_id":        run.ID.String(),
+		"story_id":      run.StoryID.String(),
 		"status":        string(model.RunStatusFailed),
 		"error_message": errMsg,
 	})
@@ -344,6 +350,7 @@ func (e *PipelineExecutor) handleCancellation(run *model.Run, step *model.RunSte
 
 	e.publishEvent(bgCtx, run.ProjectID, "step", step.ID, "cancelled", map[string]any{
 		"run_id":    run.ID.String(),
+		"story_id":  run.StoryID.String(),
 		"step_id":   step.ID.String(),
 		"step_name": step.StepName,
 		"status":    string(model.StepStatusCancelled),
@@ -355,9 +362,14 @@ func (e *PipelineExecutor) handleCancellation(run *model.Run, step *model.RunSte
 	}
 
 	e.publishEvent(bgCtx, run.ProjectID, "run", run.ID, "cancelled", map[string]any{
-		"run_id": run.ID.String(),
-		"status": string(model.RunStatusCancelled),
+		"run_id":   run.ID.String(),
+		"story_id": run.StoryID.String(),
+		"status":   string(model.RunStatusCancelled),
 	})
+
+	// Transition story back to "backlog" so it can be relaunched (a cancelled run
+	// must not leave the story stuck in "running" forever).
+	e.updateStoryStatus(bgCtx, run, model.StoryStatusBacklog)
 }
 
 // updateStoryStatus fetches the story linked to the run and updates its status.

--- a/backend/internal/domain/service/pipeline_executor_test.go
+++ b/backend/internal/domain/service/pipeline_executor_test.go
@@ -15,6 +15,9 @@ import (
 	"github.com/zakari/hopeitworks/backend/pkg/errors"
 )
 
+// eventRunCancelled is the event name asserted across cancellation tests.
+const eventRunCancelled = "run.cancelled"
+
 // testLogger creates a logger for tests using slog directly to avoid stdout noise.
 func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -580,7 +583,7 @@ func TestExecuteRun_Cancellation(t *testing.T) {
 		if eventName == "step.cancelled" {
 			foundStepCancelledEvent = true
 		}
-		if eventName == "run.cancelled" {
+		if eventName == eventRunCancelled {
 			foundRunCancelledEvent = true
 		}
 	}
@@ -589,6 +592,89 @@ func TestExecuteRun_Cancellation(t *testing.T) {
 	}
 	if !foundRunCancelledEvent {
 		t.Error("expected run.cancelled event to be published")
+	}
+}
+
+// TestExecuteRun_EventsIncludeStoryID verifies every run.* and step.* event
+// payload carries story_id so the live board can target the right card.
+func TestExecuteRun_EventsIncludeStoryID(t *testing.T) {
+	f := newExecutorTestFixture(2)
+	f.registerSuccessActions()
+
+	if err := f.executor.ExecuteRun(context.Background(), f.runID); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	for _, e := range f.eventPub.getEvents() {
+		name := e.Event.EventName()
+		if e.Event.EntityType != "run" && e.Event.EntityType != "step" {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(e.Event.Payload, &payload); err != nil {
+			t.Fatalf("failed to unmarshal %s payload: %v", name, err)
+		}
+		got, ok := payload["story_id"]
+		if !ok {
+			t.Errorf("%s payload: missing story_id", name)
+			continue
+		}
+		if got != f.storyID.String() {
+			t.Errorf("%s payload: expected story_id %s, got %v", name, f.storyID, got)
+		}
+	}
+}
+
+// TestExecuteRun_CancellationResetsStoryToBacklog verifies a cancelled run resets
+// its story back to backlog (relaunchable) and publishes story.status_updated and
+// run.cancelled with story_id.
+func TestExecuteRun_CancellationResetsStoryToBacklog(t *testing.T) {
+	f := newExecutorTestFixture(2)
+
+	var updatedStatus string
+	f.storyRepo.updateFn = func(_ context.Context, story *model.Story) (*model.Story, error) {
+		updatedStatus = story.Status
+		return story, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	f.actionReg.Register(&mockAction{
+		name: f.steps[0].Action,
+		executeFn: func(_ context.Context, _ *model.RunContext) error {
+			cancel()
+			return nil
+		},
+	})
+	f.actionReg.Register(&mockAction{name: f.steps[1].Action})
+
+	_ = f.executor.ExecuteRun(ctx, f.runID)
+
+	if updatedStatus != model.StoryStatusBacklog {
+		t.Errorf("expected story reset to backlog, last update was %q", updatedStatus)
+	}
+
+	// Find the run.cancelled event and assert it carries story_id, and that a
+	// story.status_updated(backlog) event was published.
+	var foundRunCancelledWithStory, foundStoryBacklog bool
+	for _, e := range f.eventPub.getEvents() {
+		var payload map[string]any
+		_ = json.Unmarshal(e.Event.Payload, &payload)
+		switch e.Event.EventName() {
+		case eventRunCancelled:
+			if payload["story_id"] == f.storyID.String() {
+				foundRunCancelledWithStory = true
+			}
+		case "story.status_updated":
+			if payload["status"] == model.StoryStatusBacklog {
+				foundStoryBacklog = true
+			}
+		}
+	}
+	if !foundRunCancelledWithStory {
+		t.Error("expected run.cancelled event with story_id")
+	}
+	if !foundStoryBacklog {
+		t.Error("expected story.status_updated event with status backlog")
 	}
 }
 
@@ -1239,4 +1325,8 @@ func TestExecuteRun_ModelInjectedPerStep(t *testing.T) {
 	if capturedHasModel[2] {
 		t.Errorf("step 2: expected no model in metadata, got %q", capturedModels[2])
 	}
+}
+
+func (m *mockStoryRepoForExecutor) CountByEpicGroupedByStatus(_ context.Context, _ uuid.UUID) (model.StoryCounts, error) {
+	return model.StoryCounts{}, nil
 }

--- a/backend/internal/domain/service/run_service.go
+++ b/backend/internal/domain/service/run_service.go
@@ -446,6 +446,7 @@ func (s *RunService) PauseRun(ctx context.Context, projectID, runID uuid.UUID) (
 
 	s.publishRunEvent(ctx, updated.ProjectID, updated.ID, "paused", map[string]any{
 		"run_id":    runID.String(),
+		"story_id":  updated.StoryID.String(),
 		"status":    string(model.RunStatusPaused),
 		"paused_at": now.Format(time.RFC3339),
 	})
@@ -476,8 +477,9 @@ func (s *RunService) ResumeRun(ctx context.Context, projectID, runID uuid.UUID) 
 	}
 
 	s.publishRunEvent(ctx, updated.ProjectID, updated.ID, "resumed", map[string]any{
-		"run_id": runID.String(),
-		"status": string(model.RunStatusRunning),
+		"run_id":   runID.String(),
+		"story_id": updated.StoryID.String(),
+		"status":   string(model.RunStatusRunning),
 	})
 
 	// Re-enqueue the run for continued execution
@@ -555,11 +557,62 @@ func (s *RunService) CancelRun(ctx context.Context, projectID, runID uuid.UUID) 
 
 	s.publishRunEvent(ctx, updated.ProjectID, updated.ID, "cancelled", map[string]any{
 		"run_id":       runID.String(),
+		"story_id":     updated.StoryID.String(),
 		"status":       string(model.RunStatusCancelled),
 		"cancelled_at": now.Format(time.RFC3339),
 	})
 
+	// Transition the story back to "backlog" so it can be relaunched. A cancelled
+	// run must not leave the story stuck in "running" forever.
+	s.transitionStoryToBacklog(ctx, updated)
+
 	return updated, nil
+}
+
+// transitionStoryToBacklog resets the run's story to backlog and publishes a
+// story.status_updated event. Best-effort: errors are swallowed so cancellation
+// still succeeds. Mirrors PipelineExecutor.updateStoryStatus.
+func (s *RunService) transitionStoryToBacklog(ctx context.Context, run *model.Run) {
+	if run.StoryID == uuid.Nil {
+		return
+	}
+	story, err := s.storyRepo.GetByID(ctx, run.StoryID)
+	if err != nil {
+		return
+	}
+	if story.Status == model.StoryStatusBacklog {
+		return
+	}
+	story.Status = model.StoryStatusBacklog
+	if _, err := s.storyRepo.Update(ctx, story); err != nil {
+		return
+	}
+	s.publishStoryEvent(ctx, run.ProjectID, run.StoryID, run.ID, model.StoryStatusBacklog)
+}
+
+// publishStoryEvent publishes a story.status_updated event.
+func (s *RunService) publishStoryEvent(ctx context.Context, projectID, storyID, runID uuid.UUID, status string) {
+	if s.eventPub == nil {
+		return
+	}
+	payload := map[string]any{
+		"story_id": storyID.String(),
+		"run_id":   runID.String(),
+		"status":   status,
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	event := model.Event{
+		ID:         uuid.New(),
+		ProjectID:  projectID,
+		EntityType: "story",
+		EntityID:   storyID,
+		Action:     "status_updated",
+		Payload:    payloadJSON,
+	}
+	_ = s.eventPub.Publish(ctx, event)
 }
 
 // CancelEpicRun cancels an epic run. This is a placeholder that operates on the run

--- a/backend/internal/domain/service/run_service_test.go
+++ b/backend/internal/domain/service/run_service_test.go
@@ -122,6 +122,7 @@ func (m *mockRunRepo) ListRetryStepsByParent(ctx context.Context, parentStepID u
 // mockStoryRepoForRun implements port.StoryRepository for testing.
 type mockStoryRepoForRun struct {
 	getByIDFn func(ctx context.Context, id uuid.UUID) (*model.Story, error)
+	updateFn  func(ctx context.Context, story *model.Story) (*model.Story, error)
 }
 
 func (m *mockStoryRepoForRun) Create(_ context.Context, _ *model.Story) (*model.Story, error) {
@@ -151,8 +152,11 @@ func (m *mockStoryRepoForRun) CountByProject(_ context.Context, _ uuid.UUID) (in
 func (m *mockStoryRepoForRun) CountByStatus(_ context.Context, _ uuid.UUID, _ []string) (int64, error) {
 	return 0, nil
 }
-func (m *mockStoryRepoForRun) Update(_ context.Context, _ *model.Story) (*model.Story, error) {
-	return nil, nil
+func (m *mockStoryRepoForRun) Update(ctx context.Context, story *model.Story) (*model.Story, error) {
+	if m.updateFn != nil {
+		return m.updateFn(ctx, story)
+	}
+	return story, nil
 }
 func (m *mockStoryRepoForRun) Delete(_ context.Context, _ uuid.UUID) error {
 	return nil
@@ -1956,4 +1960,81 @@ func TestCancelRun_PublishesEvent(t *testing.T) {
 	if events[0].Event.Action != "cancelled" {
 		t.Errorf("expected event action 'cancelled', got %s", events[0].Event.Action)
 	}
+}
+
+// TestCancelRun_ResetsStoryToBacklog verifies cancelling a run resets its story
+// to backlog (relaunchable) and emits the corresponding events with story_id.
+func TestCancelRun_ResetsStoryToBacklog(t *testing.T) {
+	projectID := uuid.New()
+	runID := uuid.New()
+	storyID := uuid.New()
+
+	runRepo := &mockRunRepo{
+		getRunFn: func(_ context.Context, id uuid.UUID) (*model.Run, error) {
+			return &model.Run{ID: id, ProjectID: projectID, StoryID: storyID, Status: model.RunStatusRunning}, nil
+		},
+		listRunStepsByRunFn: func(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+			return nil, nil
+		},
+		updateRunStatusFn: func(_ context.Context, id uuid.UUID, status model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
+			return &model.Run{ID: id, ProjectID: projectID, StoryID: storyID, Status: status}, nil
+		},
+	}
+
+	var updatedStatus string
+	storyRepo := &mockStoryRepoForRun{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*model.Story, error) {
+			return &model.Story{ID: id, ProjectID: projectID, Status: model.StoryStatusRunning}, nil
+		},
+		updateFn: func(_ context.Context, s *model.Story) (*model.Story, error) {
+			updatedStatus = s.Status
+			return s, nil
+		},
+	}
+
+	eventPub := newMockEventPublisher()
+	svc := NewRunService(runRepo, newMockProjectRepoForService(), storyRepo, nil, nil, eventPub)
+
+	_, err := svc.CancelRun(context.Background(), projectID, runID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if updatedStatus != model.StoryStatusBacklog {
+		t.Errorf("expected story reset to backlog, got %q", updatedStatus)
+	}
+
+	var foundCancelledWithStory, foundStoryBacklog bool
+	for _, e := range eventPub.getEvents() {
+		var payload map[string]any
+		_ = json.Unmarshal(e.Event.Payload, &payload)
+		switch e.Event.EventName() {
+		case eventRunCancelled:
+			if payload["story_id"] == storyID.String() {
+				foundCancelledWithStory = true
+			}
+		case "story.status_updated":
+			if payload["status"] == model.StoryStatusBacklog && payload["story_id"] == storyID.String() {
+				foundStoryBacklog = true
+			}
+		}
+	}
+	if !foundCancelledWithStory {
+		t.Error("expected run.cancelled event with story_id")
+	}
+	if !foundStoryBacklog {
+		t.Error("expected story.status_updated event with status backlog")
+	}
+}
+
+func (m *mockStoryRepoForRun) CountByEpicGroupedByStatus(_ context.Context, _ uuid.UUID) (model.StoryCounts, error) {
+	return model.StoryCounts{}, nil
+}
+
+func (m *mockRunRepo) GetLatestRunByStory(_ context.Context, _ uuid.UUID) (*model.LatestRun, error) {
+	return nil, nil
+}
+
+func (m *mockRunRepo) GetLatestRunsByStories(_ context.Context, _ []uuid.UUID) (map[uuid.UUID]*model.LatestRun, error) {
+	return map[uuid.UUID]*model.LatestRun{}, nil
 }

--- a/backend/internal/domain/service/story_service_test.go
+++ b/backend/internal/domain/service/story_service_test.go
@@ -779,3 +779,7 @@ func TestStoryService_Import_CreateFailure(t *testing.T) {
 func storyStrPtr(s string) *string {
 	return &s
 }
+
+func (m *mockStoryRepo) CountByEpicGroupedByStatus(_ context.Context, _ uuid.UUID) (model.StoryCounts, error) {
+	return model.StoryCounts{}, nil
+}

--- a/backend/queries/runs.sql
+++ b/backend/queries/runs.sql
@@ -63,3 +63,50 @@ RETURNING *;
 SELECT * FROM runs
 WHERE project_id = $1 AND pipeline_config_snapshot @> sqlc.arg('parent_filter')::jsonb
 ORDER BY created_at ASC;
+
+-- name: GetLatestRunByStory :one
+-- Returns the most recent run for a story along with its current in-progress step
+-- (running or waiting_approval, lowest step_order) and the total step count.
+-- current_step is a JSON object (NULL when no step is in progress) carrying
+-- id, name, action_type, status and index (step_order).
+SELECT
+    r.id AS run_id,
+    r.status AS run_status,
+    (
+        SELECT to_jsonb(cs)
+        FROM (
+            SELECT s.id, s.step_name AS name, s.action AS action_type, s.status, s.step_order AS index
+            FROM run_steps s
+            WHERE s.run_id = r.id AND s.status IN ('running', 'waiting_approval')
+            ORDER BY s.step_order ASC
+            LIMIT 1
+        ) cs
+    ) AS current_step,
+    (SELECT COUNT(*) FROM run_steps s WHERE s.run_id = r.id)::int AS total_steps
+FROM runs r
+WHERE r.story_id = $1
+ORDER BY r.created_at DESC
+LIMIT 1;
+
+-- name: GetLatestRunsByStories :many
+-- Batch version of GetLatestRunByStory: returns the most recent run per story
+-- for the given story IDs, with current step (JSON) and total step count.
+-- Avoids N+1 when listing stories of an epic.
+SELECT DISTINCT ON (r.story_id)
+    r.story_id AS story_id,
+    r.id AS run_id,
+    r.status AS run_status,
+    (
+        SELECT to_jsonb(cs)
+        FROM (
+            SELECT s.id, s.step_name AS name, s.action AS action_type, s.status, s.step_order AS index
+            FROM run_steps s
+            WHERE s.run_id = r.id AND s.status IN ('running', 'waiting_approval')
+            ORDER BY s.step_order ASC
+            LIMIT 1
+        ) cs
+    ) AS current_step,
+    (SELECT COUNT(*) FROM run_steps s WHERE s.run_id = r.id)::int AS total_steps
+FROM runs r
+WHERE r.story_id = ANY($1::uuid[])
+ORDER BY r.story_id, r.created_at DESC;

--- a/backend/queries/stories.sql
+++ b/backend/queries/stories.sql
@@ -33,6 +33,12 @@ SELECT COUNT(*) FROM stories WHERE project_id = $1;
 -- name: CountStoriesByStatus :one
 SELECT COUNT(*) FROM stories WHERE project_id = $1 AND status = ANY($2::text[]);
 
+-- name: CountStoriesByEpicGroupedByStatus :many
+SELECT status, COUNT(*) AS count
+FROM stories
+WHERE epic_id = $1
+GROUP BY status;
+
 -- name: UpdateStory :one
 UPDATE stories
 SET title = COALESCE(sqlc.narg('title'), title),


### PR DESCRIPTION
## Goal

Prepare the backend API + events for a **live kanban**: lifecycle columns (Backlog / In Progress / Blocked-HITL / Done / Failed) with cards showing the current pipeline step, updated live.

## Changes

### 1. `story.latest_run` (new)
- New `RunRepository.GetLatestRunByStory` + batched `GetLatestRunsByStories` (sqlc). The current step is projected as a nullable JSONB object (`to_jsonb`), so it is correctly `NULL` when no step is running/waiting_approval — no LEFT JOIN nullability pitfalls.
- `StoryHandler` now enriches each story with `latest_run`. Lists use the **batch** query (no N+1); single fetches use the per-story query. `runRepo` wired into `StoryHandler`.
- New domain types `model.LatestRun` / `model.LatestRunStep`.

### 2. `epic.story_counts` (now populated)
- New `StoryRepository.CountByEpicGroupedByStatus` — a single `GROUP BY status` query (not 4 queries).
- `EpicHandler.toAPIEpic` fills `story_counts {backlog, running, done, failed}` on every epic response. Previously the field existed in the contract but was always zero-valued.

### 3. `story_id` in run/step events
- Added `story_id` to **all** `run.*` (started/completed/failed/paused/resumed/cancelled) and `step.*` (started/completed/failed/cancelled) event payloads. Existing fields kept. Lets the front update the right card live without refetch.

### 4. Cancel → backlog fix
- Cancelling a run previously left the story stuck in `running` forever. Both `PipelineExecutor.handleCancellation` (context cancellation) and `RunService.CancelRun` (user cancel) now reset the story to `backlog` (relaunchable) and publish `story.status_updated`.

## Contract impact (`api/openapi.yaml`)

New, all **additive** (no breaking changes):

```yaml
# Story.properties
latest_run:
  $ref: "#/components/schemas/LatestRun"
  nullable: true   # null when the story has never run

# new schemas
LatestRun:        { id: uuid, status: string, current_step: LatestRunStep|null }
LatestRunStep:    { id: uuid, name: string, action_type: string, status: string,
                    index: int, total: int }
```

`story_counts` (StoryCounts) already existed in the schema — this PR just **populates** it.

Event payloads gain a `story_id` field (additive).

## Validation

- `make generate` (oapi-codegen + sqlc) — clean
- `go build ./...` — OK
- `go test ./...` (unit + testcontainers integration) — all pass, incl. new integration tests for the latest-run queries (running / waiting_approval / no-step / batch) and grouped counts against real Postgres
- `golangci-lint run` on modified packages — clean
- `make lint-api` (redocly) — valid (only 2 pre-existing ambiguous-path warnings)

## Tests added
- Story handler: latest_run population (single, nil, batch)
- Epic handler: story_counts population (single, list)
- Pipeline executor: story_id in all events, cancel→backlog
- Run service: cancel→backlog + story_id
- Postgres integration: latest-run queries + grouped counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>