### PR TITLE
feat(runtime): P2c2a+b — network methods + SidecarManager (foundation, non-wired)

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/aymerick/raymond v2.0.2+incompatible
+	github.com/containerd/errdefs v1.0.0
 	github.com/docker/docker v28.5.1+incompatible
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/go-chi/chi/v5 v5.2.5
@@ -37,7 +38,6 @@ require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -98,6 +98,10 @@ func (m *mockContainerManager) ListContainers(ctx context.Context, labels map[st
 	return nil, nil
 }
 
+func (m *mockContainerManager) ListRunningContainers(_ context.Context, _ map[string]string) ([]port.ContainerInfo, error) {
+	return nil, nil
+}
+
 func (m *mockContainerManager) CreateNetwork(_ context.Context, _ string, _ map[string]string) (string, error) {
 	return "", nil
 }

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -98,6 +98,26 @@ func (m *mockContainerManager) ListContainers(ctx context.Context, labels map[st
 	return nil, nil
 }
 
+func (m *mockContainerManager) CreateNetwork(_ context.Context, _ string, _ map[string]string) (string, error) {
+	return "", nil
+}
+
+func (m *mockContainerManager) RemoveNetwork(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *mockContainerManager) ConnectContainer(_ context.Context, _, _ string, _ []string) error {
+	return nil
+}
+
+func (m *mockContainerManager) ListNetworks(_ context.Context, _ map[string]string) ([]model.NetworkInfo, error) {
+	return nil, nil
+}
+
+func (m *mockContainerManager) InspectHealth(_ context.Context, _ string) (string, error) {
+	return model.HealthRunning, nil
+}
+
 type mockLogStreamer struct {
 	streamLogsFn func(ctx context.Context, containerID, runID, stepID string) (<-chan model.LogEvent, <-chan int, error)
 }

--- a/backend/internal/adapter/docker/container_manager.go
+++ b/backend/internal/adapter/docker/container_manager.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
@@ -320,7 +321,7 @@ func (m *ContainerManager) CreateNetwork(ctx context.Context, name string, label
 // network that does not exist is treated as success.
 func (m *ContainerManager) RemoveNetwork(ctx context.Context, nameOrID string) error {
 	if err := m.client.NetworkRemove(ctx, nameOrID); err != nil {
-		if client.IsErrNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			m.logger.Debug("network already absent", slog.String("network", nameOrID))
 			return nil
 		}

--- a/backend/internal/adapter/docker/container_manager.go
+++ b/backend/internal/adapter/docker/container_manager.go
@@ -99,9 +99,16 @@ func (m *ContainerManager) Create(ctx context.Context, opts model.ContainerOpts)
 
 	var networkingConfig *network.NetworkingConfig
 	if opts.NetworkName != "" {
+		endpoint := &network.EndpointSettings{}
+		// Honour a DNS alias declared for the primary network so a container
+		// attached at creation time (no ExtraNetworks) is still reachable by its
+		// service name on that network.
+		if alias, ok := opts.Aliases[opts.NetworkName]; ok && alias != "" {
+			endpoint.Aliases = []string{alias}
+		}
 		networkingConfig = &network.NetworkingConfig{
 			EndpointsConfig: map[string]*network.EndpointSettings{
-				opts.NetworkName: {},
+				opts.NetworkName: endpoint,
 			},
 		}
 	}
@@ -120,13 +127,24 @@ func (m *ContainerManager) Create(ctx context.Context, opts model.ContainerOpts)
 	)
 
 	// Attach to any additional networks. Empty/nil ExtraNetworks leaves the
-	// current single-network behaviour untouched.
+	// current single-network behaviour untouched. If a connect fails, the
+	// freshly-created container is removed best-effort so Create stays
+	// all-or-nothing (the caller never learns the id, so it cannot clean up).
 	for _, netName := range opts.ExtraNetworks {
 		var aliases []string
 		if alias, ok := opts.Aliases[netName]; ok && alias != "" {
 			aliases = []string{alias}
 		}
 		if err := m.ConnectContainer(ctx, netName, resp.ID, aliases); err != nil {
+			if rmErr := m.client.ContainerRemove(ctx, resp.ID, dockercontainer.RemoveOptions{
+				Force:         true,
+				RemoveVolumes: true,
+			}); rmErr != nil {
+				m.logger.Warn("create rollback: remove container failed",
+					slog.String("container_id", resp.ID),
+					slog.String("error", rmErr.Error()),
+				)
+			}
 			return "", err
 		}
 	}
@@ -205,15 +223,30 @@ func (m *ContainerManager) Wait(ctx context.Context, containerID string) (int, e
 	return 0, nil
 }
 
-// ListContainers lists all containers matching the specified labels.
+// ListContainers lists all containers (any state) matching the specified labels.
 func (m *ContainerManager) ListContainers(ctx context.Context, labels map[string]string) ([]port.ContainerInfo, error) {
+	return m.listContainers(ctx, labels, false)
+}
+
+// ListRunningContainers lists only running containers matching the labels.
+func (m *ContainerManager) ListRunningContainers(ctx context.Context, labels map[string]string) ([]port.ContainerInfo, error) {
+	return m.listContainers(ctx, labels, true)
+}
+
+// listContainers is the shared listing implementation. When runningOnly is true
+// it sets All=false and a status=running filter so exited containers are
+// excluded; otherwise it lists every state (All=true).
+func (m *ContainerManager) listContainers(ctx context.Context, labels map[string]string, runningOnly bool) ([]port.ContainerInfo, error) {
 	filterArgs := filters.NewArgs()
 	for key, value := range labels {
 		filterArgs.Add("label", key+"="+value)
 	}
+	if runningOnly {
+		filterArgs.Add("status", "running")
+	}
 
 	containers, err := m.client.ContainerList(ctx, dockercontainer.ListOptions{
-		All:     true,
+		All:     !runningOnly,
 		Filters: filterArgs,
 	})
 	if err != nil {
@@ -234,6 +267,7 @@ func (m *ContainerManager) ListContainers(ctx context.Context, labels map[string
 
 	m.logger.Debug("containers listed",
 		slog.Int("count", len(result)),
+		slog.Bool("running_only", runningOnly),
 	)
 
 	return result, nil

--- a/backend/internal/adapter/docker/container_manager.go
+++ b/backend/internal/adapter/docker/container_manager.go
@@ -349,3 +349,24 @@ func (m *ContainerManager) ListNetworks(ctx context.Context, labelFilter map[str
 	m.logger.Debug("networks listed", slog.Int("count", len(result)))
 	return result, nil
 }
+
+// InspectHealth reports a container's readiness. If the container declares a
+// Docker HEALTHCHECK its health status is returned; otherwise a running /
+// not-running signal is returned.
+func (m *ContainerManager) InspectHealth(ctx context.Context, containerID string) (string, error) {
+	info, err := m.client.ContainerInspect(ctx, containerID)
+	if err != nil {
+		return "", apperrors.NewContainerError(
+			fmt.Sprintf("failed to inspect container %s: %v", containerID, err),
+			err,
+		)
+	}
+
+	if info.State != nil && info.State.Health != nil {
+		return info.State.Health.Status, nil
+	}
+	if info.State != nil && info.State.Running {
+		return model.HealthRunning, nil
+	}
+	return model.HealthNotRunning, nil
+}

--- a/backend/internal/adapter/docker/container_manager.go
+++ b/backend/internal/adapter/docker/container_manager.go
@@ -26,6 +26,11 @@ type dockerClient interface {
 	ContainerRemove(ctx context.Context, containerID string, options dockercontainer.RemoveOptions) error
 	ContainerWait(ctx context.Context, containerID string, condition dockercontainer.WaitCondition) (<-chan dockercontainer.WaitResponse, <-chan error)
 	ContainerList(ctx context.Context, options dockercontainer.ListOptions) ([]dockercontainer.Summary, error)
+	ContainerInspect(ctx context.Context, containerID string) (dockercontainer.InspectResponse, error)
+	NetworkCreate(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error)
+	NetworkRemove(ctx context.Context, networkID string) error
+	NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error
+	NetworkList(ctx context.Context, options network.ListOptions) ([]network.Summary, error)
 }
 
 // Ensure ContainerManager implements port.ContainerManager at compile time.
@@ -68,6 +73,15 @@ func (m *ContainerManager) Create(ctx context.Context, opts model.ContainerOpts)
 		Env:    opts.Env,
 		Labels: opts.Labels,
 	}
+	if opts.Healthcheck != nil {
+		config.Healthcheck = &dockercontainer.HealthConfig{
+			Test:        opts.Healthcheck.Test,
+			Interval:    opts.Healthcheck.Interval,
+			Timeout:     opts.Healthcheck.Timeout,
+			Retries:     opts.Healthcheck.Retries,
+			StartPeriod: opts.Healthcheck.StartPeriod,
+		}
+	}
 
 	resources := dockercontainer.Resources{}
 	if opts.Memory > 0 {
@@ -104,6 +118,18 @@ func (m *ContainerManager) Create(ctx context.Context, opts model.ContainerOpts)
 		slog.String("container_id", resp.ID),
 		slog.String("image", opts.Image),
 	)
+
+	// Attach to any additional networks. Empty/nil ExtraNetworks leaves the
+	// current single-network behaviour untouched.
+	for _, netName := range opts.ExtraNetworks {
+		var aliases []string
+		if alias, ok := opts.Aliases[netName]; ok && alias != "" {
+			aliases = []string{alias}
+		}
+		if err := m.ConnectContainer(ctx, netName, resp.ID, aliases); err != nil {
+			return "", err
+		}
+	}
 
 	return resp.ID, nil
 }
@@ -210,5 +236,116 @@ func (m *ContainerManager) ListContainers(ctx context.Context, labels map[string
 		slog.Int("count", len(result)),
 	)
 
+	return result, nil
+}
+
+// CreateNetwork creates a Docker network and returns its ID. It is idempotent:
+// if a network with the same name already exists, its ID is returned instead of
+// erroring.
+func (m *ContainerManager) CreateNetwork(ctx context.Context, name string, labels map[string]string) (string, error) {
+	// Idempotency: return the existing network's ID if one already has this name.
+	nameFilter := filters.NewArgs()
+	nameFilter.Add("name", name)
+	existing, err := m.client.NetworkList(ctx, network.ListOptions{Filters: nameFilter})
+	if err != nil {
+		return "", apperrors.NewContainerError(
+			fmt.Sprintf("failed to list networks for %s: %v", name, err),
+			err,
+		)
+	}
+	for _, n := range existing {
+		// The name filter matches substrings; require an exact name match.
+		if n.Name == name {
+			m.logger.Debug("network already exists",
+				slog.String("network", name),
+				slog.String("network_id", n.ID),
+			)
+			return n.ID, nil
+		}
+	}
+
+	resp, err := m.client.NetworkCreate(ctx, name, network.CreateOptions{
+		Driver: "bridge",
+		Labels: labels,
+	})
+	if err != nil {
+		return "", apperrors.NewContainerError(
+			fmt.Sprintf("failed to create network %s: %v", name, err),
+			err,
+		)
+	}
+
+	m.logger.Debug("network created",
+		slog.String("network", name),
+		slog.String("network_id", resp.ID),
+	)
+	return resp.ID, nil
+}
+
+// RemoveNetwork removes a Docker network by name or ID. It is idempotent: a
+// network that does not exist is treated as success.
+func (m *ContainerManager) RemoveNetwork(ctx context.Context, nameOrID string) error {
+	if err := m.client.NetworkRemove(ctx, nameOrID); err != nil {
+		if client.IsErrNotFound(err) {
+			m.logger.Debug("network already absent", slog.String("network", nameOrID))
+			return nil
+		}
+		return apperrors.NewContainerError(
+			fmt.Sprintf("failed to remove network %s: %v", nameOrID, err),
+			err,
+		)
+	}
+
+	m.logger.Debug("network removed", slog.String("network", nameOrID))
+	return nil
+}
+
+// ConnectContainer attaches a container to a network, optionally registering DNS
+// aliases for it on that network.
+func (m *ContainerManager) ConnectContainer(ctx context.Context, networkNameOrID, containerID string, aliases []string) error {
+	var cfg *network.EndpointSettings
+	if len(aliases) > 0 {
+		cfg = &network.EndpointSettings{Aliases: aliases}
+	}
+	if err := m.client.NetworkConnect(ctx, networkNameOrID, containerID, cfg); err != nil {
+		return apperrors.NewContainerError(
+			fmt.Sprintf("failed to connect container %s to network %s: %v", containerID, networkNameOrID, err),
+			err,
+		)
+	}
+
+	m.logger.Debug("container connected to network",
+		slog.String("container_id", containerID),
+		slog.String("network", networkNameOrID),
+	)
+	return nil
+}
+
+// ListNetworks lists Docker networks matching the given label filter.
+func (m *ContainerManager) ListNetworks(ctx context.Context, labelFilter map[string]string) ([]model.NetworkInfo, error) {
+	filterArgs := filters.NewArgs()
+	for key, value := range labelFilter {
+		filterArgs.Add("label", key+"="+value)
+	}
+
+	networks, err := m.client.NetworkList(ctx, network.ListOptions{Filters: filterArgs})
+	if err != nil {
+		return nil, apperrors.NewContainerError(
+			fmt.Sprintf("failed to list networks: %v", err),
+			err,
+		)
+	}
+
+	result := make([]model.NetworkInfo, 0, len(networks))
+	for _, n := range networks {
+		result = append(result, model.NetworkInfo{
+			ID:        n.ID,
+			Name:      n.Name,
+			Labels:    n.Labels,
+			CreatedAt: n.Created,
+		})
+	}
+
+	m.logger.Debug("networks listed", slog.Int("count", len(result)))
 	return result, nil
 }

--- a/backend/internal/adapter/docker/container_manager_test.go
+++ b/backend/internal/adapter/docker/container_manager_test.go
@@ -47,8 +47,6 @@ type mockDockerClient struct {
 	netConnectNet string
 	netConnectCtr string
 	netConnectCfg *network.EndpointSettings
-	netListOpts   network.ListOptions
-	inspectID     string
 
 	// Configurable return values.
 	createResp     dockercontainer.CreateResponse
@@ -123,8 +121,7 @@ func (m *mockDockerClient) ContainerList(_ context.Context, opts dockercontainer
 	return m.listContainers, m.listErr
 }
 
-func (m *mockDockerClient) ContainerInspect(_ context.Context, containerID string) (dockercontainer.InspectResponse, error) {
-	m.inspectID = containerID
+func (m *mockDockerClient) ContainerInspect(_ context.Context, _ string) (dockercontainer.InspectResponse, error) {
 	return m.inspectResp, m.inspectErr
 }
 
@@ -146,8 +143,7 @@ func (m *mockDockerClient) NetworkConnect(_ context.Context, networkID, containe
 	return m.netConnectErr
 }
 
-func (m *mockDockerClient) NetworkList(_ context.Context, options network.ListOptions) ([]network.Summary, error) {
-	m.netListOpts = options
+func (m *mockDockerClient) NetworkList(_ context.Context, _ network.ListOptions) ([]network.Summary, error) {
 	return m.netList, m.netListErr
 }
 

--- a/backend/internal/adapter/docker/container_manager_test.go
+++ b/backend/internal/adapter/docker/container_manager_test.go
@@ -7,9 +7,11 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/errdefs"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
@@ -38,6 +40,16 @@ type mockDockerClient struct {
 	// List captured args.
 	listOpts dockercontainer.ListOptions
 
+	// Network captured args.
+	netCreateName string
+	netCreateOpts network.CreateOptions
+	netRemoveID   string
+	netConnectNet string
+	netConnectCtr string
+	netConnectCfg *network.EndpointSettings
+	netListOpts   network.ListOptions
+	inspectID     string
+
 	// Configurable return values.
 	createResp     dockercontainer.CreateResponse
 	createErr      error
@@ -48,6 +60,15 @@ type mockDockerClient struct {
 	waitErr        error
 	listContainers []dockercontainer.Summary
 	listErr        error
+
+	netCreateResp network.CreateResponse
+	netCreateErr  error
+	netRemoveErr  error
+	netConnectErr error
+	netList       []network.Summary
+	netListErr    error
+	inspectResp   dockercontainer.InspectResponse
+	inspectErr    error
 }
 
 func (m *mockDockerClient) ContainerCreate(
@@ -100,6 +121,34 @@ func (m *mockDockerClient) ContainerWait(_ context.Context, containerID string, 
 func (m *mockDockerClient) ContainerList(_ context.Context, opts dockercontainer.ListOptions) ([]dockercontainer.Summary, error) {
 	m.listOpts = opts
 	return m.listContainers, m.listErr
+}
+
+func (m *mockDockerClient) ContainerInspect(_ context.Context, containerID string) (dockercontainer.InspectResponse, error) {
+	m.inspectID = containerID
+	return m.inspectResp, m.inspectErr
+}
+
+func (m *mockDockerClient) NetworkCreate(_ context.Context, name string, options network.CreateOptions) (network.CreateResponse, error) {
+	m.netCreateName = name
+	m.netCreateOpts = options
+	return m.netCreateResp, m.netCreateErr
+}
+
+func (m *mockDockerClient) NetworkRemove(_ context.Context, networkID string) error {
+	m.netRemoveID = networkID
+	return m.netRemoveErr
+}
+
+func (m *mockDockerClient) NetworkConnect(_ context.Context, networkID, containerID string, config *network.EndpointSettings) error {
+	m.netConnectNet = networkID
+	m.netConnectCtr = containerID
+	m.netConnectCfg = config
+	return m.netConnectErr
+}
+
+func (m *mockDockerClient) NetworkList(_ context.Context, options network.ListOptions) ([]network.Summary, error) {
+	m.netListOpts = options
+	return m.netList, m.netListErr
 }
 
 func newTestManager(mock *mockDockerClient) *ContainerManager {
@@ -583,5 +632,245 @@ func TestListContainers_Error(t *testing.T) {
 	}
 	if domainErr.Code != testErrCode {
 		t.Errorf("expected error code %s, got %s", testErrCode, domainErr.Code)
+	}
+}
+
+// --- Network method tests (P2c2a) ---
+
+func TestCreateNetwork_New(t *testing.T) {
+	mock := &mockDockerClient{
+		netCreateResp: network.CreateResponse{ID: "net-new"},
+	}
+	mgr := newTestManager(mock)
+
+	id, err := mgr.CreateNetwork(context.Background(), "hopeitworks-run-1", map[string]string{"managed_by": "hopeitworks"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if id != "net-new" {
+		t.Errorf("expected net-new, got %s", id)
+	}
+	if mock.netCreateName != "hopeitworks-run-1" {
+		t.Errorf("expected create name hopeitworks-run-1, got %s", mock.netCreateName)
+	}
+	if mock.netCreateOpts.Labels["managed_by"] != "hopeitworks" {
+		t.Errorf("expected managed_by label propagated, got %v", mock.netCreateOpts.Labels)
+	}
+}
+
+func TestCreateNetwork_IdempotentExisting(t *testing.T) {
+	// A network with the exact name already exists: return its ID, no create.
+	mock := &mockDockerClient{
+		netList: []network.Summary{
+			{ID: "net-existing", Name: "hopeitworks-run-1"},
+			{ID: "net-other", Name: "hopeitworks-run-1-suffix"},
+		},
+		// Make NetworkCreate fail loudly so the test proves it is NOT called.
+		netCreateErr: errors.New("create should not be called"),
+	}
+	mgr := newTestManager(mock)
+
+	id, err := mgr.CreateNetwork(context.Background(), "hopeitworks-run-1", nil)
+	if err != nil {
+		t.Fatalf("expected no error for existing network, got %v", err)
+	}
+	if id != "net-existing" {
+		t.Errorf("expected existing ID net-existing, got %s", id)
+	}
+	if mock.netCreateName != "" {
+		t.Errorf("expected NetworkCreate not called, but was called with %s", mock.netCreateName)
+	}
+}
+
+func TestCreateNetwork_Error(t *testing.T) {
+	mock := &mockDockerClient{
+		netCreateErr: errors.New("daemon error"),
+	}
+	mgr := newTestManager(mock)
+
+	_, err := mgr.CreateNetwork(context.Background(), "n", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var domainErr *apperrors.DomainError
+	if !errors.As(err, &domainErr) {
+		t.Fatalf("expected DomainError, got %T", err)
+	}
+}
+
+func TestRemoveNetwork_Success(t *testing.T) {
+	mock := &mockDockerClient{}
+	mgr := newTestManager(mock)
+
+	if err := mgr.RemoveNetwork(context.Background(), "net-1"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if mock.netRemoveID != "net-1" {
+		t.Errorf("expected removeID net-1, got %s", mock.netRemoveID)
+	}
+}
+
+func TestRemoveNetwork_IdempotentNotFound(t *testing.T) {
+	// Absent network -> NetworkRemove returns a NotFound error -> treated as nil.
+	mock := &mockDockerClient{
+		netRemoveErr: errdefs.NotFound(errors.New("network n missing")),
+	}
+	mgr := newTestManager(mock)
+
+	if err := mgr.RemoveNetwork(context.Background(), "n"); err != nil {
+		t.Fatalf("expected nil for absent network (idempotent), got %v", err)
+	}
+}
+
+func TestRemoveNetwork_RealError(t *testing.T) {
+	mock := &mockDockerClient{
+		netRemoveErr: errors.New("network in use"),
+	}
+	mgr := newTestManager(mock)
+
+	err := mgr.RemoveNetwork(context.Background(), "n")
+	if err == nil {
+		t.Fatal("expected error for non-not-found failure, got nil")
+	}
+	var domainErr *apperrors.DomainError
+	if !errors.As(err, &domainErr) {
+		t.Fatalf("expected DomainError, got %T", err)
+	}
+}
+
+func TestConnectContainer_WithAliases(t *testing.T) {
+	mock := &mockDockerClient{}
+	mgr := newTestManager(mock)
+
+	err := mgr.ConnectContainer(context.Background(), "net-1", "ctr-1", []string{"postgres"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if mock.netConnectNet != "net-1" || mock.netConnectCtr != "ctr-1" {
+		t.Errorf("expected connect net-1/ctr-1, got %s/%s", mock.netConnectNet, mock.netConnectCtr)
+	}
+	if mock.netConnectCfg == nil || len(mock.netConnectCfg.Aliases) != 1 || mock.netConnectCfg.Aliases[0] != "postgres" {
+		t.Errorf("expected alias postgres, got %v", mock.netConnectCfg)
+	}
+}
+
+func TestConnectContainer_NoAliases(t *testing.T) {
+	mock := &mockDockerClient{}
+	mgr := newTestManager(mock)
+
+	if err := mgr.ConnectContainer(context.Background(), "net-1", "ctr-1", nil); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if mock.netConnectCfg != nil {
+		t.Errorf("expected nil endpoint config when no aliases, got %v", mock.netConnectCfg)
+	}
+}
+
+func TestConnectContainer_Error(t *testing.T) {
+	mock := &mockDockerClient{
+		netConnectErr: errors.New("no such network"),
+	}
+	mgr := newTestManager(mock)
+
+	err := mgr.ConnectContainer(context.Background(), "net-1", "ctr-1", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var domainErr *apperrors.DomainError
+	if !errors.As(err, &domainErr) {
+		t.Fatalf("expected DomainError, got %T", err)
+	}
+}
+
+func TestListNetworks_Success(t *testing.T) {
+	created := time.Unix(1700000000, 0)
+	mock := &mockDockerClient{
+		netList: []network.Summary{
+			{ID: "n1", Name: "hopeitworks-run-1", Labels: map[string]string{"managed_by": "hopeitworks"}, Created: created},
+		},
+	}
+	mgr := newTestManager(mock)
+
+	result, err := mgr.ListNetworks(context.Background(), map[string]string{"managed_by": "hopeitworks"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 network, got %d", len(result))
+	}
+	if result[0].ID != "n1" || result[0].Name != "hopeitworks-run-1" {
+		t.Errorf("unexpected network info: %+v", result[0])
+	}
+	if !result[0].CreatedAt.Equal(created) {
+		t.Errorf("expected CreatedAt %v, got %v", created, result[0].CreatedAt)
+	}
+}
+
+func TestListNetworks_Error(t *testing.T) {
+	mock := &mockDockerClient{
+		netListErr: errors.New("daemon unreachable"),
+	}
+	mgr := newTestManager(mock)
+
+	_, err := mgr.ListNetworks(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var domainErr *apperrors.DomainError
+	if !errors.As(err, &domainErr) {
+		t.Fatalf("expected DomainError, got %T", err)
+	}
+}
+
+func TestCreate_ExtraNetworksConnected(t *testing.T) {
+	mock := &mockDockerClient{
+		createResp: dockercontainer.CreateResponse{ID: "ctr-multi"},
+	}
+	mgr := newTestManager(mock)
+
+	opts := model.ContainerOpts{
+		Image:         "alpine:latest",
+		NetworkName:   "primary",
+		ExtraNetworks: []string{"run-net"},
+		Aliases:       map[string]string{"run-net": "myalias"},
+	}
+
+	id, err := mgr.Create(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if id != "ctr-multi" {
+		t.Errorf("expected ctr-multi, got %s", id)
+	}
+	// Primary network still set via networkingConfig.
+	if _, ok := mock.createNetConfig.EndpointsConfig["primary"]; !ok {
+		t.Error("expected primary network in networkingConfig")
+	}
+	// Extra network connected via NetworkConnect with the alias.
+	if mock.netConnectNet != "run-net" || mock.netConnectCtr != "ctr-multi" {
+		t.Errorf("expected connect run-net/ctr-multi, got %s/%s", mock.netConnectNet, mock.netConnectCtr)
+	}
+	if mock.netConnectCfg == nil || len(mock.netConnectCfg.Aliases) != 1 || mock.netConnectCfg.Aliases[0] != "myalias" {
+		t.Errorf("expected alias myalias, got %v", mock.netConnectCfg)
+	}
+}
+
+func TestCreate_NoExtraNetworksUnchanged(t *testing.T) {
+	mock := &mockDockerClient{
+		createResp: dockercontainer.CreateResponse{ID: "ctr-plain"},
+	}
+	mgr := newTestManager(mock)
+
+	opts := model.ContainerOpts{
+		Image:       "alpine:latest",
+		NetworkName: "primary",
+	}
+
+	if _, err := mgr.Create(context.Background(), opts); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	// No extra networks -> NetworkConnect must not be called.
+	if mock.netConnectNet != "" {
+		t.Errorf("expected no NetworkConnect call, got network %s", mock.netConnectNet)
 	}
 }

--- a/backend/internal/adapter/docker/container_manager_test.go
+++ b/backend/internal/adapter/docker/container_manager_test.go
@@ -870,3 +870,115 @@ func TestCreate_NoExtraNetworksUnchanged(t *testing.T) {
 		t.Errorf("expected no NetworkConnect call, got network %s", mock.netConnectNet)
 	}
 }
+
+func TestCreate_AtomicOnConnectFailure(t *testing.T) {
+	// ConnectContainer fails after ContainerCreate succeeds: the freshly-created
+	// container must be force-removed so Create stays all-or-nothing (the caller
+	// never learns the id and cannot clean up).
+	mock := &mockDockerClient{
+		createResp:    dockercontainer.CreateResponse{ID: "ctr-leak"},
+		netConnectErr: errors.New("no such network"),
+	}
+	mgr := newTestManager(mock)
+
+	opts := model.ContainerOpts{
+		Image:         "alpine:latest",
+		ExtraNetworks: []string{"run-net"},
+	}
+
+	id, err := mgr.Create(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected error from connect failure, got nil")
+	}
+	if id != "" {
+		t.Errorf("expected empty id on failure, got %q", id)
+	}
+	if mock.removeID != "ctr-leak" {
+		t.Errorf("expected ContainerRemove on ctr-leak, got %q", mock.removeID)
+	}
+	if !mock.removeOpts.Force {
+		t.Error("expected force removal during create rollback")
+	}
+}
+
+func TestCreate_PrimaryNetworkAlias(t *testing.T) {
+	// An alias declared for the primary NetworkName is applied on that endpoint
+	// at creation, no ExtraNetworks / NetworkConnect needed.
+	mock := &mockDockerClient{
+		createResp: dockercontainer.CreateResponse{ID: "ctr-alias"},
+	}
+	mgr := newTestManager(mock)
+
+	opts := model.ContainerOpts{
+		Image:       "postgres:16",
+		NetworkName: "run-net",
+		Aliases:     map[string]string{"run-net": "db"},
+	}
+
+	if _, err := mgr.Create(context.Background(), opts); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	ep := mock.createNetConfig.EndpointsConfig["run-net"]
+	if ep == nil || len(ep.Aliases) != 1 || ep.Aliases[0] != "db" {
+		t.Errorf("expected alias db on primary endpoint, got %+v", ep)
+	}
+	if mock.netConnectNet != "" {
+		t.Errorf("expected no NetworkConnect, got %q", mock.netConnectNet)
+	}
+}
+
+func TestInspectHealth(t *testing.T) {
+	running := &dockercontainer.State{Running: true}
+	stopped := &dockercontainer.State{Running: false}
+	withHealth := func(status string) *dockercontainer.State {
+		return &dockercontainer.State{Running: true, Health: &dockercontainer.Health{Status: status}}
+	}
+
+	tests := []struct {
+		name    string
+		resp    dockercontainer.InspectResponse
+		respErr error
+		want    string
+		wantErr bool
+	}{
+		{name: "healthcheck healthy", resp: inspectWith(withHealth(model.HealthHealthy)), want: model.HealthHealthy},
+		{name: "healthcheck unhealthy", resp: inspectWith(withHealth(model.HealthUnhealthy)), want: model.HealthUnhealthy},
+		{name: "healthcheck starting", resp: inspectWith(withHealth(model.HealthStarting)), want: model.HealthStarting},
+		{name: "no healthcheck running", resp: inspectWith(running), want: model.HealthRunning},
+		{name: "no healthcheck not running", resp: inspectWith(stopped), want: model.HealthNotRunning},
+		{name: "nil state", resp: inspectWith(nil), want: model.HealthNotRunning},
+		{name: "inspect error", respErr: errors.New("daemon down"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDockerClient{inspectResp: tt.resp, inspectErr: tt.respErr}
+			mgr := newTestManager(mock)
+
+			got, err := mgr.InspectHealth(context.Background(), "c")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				var domainErr *apperrors.DomainError
+				if !errors.As(err, &domainErr) {
+					t.Fatalf("expected DomainError, got %T", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("InspectHealth = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// inspectWith builds an InspectResponse carrying the given state.
+func inspectWith(state *dockercontainer.State) dockercontainer.InspectResponse {
+	return dockercontainer.InspectResponse{
+		ContainerJSONBase: &dockercontainer.ContainerJSONBase{State: state},
+	}
+}

--- a/backend/internal/adapter/docker/sidecar_manager.go
+++ b/backend/internal/adapter/docker/sidecar_manager.go
@@ -35,6 +35,10 @@ const (
 	// defaultRunningGrace is the short settle delay used as a fallback for
 	// services that declare no sensible healthcheck.
 	defaultRunningGrace = 1 * time.Second
+	// defaultTeardownTimeout bounds rollback/Stop/Cleanup. Teardown runs on a
+	// context detached from the caller's (which may already be cancelled), so it
+	// needs its own deadline to avoid hanging forever against the real daemon.
+	defaultTeardownTimeout = 30 * time.Second
 )
 
 // serviceProfile holds the per-type knowledge needed to probe and (later, in
@@ -51,6 +55,12 @@ type serviceProfile struct {
 
 // serviceProfiles maps a detected service type to its probe/port profile. It is
 // intentionally small and additive; unknown types fall back to a running check.
+//
+// TODO(P2c2c): probe creds (redis AUTH / mariadb-admin). These probes assume no
+// auth: a redis configured with requirepass returns NOAUTH (false unhealthy),
+// and mysqladmin is deprecated on recent MariaDB (use mariadb-admin). The real
+// fix injects the service credentials into the probe, which is part of the
+// connection-string work in P2c2c.
 var serviceProfiles = map[string]serviceProfile{
 	"postgres": {healthTest: []string{"CMD-SHELL", "pg_isready -U postgres || pg_isready"}, port: 5432},
 	"redis":    {healthTest: []string{"CMD", "redis-cli", "ping"}, port: 6379},
@@ -93,6 +103,7 @@ type DockerSidecarManager struct {
 	readinessTimeout  time.Duration
 	readinessInterval time.Duration
 	runningGrace      time.Duration
+	teardownTimeout   time.Duration
 
 	// now is injectable so GC windowing is deterministic in tests.
 	now func() time.Time
@@ -108,8 +119,16 @@ func NewDockerSidecarManager(containers port.ContainerManager, logger *slog.Logg
 		readinessTimeout:  defaultReadinessTimeout,
 		readinessInterval: defaultReadinessInterval,
 		runningGrace:      defaultRunningGrace,
+		teardownTimeout:   defaultTeardownTimeout,
 		now:               time.Now,
 	}
+}
+
+// teardownContext derives a context for teardown that is immune to the caller's
+// cancellation (Launch's ctx may already be cancelled when rollback runs) but
+// still bounded by its own timeout so it cannot hang forever.
+func (s *DockerSidecarManager) teardownContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), s.teardownTimeout)
 }
 
 // networkName returns the per-run network name for a run id (full UUID).
@@ -164,11 +183,15 @@ func (s *DockerSidecarManager) Launch(ctx context.Context, runID uuid.UUID, env 
 func (s *DockerSidecarManager) launchService(ctx context.Context, sc *port.SidecarContext, runID uuid.UUID, svc model.EnvironmentService) error {
 	svcType := detectServiceType(svc.Image)
 
+	// Attach the sidecar to the run network DIRECTLY at creation (NetworkName,
+	// not ExtraNetworks) so it never lands on the default bridge first — that
+	// would break per-run isolation. The alias makes it reachable by svc.Name on
+	// the run network (Create applies Aliases on the primary endpoint too).
 	opts := model.ContainerOpts{
-		Image:         svc.Image,
-		Env:           envMapToSlice(svc.Env),
-		ExtraNetworks: []string{sc.NetworkName},
-		Aliases:       map[string]string{sc.NetworkName: svc.Name},
+		Image:       svc.Image,
+		Env:         envMapToSlice(svc.Env),
+		NetworkName: sc.NetworkName,
+		Aliases:     map[string]string{sc.NetworkName: svc.Name},
 		Labels: map[string]string{
 			labelManagedBy: managedByLabel,
 			labelRunID:     runID.String(),
@@ -188,7 +211,7 @@ func (s *DockerSidecarManager) launchService(ctx context.Context, sc *port.Sidec
 		return fmt.Errorf("starting sidecar %s: %w", svc.Name, err)
 	}
 
-	if err := s.waitReady(ctx, id, svcType); err != nil {
+	if err := s.waitReady(ctx, id); err != nil {
 		return fmt.Errorf("sidecar %s not ready: %w", svc.Name, err)
 	}
 
@@ -198,11 +221,12 @@ func (s *DockerSidecarManager) launchService(ctx context.Context, sc *port.Sidec
 }
 
 // waitReady blocks until the sidecar is ready or the readiness timeout elapses.
-// Services with a real healthcheck are polled via InspectHealth until "healthy";
-// services without one fall back to a running check plus a short grace delay.
-func (s *DockerSidecarManager) waitReady(ctx context.Context, containerID, svcType string) error {
-	hasHealthcheck := svcType != "" && len(serviceProfiles[svcType].healthTest) > 0
-
+// Readiness is deduced from the status actually returned by InspectHealth, not
+// only from whether we configured a profile healthcheck: a custom image may bake
+// its own HEALTHCHECK, so "healthy" must count as ready even for unknown types,
+// and "unhealthy" must count as failure. Containers with no healthcheck at all
+// fall back to a running check plus a short grace delay.
+func (s *DockerSidecarManager) waitReady(ctx context.Context, containerID string) error {
 	deadline := s.now().Add(s.readinessTimeout)
 	for {
 		status, err := s.containers.InspectHealth(ctx, containerID)
@@ -210,25 +234,25 @@ func (s *DockerSidecarManager) waitReady(ctx context.Context, containerID, svcTy
 			return err
 		}
 
-		if hasHealthcheck {
-			switch status {
-			case model.HealthHealthy:
-				return nil
-			case model.HealthUnhealthy:
-				return fmt.Errorf("container %s reported unhealthy", containerID)
+		switch status {
+		case model.HealthHealthy:
+			// A passing healthcheck (configured by us OR baked in the image) is
+			// the strongest readiness signal.
+			return nil
+		case model.HealthUnhealthy:
+			return fmt.Errorf("container %s reported unhealthy", containerID)
+		case model.HealthRunning:
+			// No healthcheck reported by Docker: a running container plus a short
+			// grace delay is the best signal we have. Documented limit: readiness
+			// is approximate when neither we nor the image declare a healthcheck.
+			if err := s.sleep(ctx, s.runningGrace); err != nil {
+				return err
 			}
-		} else {
-			// No sensible healthcheck for this type: a running container plus a
-			// short grace delay is the best signal we have. Documented limit:
-			// readiness is approximate for unknown service types.
-			if status == model.HealthRunning {
-				s.sleep(ctx, s.runningGrace)
-				return nil
-			}
-			if status == model.HealthNotRunning {
-				return fmt.Errorf("container %s is not running", containerID)
-			}
+			return nil
+		case model.HealthNotRunning:
+			return fmt.Errorf("container %s is not running", containerID)
 		}
+		// model.HealthStarting (healthcheck in its start period): keep polling.
 
 		if !s.now().Before(deadline) {
 			return fmt.Errorf("readiness timeout after %s (last status %q)", s.readinessTimeout, status)
@@ -255,11 +279,16 @@ func (s *DockerSidecarManager) sleep(ctx context.Context, d time.Duration) error
 }
 
 // rollback tears down a partially-launched run: stop+remove every started
-// container, then remove the network. Best-effort, log-only, never panics.
+// container, then remove the network. Best-effort, log-only, never panics. Runs
+// on a context detached from the caller's so it still works if Launch's ctx was
+// cancelled (otherwise every teardown call would fail with context.Canceled).
 func (s *DockerSidecarManager) rollback(ctx context.Context, sc *port.SidecarContext) {
-	s.teardownContainers(ctx, sc)
+	tctx, cancel := s.teardownContext(ctx)
+	defer cancel()
+
+	s.teardownContainers(tctx, sc)
 	if sc.NetworkName != "" {
-		if err := s.containers.RemoveNetwork(ctx, sc.NetworkName); err != nil {
+		if err := s.containers.RemoveNetwork(tctx, sc.NetworkName); err != nil {
 			s.logger.Warn("rollback: remove network failed",
 				slog.String("network", sc.NetworkName),
 				slog.String("error", err.Error()),
@@ -289,12 +318,17 @@ func (s *DockerSidecarManager) teardownContainers(ctx context.Context, sc *port.
 }
 
 // Stop stops the sidecar containers in sc. Best-effort, idempotent, defer-safe.
+// Runs on a detached, bounded context so it still works when called from a defer
+// after the run's context was cancelled.
 func (s *DockerSidecarManager) Stop(ctx context.Context, sc *port.SidecarContext) error {
 	if sc == nil || len(sc.ContainerIDs) == 0 {
 		return nil
 	}
+	tctx, cancel := s.teardownContext(ctx)
+	defer cancel()
+
 	for name, id := range sc.ContainerIDs {
-		if err := s.containers.Stop(ctx, id); err != nil {
+		if err := s.containers.Stop(tctx, id); err != nil {
 			s.logger.Warn("stop sidecar failed",
 				slog.String("sidecar", name),
 				slog.String("container_id", id),
@@ -306,14 +340,18 @@ func (s *DockerSidecarManager) Stop(ctx context.Context, sc *port.SidecarContext
 }
 
 // Cleanup stops+removes the sidecar containers and removes the run network.
-// Best-effort, idempotent, defer-safe.
+// Best-effort, idempotent, defer-safe. Runs on a detached, bounded context so it
+// still works when called from a defer after the run's context was cancelled.
 func (s *DockerSidecarManager) Cleanup(ctx context.Context, sc *port.SidecarContext) error {
 	if sc == nil || (len(sc.ContainerIDs) == 0 && sc.NetworkName == "") {
 		return nil
 	}
-	s.teardownContainers(ctx, sc)
+	tctx, cancel := s.teardownContext(ctx)
+	defer cancel()
+
+	s.teardownContainers(tctx, sc)
 	if sc.NetworkName != "" {
-		if err := s.containers.RemoveNetwork(ctx, sc.NetworkName); err != nil {
+		if err := s.containers.RemoveNetwork(tctx, sc.NetworkName); err != nil {
 			s.logger.Warn("cleanup: remove network failed",
 				slog.String("network", sc.NetworkName),
 				slog.String("error", err.Error()),
@@ -323,9 +361,10 @@ func (s *DockerSidecarManager) Cleanup(ctx context.Context, sc *port.SidecarCont
 	return nil
 }
 
-// ListOrphanNetworks lists managed run networks with no managed sidecar
-// container still attached. A network is matched to its containers by the
-// shared run_id label, avoiding a per-network container lookup.
+// ListOrphanNetworks lists managed run networks with no RUNNING managed sidecar
+// container still attached. A network is matched to its containers by the shared
+// run_id label, avoiding a per-network container lookup. Only running containers
+// keep a network alive — exited-but-not-yet-removed sidecars must not block GC.
 func (s *DockerSidecarManager) ListOrphanNetworks(ctx context.Context) ([]model.NetworkInfo, error) {
 	managed := map[string]string{labelManagedBy: managedByLabel}
 
@@ -333,7 +372,7 @@ func (s *DockerSidecarManager) ListOrphanNetworks(ctx context.Context) ([]model.
 	if err != nil {
 		return nil, err
 	}
-	containers, err := s.containers.ListContainers(ctx, managed)
+	containers, err := s.containers.ListRunningContainers(ctx, managed)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/adapter/docker/sidecar_manager.go
+++ b/backend/internal/adapter/docker/sidecar_manager.go
@@ -13,8 +13,8 @@ import (
 	"github.com/zakari/hopeitworks/backend/internal/domain/port"
 )
 
-// Ensure DockerSidecarManager implements port.SidecarManager at compile time.
-var _ port.SidecarManager = (*DockerSidecarManager)(nil)
+// Ensure SidecarManager implements port.SidecarManager at compile time.
+var _ port.SidecarManager = (*SidecarManager)(nil)
 
 const (
 	// sidecarNetworkPrefix is the name prefix for per-run sidecar networks. The
@@ -93,9 +93,9 @@ func detectServiceType(image string) string {
 	return ""
 }
 
-// DockerSidecarManager orchestrates Environment sidecars over the injected
+// SidecarManager orchestrates Environment sidecars over the injected
 // ContainerManager. It does not own a Docker client of its own.
-type DockerSidecarManager struct {
+type SidecarManager struct {
 	containers port.ContainerManager
 	logger     *slog.Logger
 
@@ -112,8 +112,8 @@ type DockerSidecarManager struct {
 // NewDockerSidecarManager builds a SidecarManager backed by the given
 // ContainerManager. The ContainerManager is reused for both networks and
 // containers — no second Docker client is created.
-func NewDockerSidecarManager(containers port.ContainerManager, logger *slog.Logger) *DockerSidecarManager {
-	return &DockerSidecarManager{
+func NewDockerSidecarManager(containers port.ContainerManager, logger *slog.Logger) *SidecarManager {
+	return &SidecarManager{
 		containers:        containers,
 		logger:            logger,
 		readinessTimeout:  defaultReadinessTimeout,
@@ -127,7 +127,7 @@ func NewDockerSidecarManager(containers port.ContainerManager, logger *slog.Logg
 // teardownContext derives a context for teardown that is immune to the caller's
 // cancellation (Launch's ctx may already be cancelled when rollback runs) but
 // still bounded by its own timeout so it cannot hang forever.
-func (s *DockerSidecarManager) teardownContext(ctx context.Context) (context.Context, context.CancelFunc) {
+func (s *SidecarManager) teardownContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.WithoutCancel(ctx), s.teardownTimeout)
 }
 
@@ -139,7 +139,7 @@ func networkName(runID uuid.UUID) string {
 // Launch brings up the Environment's services on a fresh per-run network. It is
 // nil-safe (nil/empty env -> empty context, no side effects) and rolls back
 // atomically on any error.
-func (s *DockerSidecarManager) Launch(ctx context.Context, runID uuid.UUID, env *model.Environment) (*port.SidecarContext, error) {
+func (s *SidecarManager) Launch(ctx context.Context, runID uuid.UUID, env *model.Environment) (*port.SidecarContext, error) {
 	sc := &port.SidecarContext{
 		RunID:        runID,
 		ContainerIDs: map[string]string{},
@@ -180,7 +180,7 @@ func (s *DockerSidecarManager) Launch(ctx context.Context, runID uuid.UUID, env 
 
 // launchService creates, starts and waits-ready a single sidecar, recording it
 // into sc on success.
-func (s *DockerSidecarManager) launchService(ctx context.Context, sc *port.SidecarContext, runID uuid.UUID, svc model.EnvironmentService) error {
+func (s *SidecarManager) launchService(ctx context.Context, sc *port.SidecarContext, runID uuid.UUID, svc model.EnvironmentService) error {
 	svcType := detectServiceType(svc.Image)
 
 	// Attach the sidecar to the run network DIRECTLY at creation (NetworkName,
@@ -226,7 +226,7 @@ func (s *DockerSidecarManager) launchService(ctx context.Context, sc *port.Sidec
 // its own HEALTHCHECK, so "healthy" must count as ready even for unknown types,
 // and "unhealthy" must count as failure. Containers with no healthcheck at all
 // fall back to a running check plus a short grace delay.
-func (s *DockerSidecarManager) waitReady(ctx context.Context, containerID string) error {
+func (s *SidecarManager) waitReady(ctx context.Context, containerID string) error {
 	deadline := s.now().Add(s.readinessTimeout)
 	for {
 		status, err := s.containers.InspectHealth(ctx, containerID)
@@ -264,7 +264,7 @@ func (s *DockerSidecarManager) waitReady(ctx context.Context, containerID string
 }
 
 // sleep waits for d, honouring context cancellation.
-func (s *DockerSidecarManager) sleep(ctx context.Context, d time.Duration) error {
+func (s *SidecarManager) sleep(ctx context.Context, d time.Duration) error {
 	if d <= 0 {
 		return ctx.Err()
 	}
@@ -282,7 +282,7 @@ func (s *DockerSidecarManager) sleep(ctx context.Context, d time.Duration) error
 // container, then remove the network. Best-effort, log-only, never panics. Runs
 // on a context detached from the caller's so it still works if Launch's ctx was
 // cancelled (otherwise every teardown call would fail with context.Canceled).
-func (s *DockerSidecarManager) rollback(ctx context.Context, sc *port.SidecarContext) {
+func (s *SidecarManager) rollback(ctx context.Context, sc *port.SidecarContext) {
 	tctx, cancel := s.teardownContext(ctx)
 	defer cancel()
 
@@ -298,7 +298,7 @@ func (s *DockerSidecarManager) rollback(ctx context.Context, sc *port.SidecarCon
 }
 
 // teardownContainers stops and removes all sidecar containers in sc.
-func (s *DockerSidecarManager) teardownContainers(ctx context.Context, sc *port.SidecarContext) {
+func (s *SidecarManager) teardownContainers(ctx context.Context, sc *port.SidecarContext) {
 	for name, id := range sc.ContainerIDs {
 		if err := s.containers.Stop(ctx, id); err != nil {
 			s.logger.Warn("teardown: stop sidecar failed",
@@ -320,7 +320,7 @@ func (s *DockerSidecarManager) teardownContainers(ctx context.Context, sc *port.
 // Stop stops the sidecar containers in sc. Best-effort, idempotent, defer-safe.
 // Runs on a detached, bounded context so it still works when called from a defer
 // after the run's context was cancelled.
-func (s *DockerSidecarManager) Stop(ctx context.Context, sc *port.SidecarContext) error {
+func (s *SidecarManager) Stop(ctx context.Context, sc *port.SidecarContext) error {
 	if sc == nil || len(sc.ContainerIDs) == 0 {
 		return nil
 	}
@@ -342,7 +342,7 @@ func (s *DockerSidecarManager) Stop(ctx context.Context, sc *port.SidecarContext
 // Cleanup stops+removes the sidecar containers and removes the run network.
 // Best-effort, idempotent, defer-safe. Runs on a detached, bounded context so it
 // still works when called from a defer after the run's context was cancelled.
-func (s *DockerSidecarManager) Cleanup(ctx context.Context, sc *port.SidecarContext) error {
+func (s *SidecarManager) Cleanup(ctx context.Context, sc *port.SidecarContext) error {
 	if sc == nil || (len(sc.ContainerIDs) == 0 && sc.NetworkName == "") {
 		return nil
 	}
@@ -365,7 +365,7 @@ func (s *DockerSidecarManager) Cleanup(ctx context.Context, sc *port.SidecarCont
 // container still attached. A network is matched to its containers by the shared
 // run_id label, avoiding a per-network container lookup. Only running containers
 // keep a network alive — exited-but-not-yet-removed sidecars must not block GC.
-func (s *DockerSidecarManager) ListOrphanNetworks(ctx context.Context) ([]model.NetworkInfo, error) {
+func (s *SidecarManager) ListOrphanNetworks(ctx context.Context) ([]model.NetworkInfo, error) {
 	managed := map[string]string{labelManagedBy: managedByLabel}
 
 	networks, err := s.containers.ListNetworks(ctx, managed)
@@ -399,7 +399,7 @@ func (s *DockerSidecarManager) ListOrphanNetworks(ctx context.Context) ([]model.
 }
 
 // GC removes orphan run networks older than olderThan. Best-effort, log-only.
-func (s *DockerSidecarManager) GC(ctx context.Context, olderThan time.Duration) error {
+func (s *SidecarManager) GC(ctx context.Context, olderThan time.Duration) error {
 	orphans, err := s.ListOrphanNetworks(ctx)
 	if err != nil {
 		return err

--- a/backend/internal/adapter/docker/sidecar_manager.go
+++ b/backend/internal/adapter/docker/sidecar_manager.go
@@ -1,0 +1,420 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+)
+
+// Ensure DockerSidecarManager implements port.SidecarManager at compile time.
+var _ port.SidecarManager = (*DockerSidecarManager)(nil)
+
+const (
+	// sidecarNetworkPrefix is the name prefix for per-run sidecar networks. The
+	// full run UUID is appended (never truncated) to avoid collisions.
+	sidecarNetworkPrefix = "hopeitworks-run-"
+
+	// labelManagedBy / labelRunID / labelSidecar are the bookkeeping labels put
+	// on every sidecar network and container so GC can find and reap them.
+	labelManagedBy = "managed_by"
+	labelRunID     = "run_id"
+	labelSidecar   = "sidecar"
+
+	// defaultReadinessTimeout bounds how long Launch waits for a sidecar to
+	// become ready before failing and rolling back. Never infinite.
+	defaultReadinessTimeout = 30 * time.Second
+	// defaultReadinessInterval is the poll period while waiting for readiness.
+	defaultReadinessInterval = 2 * time.Second
+	// defaultRunningGrace is the short settle delay used as a fallback for
+	// services that declare no sensible healthcheck.
+	defaultRunningGrace = 1 * time.Second
+)
+
+// serviceProfile holds the per-type knowledge needed to probe and (later, in
+// P2c2c) build connection strings for a sidecar. It is keyed by a detected
+// service type derived from the image name.
+type serviceProfile struct {
+	// healthTest is the Docker HEALTHCHECK command for this service type. Empty
+	// means "no sensible healthcheck" -> fall back to running + grace delay.
+	healthTest []string
+	// port is the service's default listen port, factored here for reuse by
+	// P2c2c connection-string injection.
+	port int
+}
+
+// serviceProfiles maps a detected service type to its probe/port profile. It is
+// intentionally small and additive; unknown types fall back to a running check.
+var serviceProfiles = map[string]serviceProfile{
+	"postgres": {healthTest: []string{"CMD-SHELL", "pg_isready -U postgres || pg_isready"}, port: 5432},
+	"redis":    {healthTest: []string{"CMD", "redis-cli", "ping"}, port: 6379},
+	"mysql":    {healthTest: []string{"CMD-SHELL", "mysqladmin ping -h 127.0.0.1 --silent"}, port: 3306},
+	"mariadb":  {healthTest: []string{"CMD-SHELL", "mysqladmin ping -h 127.0.0.1 --silent"}, port: 3306},
+	"mongo":    {healthTest: []string{"CMD-SHELL", "mongosh --eval 'db.runCommand({ping:1})' || mongo --eval 'db.runCommand({ping:1})'"}, port: 27017},
+}
+
+// servicePort returns the default listen port for a detected service type, or
+// 0 when unknown. Factored here for reuse by P2c2c connection-string injection.
+func servicePort(svcType string) int {
+	return serviceProfiles[svcType].port
+}
+
+// detectServiceType maps an image reference to a known service type, or "" when
+// unknown. It matches on the repository segment of the image (ignoring registry
+// host and tag), e.g. "docker.io/library/postgres:16" -> "postgres".
+func detectServiceType(image string) string {
+	ref := image
+	if i := strings.LastIndex(ref, "/"); i >= 0 {
+		ref = ref[i+1:]
+	}
+	if i := strings.IndexAny(ref, ":@"); i >= 0 {
+		ref = ref[:i]
+	}
+	ref = strings.ToLower(ref)
+	if _, ok := serviceProfiles[ref]; ok {
+		return ref
+	}
+	return ""
+}
+
+// DockerSidecarManager orchestrates Environment sidecars over the injected
+// ContainerManager. It does not own a Docker client of its own.
+type DockerSidecarManager struct {
+	containers port.ContainerManager
+	logger     *slog.Logger
+
+	// Tunables (defaulted in the constructor) kept as fields for testability.
+	readinessTimeout  time.Duration
+	readinessInterval time.Duration
+	runningGrace      time.Duration
+
+	// now is injectable so GC windowing is deterministic in tests.
+	now func() time.Time
+}
+
+// NewDockerSidecarManager builds a SidecarManager backed by the given
+// ContainerManager. The ContainerManager is reused for both networks and
+// containers — no second Docker client is created.
+func NewDockerSidecarManager(containers port.ContainerManager, logger *slog.Logger) *DockerSidecarManager {
+	return &DockerSidecarManager{
+		containers:        containers,
+		logger:            logger,
+		readinessTimeout:  defaultReadinessTimeout,
+		readinessInterval: defaultReadinessInterval,
+		runningGrace:      defaultRunningGrace,
+		now:               time.Now,
+	}
+}
+
+// networkName returns the per-run network name for a run id (full UUID).
+func networkName(runID uuid.UUID) string {
+	return sidecarNetworkPrefix + runID.String()
+}
+
+// Launch brings up the Environment's services on a fresh per-run network. It is
+// nil-safe (nil/empty env -> empty context, no side effects) and rolls back
+// atomically on any error.
+func (s *DockerSidecarManager) Launch(ctx context.Context, runID uuid.UUID, env *model.Environment) (*port.SidecarContext, error) {
+	sc := &port.SidecarContext{
+		RunID:        runID,
+		ContainerIDs: map[string]string{},
+		ServiceAddrs: map[string]string{},
+	}
+
+	// Nil-safe: nothing to do.
+	if env == nil || len(env.Services) == 0 {
+		return sc, nil
+	}
+
+	netName := networkName(runID)
+	labels := map[string]string{
+		labelManagedBy: managedByLabel,
+		labelRunID:     runID.String(),
+	}
+
+	if _, err := s.containers.CreateNetwork(ctx, netName, labels); err != nil {
+		return nil, fmt.Errorf("creating run network %s: %w", netName, err)
+	}
+	sc.NetworkName = netName
+
+	for _, svc := range env.Services {
+		if err := s.launchService(ctx, sc, runID, svc); err != nil {
+			// Rollback atomically: tear down everything started so far.
+			s.rollback(ctx, sc)
+			return nil, err
+		}
+	}
+
+	s.logger.Info("sidecars launched",
+		slog.String("run_id", runID.String()),
+		slog.String("network", netName),
+		slog.Int("services", len(sc.ContainerIDs)),
+	)
+	return sc, nil
+}
+
+// launchService creates, starts and waits-ready a single sidecar, recording it
+// into sc on success.
+func (s *DockerSidecarManager) launchService(ctx context.Context, sc *port.SidecarContext, runID uuid.UUID, svc model.EnvironmentService) error {
+	svcType := detectServiceType(svc.Image)
+
+	opts := model.ContainerOpts{
+		Image:         svc.Image,
+		Env:           envMapToSlice(svc.Env),
+		ExtraNetworks: []string{sc.NetworkName},
+		Aliases:       map[string]string{sc.NetworkName: svc.Name},
+		Labels: map[string]string{
+			labelManagedBy: managedByLabel,
+			labelRunID:     runID.String(),
+			labelSidecar:   svc.Name,
+		},
+		Healthcheck: healthcheckFor(svcType, s.readinessInterval),
+	}
+
+	id, err := s.containers.Create(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("creating sidecar %s: %w", svc.Name, err)
+	}
+	// Record immediately so rollback can reach it even if Start/readiness fails.
+	sc.ContainerIDs[svc.Name] = id
+
+	if err := s.containers.Start(ctx, id); err != nil {
+		return fmt.Errorf("starting sidecar %s: %w", svc.Name, err)
+	}
+
+	if err := s.waitReady(ctx, id, svcType); err != nil {
+		return fmt.Errorf("sidecar %s not ready: %w", svc.Name, err)
+	}
+
+	// DNS hostname on the run network is the service name (set as alias above).
+	sc.ServiceAddrs[svc.Name] = svc.Name
+	return nil
+}
+
+// waitReady blocks until the sidecar is ready or the readiness timeout elapses.
+// Services with a real healthcheck are polled via InspectHealth until "healthy";
+// services without one fall back to a running check plus a short grace delay.
+func (s *DockerSidecarManager) waitReady(ctx context.Context, containerID, svcType string) error {
+	hasHealthcheck := svcType != "" && len(serviceProfiles[svcType].healthTest) > 0
+
+	deadline := s.now().Add(s.readinessTimeout)
+	for {
+		status, err := s.containers.InspectHealth(ctx, containerID)
+		if err != nil {
+			return err
+		}
+
+		if hasHealthcheck {
+			switch status {
+			case model.HealthHealthy:
+				return nil
+			case model.HealthUnhealthy:
+				return fmt.Errorf("container %s reported unhealthy", containerID)
+			}
+		} else {
+			// No sensible healthcheck for this type: a running container plus a
+			// short grace delay is the best signal we have. Documented limit:
+			// readiness is approximate for unknown service types.
+			if status == model.HealthRunning {
+				s.sleep(ctx, s.runningGrace)
+				return nil
+			}
+			if status == model.HealthNotRunning {
+				return fmt.Errorf("container %s is not running", containerID)
+			}
+		}
+
+		if !s.now().Before(deadline) {
+			return fmt.Errorf("readiness timeout after %s (last status %q)", s.readinessTimeout, status)
+		}
+		if err := s.sleep(ctx, s.readinessInterval); err != nil {
+			return err
+		}
+	}
+}
+
+// sleep waits for d, honouring context cancellation.
+func (s *DockerSidecarManager) sleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// rollback tears down a partially-launched run: stop+remove every started
+// container, then remove the network. Best-effort, log-only, never panics.
+func (s *DockerSidecarManager) rollback(ctx context.Context, sc *port.SidecarContext) {
+	s.teardownContainers(ctx, sc)
+	if sc.NetworkName != "" {
+		if err := s.containers.RemoveNetwork(ctx, sc.NetworkName); err != nil {
+			s.logger.Warn("rollback: remove network failed",
+				slog.String("network", sc.NetworkName),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+}
+
+// teardownContainers stops and removes all sidecar containers in sc.
+func (s *DockerSidecarManager) teardownContainers(ctx context.Context, sc *port.SidecarContext) {
+	for name, id := range sc.ContainerIDs {
+		if err := s.containers.Stop(ctx, id); err != nil {
+			s.logger.Warn("teardown: stop sidecar failed",
+				slog.String("sidecar", name),
+				slog.String("container_id", id),
+				slog.String("error", err.Error()),
+			)
+		}
+		if err := s.containers.Remove(ctx, id); err != nil {
+			s.logger.Warn("teardown: remove sidecar failed",
+				slog.String("sidecar", name),
+				slog.String("container_id", id),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+}
+
+// Stop stops the sidecar containers in sc. Best-effort, idempotent, defer-safe.
+func (s *DockerSidecarManager) Stop(ctx context.Context, sc *port.SidecarContext) error {
+	if sc == nil || len(sc.ContainerIDs) == 0 {
+		return nil
+	}
+	for name, id := range sc.ContainerIDs {
+		if err := s.containers.Stop(ctx, id); err != nil {
+			s.logger.Warn("stop sidecar failed",
+				slog.String("sidecar", name),
+				slog.String("container_id", id),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+	return nil
+}
+
+// Cleanup stops+removes the sidecar containers and removes the run network.
+// Best-effort, idempotent, defer-safe.
+func (s *DockerSidecarManager) Cleanup(ctx context.Context, sc *port.SidecarContext) error {
+	if sc == nil || (len(sc.ContainerIDs) == 0 && sc.NetworkName == "") {
+		return nil
+	}
+	s.teardownContainers(ctx, sc)
+	if sc.NetworkName != "" {
+		if err := s.containers.RemoveNetwork(ctx, sc.NetworkName); err != nil {
+			s.logger.Warn("cleanup: remove network failed",
+				slog.String("network", sc.NetworkName),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+	return nil
+}
+
+// ListOrphanNetworks lists managed run networks with no managed sidecar
+// container still attached. A network is matched to its containers by the
+// shared run_id label, avoiding a per-network container lookup.
+func (s *DockerSidecarManager) ListOrphanNetworks(ctx context.Context) ([]model.NetworkInfo, error) {
+	managed := map[string]string{labelManagedBy: managedByLabel}
+
+	networks, err := s.containers.ListNetworks(ctx, managed)
+	if err != nil {
+		return nil, err
+	}
+	containers, err := s.containers.ListContainers(ctx, managed)
+	if err != nil {
+		return nil, err
+	}
+
+	liveRunIDs := map[string]bool{}
+	for _, c := range containers {
+		if rid := c.Labels[labelRunID]; rid != "" {
+			liveRunIDs[rid] = true
+		}
+	}
+
+	orphans := make([]model.NetworkInfo, 0)
+	for _, n := range networks {
+		rid := n.Labels[labelRunID]
+		if rid == "" {
+			// Not a per-run sidecar network; leave it alone.
+			continue
+		}
+		if !liveRunIDs[rid] {
+			orphans = append(orphans, n)
+		}
+	}
+	return orphans, nil
+}
+
+// GC removes orphan run networks older than olderThan. Best-effort, log-only.
+func (s *DockerSidecarManager) GC(ctx context.Context, olderThan time.Duration) error {
+	orphans, err := s.ListOrphanNetworks(ctx)
+	if err != nil {
+		return err
+	}
+
+	cutoff := s.now().Add(-olderThan)
+	removed := 0
+	for _, n := range orphans {
+		if n.CreatedAt.After(cutoff) {
+			// Too recent: a run may still be starting up. Keep it.
+			continue
+		}
+		if err := s.containers.RemoveNetwork(ctx, n.ID); err != nil {
+			s.logger.Warn("gc: remove orphan network failed",
+				slog.String("network", n.Name),
+				slog.String("network_id", n.ID),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		removed++
+	}
+
+	if removed > 0 {
+		s.logger.Info("gc removed orphan networks", slog.Int("count", removed))
+	}
+	return nil
+}
+
+// healthcheckFor returns the HEALTHCHECK config for a service type, or nil when
+// no sensible healthcheck exists (readiness then falls back to running+grace).
+func healthcheckFor(svcType string, interval time.Duration) *model.ContainerHealthcheck {
+	profile, ok := serviceProfiles[svcType]
+	if !ok || len(profile.healthTest) == 0 {
+		return nil
+	}
+	return &model.ContainerHealthcheck{
+		Test:        profile.healthTest,
+		Interval:    interval,
+		Timeout:     3 * time.Second,
+		Retries:     3,
+		StartPeriod: 1 * time.Second,
+	}
+}
+
+// envMapToSlice converts a service env map to the KEY=value slice the Docker
+// adapter expects. A nil map yields a nil slice.
+func envMapToSlice(env map[string]string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(env))
+	for k, v := range env {
+		out = append(out, k+"="+v)
+	}
+	return out
+}

--- a/backend/internal/adapter/docker/sidecar_manager_test.go
+++ b/backend/internal/adapter/docker/sidecar_manager_test.go
@@ -140,7 +140,7 @@ func (m *mockContainerManager) InspectHealth(_ context.Context, containerID stri
 	return model.HealthHealthy, nil
 }
 
-func newTestSidecarManager(cm *mockContainerManager) *DockerSidecarManager {
+func newTestSidecarManager(cm *mockContainerManager) *SidecarManager {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	s := NewDockerSidecarManager(cm, logger)
 	// Tighten timings so tests are fast.

--- a/backend/internal/adapter/docker/sidecar_manager_test.go
+++ b/backend/internal/adapter/docker/sidecar_manager_test.go
@@ -35,6 +35,7 @@ type mockContainerManager struct {
 	removeNetworkFn func(nameOrID string) error
 	listNetworksFn  func() ([]model.NetworkInfo, error)
 	listContainerFn func() ([]port.ContainerInfo, error)
+	listRunningFn   func() ([]port.ContainerInfo, error)
 }
 
 func newMockCM() *mockContainerManager {
@@ -90,6 +91,13 @@ func (m *mockContainerManager) Wait(_ context.Context, _ string) (int, error) {
 func (m *mockContainerManager) ListContainers(_ context.Context, _ map[string]string) ([]port.ContainerInfo, error) {
 	if m.listContainerFn != nil {
 		return m.listContainerFn()
+	}
+	return nil, nil
+}
+
+func (m *mockContainerManager) ListRunningContainers(_ context.Context, _ map[string]string) ([]port.ContainerInfo, error) {
+	if m.listRunningFn != nil {
+		return m.listRunningFn()
 	}
 	return nil, nil
 }
@@ -222,10 +230,15 @@ func TestSidecarLaunch_HappyPath(t *testing.T) {
 	if len(cm.createdOpts) != 1 || cm.createdOpts[0].Healthcheck == nil {
 		t.Errorf("expected postgres healthcheck to be configured")
 	}
-	// Sidecar attached to the run network as an extra network with alias.
-	if len(cm.createdOpts[0].ExtraNetworks) != 1 || cm.createdOpts[0].ExtraNetworks[0] != wantNet {
-		t.Errorf("expected sidecar attached to run network, got %v", cm.createdOpts[0].ExtraNetworks)
+	// Isolation: the sidecar is attached to the run network DIRECTLY at creation
+	// (NetworkName, not ExtraNetworks) so it never lands on the default bridge.
+	if cm.createdOpts[0].NetworkName != wantNet {
+		t.Errorf("expected sidecar created on run network via NetworkName, got %q", cm.createdOpts[0].NetworkName)
 	}
+	if len(cm.createdOpts[0].ExtraNetworks) != 0 {
+		t.Errorf("expected no ExtraNetworks (no bridge dual-home), got %v", cm.createdOpts[0].ExtraNetworks)
+	}
+	// DNS alias svc.Name on the run network (applied on the primary endpoint).
 	if cm.createdOpts[0].Aliases[wantNet] != "db" {
 		t.Errorf("expected dns alias db on run network, got %v", cm.createdOpts[0].Aliases)
 	}
@@ -322,6 +335,70 @@ func TestSidecarLaunch_RollbackOnUnhealthy(t *testing.T) {
 	}
 }
 
+func TestSidecarLaunch_RollbackWithCancelledContext(t *testing.T) {
+	// If the caller's context is cancelled mid-Launch (InspectHealth returns
+	// context.Canceled), teardown must still run: it uses a context detached from
+	// the caller's. The mock ignores ctx, but the real SDK would not — this proves
+	// rollback no longer reuses the dead ctx.
+	cm := newMockCM()
+	cm.inspectHealthFn = func(_ string) (string, error) { return "", context.Canceled }
+	s := newTestSidecarManager(cm)
+
+	_, err := s.Launch(context.Background(), uuid.New(), pgEnv())
+	if err == nil {
+		t.Fatal("expected error from cancelled readiness, got nil")
+	}
+	if len(cm.stoppedIDs) != 1 || len(cm.removedIDs) != 1 || len(cm.removedNetworks) != 1 {
+		t.Errorf("expected full teardown despite cancellation: stops=%d removes=%d nets=%d",
+			len(cm.stoppedIDs), len(cm.removedIDs), len(cm.removedNetworks))
+	}
+}
+
+func TestSidecarLaunch_BakedImageHealthcheckReady(t *testing.T) {
+	// Unknown service type whose IMAGE bakes its own HEALTHCHECK: InspectHealth
+	// returns "healthy" -> must be treated as ready (no false timeout/rollback),
+	// even though we configured no profile healthcheck.
+	cm := newMockCM()
+	cm.inspectHealthFn = func(_ string) (string, error) { return model.HealthHealthy, nil }
+	s := newTestSidecarManager(cm)
+
+	env := &model.Environment{
+		Services: []model.EnvironmentService{{Name: "custom", Image: "ghcr.io/acme/thing:1"}},
+	}
+	sc, err := s.Launch(context.Background(), uuid.New(), env)
+	if err != nil {
+		t.Fatalf("expected ready via baked image healthcheck, got %v", err)
+	}
+	if sc.ServiceAddrs["custom"] != "custom" {
+		t.Errorf("expected custom addr recorded")
+	}
+	// We did not configure a profile healthcheck for the unknown type.
+	if cm.createdOpts[0].Healthcheck != nil {
+		t.Errorf("expected no profile healthcheck for unknown type")
+	}
+	if len(cm.removedIDs) != 0 || len(cm.removedNetworks) != 0 {
+		t.Errorf("expected no rollback, got removes=%d nets=%d", len(cm.removedIDs), len(cm.removedNetworks))
+	}
+}
+
+func TestSidecarLaunch_BakedImageUnhealthyRollback(t *testing.T) {
+	// Unknown type, image healthcheck reports unhealthy -> failure + rollback.
+	cm := newMockCM()
+	cm.inspectHealthFn = func(_ string) (string, error) { return model.HealthUnhealthy, nil }
+	s := newTestSidecarManager(cm)
+
+	env := &model.Environment{
+		Services: []model.EnvironmentService{{Name: "custom", Image: "ghcr.io/acme/thing:1"}},
+	}
+	_, err := s.Launch(context.Background(), uuid.New(), env)
+	if err == nil {
+		t.Fatal("expected unhealthy error, got nil")
+	}
+	if len(cm.removedIDs) != 1 || len(cm.removedNetworks) != 1 {
+		t.Errorf("expected full rollback, got removes=%d nets=%d", len(cm.removedIDs), len(cm.removedNetworks))
+	}
+}
+
 func TestSidecarStop_NilContext_NoOp(t *testing.T) {
 	cm := newMockCM()
 	s := newTestSidecarManager(cm)
@@ -378,10 +455,13 @@ func TestSidecarGC_Windowed(t *testing.T) {
 			{ID: "old", Name: "hopeitworks-run-old", Labels: map[string]string{labelRunID: "run-old"}, CreatedAt: now.Add(-2 * time.Hour)},
 			{ID: "recent", Name: "hopeitworks-run-recent", Labels: map[string]string{labelRunID: "run-recent"}, CreatedAt: now.Add(-1 * time.Minute)},
 			{ID: "live", Name: "hopeitworks-run-live", Labels: map[string]string{labelRunID: "run-live"}, CreatedAt: now.Add(-2 * time.Hour)},
+			{ID: "exited", Name: "hopeitworks-run-exited", Labels: map[string]string{labelRunID: "run-exited"}, CreatedAt: now.Add(-2 * time.Hour)},
 		}, nil
 	}
-	cm.listContainerFn = func() ([]port.ContainerInfo, error) {
-		// run-live still has a container -> not an orphan.
+	// Orphan detection uses RUNNING containers only: run-live has a running
+	// container; run-exited's container is exited (absent from running list) so
+	// its old network must be reaped.
+	cm.listRunningFn = func() ([]port.ContainerInfo, error) {
 		return []port.ContainerInfo{
 			{ID: "c1", Labels: map[string]string{labelRunID: "run-live"}},
 		}, nil
@@ -393,10 +473,14 @@ func TestSidecarGC_Windowed(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Only the old orphan is removed: recent is within the window, live has a
-	// container.
-	if len(cm.removedNetworks) != 1 || cm.removedNetworks[0] != "old" {
-		t.Errorf("expected only 'old' removed, got %v", cm.removedNetworks)
+	// old + exited removed; recent within window kept; live has a running
+	// container kept.
+	if len(cm.removedNetworks) != 2 {
+		t.Fatalf("expected 2 networks removed, got %v", cm.removedNetworks)
+	}
+	got := map[string]bool{cm.removedNetworks[0]: true, cm.removedNetworks[1]: true}
+	if !got["old"] || !got["exited"] {
+		t.Errorf("expected 'old' and 'exited' removed, got %v", cm.removedNetworks)
 	}
 }
 
@@ -409,7 +493,7 @@ func TestSidecarListOrphanNetworks(t *testing.T) {
 			{ID: "n-nolabel", Labels: map[string]string{}}, // not a run network
 		}, nil
 	}
-	cm.listContainerFn = func() ([]port.ContainerInfo, error) {
+	cm.listRunningFn = func() ([]port.ContainerInfo, error) {
 		return []port.ContainerInfo{{ID: "c", Labels: map[string]string{labelRunID: "r2"}}}, nil
 	}
 	s := newTestSidecarManager(cm)

--- a/backend/internal/adapter/docker/sidecar_manager_test.go
+++ b/backend/internal/adapter/docker/sidecar_manager_test.go
@@ -1,0 +1,455 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+)
+
+// mockContainerManager is a hand-written test double for port.ContainerManager.
+// It records calls and exposes configurable behaviour via function hooks.
+type mockContainerManager struct {
+	mu sync.Mutex
+
+	createdNetworks []string
+	removedNetworks []string
+	createdOpts     []model.ContainerOpts
+	startedIDs      []string
+	stoppedIDs      []string
+	removedIDs      []string
+
+	// Hooks. Defaults are "succeed".
+	createNetworkFn func(name string) (string, error)
+	createFn        func(opts model.ContainerOpts) (string, error)
+	startFn         func(id string) error
+	inspectHealthFn func(id string) (string, error)
+	removeNetworkFn func(nameOrID string) error
+	listNetworksFn  func() ([]model.NetworkInfo, error)
+	listContainerFn func() ([]port.ContainerInfo, error)
+}
+
+func newMockCM() *mockContainerManager {
+	return &mockContainerManager{}
+}
+
+func (m *mockContainerManager) Create(_ context.Context, opts model.ContainerOpts) (string, error) {
+	m.mu.Lock()
+	m.createdOpts = append(m.createdOpts, opts)
+	m.mu.Unlock()
+	if m.createFn != nil {
+		return m.createFn(opts)
+	}
+	return "ctr-" + opts.Labels[labelSidecar], nil
+}
+
+func (m *mockContainerManager) Start(_ context.Context, containerID string) error {
+	m.mu.Lock()
+	m.startedIDs = append(m.startedIDs, containerID)
+	m.mu.Unlock()
+	if m.startFn != nil {
+		return m.startFn(containerID)
+	}
+	return nil
+}
+
+func (m *mockContainerManager) getStartedIDs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.startedIDs))
+	copy(out, m.startedIDs)
+	return out
+}
+
+func (m *mockContainerManager) Stop(_ context.Context, containerID string) error {
+	m.mu.Lock()
+	m.stoppedIDs = append(m.stoppedIDs, containerID)
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *mockContainerManager) Remove(_ context.Context, containerID string) error {
+	m.mu.Lock()
+	m.removedIDs = append(m.removedIDs, containerID)
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *mockContainerManager) Wait(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+
+func (m *mockContainerManager) ListContainers(_ context.Context, _ map[string]string) ([]port.ContainerInfo, error) {
+	if m.listContainerFn != nil {
+		return m.listContainerFn()
+	}
+	return nil, nil
+}
+
+func (m *mockContainerManager) CreateNetwork(_ context.Context, name string, _ map[string]string) (string, error) {
+	m.mu.Lock()
+	m.createdNetworks = append(m.createdNetworks, name)
+	m.mu.Unlock()
+	if m.createNetworkFn != nil {
+		return m.createNetworkFn(name)
+	}
+	return "id-" + name, nil
+}
+
+func (m *mockContainerManager) RemoveNetwork(_ context.Context, nameOrID string) error {
+	m.mu.Lock()
+	m.removedNetworks = append(m.removedNetworks, nameOrID)
+	m.mu.Unlock()
+	if m.removeNetworkFn != nil {
+		return m.removeNetworkFn(nameOrID)
+	}
+	return nil
+}
+
+func (m *mockContainerManager) ConnectContainer(_ context.Context, _, _ string, _ []string) error {
+	return nil
+}
+
+func (m *mockContainerManager) ListNetworks(_ context.Context, _ map[string]string) ([]model.NetworkInfo, error) {
+	if m.listNetworksFn != nil {
+		return m.listNetworksFn()
+	}
+	return nil, nil
+}
+
+func (m *mockContainerManager) InspectHealth(_ context.Context, containerID string) (string, error) {
+	if m.inspectHealthFn != nil {
+		return m.inspectHealthFn(containerID)
+	}
+	return model.HealthHealthy, nil
+}
+
+func newTestSidecarManager(cm *mockContainerManager) *DockerSidecarManager {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	s := NewDockerSidecarManager(cm, logger)
+	// Tighten timings so tests are fast.
+	s.readinessTimeout = 200 * time.Millisecond
+	s.readinessInterval = 5 * time.Millisecond
+	s.runningGrace = 0
+	return s
+}
+
+func pgEnv() *model.Environment {
+	return &model.Environment{
+		ID:        uuid.New(),
+		ProjectID: uuid.New(),
+		Services: []model.EnvironmentService{
+			{Name: "db", Image: "postgres:16", Env: map[string]string{"POSTGRES_PASSWORD": "x"}},
+		},
+	}
+}
+
+func TestSidecarLaunch_NilEnv_NoOp(t *testing.T) {
+	cm := newMockCM()
+	s := newTestSidecarManager(cm)
+
+	runID := uuid.New()
+	sc, err := s.Launch(context.Background(), runID, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if sc == nil {
+		t.Fatal("expected non-nil empty context")
+	}
+	if sc.RunID != runID {
+		t.Errorf("expected RunID propagated")
+	}
+	if sc.NetworkName != "" {
+		t.Errorf("expected no network, got %s", sc.NetworkName)
+	}
+	if len(cm.createdNetworks) != 0 || len(cm.createdOpts) != 0 {
+		t.Errorf("expected no docker calls: nets=%d ctrs=%d", len(cm.createdNetworks), len(cm.createdOpts))
+	}
+}
+
+func TestSidecarLaunch_EmptyServices_NoOp(t *testing.T) {
+	cm := newMockCM()
+	s := newTestSidecarManager(cm)
+
+	env := &model.Environment{ID: uuid.New(), Services: nil}
+	sc, err := s.Launch(context.Background(), uuid.New(), env)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if sc.NetworkName != "" {
+		t.Errorf("expected no network")
+	}
+	if len(cm.createdNetworks) != 0 || len(cm.createdOpts) != 0 {
+		t.Errorf("expected no docker calls")
+	}
+}
+
+func TestSidecarLaunch_HappyPath(t *testing.T) {
+	cm := newMockCM() // defaults: create ok, start ok, health=healthy
+	s := newTestSidecarManager(cm)
+
+	runID := uuid.New()
+	sc, err := s.Launch(context.Background(), runID, pgEnv())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	wantNet := sidecarNetworkPrefix + runID.String()
+	if sc.NetworkName != wantNet {
+		t.Errorf("expected network %s, got %s", wantNet, sc.NetworkName)
+	}
+	if len(cm.createdNetworks) != 1 || cm.createdNetworks[0] != wantNet {
+		t.Errorf("expected one network %s, got %v", wantNet, cm.createdNetworks)
+	}
+	if sc.ServiceAddrs["db"] != "db" {
+		t.Errorf("expected db addr = db, got %q", sc.ServiceAddrs["db"])
+	}
+	if _, ok := sc.ContainerIDs["db"]; !ok {
+		t.Errorf("expected db container id recorded")
+	}
+	if started := cm.getStartedIDs(); len(started) != 1 {
+		t.Errorf("expected exactly one container started, got %d", len(started))
+	}
+	// Postgres has a healthcheck configured.
+	if len(cm.createdOpts) != 1 || cm.createdOpts[0].Healthcheck == nil {
+		t.Errorf("expected postgres healthcheck to be configured")
+	}
+	// Sidecar attached to the run network as an extra network with alias.
+	if len(cm.createdOpts[0].ExtraNetworks) != 1 || cm.createdOpts[0].ExtraNetworks[0] != wantNet {
+		t.Errorf("expected sidecar attached to run network, got %v", cm.createdOpts[0].ExtraNetworks)
+	}
+	if cm.createdOpts[0].Aliases[wantNet] != "db" {
+		t.Errorf("expected dns alias db on run network, got %v", cm.createdOpts[0].Aliases)
+	}
+}
+
+func TestSidecarLaunch_UnknownType_FallbackRunning(t *testing.T) {
+	cm := newMockCM()
+	cm.inspectHealthFn = func(_ string) (string, error) { return model.HealthRunning, nil }
+	s := newTestSidecarManager(cm)
+
+	env := &model.Environment{
+		Services: []model.EnvironmentService{{Name: "custom", Image: "ghcr.io/acme/thing:1"}},
+	}
+	sc, err := s.Launch(context.Background(), uuid.New(), env)
+	if err != nil {
+		t.Fatalf("expected no error for unknown type running fallback, got %v", err)
+	}
+	if sc.ServiceAddrs["custom"] != "custom" {
+		t.Errorf("expected custom addr recorded")
+	}
+	// No healthcheck for unknown types.
+	if cm.createdOpts[0].Healthcheck != nil {
+		t.Errorf("expected no healthcheck for unknown service type")
+	}
+}
+
+func TestSidecarLaunch_RollbackOnReadinessTimeout(t *testing.T) {
+	cm := newMockCM()
+	// Postgres healthcheck never goes healthy -> timeout -> rollback.
+	cm.inspectHealthFn = func(_ string) (string, error) { return model.HealthStarting, nil }
+	s := newTestSidecarManager(cm)
+
+	runID := uuid.New()
+	sc, err := s.Launch(context.Background(), runID, pgEnv())
+	if err == nil {
+		t.Fatal("expected readiness timeout error, got nil")
+	}
+	if sc != nil {
+		t.Errorf("expected nil context on error, got %+v", sc)
+	}
+	// Rollback: the started container was stopped+removed and the network removed.
+	if len(cm.stoppedIDs) != 1 || len(cm.removedIDs) != 1 {
+		t.Errorf("expected 1 stop + 1 remove on rollback, got stops=%d removes=%d", len(cm.stoppedIDs), len(cm.removedIDs))
+	}
+	wantNet := sidecarNetworkPrefix + runID.String()
+	if len(cm.removedNetworks) != 1 || cm.removedNetworks[0] != wantNet {
+		t.Errorf("expected network %s removed on rollback, got %v", wantNet, cm.removedNetworks)
+	}
+}
+
+func TestSidecarLaunch_RollbackOnCreateError(t *testing.T) {
+	cm := newMockCM()
+	calls := 0
+	cm.createFn = func(opts model.ContainerOpts) (string, error) {
+		calls++
+		if calls == 2 {
+			return "", errors.New("boom on second create")
+		}
+		return "ctr-" + opts.Labels[labelSidecar], nil
+	}
+	s := newTestSidecarManager(cm)
+
+	env := &model.Environment{
+		Services: []model.EnvironmentService{
+			{Name: "a", Image: "redis:7"},
+			{Name: "b", Image: "redis:7"},
+		},
+	}
+	runID := uuid.New()
+	_, err := s.Launch(context.Background(), runID, env)
+	if err == nil {
+		t.Fatal("expected create error, got nil")
+	}
+	// First container "a" was created+started; it must be torn down on rollback.
+	if len(cm.removedIDs) != 1 || cm.removedIDs[0] != "ctr-a" {
+		t.Errorf("expected ctr-a removed on rollback, got %v", cm.removedIDs)
+	}
+	if len(cm.removedNetworks) != 1 {
+		t.Errorf("expected network removed on rollback, got %v", cm.removedNetworks)
+	}
+}
+
+func TestSidecarLaunch_RollbackOnUnhealthy(t *testing.T) {
+	cm := newMockCM()
+	cm.inspectHealthFn = func(_ string) (string, error) { return model.HealthUnhealthy, nil }
+	s := newTestSidecarManager(cm)
+
+	_, err := s.Launch(context.Background(), uuid.New(), pgEnv())
+	if err == nil {
+		t.Fatal("expected unhealthy error, got nil")
+	}
+	if len(cm.removedIDs) != 1 || len(cm.removedNetworks) != 1 {
+		t.Errorf("expected full rollback, got removes=%d nets=%d", len(cm.removedIDs), len(cm.removedNetworks))
+	}
+}
+
+func TestSidecarStop_NilContext_NoOp(t *testing.T) {
+	cm := newMockCM()
+	s := newTestSidecarManager(cm)
+
+	if err := s.Stop(context.Background(), nil); err != nil {
+		t.Fatalf("expected nil for nil context, got %v", err)
+	}
+	if err := s.Stop(context.Background(), &port.SidecarContext{}); err != nil {
+		t.Fatalf("expected nil for empty context, got %v", err)
+	}
+	if len(cm.stoppedIDs) != 0 {
+		t.Errorf("expected no stop calls, got %d", len(cm.stoppedIDs))
+	}
+}
+
+func TestSidecarCleanup_Idempotent(t *testing.T) {
+	cm := newMockCM()
+	s := newTestSidecarManager(cm)
+
+	// Nil + empty contexts are no-ops.
+	if err := s.Cleanup(context.Background(), nil); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if err := s.Cleanup(context.Background(), &port.SidecarContext{}); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if len(cm.removedIDs) != 0 || len(cm.removedNetworks) != 0 {
+		t.Errorf("expected no teardown for empty context")
+	}
+
+	// Populated context tears down containers + network.
+	sc := &port.SidecarContext{
+		NetworkName:  "hopeitworks-run-x",
+		ContainerIDs: map[string]string{"db": "ctr-db"},
+	}
+	if err := s.Cleanup(context.Background(), sc); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if len(cm.stoppedIDs) != 1 || len(cm.removedIDs) != 1 || len(cm.removedNetworks) != 1 {
+		t.Errorf("expected teardown: stops=%d removes=%d nets=%d", len(cm.stoppedIDs), len(cm.removedIDs), len(cm.removedNetworks))
+	}
+
+	// Calling again is harmless (RemoveNetwork/Remove are idempotent at adapter).
+	if err := s.Cleanup(context.Background(), sc); err != nil {
+		t.Fatalf("expected nil on second cleanup, got %v", err)
+	}
+}
+
+func TestSidecarGC_Windowed(t *testing.T) {
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	cm := newMockCM()
+	cm.listNetworksFn = func() ([]model.NetworkInfo, error) {
+		return []model.NetworkInfo{
+			{ID: "old", Name: "hopeitworks-run-old", Labels: map[string]string{labelRunID: "run-old"}, CreatedAt: now.Add(-2 * time.Hour)},
+			{ID: "recent", Name: "hopeitworks-run-recent", Labels: map[string]string{labelRunID: "run-recent"}, CreatedAt: now.Add(-1 * time.Minute)},
+			{ID: "live", Name: "hopeitworks-run-live", Labels: map[string]string{labelRunID: "run-live"}, CreatedAt: now.Add(-2 * time.Hour)},
+		}, nil
+	}
+	cm.listContainerFn = func() ([]port.ContainerInfo, error) {
+		// run-live still has a container -> not an orphan.
+		return []port.ContainerInfo{
+			{ID: "c1", Labels: map[string]string{labelRunID: "run-live"}},
+		}, nil
+	}
+	s := newTestSidecarManager(cm)
+	s.now = func() time.Time { return now }
+
+	if err := s.GC(context.Background(), 30*time.Minute); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Only the old orphan is removed: recent is within the window, live has a
+	// container.
+	if len(cm.removedNetworks) != 1 || cm.removedNetworks[0] != "old" {
+		t.Errorf("expected only 'old' removed, got %v", cm.removedNetworks)
+	}
+}
+
+func TestSidecarListOrphanNetworks(t *testing.T) {
+	cm := newMockCM()
+	cm.listNetworksFn = func() ([]model.NetworkInfo, error) {
+		return []model.NetworkInfo{
+			{ID: "n-orphan", Labels: map[string]string{labelRunID: "r1"}},
+			{ID: "n-live", Labels: map[string]string{labelRunID: "r2"}},
+			{ID: "n-nolabel", Labels: map[string]string{}}, // not a run network
+		}, nil
+	}
+	cm.listContainerFn = func() ([]port.ContainerInfo, error) {
+		return []port.ContainerInfo{{ID: "c", Labels: map[string]string{labelRunID: "r2"}}}, nil
+	}
+	s := newTestSidecarManager(cm)
+
+	orphans, err := s.ListOrphanNetworks(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(orphans) != 1 || orphans[0].ID != "n-orphan" {
+		t.Errorf("expected only n-orphan, got %v", orphans)
+	}
+}
+
+func TestServicePort(t *testing.T) {
+	cases := map[string]int{
+		"postgres": 5432,
+		"redis":    6379,
+		"mysql":    3306,
+		"":         0, // unknown
+	}
+	for svcType, want := range cases {
+		if got := servicePort(svcType); got != want {
+			t.Errorf("servicePort(%q) = %d, want %d", svcType, got, want)
+		}
+	}
+}
+
+func TestDetectServiceType(t *testing.T) {
+	cases := map[string]string{
+		"postgres:16":                "postgres",
+		"docker.io/library/postgres": "postgres",
+		"redis:7-alpine":             "redis",
+		"mysql:8":                    "mysql",
+		"ghcr.io/acme/custom:latest": "",
+		"registry:5000/mariadb:11":   "mariadb",
+		"mongo@sha256:abc":           "mongo",
+	}
+	for image, want := range cases {
+		if got := detectServiceType(image); got != want {
+			t.Errorf("detectServiceType(%q) = %q, want %q", image, got, want)
+		}
+	}
+}

--- a/backend/internal/domain/model/container.go
+++ b/backend/internal/domain/model/container.go
@@ -2,6 +2,18 @@ package model
 
 import "time"
 
+// Container health/readiness states reported by ContainerManager.InspectHealth.
+// The first four mirror Docker's HEALTHCHECK statuses; the last two are the
+// fallback signal used when a container declares no healthcheck.
+const (
+	HealthHealthy    = "healthy"     // healthcheck passing
+	HealthUnhealthy  = "unhealthy"   // healthcheck failing
+	HealthStarting   = "starting"    // healthcheck in its start period
+	HealthNone       = "none"        // no healthcheck configured
+	HealthRunning    = "running"     // no healthcheck, container is running
+	HealthNotRunning = "not_running" // no healthcheck, container not running
+)
+
 // ContainerOpts specifies configuration for creating an agent container.
 type ContainerOpts struct {
 	// Image is the Docker image to use (e.g., "hopeitworks/agent:latest").

--- a/backend/internal/domain/model/container.go
+++ b/backend/internal/domain/model/container.go
@@ -1,5 +1,7 @@
 package model
 
+import "time"
+
 // ContainerOpts specifies configuration for creating an agent container.
 type ContainerOpts struct {
 	// Image is the Docker image to use (e.g., "hopeitworks/agent:latest").
@@ -20,4 +22,52 @@ type ContainerOpts struct {
 
 	// CPUs is the CPU limit as a float (0 = unlimited, 1.0 = 1 CPU).
 	CPUs float64
+
+	// ExtraNetworks are additional Docker networks to attach the container to,
+	// in addition to NetworkName. Optional and nil-safe: empty/nil means the
+	// current behaviour is preserved exactly (only NetworkName is used).
+	ExtraNetworks []string
+
+	// Aliases maps a network name to a DNS alias for the container on that
+	// network. Optional and nil-safe: an entry is only applied if its network
+	// appears in ExtraNetworks. Empty/nil means no aliases are set.
+	Aliases map[string]string
+
+	// Healthcheck, when non-nil, configures a Docker HEALTHCHECK on the
+	// container so readiness can be polled via ContainerInspect. Optional and
+	// nil-safe: nil means no healthcheck is configured (current behaviour).
+	Healthcheck *ContainerHealthcheck
+}
+
+// ContainerHealthcheck describes a Docker HEALTHCHECK probe for a container.
+// All durations are optional; zero values let Docker apply its own defaults.
+type ContainerHealthcheck struct {
+	// Test is the healthcheck command, e.g. {"CMD-SHELL", "pg_isready"} or
+	// {"CMD", "redis-cli", "ping"}.
+	Test []string
+
+	// Interval is the time between two consecutive checks.
+	Interval time.Duration
+
+	// Timeout is the maximum time a single check may take before it is treated
+	// as failed.
+	Timeout time.Duration
+
+	// Retries is the number of consecutive failures before the container is
+	// considered unhealthy.
+	Retries int
+
+	// StartPeriod is the grace period during which a failing check does not
+	// count towards the retry budget.
+	StartPeriod time.Duration
+}
+
+// NetworkInfo represents metadata about a managed Docker network. It is the
+// canonical shape shared by the ContainerManager and SidecarManager ports so
+// the type is not duplicated across the port boundary.
+type NetworkInfo struct {
+	ID        string
+	Name      string
+	Labels    map[string]string
+	CreatedAt time.Time
 }

--- a/backend/internal/domain/port/container_manager.go
+++ b/backend/internal/domain/port/container_manager.go
@@ -39,9 +39,15 @@ type ContainerManager interface {
 	// Wait blocks until the container exits and returns its exit code.
 	Wait(ctx context.Context, containerID string) (int, error)
 
-	// ListContainers lists all containers matching the specified labels.
-	// labels is a map of key-value pairs for filtering (e.g., managed_by=hopeitworks).
+	// ListContainers lists all containers (any state, including exited) matching
+	// the specified labels. labels is a map of key-value pairs for filtering
+	// (e.g., managed_by=hopeitworks).
 	ListContainers(ctx context.Context, labels map[string]string) ([]ContainerInfo, error)
+
+	// ListRunningContainers lists only running containers matching the specified
+	// labels. Used by orphan detection, where exited-but-not-removed containers
+	// must NOT keep their run's network alive.
+	ListRunningContainers(ctx context.Context, labels map[string]string) ([]ContainerInfo, error)
 
 	// CreateNetwork creates a Docker network with the given name and labels and
 	// returns its ID. It is idempotent: if a network with the same name already

--- a/backend/internal/domain/port/container_manager.go
+++ b/backend/internal/domain/port/container_manager.go
@@ -42,4 +42,21 @@ type ContainerManager interface {
 	// ListContainers lists all containers matching the specified labels.
 	// labels is a map of key-value pairs for filtering (e.g., managed_by=hopeitworks).
 	ListContainers(ctx context.Context, labels map[string]string) ([]ContainerInfo, error)
+
+	// CreateNetwork creates a Docker network with the given name and labels and
+	// returns its ID. It is idempotent: if a network with the same name already
+	// exists, the existing network's ID is returned instead of erroring.
+	CreateNetwork(ctx context.Context, name string, labels map[string]string) (string, error)
+
+	// RemoveNetwork removes a Docker network by name or ID. It is idempotent: a
+	// network that does not exist is treated as success (returns nil).
+	RemoveNetwork(ctx context.Context, nameOrID string) error
+
+	// ConnectContainer attaches an existing container to a network, optionally
+	// registering DNS aliases for it on that network. aliases may be nil/empty.
+	ConnectContainer(ctx context.Context, networkNameOrID, containerID string, aliases []string) error
+
+	// ListNetworks lists managed Docker networks matching the given label
+	// filter (e.g. managed_by=hopeitworks). An empty/nil filter lists all.
+	ListNetworks(ctx context.Context, labelFilter map[string]string) ([]model.NetworkInfo, error)
 }

--- a/backend/internal/domain/port/container_manager.go
+++ b/backend/internal/domain/port/container_manager.go
@@ -59,4 +59,10 @@ type ContainerManager interface {
 	// ListNetworks lists managed Docker networks matching the given label
 	// filter (e.g. managed_by=hopeitworks). An empty/nil filter lists all.
 	ListNetworks(ctx context.Context, labelFilter map[string]string) ([]model.NetworkInfo, error)
+
+	// InspectHealth reports a container's readiness. When the container has a
+	// Docker HEALTHCHECK it returns its health status (one of model.Health*).
+	// When it has none it falls back to a running/not-running signal
+	// (model.HealthRunning / model.HealthNotRunning).
+	InspectHealth(ctx context.Context, containerID string) (string, error)
 }

--- a/backend/internal/domain/port/sidecar_manager.go
+++ b/backend/internal/domain/port/sidecar_manager.go
@@ -1,0 +1,54 @@
+package port
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+)
+
+// P2c2b scaffolding: the SidecarManager brings up an Environment's sidecar
+// services on a per-run isolated Docker network, alongside the agent container.
+// It is additive and NOT yet wired into the live agent_run flow — conn-string
+// injection (P2c2c), command execution (P2c2d) and GC scheduling (P2c2f) land
+// later. The invariant is portability: a SidecarContext must stay K8s-Pod
+// expressible (services are sidecars-in-Pod on the run network, never DinD).
+
+// SidecarContext is the handle returned by Launch describing the run's sidecar
+// topology. It is the unit Stop/Cleanup operate on. A zero-value or empty
+// context (no NetworkName / no ContainerIDs) is valid and means "nothing to do".
+type SidecarContext struct {
+	RunID        uuid.UUID
+	NetworkName  string
+	ContainerIDs map[string]string // service name -> container id
+	ServiceAddrs map[string]string // service name -> hostname (DNS on the run network)
+}
+
+// SidecarManager orchestrates an Environment's sidecar services for a single
+// run. All methods are nil-safe and idempotent where noted.
+type SidecarManager interface {
+	// Launch brings up every service declared by env on a fresh per-run network
+	// and returns the resulting SidecarContext. If env is nil or declares no
+	// services it is a no-op returning an empty context (no network/container is
+	// created). On any error it rolls back atomically (stops/removes any started
+	// container and removes the network) before returning the error.
+	Launch(ctx context.Context, runID uuid.UUID, env *model.Environment) (*SidecarContext, error)
+
+	// Stop stops the sidecar containers described by sc. Best-effort and
+	// idempotent: a nil/empty context is a no-op and individual failures are
+	// logged, not returned-fatal.
+	Stop(ctx context.Context, sc *SidecarContext) error
+
+	// Cleanup stops and removes the sidecar containers and the run network
+	// described by sc. Best-effort and idempotent.
+	Cleanup(ctx context.Context, sc *SidecarContext) error
+
+	// ListOrphanNetworks lists managed run networks that no longer have any
+	// managed sidecar container attached.
+	ListOrphanNetworks(ctx context.Context) ([]model.NetworkInfo, error)
+
+	// GC removes orphan run networks older than olderThan. Best-effort.
+	GC(ctx context.Context, olderThan time.Duration) error
+}

--- a/backend/internal/domain/service/timeout_enforcer_test.go
+++ b/backend/internal/domain/service/timeout_enforcer_test.go
@@ -75,6 +75,22 @@ func (m *mockContainerManager) Wait(ctx context.Context, containerID string) (in
 	return 0, nil
 }
 
+func (m *mockContainerManager) CreateNetwork(_ context.Context, _ string, _ map[string]string) (string, error) {
+	return "", nil
+}
+
+func (m *mockContainerManager) RemoveNetwork(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *mockContainerManager) ConnectContainer(_ context.Context, _, _ string, _ []string) error {
+	return nil
+}
+
+func (m *mockContainerManager) ListNetworks(_ context.Context, _ map[string]string) ([]model.NetworkInfo, error) {
+	return nil, nil
+}
+
 func (m *mockContainerManager) getStopCalls() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/backend/internal/domain/service/timeout_enforcer_test.go
+++ b/backend/internal/domain/service/timeout_enforcer_test.go
@@ -91,6 +91,10 @@ func (m *mockContainerManager) ListNetworks(_ context.Context, _ map[string]stri
 	return nil, nil
 }
 
+func (m *mockContainerManager) InspectHealth(_ context.Context, _ string) (string, error) {
+	return model.HealthRunning, nil
+}
+
 func (m *mockContainerManager) getStopCalls() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/backend/internal/domain/service/timeout_enforcer_test.go
+++ b/backend/internal/domain/service/timeout_enforcer_test.go
@@ -75,6 +75,10 @@ func (m *mockContainerManager) Wait(ctx context.Context, containerID string) (in
 	return 0, nil
 }
 
+func (m *mockContainerManager) ListRunningContainers(_ context.Context, _ map[string]string) ([]port.ContainerInfo, error) {
+	return nil, nil
+}
+
 func (m *mockContainerManager) CreateNetwork(_ context.Context, _ string, _ map[string]string) (string, error) {
 	return "", nil
 }


### PR DESCRIPTION
## P2c2a + P2c2b — Fondation sidecars/réseau (non câblée)
Première moitié de P2c2 (runtime rework). **Additif, non câblé au chemin live** : `agent_run.go`/`main.go` intacts. Le câblage live = P2c2c (séparé).

### P2c2a — réseau sur ContainerManager
- `ContainerOpts.{ExtraNetworks, Aliases, Healthcheck}` (nil-safe : zéro-value = comportement actuel).
- Port `ContainerManager` : `CreateNetwork`/`RemoveNetwork`/`ConnectContainer`/`ListNetworks`/`ListRunningContainers`/`InspectHealth` + impl docker (SDK v28.5.1).
- `Create` **atomique** (ContainerRemove si un ConnectContainer échoue) + applique les Aliases sur l'endpoint primaire.

### P2c2b — SidecarManager
- Port `SidecarManager` + `SidecarContext` ; `DockerSidecarManager` réutilise le `ContainerManager` injecté.
- `Launch` nil-safe (env nil/vide = no-op total) ; sidecars attachés **directement au réseau du run** (pas de bridge) avec alias = `Name` ; readiness via **healthcheck Docker** (poll borné, jamais de `net.Dial` backend), status-driven (honore un HEALTHCHECK baké dans l'image) ; **rollback atomique** ; `Stop`/`Cleanup` defer-safe/idempotents sur **contexte détaché** (`WithoutCancel`+timeout) ; `GC` running-only + fenêtre temporelle.

### Review adversariale (orchestrateur) → corrigée
Workflow multi-dimensions : 1 blocker + 6 findings réels **tous corrigés et testés** : Create atomique (blocker), isolation sidecars (bridge), readiness healthcheck d'image, teardown ctx détaché, GC running-only, couverture InspectHealth, grace ctx. Hexagonal OK (aucune fuite de type Docker dans le domaine : InspectHealth→string, ListNetworks→model.NetworkInfo). `go build/vet/test -short` verts.

> Suivi P2c2c (creds dans les probes redis-AUTH/mariadb) documenté `// TODO(P2c2c)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)