### PR TITLE
feat(runtime): P0 — port AgentRuntime + RuntimeKind dispatch + scaffolding domaine

### DIFF
--- a/backend/internal/adapter/action/agent_run.go
+++ b/backend/internal/adapter/action/agent_run.go
@@ -28,10 +28,10 @@ type AgentConfig struct {
 	LogTailLines int
 }
 
-// AgentRunAction implements model.Action for running Claude Code agents in containers.
-// It supports two execution modes:
-//   - Callback mode: for hopeitworks/agent-* images, uses HTTP callbacks for logs/cost/status
-//   - Legacy mode: for other images, uses Docker log streaming and exit code detection
+// AgentRunAction implements model.Action for running coding agents in containers.
+// It supports two execution modes, selected by the agent's runtime kind:
+//   - Callback mode: claude_code/opencode/cma runtimes use HTTP callbacks for logs/cost/status
+//   - Legacy mode: no runtime kind (older images) uses Docker log streaming and exit code detection
 type AgentRunAction struct {
 	containerMgr port.ContainerManager
 	logStreamer  port.LogStreamer
@@ -51,7 +51,7 @@ type AgentRunAction struct {
 
 // NewAgentRunAction creates a new agent run action.
 // The apiKeySvc, tokenStore, statusStore, and callbackURL parameters enable callback mode
-// for hopeitworks/agent-* container images. Pass nil/empty to disable callback mode.
+// for the claude_code/opencode/cma runtimes. Pass nil/empty to disable callback mode.
 func NewAgentRunAction(
 	containerMgr port.ContainerManager,
 	logStreamer port.LogStreamer,
@@ -147,8 +147,9 @@ func (a *AgentRunAction) Execute(ctx context.Context, runCtx *model.RunContext) 
 		return fmt.Errorf("agent_image is required in run metadata but was not set")
 	}
 
-	// 5. Detect execution mode: callback for hopeitworks/agent-* images, legacy otherwise
-	isCallbackMode := a.isCallbackMode(agentImage)
+	// 5. Detect execution mode from the agent's runtime kind (not the image string).
+	runtimeKind, _ := runCtx.Metadata["runtime_kind"].(string)
+	isCallbackMode := a.isCallbackMode(runtimeKind, agentImage)
 
 	// 6. Create container
 	containerID, err := a.createContainer(ctx, runCtx, project, story, agentImage, prompt, branchName)
@@ -254,7 +255,7 @@ func resolveRole(runCtx *model.RunContext) string {
 }
 
 // createContainer builds ContainerOpts and creates the container.
-// For callback mode (hopeitworks/agent-* images), it injects CALLBACK_URL, AUTH_TOKEN,
+// In callback mode (claude_code/opencode/cma runtimes), it injects CALLBACK_URL, AUTH_TOKEN,
 // API_KEY, PROVIDER, MODEL, RUN_ID, and STEP_ID env vars instead of CLAUDE_CODE_OAUTH_TOKEN.
 func (a *AgentRunAction) createContainer(
 	ctx context.Context,
@@ -297,7 +298,8 @@ func (a *AgentRunAction) createContainer(
 		"CLAUDE_MD_CONTENT=" + buildClaudeMD(project, role, story) + a.priorFailureContext(ctx, story.ID, runCtx.Run.ID),
 	}
 
-	isCallback := a.isCallbackMode(agentImage)
+	runtimeKind, _ := runCtx.Metadata["runtime_kind"].(string)
+	isCallback := a.isCallbackMode(runtimeKind, agentImage)
 
 	if isCallback {
 		// Callback mode: use per-user API key and container token auth
@@ -527,10 +529,29 @@ func extractAgentID(runCtx *model.RunContext) *uuid.UUID {
 	return nil
 }
 
-// isCallbackMode returns true if the agent image is a hopeitworks/agent-* image
-// that supports HTTP callback mode for logs, cost, and status reporting.
-func (a *AgentRunAction) isCallbackMode(agentImage string) bool {
-	return a.statusStore != nil && strings.Contains(agentImage, "hopeitworks/agent-")
+// isCallbackMode returns true when the run should use HTTP callback mode for
+// logs, cost, and status reporting.
+//
+// The primary signal is the agent's runtime kind: claude_code, opencode and cma
+// all execute via the agent-runtime binary and report over the callback channel.
+// Callback mode also requires a configured statusStore.
+//
+// Back-compat: when runtimeKind is empty — runs launched before the runtime_kind
+// migration and resumed after deploy carry no runtime_kind in their persisted
+// metadata — we fall back to the legacy image-substring heuristic one last time.
+// New runs always thread runtime_kind, so this fallback fades out on its own.
+func (a *AgentRunAction) isCallbackMode(runtimeKind, agentImage string) bool {
+	if a.statusStore == nil {
+		return false
+	}
+	switch runtimeKind {
+	case model.RuntimeKindClaudeCode, model.RuntimeKindOpenCode, model.RuntimeKindCMA:
+		return true
+	case "":
+		return strings.Contains(agentImage, "hopeitworks/agent-")
+	default:
+		return false
+	}
 }
 
 // waitForCallback waits for the agent container to report its exit status via

--- a/backend/internal/adapter/postgres/agent_repo.go
+++ b/backend/internal/adapter/postgres/agent_repo.go
@@ -35,11 +35,16 @@ func (r *AgentRepo) CreateAgent(ctx context.Context, agent *model.Agent) (*model
 	if provider == "" {
 		provider = model.ProviderClaude
 	}
+	runtimeKind := agent.RuntimeKind
+	if runtimeKind == "" {
+		runtimeKind = model.RuntimeKindFromProvider(provider)
+	}
 	params := CreateAgentParams{
 		ID:              agent.ID,
 		Name:            agent.Name,
 		Model:           textFromString(agent.Model),
 		Image:           textFromString(agent.Image),
+		RuntimeKind:     runtimeKind,
 		TemplateContent: agent.TemplateContent,
 		Type:            agentType,
 		Scope:           agent.Scope,
@@ -118,11 +123,16 @@ func (r *AgentRepo) UpdateAgent(ctx context.Context, agent *model.Agent) (*model
 	if provider == "" {
 		provider = model.ProviderClaude
 	}
+	runtimeKind := agent.RuntimeKind
+	if runtimeKind == "" {
+		runtimeKind = model.RuntimeKindFromProvider(provider)
+	}
 	params := UpdateAgentParams{
 		ID:              agent.ID,
 		Name:            agent.Name,
 		Model:           textFromString(agent.Model),
 		Image:           textFromString(agent.Image),
+		RuntimeKind:     runtimeKind,
 		TemplateContent: agent.TemplateContent,
 		Provider:        provider,
 	}
@@ -154,6 +164,7 @@ func toDomainAgent(a Agent) *model.Agent {
 	agent := &model.Agent{
 		ID:              a.ID,
 		Name:            a.Name,
+		RuntimeKind:     a.RuntimeKind,
 		TemplateContent: a.TemplateContent,
 		Type:            a.Type,
 		Scope:           a.Scope,
@@ -178,6 +189,11 @@ func toDomainAgent(a Agent) *model.Agent {
 	// Default provider to "claude" for existing agents migrated without an explicit value.
 	if agent.Provider == "" {
 		agent.Provider = model.ProviderClaude
+	}
+
+	// Default runtime_kind from the provider for rows predating the column.
+	if agent.RuntimeKind == "" {
+		agent.RuntimeKind = model.RuntimeKindFromProvider(agent.Provider)
 	}
 
 	return agent

--- a/backend/internal/adapter/postgres/agents.sql.go
+++ b/backend/internal/adapter/postgres/agents.sql.go
@@ -13,9 +13,9 @@ import (
 )
 
 const createAgent = `-- name: CreateAgent :one
-INSERT INTO agents (id, name, model, image, template_content, type, scope, provider, project_id, created_at, updated_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW())
-RETURNING id, project_id, name, template_content, type, created_at, updated_at, scope, model, image, provider
+INSERT INTO agents (id, name, model, image, runtime_kind, template_content, type, scope, provider, project_id, created_at, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW(), NOW())
+RETURNING id, project_id, name, template_content, type, created_at, updated_at, scope, model, image, provider, runtime_kind
 `
 
 type CreateAgentParams struct {
@@ -23,6 +23,7 @@ type CreateAgentParams struct {
 	Name            string      `json:"name"`
 	Model           pgtype.Text `json:"model"`
 	Image           pgtype.Text `json:"image"`
+	RuntimeKind     string      `json:"runtime_kind"`
 	TemplateContent string      `json:"template_content"`
 	Type            string      `json:"type"`
 	Scope           string      `json:"scope"`
@@ -36,6 +37,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		arg.Name,
 		arg.Model,
 		arg.Image,
+		arg.RuntimeKind,
 		arg.TemplateContent,
 		arg.Type,
 		arg.Scope,
@@ -55,6 +57,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		&i.Model,
 		&i.Image,
 		&i.Provider,
+		&i.RuntimeKind,
 	)
 	return i, err
 }
@@ -69,7 +72,7 @@ func (q *Queries) DeleteAgent(ctx context.Context, id uuid.UUID) error {
 }
 
 const getAgent = `-- name: GetAgent :one
-SELECT id, project_id, name, template_content, type, created_at, updated_at, scope, model, image, provider FROM agents WHERE id = $1 LIMIT 1
+SELECT id, project_id, name, template_content, type, created_at, updated_at, scope, model, image, provider, runtime_kind FROM agents WHERE id = $1 LIMIT 1
 `
 
 func (q *Queries) GetAgent(ctx context.Context, id uuid.UUID) (Agent, error) {
@@ -87,12 +90,13 @@ func (q *Queries) GetAgent(ctx context.Context, id uuid.UUID) (Agent, error) {
 		&i.Model,
 		&i.Image,
 		&i.Provider,
+		&i.RuntimeKind,
 	)
 	return i, err
 }
 
 const listAgentsByProject = `-- name: ListAgentsByProject :many
-SELECT id, project_id, name, template_content, type, created_at, updated_at, scope, model, image, provider FROM agents WHERE project_id = $1 ORDER BY name ASC
+SELECT id, project_id, name, template_content, type, created_at, updated_at, scope, model, image, provider, runtime_kind FROM agents WHERE project_id = $1 ORDER BY name ASC
 `
 
 func (q *Queries) ListAgentsByProject(ctx context.Context, projectID pgtype.UUID) ([]Agent, error) {
@@ -116,6 +120,7 @@ func (q *Queries) ListAgentsByProject(ctx context.Context, projectID pgtype.UUID
 			&i.Model,
 			&i.Image,
 			&i.Provider,
+			&i.RuntimeKind,
 		); err != nil {
 			return nil, err
 		}
@@ -128,7 +133,7 @@ func (q *Queries) ListAgentsByProject(ctx context.Context, projectID pgtype.UUID
 }
 
 const listAgentsByProjectMerged = `-- name: ListAgentsByProjectMerged :many
-SELECT id, project_id, name, template_content, type, created_at, updated_at, scope, model, image, provider FROM agents
+SELECT id, project_id, name, template_content, type, created_at, updated_at, scope, model, image, provider, runtime_kind FROM agents
 WHERE project_id = $1 OR scope = 'global'
 ORDER BY scope DESC, name ASC
 `
@@ -154,6 +159,7 @@ func (q *Queries) ListAgentsByProjectMerged(ctx context.Context, projectID pgtyp
 			&i.Model,
 			&i.Image,
 			&i.Provider,
+			&i.RuntimeKind,
 		); err != nil {
 			return nil, err
 		}
@@ -166,7 +172,7 @@ func (q *Queries) ListAgentsByProjectMerged(ctx context.Context, projectID pgtyp
 }
 
 const listGlobalAgents = `-- name: ListGlobalAgents :many
-SELECT id, project_id, name, template_content, type, created_at, updated_at, scope, model, image, provider FROM agents WHERE scope = 'global' ORDER BY name ASC
+SELECT id, project_id, name, template_content, type, created_at, updated_at, scope, model, image, provider, runtime_kind FROM agents WHERE scope = 'global' ORDER BY name ASC
 `
 
 func (q *Queries) ListGlobalAgents(ctx context.Context) ([]Agent, error) {
@@ -190,6 +196,7 @@ func (q *Queries) ListGlobalAgents(ctx context.Context) ([]Agent, error) {
 			&i.Model,
 			&i.Image,
 			&i.Provider,
+			&i.RuntimeKind,
 		); err != nil {
 			return nil, err
 		}
@@ -203,9 +210,9 @@ func (q *Queries) ListGlobalAgents(ctx context.Context) ([]Agent, error) {
 
 const updateAgent = `-- name: UpdateAgent :one
 UPDATE agents
-SET name = $2, model = $3, image = $4, template_content = $5, provider = $6, updated_at = NOW()
+SET name = $2, model = $3, image = $4, runtime_kind = $5, template_content = $6, provider = $7, updated_at = NOW()
 WHERE id = $1
-RETURNING id, project_id, name, template_content, type, created_at, updated_at, scope, model, image, provider
+RETURNING id, project_id, name, template_content, type, created_at, updated_at, scope, model, image, provider, runtime_kind
 `
 
 type UpdateAgentParams struct {
@@ -213,6 +220,7 @@ type UpdateAgentParams struct {
 	Name            string      `json:"name"`
 	Model           pgtype.Text `json:"model"`
 	Image           pgtype.Text `json:"image"`
+	RuntimeKind     string      `json:"runtime_kind"`
 	TemplateContent string      `json:"template_content"`
 	Provider        string      `json:"provider"`
 }
@@ -223,6 +231,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		arg.Name,
 		arg.Model,
 		arg.Image,
+		arg.RuntimeKind,
 		arg.TemplateContent,
 		arg.Provider,
 	)
@@ -239,6 +248,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		&i.Model,
 		&i.Image,
 		&i.Provider,
+		&i.RuntimeKind,
 	)
 	return i, err
 }

--- a/backend/internal/adapter/postgres/models.go
+++ b/backend/internal/adapter/postgres/models.go
@@ -70,6 +70,7 @@ type Agent struct {
 	Model           pgtype.Text `json:"model"`
 	Image           pgtype.Text `json:"image"`
 	Provider        string      `json:"provider"`
+	RuntimeKind     string      `json:"runtime_kind"`
 }
 
 type CostRecord struct {

--- a/backend/internal/domain/model/agent.go
+++ b/backend/internal/domain/model/agent.go
@@ -18,6 +18,25 @@ const (
 	ProviderOpenCode = "opencode"
 )
 
+// RuntimeKind identifies the pluggable agent runtime an agent executes on.
+// It is the stable dispatch signal for execution mode, replacing the legacy
+// heuristic that inspected the free-form image string. Each kind maps to a
+// runtime adapter that wraps an existing coding harness.
+const (
+	RuntimeKindClaudeCode = "claude_code" // CLI `claude -p` via the agent-runtime binary
+	RuntimeKindOpenCode   = "opencode"    // CLI `opencode` via the agent-runtime binary
+	RuntimeKindCMA        = "cma"         // Anthropic Managed Agents (optional, cloud)
+)
+
+// RuntimeKindFromProvider derives a default RuntimeKind from the legacy provider
+// value. Used to backfill/derive a runtime when none is set explicitly.
+func RuntimeKindFromProvider(provider string) string {
+	if provider == ProviderOpenCode {
+		return RuntimeKindOpenCode
+	}
+	return RuntimeKindClaudeCode
+}
+
 // Agent represents an AI agent definition with its runtime configuration and prompt template.
 // Agents can be scoped globally (available to all projects) or to a specific project.
 type Agent struct {
@@ -25,6 +44,7 @@ type Agent struct {
 	Name            string     `json:"name"`
 	Model           string     `json:"model"`
 	Image           string     `json:"image"`
+	RuntimeKind     string     `json:"runtime_kind"` // "claude_code", "opencode" or "cma"
 	TemplateContent string     `json:"template_content"`
 	Type            string     `json:"type"`     // "implement", "review", "merge", "retry", "custom"
 	Scope           string     `json:"scope"`    // "global" or "project"

--- a/backend/internal/domain/model/capability.go
+++ b/backend/internal/domain/model/capability.go
@@ -1,0 +1,105 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// NOTE: This file is P0 scaffolding for the runtime/capabilities rework. The
+// types describe the agnostic capability model that runtime adapters translate
+// to their native mechanism (see port.AgentRuntime). Persistence (the
+// `capabilities` / `agent_capabilities` tables), the fetch-at-startup bundle and
+// the per-adapter Provision implementations land in P1 — nothing here is wired
+// yet.
+
+// Capability kinds. A capability is platform data, agnostic to the runtime; each
+// adapter advertises which kinds it can translate via AgentRuntime.SupportedCapabilities.
+const (
+	CapabilityKindSkill      = "skill"       // SKILL.md + resources (pure data)
+	CapabilityKindMCPServer  = "mcp_server"  // HTTP service (default) or in-image stdio binary
+	CapabilityKindToolPolicy = "tool_policy" // allow/deny tools, by role
+)
+
+// Capability scopes. Global capabilities form the admin-curated catalogue;
+// project capabilities are owned by a single project.
+const (
+	CapabilityScopeGlobal  = "global"
+	CapabilityScopeProject = "project"
+)
+
+// Capability is a versioned, runtime-agnostic capability (skill, MCP server or
+// tool policy) that can be composed onto an agent.
+type Capability struct {
+	ID        uuid.UUID  `json:"id"`
+	Kind      string     `json:"kind"` // CapabilityKind*
+	Name      string     `json:"name"`
+	Version   int        `json:"version"` // bumped on edit; agents pin or follow latest
+	Scope     string     `json:"scope"`   // CapabilityScope*
+	ProjectID *uuid.UUID `json:"project_id"`
+	Spec      []byte     `json:"spec"` // agnostic spec (jsonb): skill text / url+auth / allow-deny
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+// AgentCapability is the composition join binding a capability onto an agent.
+type AgentCapability struct {
+	AgentID      uuid.UUID `json:"agent_id"`
+	CapabilityID uuid.UUID `json:"capability_id"`
+}
+
+// CapabilitySpec is the assembled, runtime-agnostic set of capabilities for a
+// single agent run. The platform builds it from the agent's composed
+// capabilities; an adapter's Provision turns it into the harness-native form.
+type CapabilitySpec struct {
+	Skills     []SkillSpec     `json:"skills"`
+	MCPServers []MCPServerSpec `json:"mcp_servers"`
+	ToolPolicy *ToolPolicySpec `json:"tool_policy"`
+}
+
+// SkillSpec is a skill rendered as files (e.g. SKILL.md plus scripts/rubrics).
+// Keyed by relative path so the runtime can materialise it on disk.
+type SkillSpec struct {
+	Name  string            `json:"name"`
+	Files map[string]string `json:"files"`
+}
+
+// MCPServerSpec describes one MCP server. Transport "http" carries a URL plus
+// headers (the default); "stdio" references an in-image binary for the
+// ultra-sensitive case. CredentialRef points at a secret resolved at runtime —
+// secrets are never baked nor stored in the spec in clear.
+type MCPServerSpec struct {
+	Name          string            `json:"name"`
+	Transport     string            `json:"transport"` // "http" | "stdio"
+	URL           string            `json:"url,omitempty"`
+	Headers       map[string]string `json:"headers,omitempty"`
+	Command       string            `json:"command,omitempty"`
+	CredentialRef string            `json:"credential_ref,omitempty"`
+}
+
+// ToolPolicySpec is an allow/deny list of tools, applied per role.
+type ToolPolicySpec struct {
+	Allow []string `json:"allow"`
+	Deny  []string `json:"deny"`
+}
+
+// CapabilitySet declares which capability kinds an adapter can translate. The
+// invariant is warn+skip: an unsupported capability degrades the run, never
+// blocks it (see the capability × runtime matrix in the plan).
+type CapabilitySet struct {
+	Skills          bool `json:"skills"`
+	MCPServersHTTP  bool `json:"mcp_servers_http"`
+	MCPServersStdio bool `json:"mcp_servers_stdio"`
+	ToolPolicy      bool `json:"tool_policy"`
+}
+
+// ProvisionResult reports what an adapter applied and what it skipped.
+type ProvisionResult struct {
+	Applied  []string           `json:"applied"`
+	Warnings []ProvisionWarning `json:"warnings"`
+}
+
+// ProvisionWarning records a capability that was skipped (warn+skip), with the reason.
+type ProvisionWarning struct {
+	Capability string `json:"capability"`
+	Reason     string `json:"reason"`
+}

--- a/backend/internal/domain/model/environment.go
+++ b/backend/internal/domain/model/environment.go
@@ -1,0 +1,43 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// NOTE: This file is P0 scaffolding. The `environments` table, sidecar
+// orchestration on a per-run isolated network, conn-string injection and golden
+// images land in P2. The invariant is portability: an Environment must stay
+// K8s-Pod-expressible (services are sidecars-in-Pod, never DinD). Nothing here
+// is persisted or wired yet.
+
+// Environment sources — where the run composition is derived from. The repo's
+// own files win when present; otherwise the stack + services are declared in UI.
+const (
+	EnvironmentSourceDevcontainer = "devcontainer"
+	EnvironmentSourceCompose      = "compose"
+	EnvironmentSourceMakefile     = "makefile"
+	EnvironmentSourceDeclared     = "declared"
+)
+
+// Environment is a project's execution composition: stack(s) + sidecar services
+// + the commands to run (test/migrate/seed). It is distinct from a Stack image:
+// a Stack is a base image, an Environment is how a project actually runs.
+type Environment struct {
+	ID        uuid.UUID            `json:"id"`
+	ProjectID uuid.UUID            `json:"project_id"`
+	Stacks    []string             `json:"stacks"`   // one or more StackKey values
+	Services  []EnvironmentService `json:"services"` // sidecars (postgres/redis/mailhog…)
+	Source    string               `json:"source"`   // EnvironmentSource*
+	Commands  map[string]string    `json:"commands"` // {test:"make test", migrate:"…", seed:"…"}
+	CreatedAt time.Time            `json:"created_at"`
+}
+
+// EnvironmentService is a sidecar brought up alongside the agent on a per-run
+// isolated network, with its connection string injected into the run env.
+type EnvironmentService struct {
+	Name  string            `json:"name"`
+	Image string            `json:"image"`
+	Env   map[string]string `json:"env"`
+}

--- a/backend/internal/domain/model/stack.go
+++ b/backend/internal/domain/model/stack.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// NOTE: This file is P0 scaffolding. The `stacks` table, multi-arch pinned
+// images and the agent StackRef foreign key land in P2. The free-form
+// `agents.image` column is kept until then; nothing here is persisted or wired yet.
+
+// Stack keys for the catalogued runtime images.
+const (
+	StackKeyGo     = "go"
+	StackKeyNode   = "node"
+	StackKeyPython = "python"
+	StackKeyGoNode = "go-node"
+)
+
+// Stack is a catalogued, digest-pinned, multi-arch image carrying a toolchain,
+// the runtime CLI (claude/opencode) and the per-language LSP. Agents will
+// reference a stack by key instead of a free-form image string.
+type Stack struct {
+	ID        uuid.UUID `json:"id"`
+	Key       string    `json:"key"`       // StackKey*
+	ImageRef  string    `json:"image_ref"` // digest-pinned, multi-arch
+	Toolchain []byte    `json:"toolchain"` // jsonb: toolchain + CLI + LSP versions
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/backend/internal/domain/port/agent_runtime.go
+++ b/backend/internal/domain/port/agent_runtime.go
@@ -1,0 +1,62 @@
+package port
+
+import (
+	"context"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+)
+
+// NOTE: This is the P0 target port — an agent-execution abstraction that
+// supersedes the Docker-shaped ContainerManager as the domain's runtime port.
+// It is scaffolding: no adapter implements it yet. The Docker substrate
+// (microsandbox/K8s later) will implement AgentRuntime and keep ContainerManager
+// as an internal detail. The live agent_run flow still drives ContainerManager
+// directly; it migrates onto AgentRuntime in a later phase without touching the
+// domain.
+
+// RunSpec is everything an adapter needs to launch one agent execution. It is
+// substrate-agnostic: the adapter realises it on Docker, a microVM or a Pod.
+type RunSpec struct {
+	RuntimeKind  string               // model.RuntimeKind* — selects the harness
+	Model        string               // model id passed to the harness
+	Provider     string               // model.Provider* — auth/provider selection
+	Image        string               // stack image (free-form until the catalogue lands)
+	Prompt       string               // rendered prompt
+	Env          []string             // KEY=value pairs (no secrets once fetch-at-startup lands)
+	Labels       map[string]string    // bookkeeping labels (run_id/step_id/story_key)
+	Capabilities model.CapabilitySpec // composed skills/mcp/tool-policy for this run
+}
+
+// RunHandle identifies a launched execution (container/microVM/pod id).
+type RunHandle struct {
+	ID string
+}
+
+// RunResult is the terminal outcome of an execution.
+type RunResult struct {
+	ExitCode int
+	Error    string
+}
+
+// AgentRuntime is the stable, agent-oriented runtime port. Adapters wrap an
+// existing coding harness (claude / opencode CLI, CMA service) — they never
+// reimplement the agentic loop as raw API calls.
+type AgentRuntime interface {
+	// Provision applies the agnostic capability spec to the adapter's native
+	// mechanism. An unsupported capability is warn+skip, never a blocking error.
+	Provision(ctx context.Context, spec model.CapabilitySpec) (model.ProvisionResult, error)
+
+	// Launch starts an agent execution (clone + harness + capabilities) and
+	// returns a handle to it.
+	Launch(ctx context.Context, spec RunSpec) (RunHandle, error)
+
+	// Wait blocks until the execution terminates and returns its result.
+	Wait(ctx context.Context, h RunHandle) (RunResult, error)
+
+	// Stop terminates a running execution.
+	Stop(ctx context.Context, h RunHandle) error
+
+	// SupportedCapabilities declares which capability kinds this adapter can
+	// translate (skills / mcp-http / mcp-stdio / tool-policy …).
+	SupportedCapabilities() model.CapabilitySet
+}

--- a/backend/internal/domain/port/container_manager.go
+++ b/backend/internal/domain/port/container_manager.go
@@ -15,6 +15,13 @@ type ContainerInfo struct {
 }
 
 // ContainerManager abstracts Docker container lifecycle operations.
+//
+// As of the runtime rework this is no longer the domain's agent-execution port —
+// AgentRuntime is (see agent_runtime.go). ContainerManager is being reclassified
+// into an internal dependency of the Docker substrate adapter: a low-level
+// container CRUD that AgentRuntime adapters build on, not an agent abstraction.
+// It is kept here (not removed) because the live agent_run flow still drives it
+// directly until the AgentRuntime adapter takes over in a later phase.
 type ContainerManager interface {
 	// Create creates a container with the specified options.
 	// Returns the container ID on success.

--- a/backend/internal/domain/service/pipeline_executor.go
+++ b/backend/internal/domain/service/pipeline_executor.go
@@ -277,6 +277,13 @@ func (e *PipelineExecutor) executeStep(ctx context.Context, run *model.Run, step
 		delete(runCtx.Metadata, "agent_image")
 	}
 
+	runtimeKindKey := fmt.Sprintf("step_%d_runtime_kind", step.StepOrder)
+	if runtimeKind, ok := runCtx.Metadata[runtimeKindKey].(string); ok && runtimeKind != "" {
+		runCtx.Metadata["runtime_kind"] = runtimeKind
+	} else {
+		delete(runCtx.Metadata, "runtime_kind")
+	}
+
 	// Execute action
 	if err := action.Execute(ctx, runCtx); err != nil {
 		return err

--- a/backend/internal/domain/service/run_service.go
+++ b/backend/internal/domain/service/run_service.go
@@ -367,6 +367,13 @@ func (s *RunService) LaunchRun(ctx context.Context, projectID, storyID, userID u
 			if agent.Image != "" {
 				runMetadata[fmt.Sprintf("step_%d_agent_image", i)] = agent.Image
 			}
+			// runtime_kind drives the execution-mode dispatch (callback vs legacy),
+			// replacing the old image-substring heuristic. Default from provider when unset.
+			runtimeKind := agent.RuntimeKind
+			if runtimeKind == "" {
+				runtimeKind = model.RuntimeKindFromProvider(agent.Provider)
+			}
+			runMetadata[fmt.Sprintf("step_%d_runtime_kind", i)] = runtimeKind
 			if agent.TemplateContent != "" {
 				runMetadata[fmt.Sprintf("step_%d_template_content", i)] = agent.TemplateContent
 			}

--- a/backend/migrations/000032_add_runtime_kind_to_agents.down.sql
+++ b/backend/migrations/000032_add_runtime_kind_to_agents.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE agents DROP CONSTRAINT IF EXISTS agents_chk_runtime_kind;
+ALTER TABLE agents DROP COLUMN IF EXISTS runtime_kind;

--- a/backend/migrations/000032_add_runtime_kind_to_agents.up.sql
+++ b/backend/migrations/000032_add_runtime_kind_to_agents.up.sql
@@ -1,0 +1,20 @@
+-- Add runtime_kind: the pluggable agent runtime an agent runs on
+-- (claude_code | opencode | cma). This replaces the implicit execution-mode
+-- detection that used to key off the free-form `image` string
+-- (strings.Contains(image, "hopeitworks/agent-")).
+ALTER TABLE agents ADD COLUMN runtime_kind VARCHAR(20) NOT NULL DEFAULT 'claude_code';
+
+ALTER TABLE agents ADD CONSTRAINT agents_chk_runtime_kind
+    CHECK (runtime_kind IN ('claude_code', 'opencode', 'cma'));
+
+-- One-time backfill from the legacy isCallbackMode heuristic, run once here so the
+-- image substring is never consulted again. Every existing agent runs on the
+-- agent-runtime images (hopeitworks/agent-*, i.e. callback mode); its runtime is the
+-- provider's harness: opencode -> 'opencode', everything else -> 'claude_code'
+-- (the prior default callback runtime). The `image` column is intentionally kept for
+-- now (the stack catalogue + StackRef land in a later phase).
+UPDATE agents
+SET runtime_kind = CASE
+    WHEN provider = 'opencode' AND image LIKE '%hopeitworks/agent-%' THEN 'opencode'
+    ELSE 'claude_code'
+END;

--- a/backend/queries/agents.sql
+++ b/backend/queries/agents.sql
@@ -1,6 +1,6 @@
 -- name: CreateAgent :one
-INSERT INTO agents (id, name, model, image, template_content, type, scope, provider, project_id, created_at, updated_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW())
+INSERT INTO agents (id, name, model, image, runtime_kind, template_content, type, scope, provider, project_id, created_at, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW(), NOW())
 RETURNING *;
 
 -- name: GetAgent :one
@@ -19,7 +19,7 @@ ORDER BY scope DESC, name ASC;
 
 -- name: UpdateAgent :one
 UPDATE agents
-SET name = $2, model = $3, image = $4, template_content = $5, provider = $6, updated_at = NOW()
+SET name = $2, model = $3, image = $4, runtime_kind = $5, template_content = $6, provider = $7, updated_at = NOW()
 WHERE id = $1
 RETURNING *;
 


### PR DESCRIPTION
Phase **P0** de la refonte runtime/capacités (cf. `docs/agent-runtime-capabilities-plan.md`).

## Ce que ça fait
- Nouveau port `port/agent_runtime.go` (AgentRuntime, orienté exécution d'agent) — **scaffolding**, aucun adapter ne l'implémente encore ; `ContainerManager` reclassé en dépendance interne du substrat Docker (gardé, flux actuel inchangé).
- `RuntimeKind` (`claude_code|opencode|cma`) sur le modèle agent + **migration 000032** (NOT NULL DEFAULT + CHECK + backfill depuis l'ancienne heuristique image, une dernière fois). Colonne `image` gardée (StackRef/catalogue = P2).
- **Dispatch du mode d'exécution sur `RuntimeKind`** au lieu de `strings.Contains(image,"hopeitworks/agent-")` ; threadé agent → `step_N_runtime_kind` → `runtime_kind` → action. Fallback substring uniquement pour les runs en vol sans `runtime_kind`.
- Scaffolding domaine (types only) : `model/{capability,stack,environment}.go`.

## Back-compat
- Agents en image `hopeitworks/agent-*` (tous les seedés) : **inchangés** (callback → callback).
- Mode *legacy* (image custom non-hopeitworks) **déprécié par design** (pas de RuntimeKind legacy) — assumé.

## Vérif
`go build` / `go vet` / `go test -short` / `golangci-lint` : verts. Tests testcontainers (migration+sqlc) → CI.

## Hors scope (phases suivantes)
Adapters microsandbox/K8s (P3/P4), injection de capacités (P1), catalogue de stacks (P2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)