### PR TITLE
feat(stacks): config-driven catalogue seed + pinned digests (reconciliation)

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -30,6 +31,7 @@ import (
 	"github.com/zakari/hopeitworks/backend/internal/domain/port"
 	"github.com/zakari/hopeitworks/backend/internal/domain/service"
 	"github.com/zakari/hopeitworks/backend/migrations"
+	pkgconfig "github.com/zakari/hopeitworks/backend/pkg/config"
 	pkgexec "github.com/zakari/hopeitworks/backend/pkg/exec"
 	pkglog "github.com/zakari/hopeitworks/backend/pkg/log"
 )
@@ -156,6 +158,14 @@ func run() error {
 	stackRepo := pgadapter.NewStackRepo(queries)
 	stackService := service.NewStackService(stackRepo)
 	stackHandler := handler.NewStackHandler(stackService)
+
+	// Seed the stack catalogue from versioned config (source of truth). Idempotent
+	// UPSERT on every boot, so image digests can change without a migration. An empty
+	// catalogue is a no-op fallback to the migration-inlined seed (000034); a seed
+	// error is logged but does not abort boot (the read path still works on existing rows).
+	if err := service.SeedStacks(ctx, stackRepo, stackCatalogueFromConfig(cfg.Stacks, logger), logger); err != nil {
+		logger.Error("failed to seed stack catalogue from config", "error", err)
+	}
 
 	// Template renderer (Handlebars engine for prompt templates)
 	handlebarsRenderer := hbadapter.NewRenderer()
@@ -469,6 +479,34 @@ func getEnvOrDefault(key, defaultVal string) string {
 		return val
 	}
 	return defaultVal
+}
+
+// stackCatalogueFromConfig converts the YAML stack catalogue into domain stacks,
+// marshalling each toolchain map into the jsonb bytes the model carries. Entries
+// with an empty key or image_ref are skipped (logged); a toolchain that fails to
+// marshal is skipped rather than aborting boot. Returns nil for an empty catalogue.
+func stackCatalogueFromConfig(entries []pkgconfig.StackConfig, logger *slog.Logger) []model.Stack {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]model.Stack, 0, len(entries))
+	for _, e := range entries {
+		if e.Key == "" || e.ImageRef == "" {
+			logger.Warn("skipping stack catalogue entry with empty key or image_ref", "key", e.Key, "image_ref", e.ImageRef)
+			continue
+		}
+		toolchain := []byte("{}")
+		if len(e.Toolchain) > 0 {
+			b, err := json.Marshal(e.Toolchain)
+			if err != nil {
+				logger.Warn("skipping stack catalogue entry with invalid toolchain", "key", e.Key, "error", err)
+				continue
+			}
+			toolchain = b
+		}
+		out = append(out, model.Stack{Key: e.Key, ImageRef: e.ImageRef, Toolchain: toolchain})
+	}
+	return out
 }
 
 // startTokenCleanup launches a goroutine that periodically purges expired revoked tokens.

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -37,27 +37,27 @@ smtp:
 # The migration-inlined seed (000034) stays only as a first-boot fallback.
 stacks:
   - key: go
-    image_ref: ghcr.io/zkarahacane/hopeitworks/agent-go:latest
+    image_ref: ghcr.io/zkarahacane/hopeitworks/agent-go@sha256:a9169e9d8dc0ae71ba7a4729f8892a5461195b2d2d113b85efc660fc01cc486d
     toolchain:
       go: "1.23"
       node: "22"
       cli: ["claude", "opencode"]
       tools: ["sqlc", "oapi-codegen", "wire", "golangci-lint", "gh"]
   - key: node
-    image_ref: ghcr.io/zkarahacane/hopeitworks/agent-node:latest
+    image_ref: ghcr.io/zkarahacane/hopeitworks/agent-node@sha256:c30ed2bc1e758c8c7aa34de51d8e20b857d670b655c02b6318fb4b324cec9d97
     toolchain:
       node: "22"
       cli: ["claude", "opencode"]
       tools: ["typescript", "prettier", "eslint", "gh"]
   - key: python
-    image_ref: ghcr.io/zkarahacane/hopeitworks/agent-python:latest
+    image_ref: ghcr.io/zkarahacane/hopeitworks/agent-python@sha256:c63b0460429f70f73325f2043114ce94788afb0507e91064872f5e69d0b5432a
     toolchain:
       python: "3.12"
       node: "22"
       cli: ["claude", "opencode"]
       tools: ["gh"]
   - key: go-node
-    image_ref: ghcr.io/zkarahacane/hopeitworks/agent-go-node:latest
+    image_ref: ghcr.io/zkarahacane/hopeitworks/agent-go-node@sha256:8e87a10611e1be943cf28ebd818215f62e1401d9b46efce2dcfcf0e873e23276
     toolchain:
       go: "1.23"
       node: "22"

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -29,3 +29,37 @@ smtp:
   username: ""
   password: ""
   frontend_url: http://localhost:5173
+
+# Stack catalogue: SOURCE OF TRUTH for the catalogued runtime images. Re-applied
+# as an idempotent UPSERT on every API boot (see SeedStacks), so the digests below
+# can change at every image rebuild without a migration churn. To PIN a stack to a
+# new digest, edit image_ref here (prefer `@sha256:...` over `:latest`) and restart.
+# The migration-inlined seed (000034) stays only as a first-boot fallback.
+stacks:
+  - key: go
+    image_ref: ghcr.io/zkarahacane/hopeitworks/agent-go:latest
+    toolchain:
+      go: "1.23"
+      node: "22"
+      cli: ["claude", "opencode"]
+      tools: ["sqlc", "oapi-codegen", "wire", "golangci-lint", "gh"]
+  - key: node
+    image_ref: ghcr.io/zkarahacane/hopeitworks/agent-node:latest
+    toolchain:
+      node: "22"
+      cli: ["claude", "opencode"]
+      tools: ["typescript", "prettier", "eslint", "gh"]
+  - key: python
+    image_ref: ghcr.io/zkarahacane/hopeitworks/agent-python:latest
+    toolchain:
+      python: "3.12"
+      node: "22"
+      cli: ["claude", "opencode"]
+      tools: ["gh"]
+  - key: go-node
+    image_ref: ghcr.io/zkarahacane/hopeitworks/agent-go-node:latest
+    toolchain:
+      go: "1.23"
+      node: "22"
+      cli: ["claude", "opencode"]
+      tools: ["sqlc", "oapi-codegen", "wire", "golangci-lint", "gh"]

--- a/backend/internal/adapter/postgres/stack_repo.go
+++ b/backend/internal/adapter/postgres/stack_repo.go
@@ -61,6 +61,24 @@ func (r *StackRepo) GetByKey(ctx context.Context, key string) (*model.Stack, err
 	return toDomainStack(row), nil
 }
 
+// Upsert inserts a stack or, on key conflict, updates its image_ref and toolchain.
+// Idempotent: backs the boot-time seeder that re-applies the versioned config catalogue.
+func (r *StackRepo) Upsert(ctx context.Context, s *model.Stack) (*model.Stack, error) {
+	toolchain := s.Toolchain
+	if toolchain == nil {
+		toolchain = []byte("{}")
+	}
+	row, err := r.queries.UpsertStack(ctx, UpsertStackParams{
+		Key:       s.Key,
+		ImageRef:  s.ImageRef,
+		Toolchain: toolchain,
+	})
+	if err != nil {
+		return nil, apperrors.NewInternal("failed to upsert stack", err)
+	}
+	return toDomainStack(row), nil
+}
+
 // toDomainStack maps a sqlc-generated Stack to the domain model.
 func toDomainStack(s Stack) *model.Stack {
 	return &model.Stack{

--- a/backend/internal/adapter/postgres/stacks.sql.go
+++ b/backend/internal/adapter/postgres/stacks.sql.go
@@ -74,3 +74,28 @@ func (q *Queries) ListStacks(ctx context.Context) ([]Stack, error) {
 	}
 	return items, nil
 }
+
+const upsertStack = `-- name: UpsertStack :one
+INSERT INTO stacks (key, image_ref, toolchain) VALUES ($1, $2, $3)
+ON CONFLICT (key) DO UPDATE SET image_ref = EXCLUDED.image_ref, toolchain = EXCLUDED.toolchain
+RETURNING id, key, image_ref, toolchain, created_at
+`
+
+type UpsertStackParams struct {
+	Key       string `json:"key"`
+	ImageRef  string `json:"image_ref"`
+	Toolchain []byte `json:"toolchain"`
+}
+
+func (q *Queries) UpsertStack(ctx context.Context, arg UpsertStackParams) (Stack, error) {
+	row := q.db.QueryRow(ctx, upsertStack, arg.Key, arg.ImageRef, arg.Toolchain)
+	var i Stack
+	err := row.Scan(
+		&i.ID,
+		&i.Key,
+		&i.ImageRef,
+		&i.Toolchain,
+		&i.CreatedAt,
+	)
+	return i, err
+}

--- a/backend/internal/config/loader_test.go
+++ b/backend/internal/config/loader_test.go
@@ -147,3 +147,81 @@ func TestLoad_FileNotFound(t *testing.T) {
 		t.Fatal("Load() should have returned an error for missing file")
 	}
 }
+
+func TestLoad_StacksCatalogue(t *testing.T) {
+	yaml := `
+database:
+  host: localhost
+  port: 5432
+  name: testdb
+  user: testuser
+  password: testpass
+  sslmode: disable
+
+logging:
+  level: info
+
+stacks:
+  - key: go
+    image_ref: ghcr.io/x/agent-go:latest
+    toolchain:
+      go: "1.23"
+      cli: ["claude", "opencode"]
+  - key: node
+    image_ref: ghcr.io/x/agent-node:latest
+    toolchain:
+      node: "22"
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if len(cfg.Stacks) != 2 {
+		t.Fatalf("Stacks len = %d, want 2", len(cfg.Stacks))
+	}
+	if cfg.Stacks[0].Key != "go" || cfg.Stacks[0].ImageRef != "ghcr.io/x/agent-go:latest" {
+		t.Errorf("Stacks[0] = %+v, unexpected key/image_ref", cfg.Stacks[0])
+	}
+	if cfg.Stacks[0].Toolchain["go"] != "1.23" {
+		t.Errorf("Stacks[0].Toolchain[go] = %v, want 1.23", cfg.Stacks[0].Toolchain["go"])
+	}
+	cli, ok := cfg.Stacks[0].Toolchain["cli"].([]any)
+	if !ok || len(cli) != 2 {
+		t.Errorf("Stacks[0].Toolchain[cli] = %v, want 2-element list", cfg.Stacks[0].Toolchain["cli"])
+	}
+}
+
+func TestLoad_NoStacksSection(t *testing.T) {
+	yaml := `
+database:
+  host: localhost
+  port: 5432
+  name: testdb
+  user: testuser
+  password: testpass
+  sslmode: disable
+
+logging:
+  level: info
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if len(cfg.Stacks) != 0 {
+		t.Errorf("Stacks len = %d, want 0 when section absent", len(cfg.Stacks))
+	}
+}

--- a/backend/internal/domain/port/stack_repository.go
+++ b/backend/internal/domain/port/stack_repository.go
@@ -7,10 +7,11 @@ import (
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
 )
 
-// StackRepository provides read access to the stack catalogue: the curated,
+// StackRepository provides access to the stack catalogue: the curated,
 // platform-owned set of runtime images an agent can reference instead of a
-// free-form image string. The catalogue is seeded via migration; P2a exposes
-// reads only (no create/update from the API).
+// free-form image string. Reads back the API (P2a, read-only). Upsert backs the
+// idempotent boot-time seeder that re-applies the versioned config catalogue,
+// making that config the source of truth for image_ref/toolchain.
 type StackRepository interface {
 	// List returns all catalogued stacks ordered by key.
 	List(ctx context.Context) ([]*model.Stack, error)
@@ -18,4 +19,8 @@ type StackRepository interface {
 	GetByID(ctx context.Context, id uuid.UUID) (*model.Stack, error)
 	// GetByKey returns a stack by its unique key (go | node | python | go-node).
 	GetByKey(ctx context.Context, key string) (*model.Stack, error)
+	// Upsert inserts a stack or, on key conflict, updates its image_ref and
+	// toolchain. Idempotent: safe to re-apply on every boot from the config
+	// catalogue. Returns the persisted row.
+	Upsert(ctx context.Context, s *model.Stack) (*model.Stack, error)
 }

--- a/backend/internal/domain/service/stack_seeder.go
+++ b/backend/internal/domain/service/stack_seeder.go
@@ -1,0 +1,36 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+)
+
+// SeedStacks idempotently applies the stack catalogue from versioned config to the
+// database. Each entry is UPSERTed (insert-or-update on key), so the catalogue config
+// is the source of truth for image_ref/toolchain and image rebuilds no longer require
+// an UPDATE migration. Safe to re-run on every boot.
+//
+// An empty catalogue is a no-op: it logs a warning and returns nil, leaving whatever
+// the migration-inlined seed (000034) put in place. It NEVER deletes stacks not present
+// in the catalogue, and it never crashes the boot path on an empty/absent catalogue.
+func SeedStacks(ctx context.Context, repo port.StackRepository, catalogue []model.Stack, logger *slog.Logger) error {
+	if len(catalogue) == 0 {
+		logger.Warn("stack catalogue empty in config, skipping seed (falling back to migration-inlined seed)")
+		return nil
+	}
+
+	for i := range catalogue {
+		s := catalogue[i]
+		upserted, err := repo.Upsert(ctx, &s)
+		if err != nil {
+			return err
+		}
+		logger.Info("stack catalogue upserted", "key", upserted.Key, "image_ref", upserted.ImageRef)
+	}
+
+	logger.Info("stack catalogue seeded", "count", len(catalogue))
+	return nil
+}

--- a/backend/internal/domain/service/stack_seeder_test.go
+++ b/backend/internal/domain/service/stack_seeder_test.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+func TestSeedStacks_UpsertsEachEntry(t *testing.T) {
+	repo := newMockStackRepo()
+	catalogue := []model.Stack{
+		{Key: model.StackKeyGo, ImageRef: "ghcr.io/x/agent-go:latest", Toolchain: []byte(`{"go":"1.23"}`)},
+		{Key: model.StackKeyNode, ImageRef: "ghcr.io/x/agent-node:latest", Toolchain: []byte(`{"node":"22"}`)},
+	}
+
+	if err := SeedStacks(context.Background(), repo, catalogue, discardLogger()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(repo.upsertLog) != 2 {
+		t.Fatalf("expected 2 upserts, got %d", len(repo.upsertLog))
+	}
+	if repo.upsertLog[0].Key != model.StackKeyGo || repo.upsertLog[1].Key != model.StackKeyNode {
+		t.Errorf("unexpected upsert order: %+v", repo.upsertLog)
+	}
+	if string(repo.upsertLog[0].Toolchain) != `{"go":"1.23"}` {
+		t.Errorf("toolchain not passed through: %q", repo.upsertLog[0].Toolchain)
+	}
+}
+
+func TestSeedStacks_EmptyCatalogueIsNoop(t *testing.T) {
+	repo := newMockStackRepo()
+
+	if err := SeedStacks(context.Background(), repo, nil, discardLogger()); err != nil {
+		t.Fatalf("expected no error for nil catalogue, got %v", err)
+	}
+	if err := SeedStacks(context.Background(), repo, []model.Stack{}, discardLogger()); err != nil {
+		t.Fatalf("expected no error for empty catalogue, got %v", err)
+	}
+	if len(repo.upsertLog) != 0 {
+		t.Fatalf("expected no upserts for empty catalogue, got %d", len(repo.upsertLog))
+	}
+}
+
+func TestSeedStacks_PropagatesUpsertError(t *testing.T) {
+	repo := newMockStackRepo()
+	wantErr := errors.NewInternal("boom", nil)
+	repo.upsertFn = func(_ *model.Stack) (*model.Stack, error) {
+		return nil, wantErr
+	}
+
+	catalogue := []model.Stack{{Key: model.StackKeyGo, ImageRef: "ghcr.io/x/agent-go:latest"}}
+	err := SeedStacks(context.Background(), repo, catalogue, discardLogger())
+	if err == nil {
+		t.Fatal("expected error to propagate from Upsert, got nil")
+	}
+}

--- a/backend/internal/domain/service/stack_service_test.go
+++ b/backend/internal/domain/service/stack_service_test.go
@@ -11,8 +11,10 @@ import (
 
 // mockStackRepo is a hand-written port.StackRepository for service/run tests.
 type mockStackRepo struct {
-	stacks map[uuid.UUID]*model.Stack
-	listFn func() ([]*model.Stack, error)
+	stacks    map[uuid.UUID]*model.Stack
+	listFn    func() ([]*model.Stack, error)
+	upsertFn  func(s *model.Stack) (*model.Stack, error)
+	upsertLog []model.Stack
 }
 
 func newMockStackRepo() *mockStackRepo {
@@ -44,6 +46,18 @@ func (m *mockStackRepo) GetByKey(_ context.Context, key string) (*model.Stack, e
 		}
 	}
 	return nil, errors.NewNotFound("stack", key)
+}
+
+func (m *mockStackRepo) Upsert(_ context.Context, s *model.Stack) (*model.Stack, error) {
+	m.upsertLog = append(m.upsertLog, *s)
+	if m.upsertFn != nil {
+		return m.upsertFn(s)
+	}
+	out := *s
+	if out.ID == uuid.Nil {
+		out.ID = uuid.New()
+	}
+	return &out, nil
 }
 
 func TestStackService_List(t *testing.T) {

--- a/backend/migrations/000034_create_stacks.up.sql
+++ b/backend/migrations/000034_create_stacks.up.sql
@@ -6,6 +6,11 @@
 --
 -- image_ref holds a digest-pinned ref when one is known, otherwise a tag. The platform
 -- owns these refs so pulls are deterministic.
+--
+-- NOTE: the catalogue is now driven by versioned config (backend/config.yaml `stacks:`),
+-- re-applied as an idempotent UPSERT on every API boot (service.SeedStacks). That config
+-- is the source of truth for image_ref/toolchain; the inline seed below is a first-boot
+-- fallback only. Do NOT add UPDATE migrations to re-pin digests — edit the config instead.
 CREATE TABLE stacks (
     id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     key        VARCHAR(32) NOT NULL UNIQUE CHECK (key IN ('go', 'node', 'python', 'go-node')),

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -10,6 +10,18 @@ type Config struct {
 	Log      LogConfig      `yaml:"logging"`
 	SMTP     SMTPConfig     `yaml:"smtp"`
 	Security SecurityConfig `yaml:"security"`
+	Stacks   []StackConfig  `yaml:"stacks"`
+}
+
+// StackConfig is one entry of the stack catalogue: a catalogued runtime image
+// (key -> image_ref + toolchain). This versioned config is the source of truth
+// for the catalogue; it is re-applied as an idempotent UPSERT on every API boot,
+// so pinning a stack to a new digest means editing this config, not a migration.
+// The migration-inlined seed (000034) remains a bootstrap fallback only.
+type StackConfig struct {
+	Key       string         `yaml:"key"`
+	ImageRef  string         `yaml:"image_ref"`
+	Toolchain map[string]any `yaml:"toolchain"`
 }
 
 // SMTPConfig holds outbound email relay settings.

--- a/backend/queries/stacks.sql
+++ b/backend/queries/stacks.sql
@@ -6,3 +6,8 @@ SELECT * FROM stacks WHERE id = $1 LIMIT 1;
 
 -- name: GetStackByKey :one
 SELECT * FROM stacks WHERE key = $1 LIMIT 1;
+
+-- name: UpsertStack :one
+INSERT INTO stacks (key, image_ref, toolchain) VALUES ($1, $2, $3)
+ON CONFLICT (key) DO UPDATE SET image_ref = EXCLUDED.image_ref, toolchain = EXCLUDED.toolchain
+RETURNING *;


### PR DESCRIPTION
## Réconciliation du catalogue de stacks
Rend le catalogue de stacks **piloté par config versionnée** + pinne les images aux digests multi-arch construits (suite du build durci P2b).

### Mécanisme (config-driven seed)
- `backend/config.yaml` section `stacks:` = **source de vérité** du catalogue (key → image_ref + toolchain).
- Query `UpsertStack` (INSERT … ON CONFLICT (key) DO UPDATE) + `StackRepository.Upsert` + impl.
- `service.SeedStacks` : **UPSERT idempotent au boot** depuis la config (après migrations). Catalogue vide → no-op (fallback au seed inline 000034) ; erreur loggée sans crash. → **plus de churn de migration à chaque rebuild d'image** : pinner = éditer `config.yaml`.
- 000034 : commentaire clarifié (ne plus ajouter de migration UPDATE pour re-pin).

### Pin des digests
Les 4 `image_ref` passent de `:latest` aux **digests `@sha256` de manifest multi-arch** produits par le build cross-compilé (amd64+arm64) → pull déterministe.

### Back-compat
Additif. Boot sans section `stacks:` = no-op (aucun crash). Chemin de résolution d'image inchangé. Review multi-agents du mécanisme = GO, build/vet/test -short verts, aucun drift sqlc.

> Dépend des images du build cross-compilé (PR fix/agent-images-cross-compile). Surface backend disjointe de cette dernière.

🤖 Generated with [Claude Code](https://claude.com/claude-code)