### PR TITLE
fix: functional review — board, agents, e2e harness (28/35 → 35/35)

### DIFF
--- a/backend/testdata/seed.sql
+++ b/backend/testdata/seed.sql
@@ -56,6 +56,24 @@ VALUES (
     git_token_env = EXCLUDED.git_token_env,
     default_model = EXCLUDED.default_model;
 
+INSERT INTO projects (id, name, description, owner_id, repo_url, git_provider, git_token_env, default_model)
+VALUES (
+    '00000000-0000-0000-0000-000000000102',
+    'E-commerce API',
+    'REST API for an e-commerce backend',
+    '00000000-0000-0000-0000-000000000001',
+    'http://localhost:3030/devops/todo-app',
+    'gitea',
+    'GITEA_TOKEN',
+    'claude-sonnet-4-6'
+) ON CONFLICT (name) DO UPDATE SET
+    description = EXCLUDED.description,
+    owner_id = EXCLUDED.owner_id,
+    repo_url = EXCLUDED.repo_url,
+    git_provider = EXCLUDED.git_provider,
+    git_token_env = EXCLUDED.git_token_env,
+    default_model = EXCLUDED.default_model;
+
 -- ---------------------------------------------------------------------------
 -- Project memberships
 -- ---------------------------------------------------------------------------
@@ -78,15 +96,30 @@ BEGIN
 END $$;
 
 -- ---------------------------------------------------------------------------
--- Epic: MVP
+-- Epic: Foundation
 -- ---------------------------------------------------------------------------
 
 INSERT INTO epics (id, project_id, name, description, status)
 VALUES (
     '00000000-0000-0000-0000-000000000201',
     '00000000-0000-0000-0000-000000000101',
-    'MVP',
-    'Minimum viable product — project scaffolding, CI, and basic infrastructure',
+    'Foundation',
+    'Foundation — project scaffolding, CI, and core infrastructure',
+    'in_progress'
+) ON CONFLICT (project_id, name) DO UPDATE SET
+    description = EXCLUDED.description,
+    status = EXCLUDED.status;
+
+-- ---------------------------------------------------------------------------
+-- Epic: Task Management
+-- ---------------------------------------------------------------------------
+
+INSERT INTO epics (id, project_id, name, description, status)
+VALUES (
+    '00000000-0000-0000-0000-000000000202',
+    '00000000-0000-0000-0000-000000000101',
+    'Task Management',
+    'Task management features — CRUD, assignments, and status tracking',
     'in_progress'
 ) ON CONFLICT (project_id, name) DO UPDATE SET
     description = EXCLUDED.description,
@@ -145,6 +178,42 @@ VALUES (
     'backlog',
     '["S-01"]',
     'golangci-lint runs clean on backend. ESLint + Prettier run clean on frontend. Lefthook pre-commit hook runs both. npm run format and gofmt produce no changes on committed code.'
+) ON CONFLICT (project_id, key) DO UPDATE SET
+    title = EXCLUDED.title,
+    objective = EXCLUDED.objective,
+    status = EXCLUDED.status;
+
+-- S-04: Task CRUD endpoints (Task Management epic)
+INSERT INTO stories (id, project_id, epic_id, key, title, objective, scope, status, depends_on, acceptance_criteria)
+VALUES (
+    '00000000-0000-0000-0000-000000000304',
+    '00000000-0000-0000-0000-000000000101',
+    '00000000-0000-0000-0000-000000000202',
+    'S-04',
+    'Implement task CRUD endpoints',
+    'Create REST endpoints to create, read, update, and delete tasks.',
+    'backend',
+    'completed',
+    '[]',
+    'POST/GET/PUT/DELETE /tasks all return correct status codes and persist to the database.'
+) ON CONFLICT (project_id, key) DO UPDATE SET
+    title = EXCLUDED.title,
+    objective = EXCLUDED.objective,
+    status = EXCLUDED.status;
+
+-- S-05: Task list UI with status filter (Task Management epic)
+INSERT INTO stories (id, project_id, epic_id, key, title, objective, scope, status, depends_on, acceptance_criteria)
+VALUES (
+    '00000000-0000-0000-0000-000000000305',
+    '00000000-0000-0000-0000-000000000101',
+    '00000000-0000-0000-0000-000000000202',
+    'S-05',
+    'Task list UI with status filter',
+    'Build the task list view with filtering by status.',
+    'frontend',
+    'running',
+    '["S-04"]',
+    'The task list renders, supports filtering by status, and updates live.'
 ) ON CONFLICT (project_id, key) DO UPDATE SET
     title = EXCLUDED.title,
     objective = EXCLUDED.objective,

--- a/frontend/e2e/real-tests/smoke-agents.spec.ts
+++ b/frontend/e2e/real-tests/smoke-agents.spec.ts
@@ -102,7 +102,7 @@ test.describe('smoke: agents CRUD (real backend)', () => {
     }
   })
 
-  test('agents list shows model and image columns', async ({ page }) => {
+  test('agents list shows model (inline) and image column', async ({ page }) => {
     await page.goto(`/projects/${TODO_APP_ID}/agents`)
 
     // Wait for the table to appear
@@ -110,18 +110,22 @@ test.describe('smoke: agents CRUD (real backend)', () => {
       timeout: 10000,
     })
 
-    // Column headers must be visible
+    // Column headers: Agent and Image must be visible (Model is inline in Agent column)
     await expect(
-      page.getByRole('columnheader', { name: 'Model' }),
+      page.getByRole('columnheader', { name: 'Agent' }),
     ).toBeVisible()
     await expect(
       page.getByRole('columnheader', { name: 'Image' }),
     ).toBeVisible()
 
-    // At least one row should show non-empty model and image values
+    // At least one row should exist
     const rows = page.locator('[data-testid="agents-table"] tbody tr')
     const rowCount = await rows.count()
     expect(rowCount).toBeGreaterThan(0)
+
+    // Model should be shown inline within the table (seed agents use claude-sonnet-4-6 or similar)
+    const tableLocator = page.locator('[data-testid="agents-table"]')
+    await expect(tableLocator.getByText(/claude/i).first()).toBeVisible()
   })
 
   test('can create a project-scoped agent', async ({ page, context }) => {

--- a/frontend/e2e/real-tests/smoke-board.spec.ts
+++ b/frontend/e2e/real-tests/smoke-board.spec.ts
@@ -36,20 +36,25 @@ test.describe('Board smoke tests (real backend)', () => {
     await loginViaUI(page, 'admin')
     await page.goto(`/projects/${TODO_APP_ID}/board`)
 
-    // Both seed epics must be visible in the board view
-    await expect(page.getByText('Foundation')).toBeVisible({ timeout: 10000 })
-    await expect(page.getByText('Task Management')).toBeVisible({ timeout: 5000 })
+    // On load, the first epic (Foundation) is auto-selected and visible in the subtitle
+    await expect(page.getByText(/Epic · Foundation/i)).toBeVisible({ timeout: 10000 })
+
+    // Click the epic select combobox to open the dropdown
+    const epicSelect = page.getByRole('combobox', { name: /Foundation/i })
+    await epicSelect.click()
+
+    // The second epic (Task Management) appears as an option in the dropdown
+    await expect(page.getByRole('option', { name: /Task Management/i })).toBeVisible({ timeout: 5000 })
   })
 
   test('epic detail shows stories', async ({ page }) => {
     await loginViaUI(page, 'admin')
     await page.goto(`/projects/${TODO_APP_ID}/epics/${TASK_MGMT_EPIC_ID}`)
 
-    // The page should render without error
+    // The page should render without error (not redirected to login)
     await expect(page).not.toHaveURL(/\/login/)
 
-    // Story keys like S-03, S-04 etc. should appear somewhere in the content.
-    // We look for the S- prefix pattern which is part of the seed story keys.
+    // Story keys from the Task Management epic (S-04, S-05) should be visible
     const storyKeyPattern = page.getByText(/S-0[0-9]/)
     await expect(storyKeyPattern.first()).toBeVisible({ timeout: 10000 })
   })
@@ -58,12 +63,12 @@ test.describe('Board smoke tests (real backend)', () => {
     await loginViaUI(page, 'admin')
     await page.goto(`/projects/${TODO_APP_ID}/board`)
 
-    // Wait for the board to fully render
-    await expect(page.getByText('Foundation')).toBeVisible({ timeout: 10000 })
+    // Wait for the board (Foundation epic auto-selected) to fully render
+    await expect(page.getByText(/Epic · Foundation/i)).toBeVisible({ timeout: 10000 })
 
     // The seed data includes stories in various statuses.
-    // We verify that at least one status badge from the expected set is visible.
-    // The UI may use Tag components (PrimeVue), text, or badges for status.
+    // Foundation stories are all in 'backlog' status.
+    // Verify that at least one status badge from the expected set is visible.
     const statusTexts = ['completed', 'running', 'backlog', 'failed', 'pending', 'in_progress']
 
     // Build a locator that matches ANY of the status texts (case-insensitive)

--- a/frontend/e2e/real-tests/smoke-pipeline-config.spec.ts
+++ b/frontend/e2e/real-tests/smoke-pipeline-config.spec.ts
@@ -61,10 +61,12 @@ test.describe('Pipeline config smoke tests (real backend)', () => {
 
     const body = await response.json()
 
-    // The response must include project_id and steps fields per the OpenAPI spec
+    // The response must include project_id and groups fields per the OpenAPI spec
+    // Groups contain the step hierarchy: groups[].steps[]
     expect(body, 'Response should contain project_id').toHaveProperty('project_id')
-    expect(body, 'Response should contain steps').toHaveProperty('steps')
-    expect(Array.isArray(body.steps), 'steps field should be an array').toBe(true)
-    expect(body.steps.length, 'steps array should have at least one entry').toBeGreaterThan(0)
+    expect(body, 'Response should contain groups').toHaveProperty('groups')
+    expect(Array.isArray(body.groups), 'groups field should be an array').toBe(true)
+    expect(body.groups.length, 'groups array should have at least one entry').toBeGreaterThan(0)
+    expect(Array.isArray(body.groups[0].steps), 'steps within group should be an array').toBe(true)
   })
 })

--- a/frontend/e2e/real-tests/smoke-projects.spec.ts
+++ b/frontend/e2e/real-tests/smoke-projects.spec.ts
@@ -34,9 +34,9 @@ test.describe('Projects smoke tests (real backend)', () => {
     await loginViaUI(page, 'admin')
     await page.goto('/projects')
 
-    // Wait for the project list to render — use row-scoped selectors to avoid strict mode violations
-    await expect(page.getByRole('row', { name: /Todo App/i }).first()).toBeVisible({ timeout: 10000 })
-    await expect(page.getByRole('row', { name: /E-commerce API/i }).first()).toBeVisible({ timeout: 5000 })
+    // Wait for the project list to render — projects are rendered as card buttons with aria-label
+    await expect(page.getByRole('button', { name: /Project: Todo App/i }).first()).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('button', { name: /Project: E-commerce API/i }).first()).toBeVisible({ timeout: 5000 })
   })
 
   test('click project navigates to project detail', async ({ page }) => {

--- a/frontend/src/composables/useAgentEditor.ts
+++ b/frontend/src/composables/useAgentEditor.ts
@@ -21,6 +21,21 @@ const sampleContext = {
   repo_url: 'https://github.com/user/repo',
 }
 
+/** Default starter template for new agents */
+const DEFAULT_AGENT_TEMPLATE = `# Agent Instructions
+
+You are an AI agent. Describe this agent's role, responsibilities, and constraints here.
+
+## Context
+Explain what context this agent receives and how it should use it.
+
+## Task
+Describe step by step what this agent should do.
+
+## Output
+Describe the expected output format.
+`
+
 /**
  * Composable for agent editor state and actions.
  * Handles fetching, saving, and previewing agents.
@@ -40,9 +55,22 @@ export function useAgentEditor(projectId: string, agentId: string) {
   const previewError = ref<string | null>(null)
   const previewContent = ref('')
   const originalContent = ref('')
+  const originalName = ref('')
+  const originalModel = ref('claude-sonnet-4-6')
+  const originalImage = ref('')
+  const originalScope = ref<AgentScope>('project')
+  const originalProvider = ref('claude')
 
   const isNewAgent = computed(() => agentId === 'new')
-  const isDirty = computed(() => content.value !== originalContent.value)
+  const isDirty = computed(
+    () =>
+      content.value !== originalContent.value ||
+      name.value !== originalName.value ||
+      model.value !== originalModel.value ||
+      image.value !== originalImage.value ||
+      scope.value !== originalScope.value ||
+      provider.value !== originalProvider.value,
+  )
   const canSave = computed(
     () =>
       isDirty.value &&
@@ -71,10 +99,15 @@ export function useAgentEditor(projectId: string, agentId: string) {
       content.value = a.template_content
       originalContent.value = a.template_content
       name.value = a.name
+      originalName.value = a.name
       model.value = a.model
+      originalModel.value = a.model
       image.value = a.image
+      originalImage.value = a.image
       scope.value = a.scope
+      originalScope.value = a.scope
       provider.value = a.provider ?? 'claude'
+      originalProvider.value = a.provider ?? 'claude'
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to load agent'
     } finally {
@@ -132,6 +165,11 @@ export function useAgentEditor(projectId: string, agentId: string) {
         }
       }
       originalContent.value = content.value
+      originalName.value = name.value
+      originalModel.value = model.value
+      originalImage.value = image.value
+      originalScope.value = scope.value
+      originalProvider.value = provider.value
       return true
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to save agent'
@@ -156,7 +194,10 @@ export function useAgentEditor(projectId: string, agentId: string) {
   }
 
   onMounted(() => {
-    if (!isNewAgent.value) {
+    if (isNewAgent.value) {
+      // Initialize new agent with starter template, keep originalContent empty so editor is dirty
+      content.value = DEFAULT_AGENT_TEMPLATE
+    } else {
       fetchAgent()
     }
   })

--- a/frontend/src/composables/useBoard.ts
+++ b/frontend/src/composables/useBoard.ts
@@ -29,7 +29,7 @@ export function useBoard(projectId: string) {
     if (epicId) {
       storiesStore.fetchStoriesByEpic(projectId, epicId)
     } else {
-      storiesStore.reset()
+      storiesStore.fetchAllStories(projectId)
     }
   }
 

--- a/frontend/src/features/agents/AgentEditorLayout.vue
+++ b/frontend/src/features/agents/AgentEditorLayout.vue
@@ -96,8 +96,9 @@ const editorRef = ref<InstanceType<typeof MonacoEditorWrapper> | null>(null)
       :style="{ borderBottom: '1px solid var(--surface-border)' }"
     >
       <div class="flex min-w-[200px] flex-1 flex-col gap-1">
-        <label class="text-xs font-medium" :style="{ color: 'var(--p-text-muted-color)' }">Agent Name</label>
+        <label for="agent-name" class="text-xs font-medium" :style="{ color: 'var(--p-text-muted-color)' }">Agent Name</label>
         <InputText
+          id="agent-name"
           :value="agentName"
           placeholder="e.g. Default Implement Agent"
           size="small"
@@ -107,8 +108,9 @@ const editorRef = ref<InstanceType<typeof MonacoEditorWrapper> | null>(null)
         />
       </div>
       <div class="flex flex-col gap-1">
-        <label class="text-xs font-medium" :style="{ color: 'var(--p-text-muted-color)' }">Model</label>
+        <label for="agent-model" class="text-xs font-medium" :style="{ color: 'var(--p-text-muted-color)' }">Model</label>
         <AutoComplete
+          inputId="agent-model"
           :model-value="agentModel"
           :suggestions="filteredModels"
           dropdown
@@ -120,8 +122,9 @@ const editorRef = ref<InstanceType<typeof MonacoEditorWrapper> | null>(null)
         />
       </div>
       <div class="flex flex-col gap-1">
-        <label class="text-xs font-medium" :style="{ color: 'var(--p-text-muted-color)' }">Provider</label>
+        <label for="agent-provider" class="text-xs font-medium" :style="{ color: 'var(--p-text-muted-color)' }">Provider</label>
         <Select
+          inputId="agent-provider"
           :model-value="agentProvider"
           :options="providerOptions"
           option-label="label"
@@ -133,8 +136,9 @@ const editorRef = ref<InstanceType<typeof MonacoEditorWrapper> | null>(null)
         />
       </div>
       <div class="flex min-w-[200px] flex-1 flex-col gap-1">
-        <label class="text-xs font-medium" :style="{ color: 'var(--p-text-muted-color)' }">Docker Image</label>
+        <label for="agent-image" class="text-xs font-medium" :style="{ color: 'var(--p-text-muted-color)' }">Docker Image</label>
         <InputText
+          id="agent-image"
           :value="agentImage"
           placeholder="ghcr.io/org/agent-name:latest"
           size="small"
@@ -144,8 +148,9 @@ const editorRef = ref<InstanceType<typeof MonacoEditorWrapper> | null>(null)
         />
       </div>
       <div class="flex flex-col gap-1">
-        <label class="text-xs font-medium" :style="{ color: 'var(--p-text-muted-color)' }">Scope</label>
+        <label for="agent-scope" class="text-xs font-medium" :style="{ color: 'var(--p-text-muted-color)' }">Scope</label>
         <Select
+          inputId="agent-scope"
           :model-value="agentScope"
           :options="scopeOptions"
           option-label="label"

--- a/frontend/src/stores/stories.ts
+++ b/frontend/src/stores/stories.ts
@@ -168,8 +168,35 @@ export const useStoriesStore = defineStore('stories', () => {
         {
           params: {
             path: { projectId },
-            // epic_id is not in the OpenAPI query params for listStories; pass as extra query
-            query: { epic_id: epicId } as Record<string, string>,
+          },
+        },
+      )
+      if (apiError) {
+        error.value = 'Failed to load stories'
+        return
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const responseData = data as any
+      const allStories = responseData?.data ?? []
+      // Filter by epic_id since the API doesn't support epic_id as a query param
+      items.value = allStories.filter((s: Story) => s.epic_id === epicId)
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load stories'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  /** Fetch all stories for a project (across all epics) from the API */
+  async function fetchAllStories(projectId: string) {
+    isLoading.value = true
+    error.value = null
+    try {
+      const { data, error: apiError } = await apiClient.GET(
+        '/projects/{projectId}/stories',
+        {
+          params: {
+            path: { projectId },
           },
         },
       )
@@ -373,6 +400,7 @@ export const useStoriesStore = defineStore('stories', () => {
     filteredStories,
     selectedStory,
     fetchStoriesByEpic,
+    fetchAllStories,
     updateStory,
     createStory,
     setSelectedStory,

--- a/frontend/src/views/AgentEditorView.vue
+++ b/frontend/src/views/AgentEditorView.vue
@@ -56,9 +56,8 @@ async function handleSave() {
       detail: isNewAgent.value ? 'Agent created successfully' : 'Agent saved successfully',
       life: 3000,
     })
-    if (isNewAgent.value) {
-      router.push({ name: 'project-agents', params: { id: projectId.value } })
-    }
+    // Return to the agents list after a successful save (consistent for create and edit)
+    router.push({ name: 'project-agents', params: { id: projectId.value } })
   } else {
     toast.add({
       severity: 'error',

--- a/frontend/src/views/AgentListView.vue
+++ b/frontend/src/views/AgentListView.vue
@@ -76,7 +76,7 @@ function handleDelete(agentId: string) {
         </p>
       </div>
       <Button
-        v-if="isAdmin && agents.length > 0"
+        v-if="isAdmin"
         label="New Agent"
         icon="pi pi-plus"
         severity="success"

--- a/frontend/src/views/BoardView.vue
+++ b/frontend/src/views/BoardView.vue
@@ -32,6 +32,12 @@ const {
   storiesError,
 } = useBoard(projectId)
 
+const selectedEpicName = computed(() => {
+  if (!selectedEpicId.value) return 'All epics'
+  const epic = epics.value.find((e) => e.id === selectedEpicId.value)
+  return epic?.name ?? 'Unknown epic'
+})
+
 const { project } = useProject(projectId)
 
 // ── PLANNED IN segmented control ─────────────────────────────────────────────
@@ -178,7 +184,7 @@ async function handleConfirm() {
           class="m-0"
           style="font-size: 0.82rem; color: var(--p-text-muted-color)"
         >
-          Epic · MVP — board generated from your stories, kept live by the runtime
+          Epic · {{ selectedEpicName }} — board generated from your stories, kept live by the runtime
         </p>
       </div>
 

--- a/scripts/e2e-stack.sh
+++ b/scripts/e2e-stack.sh
@@ -144,18 +144,33 @@ cmd_reset() {
   docker exec "${container}" psql -U "${db_user}" -d postgres \
     -c "CREATE DATABASE ${db_name} OWNER ${db_user};"
 
-  # Run migrations (sorted order)
-  log_info "Running migrations..."
-  local migration_dir="${PROJECT_ROOT}/backend/migrations"
-  local migration_count=0
-  for f in "${migration_dir}"/*.up.sql; do
-    [ -f "$f" ] || continue
-    docker exec -i "${container}" psql -U "${db_user}" -d "${db_name}" --set ON_ERROR_STOP=1 < "$f"
-    migration_count=$((migration_count + 1))
+  # Restart the API so it applies all migrations against the fresh database at startup
+  # (DB_AUTO_MIGRATE=true). The API runs BOTH golang-migrate (schema migrations, which
+  # also writes the schema_migrations tracking table correctly) AND rivermigrate (the
+  # River job-queue tables river_job/river_leader). Doing it this way avoids re-applying
+  # migrations by hand and the brittle "schema_migrations version == file count" hack;
+  # it also guarantees the River tables exist, otherwise Launch Run 500s with
+  # "relation \"river_job\" does not exist".
+  log_info "Restarting API to apply migrations (schema + River job queue) on the fresh DB..."
+  docker compose -f "${COMPOSE_FILE}" restart api
+  log_info "Waiting for backend to be healthy (migrations run at startup)..."
+  local elapsed=0
+  local interval=2
+  while true; do
+    if check_backend; then
+      log_success "Backend is healthy."
+      break
+    fi
+    sleep "${interval}"
+    elapsed=$((elapsed + interval))
+    if [ "${elapsed}" -ge "${HEALTH_TIMEOUT}" ]; then
+      log_error "Backend health timeout reached (${HEALTH_TIMEOUT}s) after restart."
+      return 1
+    fi
+    log_info "Backend not ready yet (${elapsed}s)..."
   done
-  log_info "Applied ${migration_count} migrations."
 
-  # Seed dev data
+  # Seed dev data (tables now exist after the API applied its startup migrations)
   log_info "Seeding dev data..."
   docker exec -i "${container}" psql -U "${db_user}" -d "${db_name}" --set ON_ERROR_STOP=1 \
     < "${PROJECT_ROOT}/backend/testdata/seed.sql"


### PR DESCRIPTION
## Contexte
Revue fonctionnelle e2e de l'app. Tri des échecs en *vrais bugs produit* vs *tests obsolètes / harness*. Suite e2e passée de **28/35 à 35/35**, 943 tests unitaires + lint + type-check verts.

## Vrais bugs produit corrigés
- **Board "All epics" → board vide** : `setEpicId(null)` faisait `reset()`. En prime, le filtre par epic ne filtrait rien (`epic_id` hors-contrat `listStories`, ignoré par le backend). → `fetchAllStories` + vrai filtre client + sous-titre réactif.
- **Édition d'agent insauvable** : `isDirty` ne traquait que le corps du template → modifier seulement nom/modèle/image/scope laissait Save grisé. → snapshot original de tous les champs.
- **Pas de retour à la liste après save (edit)** : navigation conditionnée à `isNewAgent`. → cohérent create + edit.
- **Form agent non accessible (WCAG)** : labels sans association ; `InputText` veut `id`, pas `inputId`.
- **Éditeur agent blank, Save grisé sans explication** : template starter par défaut pour un nouvel agent (l'API exige `template_content`).
- **Bouton "New Agent" invisible si 0 agent** : `v-if="agents.length > 0"` retiré pour les admins.

## Infra / harness
- **`e2e-stack.sh reset`** rejouait les migrations via psql sans redémarrer l'API → tables River (créées au boot via `rivermigrate`, **hors golang-migrate**) jamais recréées → Launch Run 500 + spam de logs. Réécrit : drop DB → restart API (applique schema + River, écrit `schema_migrations`) → seed. Supprime le hack `schema_migrations`.

## Tests alignés sur le design actuel (faux positifs)
pipeline-config (`groups` vs `steps`), projets en cards, modèle inline, board filtre mono-epic. Seed restauré à 2 epics (Foundation + Task Management) + 2e projet.

## Validation
35/35 e2e · 943 unit · lint + type-check OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)