### PR TITLE
fix(agent-images): cross-compile Go tools to kill the arm64 QEMU build penalty

### DIFF
--- a/agent-images/base/Dockerfile
+++ b/agent-images/base/Dockerfile
@@ -1,9 +1,12 @@
 # syntax=docker/dockerfile:1
-# Builder: pinned by digest (multi-arch manifest list) for reproducibility.
-FROM golang:1.23-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db AS builder
+# Builder: runs on the BUILD platform (no QEMU) and cross-compiles agent-runtime to
+# the target arch. Pinned by digest (multi-arch manifest list) for reproducibility.
+FROM --platform=$BUILDPLATFORM golang:1.23-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db AS builder
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /build
 COPY agent-runtime/ ./
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /agent-runtime .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o /agent-runtime .
 
 # Base runtime: pinned by digest (multi-arch manifest list).
 FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716

--- a/agent-images/stacks/go-node/Dockerfile
+++ b/agent-images/stacks/go-node/Dockerfile
@@ -1,8 +1,5 @@
 # syntax=docker/dockerfile:1
 # go-node = real union of the go and node stacks (NOT a copy of go).
-FROM hopeitworks/agent-base:latest
-
-USER root
 
 # Pinned Go tool versions.
 ARG SQLC_VERSION=v1.31.1
@@ -11,6 +8,37 @@ ARG WIRE_VERSION=v0.7.0
 ARG GOLANGCI_LINT_VERSION=v1.64.8
 ARG GOPLS_VERSION=v0.22.0
 ARG GOVULNCHECK_VERSION=v1.4.0
+
+# Go dev tools cross-compiled on the BUILD platform (no QEMU): GOARCH=$TARGETARCH.
+# Compiling gopls/sqlc under arm64 emulation took 25+ min; cross-compiling from the
+# native builder is a few minutes. Pinned by digest (multi-arch manifest list).
+FROM --platform=$BUILDPLATFORM golang:1.23-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db AS gotools
+ARG TARGETOS
+ARG TARGETARCH
+ARG SQLC_VERSION
+ARG OAPI_CODEGEN_VERSION
+ARG WIRE_VERSION
+ARG GOPLS_VERSION
+ARG GOVULNCHECK_VERSION
+# GOTOOLCHAIN=auto: the golang image pins it to "local", but sqlc@v1.31.1 needs
+# go >= 1.26; auto lets `go install` fetch the required toolchain (host-native).
+ENV GOPATH=/go GOTOOLCHAIN=auto
+# go install refuses GOBIN for cross-compiled binaries and drops them under
+# $GOPATH/bin/<os>_<arch>/ when cross-compiling ($GOPATH/bin when native).
+# Normalise both layouts into /gotools for a single COPY in the final stage.
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go install github.com/sqlc-dev/sqlc/cmd/sqlc@${SQLC_VERSION} \
+    && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@${OAPI_CODEGEN_VERSION} \
+    && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go install github.com/google/wire/cmd/wire@${WIRE_VERSION} \
+    && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go install golang.org/x/tools/gopls@${GOPLS_VERSION} \
+    && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
+    && mkdir -p /gotools \
+    && if [ -d "/go/bin/${TARGETOS}_${TARGETARCH}" ]; then cp /go/bin/${TARGETOS}_${TARGETARCH}/* /gotools/; else cp /go/bin/* /gotools/; fi
+
+FROM hopeitworks/agent-base:latest
+
+USER root
+
+ARG GOLANGCI_LINT_VERSION
 # Pinned Node tool versions.
 ARG TYPESCRIPT_VERSION=6.0.3
 ARG PRETTIER_VERSION=3.8.4
@@ -24,23 +52,20 @@ COPY --from=golang:1.23-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e76
 ENV PATH="/usr/local/go/bin:/home/agent/go/bin:${PATH}"
 ENV GOPATH="/home/agent/go"
 
-# Go dev tools (pinned) + LSP (gopls) + vuln scanner (govulncheck).
-RUN go install github.com/sqlc-dev/sqlc/cmd/sqlc@${SQLC_VERSION} \
-    && go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@${OAPI_CODEGEN_VERSION} \
-    && go install github.com/google/wire/cmd/wire@${WIRE_VERSION} \
-    && go install golang.org/x/tools/gopls@${GOPLS_VERSION} \
-    && go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
-    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCI_LINT_VERSION}/install.sh | sh -s -- -b /usr/local/bin ${GOLANGCI_LINT_VERSION}
+# Cross-compiled Go dev tools + LSP (gopls) + vuln scanner (govulncheck), from the
+# gotools stage. golangci-lint ships a prebuilt binary (install.sh only downloads).
+COPY --from=gotools /gotools/ /home/agent/go/bin/
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCI_LINT_VERSION}/install.sh | sh -s -- -b /usr/local/bin ${GOLANGCI_LINT_VERSION}
 
 # --- Node side (Node + npm already in agent-base) ---
-# Node dev tools (pinned) + LSP (typescript-language-server) + pnpm.
+# Node dev tools (pinned) + LSP (typescript-language-server) + pnpm. These are JS
+# package downloads (no native compile), so they stay fast even under emulation.
+# gh comes from agent-base — do not re-install it here.
 RUN npm install -g \
     typescript@${TYPESCRIPT_VERSION} \
     prettier@${PRETTIER_VERSION} \
     eslint@${ESLINT_VERSION} \
     typescript-language-server@${TS_LANGUAGE_SERVER_VERSION} \
     pnpm@${PNPM_VERSION}
-
-# gh comes from agent-base — do not re-install it here.
 
 USER agent

--- a/agent-images/stacks/go/Dockerfile
+++ b/agent-images/stacks/go/Dockerfile
@@ -1,7 +1,4 @@
 # syntax=docker/dockerfile:1
-FROM hopeitworks/agent-base:latest
-
-USER root
 
 # Pinned tool versions (no @latest / @HEAD).
 ARG SQLC_VERSION=v1.31.1
@@ -11,18 +8,46 @@ ARG GOLANGCI_LINT_VERSION=v1.64.8
 ARG GOPLS_VERSION=v0.22.0
 ARG GOVULNCHECK_VERSION=v1.4.0
 
+# Go dev tools cross-compiled on the BUILD platform (no QEMU): GOARCH=$TARGETARCH.
+# Compiling gopls/sqlc under arm64 emulation took 25+ min; cross-compiling from the
+# native builder is a few minutes. Pinned by digest (multi-arch manifest list).
+FROM --platform=$BUILDPLATFORM golang:1.23-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db AS gotools
+ARG TARGETOS
+ARG TARGETARCH
+ARG SQLC_VERSION
+ARG OAPI_CODEGEN_VERSION
+ARG WIRE_VERSION
+ARG GOPLS_VERSION
+ARG GOVULNCHECK_VERSION
+# GOTOOLCHAIN=auto: the golang image pins it to "local", but sqlc@v1.31.1 needs
+# go >= 1.26; auto lets `go install` fetch the required toolchain (host-native).
+ENV GOPATH=/go GOTOOLCHAIN=auto
+# go install refuses GOBIN for cross-compiled binaries and drops them under
+# $GOPATH/bin/<os>_<arch>/ when cross-compiling ($GOPATH/bin when native).
+# Normalise both layouts into /gotools for a single COPY in the final stage.
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go install github.com/sqlc-dev/sqlc/cmd/sqlc@${SQLC_VERSION} \
+    && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@${OAPI_CODEGEN_VERSION} \
+    && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go install github.com/google/wire/cmd/wire@${WIRE_VERSION} \
+    && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go install golang.org/x/tools/gopls@${GOPLS_VERSION} \
+    && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
+    && mkdir -p /gotools \
+    && if [ -d "/go/bin/${TARGETOS}_${TARGETARCH}" ]; then cp /go/bin/${TARGETOS}_${TARGETARCH}/* /gotools/; else cp /go/bin/* /gotools/; fi
+
+FROM hopeitworks/agent-base:latest
+
+USER root
+
+ARG GOLANGCI_LINT_VERSION
+
 # Go 1.23 (toolchain copied from pinned-by-digest golang image, multi-arch).
 COPY --from=golang:1.23-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db /usr/local/go /usr/local/go
 ENV PATH="/usr/local/go/bin:/home/agent/go/bin:${PATH}"
 ENV GOPATH="/home/agent/go"
 
-# Go dev tools (pinned) + LSP (gopls) + vuln scanner (govulncheck).
+# Cross-compiled Go dev tools + LSP (gopls) + vuln scanner (govulncheck), from the
+# gotools stage. golangci-lint ships a prebuilt binary (install.sh only downloads).
 # gh comes from agent-base — do not re-install it here.
-RUN go install github.com/sqlc-dev/sqlc/cmd/sqlc@${SQLC_VERSION} \
-    && go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@${OAPI_CODEGEN_VERSION} \
-    && go install github.com/google/wire/cmd/wire@${WIRE_VERSION} \
-    && go install golang.org/x/tools/gopls@${GOPLS_VERSION} \
-    && go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
-    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCI_LINT_VERSION}/install.sh | sh -s -- -b /usr/local/bin ${GOLANGCI_LINT_VERSION}
+COPY --from=gotools /gotools/ /home/agent/go/bin/
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCI_LINT_VERSION}/install.sh | sh -s -- -b /usr/local/bin ${GOLANGCI_LINT_VERSION}
 
 USER agent


### PR DESCRIPTION
## Problème
Les stacks `go`/`go-node` compilaient 5 outils Go (`sqlc`, `oapi-codegen`, `wire`, `gopls`, `govulncheck`) **dans l'architecture cible** via `go install`. Pour le manifest arm64, ça tournait donc **sous émulation QEMU** : ~26 min par stack, vs ~1-4 min pour node/python (qui ne compilent aucun outil Go). Perçu comme un build bloqué.

## Fix
- Étage builder/`gotools` épinglé à `--platform=$BUILDPLATFORM` (runner natif amd64) + `GOOS=$TARGETOS GOARCH=$TARGETARCH` → **cross-compilation native**, zéro QEMU pour la compilation. Puis `COPY` des binaires cross-compilés dans l'image finale.
- `base` : `agent-runtime` cross-compilé pareil (`GOARCH=$TARGETARCH go build`).
- `GOTOOLCHAIN=auto` dans l'étage gotools (l'image `golang` force `local`, or `sqlc@v1.31.1` exige go ≥ 1.26 → auto récupère le toolchain hôte-natif).
- `golangci-lint` reste un download `install.sh` (pas de compilation). Layouts `$GOPATH/bin` (natif) vs `$GOPATH/bin/<os>_<arch>` (cross) normalisés.

## Validation
Build workflow `agent-images` **vert sur les 5 images, multi-arch amd64+arm64** :

| Image | Avant | Après |
|---|---|---|
| agent-base | 8m35s | **1m16s** |
| agent-node | 1m26s | 35s |
| agent-python | 4m31s | 25s |
| agent-go | ~26min | **9m32s** |
| agent-go-node | ~26min | **12m18s** |

Images fonctionnellement identiques (mêmes versions d'outils pinnées). Le cache `gha` accélérera les rebuilds suivants (layer gotools réutilisé). Le workflow ne se déclenche que sur `workflow_dispatch`/tag `v*` (pas sur merge develop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)