### PR TITLE
chore(deploy): frontend container image + gitignore local overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,12 @@ frontend/*.tsbuildinfo
 
 # Docker
 docker-compose.override.yml
+
+# Local personal deploy overrides (reverse proxy, hostnames)
+deploy/Caddyfile.local
+deploy/docker-compose.local.yml
+# Scratch screenshots
+/image.png
+
+# Claude Code agent worktrees (harness-managed)
+.claude/worktrees/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,18 @@
+# ─── Build stage ──────────────────────────────────────────────────────────────
+FROM node:22-alpine AS build
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm build
+
+# ─── Serve stage ──────────────────────────────────────────────────────────────
+FROM nginx:alpine
+
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/templates/default.conf.template
+
+EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,24 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # API reverse proxy
+    location /api/v1/ {
+        proxy_pass ${API_BACKEND};
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # SSE support (no buffering for event streams)
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+    }
+}


### PR DESCRIPTION
## Quoi

Ménage de reprise — versionne l'infra deploy frontend qui traînait en local depuis février et nettoie le `.gitignore`.

- **`frontend/Dockerfile`** : build multi-stage (pnpm build → `nginx:alpine`)
- **`frontend/nginx.conf`** : SPA fallback + reverse-proxy `/api/v1` avec buffering désactivé (SSE-friendly)
- **`.gitignore`** : ignore les overrides reverse-proxy perso (`deploy/*.local`), `image.png`, et `.claude/worktrees/` (harness)

## Contexte

Fait partie du ménage de reprise du projet : worktrees lockés supprimés, ~50 branches mortes purgées, PR #230 et #233 mergées. Ces deux fichiers étaient les seuls artefacts non versionnés légitimes restants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)