### PR TITLE
fix(runs): allow relaunching failed/done stories

### DIFF
--- a/frontend/src/features/runs/RunLaunchButton.vue
+++ b/frontend/src/features/runs/RunLaunchButton.vue
@@ -1,27 +1,58 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import Button from 'primevue/button'
+import { statusFamily } from '@/utils/statusToken'
 
-defineProps<{
+const props = defineProps<{
   storyId: string
   storyKey: string
   storyTitle: string
-  status: 'backlog' | 'running' | 'done' | 'failed'
+  /** Raw story status — normalized through statusFamily so any enum value works. */
+  status: string
 }>()
 
 const emit = defineEmits<{
   launchClick: []
 }>()
+
+const family = computed(() => statusFamily(props.status))
 </script>
 
 <template>
+  <!-- A run is active → not launchable -->
+  <span v-if="family === 'running'" v-tooltip="'A run is already in progress'">
+    <Button label="Running..." icon="pi pi-spin pi-spinner" disabled />
+  </span>
+  <span v-else-if="family === 'gate'" v-tooltip="'Run is paused on a human gate'">
+    <Button label="Awaiting gate" icon="pi pi-pause" severity="warn" disabled />
+  </span>
+
+  <!-- Failed → relaunch -->
   <Button
-    v-if="status === 'backlog'"
+    v-else-if="family === 'failed'"
+    label="Retry Run"
+    icon="pi pi-refresh"
+    severity="danger"
+    outlined
+    @click="emit('launchClick')"
+  />
+
+  <!-- Done → re-run -->
+  <Button
+    v-else-if="family === 'done'"
+    label="Re-run"
+    icon="pi pi-replay"
+    severity="secondary"
+    outlined
+    @click="emit('launchClick')"
+  />
+
+  <!-- Backlog / queued → launch -->
+  <Button
+    v-else
     label="Launch Run"
     icon="pi pi-play"
     severity="success"
     @click="emit('launchClick')"
   />
-  <span v-else-if="status === 'running'" v-tooltip="'A run is already in progress'">
-    <Button label="Running..." icon="pi pi-spin pi-spinner" disabled />
-  </span>
 </template>

--- a/frontend/src/features/runs/__tests__/RunLaunchButton.spec.ts
+++ b/frontend/src/features/runs/__tests__/RunLaunchButton.spec.ts
@@ -65,24 +65,34 @@ describe('RunLaunchButton', () => {
     expect(button.attributes('disabled')).toBeDefined()
   })
 
-  it('does not render any button when status is done', () => {
+  it('renders "Re-run" button when status is done and emits launchClick', async () => {
     mountComponent({
       storyId: 's-1',
       storyKey: 'S-01',
       storyTitle: 'Test Story',
       status: 'done',
     })
-    expect(wrapper.find('button').exists()).toBe(false)
+    const button = wrapper.find('button')
+    expect(button.exists()).toBe(true)
+    expect(button.text()).toContain('Re-run')
+    expect(button.attributes('disabled')).toBeUndefined()
+    await button.trigger('click')
+    expect(wrapper.emitted('launchClick')).toHaveLength(1)
   })
 
-  it('does not render any button when status is failed', () => {
+  it('renders "Retry Run" button when status is failed and emits launchClick', async () => {
     mountComponent({
       storyId: 's-1',
       storyKey: 'S-01',
       storyTitle: 'Test Story',
       status: 'failed',
     })
-    expect(wrapper.find('button').exists()).toBe(false)
+    const button = wrapper.find('button')
+    expect(button.exists()).toBe(true)
+    expect(button.text()).toContain('Retry Run')
+    expect(button.attributes('disabled')).toBeUndefined()
+    await button.trigger('click')
+    expect(wrapper.emitted('launchClick')).toHaveLength(1)
   })
 
   it('does not emit launchClick when running button is clicked', async () => {


### PR DESCRIPTION
Une story **failed** n'affichait aucun bouton → impossible de la relancer.

## Cause
`RunLaunchButton` ne rendait un bouton que pour `status === 'backlog'` (+ état désactivé pour `running`). `failed` et `done` → rien.

## Fix
Le bouton est piloté par `statusFamily(status)` :
- `running` / `gate` → désactivé (un run est actif/en pause)
- `failed` → **Retry Run**
- `done` → **Re-run**
- `backlog` / `queued` → **Launch Run**

## Vérif
type-check + lint verts ; unit RunLaunchButton 6/6 ; e2e run-launch 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)