### PR TITLE
feat(runtime): P2c2c — wire Environment sidecars + conn-strings into agent run

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -168,11 +168,10 @@ func run() error {
 	}
 
 	// Environment persistence (P2c1): one execution composition per project (stacks +
-	// sidecar services + config source + commands). Instantiated at boot so it is ready
-	// for the service/handler + run-path wiring that lands in P2c2. The blank assignment
-	// keeps it constructed without an API surface yet.
+	// sidecar services + config source + commands). Wired into the agent_run path below
+	// (P2c2c): when a project has an Environment with sidecar services, they are brought
+	// up per-run and their connection strings injected into the agent container.
 	environmentRepo := pgadapter.NewEnvironmentRepo(queries)
-	_ = environmentRepo
 
 	// Template renderer (Handlebars engine for prompt templates)
 	handlebarsRenderer := hbadapter.NewRenderer()
@@ -281,9 +280,13 @@ func run() error {
 				NetworkName:   cfg.Docker.AgentNetwork,
 				LogTailLines:  50,
 			}
+			// Sidecar manager brings up an Environment's services on a per-run
+			// isolated network over the same Docker ContainerManager.
+			sidecarMgr := dockeradapter.NewDockerSidecarManager(containerMgr, logger)
 			agentRunAction := actionadapter.NewAgentRunAction(
 				containerMgr, logStreamer, eventRepo,
 				storyRepo, projectRepo, runRepo,
+				environmentRepo, sidecarMgr,
 				handlebarsRenderer, costSvc, agentCfg, logger,
 				apiKeySvc, containerTokenStore, callbackStatusStore,
 				cfg.Docker.CallbackBaseURL,

--- a/backend/internal/adapter/action/agent_run.go
+++ b/backend/internal/adapter/action/agent_run.go
@@ -33,25 +33,32 @@ type AgentConfig struct {
 //   - Callback mode: claude_code/opencode/cma runtimes use HTTP callbacks for logs/cost/status
 //   - Legacy mode: no runtime kind (older images) uses Docker log streaming and exit code detection
 type AgentRunAction struct {
-	containerMgr port.ContainerManager
-	logStreamer  port.LogStreamer
-	eventPub     port.EventPublisher
-	storyRepo    port.StoryRepository
-	projectRepo  port.ProjectRepository
-	runRepo      port.RunRepository
-	renderer     port.TemplateRenderer
-	costSvc      *service.CostService
-	config       AgentConfig
-	logger       *slog.Logger
-	apiKeySvc    *service.APIKeyService
-	tokenStore   port.ContainerTokenStore
-	statusStore  port.CallbackStatusStore
-	callbackURL  string
+	containerMgr    port.ContainerManager
+	logStreamer     port.LogStreamer
+	eventPub        port.EventPublisher
+	storyRepo       port.StoryRepository
+	projectRepo     port.ProjectRepository
+	runRepo         port.RunRepository
+	environmentRepo port.EnvironmentRepository
+	sidecarMgr      port.SidecarManager
+	renderer        port.TemplateRenderer
+	costSvc         *service.CostService
+	config          AgentConfig
+	logger          *slog.Logger
+	apiKeySvc       *service.APIKeyService
+	tokenStore      port.ContainerTokenStore
+	statusStore     port.CallbackStatusStore
+	callbackURL     string
 }
 
 // NewAgentRunAction creates a new agent run action.
 // The apiKeySvc, tokenStore, statusStore, and callbackURL parameters enable callback mode
 // for the claude_code/opencode/cma runtimes. Pass nil/empty to disable callback mode.
+//
+// environmentRepo and sidecarMgr drive the per-run Environment: when the project has an
+// Environment with sidecar services, sidecarMgr brings them up on an isolated per-run
+// network and their connection strings are injected into the agent container. Both are
+// nil-safe at the call sites; a project without an Environment behaves exactly as before.
 func NewAgentRunAction(
 	containerMgr port.ContainerManager,
 	logStreamer port.LogStreamer,
@@ -59,6 +66,8 @@ func NewAgentRunAction(
 	storyRepo port.StoryRepository,
 	projectRepo port.ProjectRepository,
 	runRepo port.RunRepository,
+	environmentRepo port.EnvironmentRepository,
+	sidecarMgr port.SidecarManager,
 	renderer port.TemplateRenderer,
 	costSvc *service.CostService,
 	config AgentConfig,
@@ -69,20 +78,22 @@ func NewAgentRunAction(
 	callbackURL string,
 ) *AgentRunAction {
 	return &AgentRunAction{
-		containerMgr: containerMgr,
-		logStreamer:  logStreamer,
-		eventPub:     eventPub,
-		storyRepo:    storyRepo,
-		projectRepo:  projectRepo,
-		runRepo:      runRepo,
-		renderer:     renderer,
-		costSvc:      costSvc,
-		config:       config,
-		logger:       logger,
-		apiKeySvc:    apiKeySvc,
-		tokenStore:   tokenStore,
-		statusStore:  statusStore,
-		callbackURL:  callbackURL,
+		containerMgr:    containerMgr,
+		logStreamer:     logStreamer,
+		eventPub:        eventPub,
+		storyRepo:       storyRepo,
+		projectRepo:     projectRepo,
+		runRepo:         runRepo,
+		environmentRepo: environmentRepo,
+		sidecarMgr:      sidecarMgr,
+		renderer:        renderer,
+		costSvc:         costSvc,
+		config:          config,
+		logger:          logger,
+		apiKeySvc:       apiKeySvc,
+		tokenStore:      tokenStore,
+		statusStore:     statusStore,
+		callbackURL:     callbackURL,
 	}
 }
 
@@ -151,22 +162,56 @@ func (a *AgentRunAction) Execute(ctx context.Context, runCtx *model.RunContext) 
 	runtimeKind, _ := runCtx.Metadata["runtime_kind"].(string)
 	isCallbackMode := a.isCallbackMode(runtimeKind, agentImage)
 
-	// 6. Create container
-	containerID, err := a.createContainer(ctx, runCtx, project, story, agentImage, prompt, branchName)
+	// 6. Resolve the project's Environment and bring up its sidecar services.
+	// Back-compat is HARD: a project without an Environment (GetByProjectID ->
+	// NotFound) leaves env nil, no network/sidecar is created, and the container
+	// is built exactly as before. Only env-level errors other than NotFound fail.
+	env, err := a.resolveEnvironment(ctx, runCtx.ProjectID)
+	if err != nil {
+		return fmt.Errorf("resolve environment: %w", err)
+	}
+
+	// Launch sidecars on a per-run isolated network. Nil-safe: env==nil or no
+	// services yields a nil sidecarCtx and is a no-op. Fail-fast on launch error.
+	var sidecarCtx *port.SidecarContext
+	if env != nil && len(env.Services) > 0 {
+		sc, launchErr := a.sidecarMgr.Launch(ctx, runCtx.Run.ID, env)
+		if launchErr != nil {
+			return fmt.Errorf("launch sidecars: %w", launchErr)
+		}
+		sidecarCtx = sc
+		// Teardown is GUARANTEED even if a later step fails. Cleanup runs on its
+		// own detached, bounded context inside the SidecarManager, so it works
+		// even when ctx is already cancelled.
+		defer func() {
+			if cleanupErr := a.sidecarMgr.Cleanup(context.Background(), sidecarCtx); cleanupErr != nil {
+				a.logger.Warn("failed to clean up sidecars",
+					"run_id", runCtx.Run.ID, "error", cleanupErr)
+			}
+		}()
+	}
+
+	// Build connection strings for the sidecar services (DATABASE_URL, etc.).
+	// nil when there is no Environment — extraEnv stays nil and the container env
+	// is byte-for-byte identical to the pre-Environment behaviour.
+	extraEnv := buildConnStrings(env)
+
+	// 7. Create container
+	containerID, err := a.createContainer(ctx, runCtx, project, story, agentImage, prompt, branchName, extraEnv, sidecarCtx)
 	if err != nil {
 		return fmt.Errorf("create container: %w", err)
 	}
 	defer a.cleanupContainer(containerID)
 
-	// 7. Start container
+	// 8. Start container
 	if err := a.containerMgr.Start(ctx, containerID); err != nil {
 		return fmt.Errorf("start container: %w", err)
 	}
 
-	// 8. Persist container ID to run step
+	// 9. Persist container ID to run step
 	a.persistContainerID(ctx, runCtx.RunStep.ID, containerID)
 
-	// 9. Wait for completion using the appropriate mode
+	// 10. Wait for completion using the appropriate mode
 	var exitCode int
 	if isCallbackMode {
 		exitCode, err = a.waitForCallback(ctx, runCtx)
@@ -177,7 +222,7 @@ func (a *AgentRunAction) Execute(ctx context.Context, runCtx *model.RunContext) 
 		return fmt.Errorf("stream/wait: %w", err)
 	}
 
-	// 10. Check exit code
+	// 11. Check exit code
 	if exitCode != 0 {
 		return fmt.Errorf("agent exited with code %d", exitCode)
 	}
@@ -263,6 +308,8 @@ func (a *AgentRunAction) createContainer(
 	project *model.Project,
 	story *model.Story,
 	agentImage, prompt, branchName string,
+	extraEnv []string,
+	sidecarCtx *port.SidecarContext,
 ) (string, error) {
 	repoURL := ""
 	if project.RepoURL != nil {
@@ -353,6 +400,10 @@ func (a *AgentRunAction) createContainer(
 		}
 	}
 
+	// Append sidecar connection strings LAST, preserving the existing env order so
+	// the slice is byte-for-byte identical to before when extraEnv is nil.
+	env = append(env, extraEnv...)
+
 	opts := model.ContainerOpts{
 		Image:       agentImage,
 		NetworkName: a.config.NetworkName,
@@ -365,6 +416,14 @@ func (a *AgentRunAction) createContainer(
 			"step_id":    runCtx.RunStep.ID.String(),
 			"story_key":  story.Key,
 		},
+	}
+
+	// Dual-home the agent container: it keeps its shared NetworkName (API callback
+	// / egress) AND attaches to the run network so it can reach the sidecars by
+	// their service-name DNS alias. Only set when a run network actually exists,
+	// so a project without an Environment keeps identical ContainerOpts.
+	if sidecarCtx != nil && sidecarCtx.NetworkName != "" {
+		opts.ExtraNetworks = []string{sidecarCtx.NetworkName}
 	}
 
 	return a.containerMgr.Create(ctx, opts)

--- a/backend/internal/adapter/action/agent_run_environment.go
+++ b/backend/internal/adapter/action/agent_run_environment.go
@@ -3,6 +3,8 @@ package action
 import (
 	"context"
 	stderrors "errors"
+	"net/url"
+	"strconv"
 
 	"github.com/google/uuid"
 
@@ -57,62 +59,88 @@ func buildConnStrings(env *model.Environment) []string {
 
 // connStringsForService returns the connection-string env entries for a single
 // service, or nil when its type is unknown.
+//
+// URLs are assembled with net/url, never by raw concatenation: svc.Env is
+// user-controlled, so a password containing reserved characters (@ : / # ?) is
+// percent-encoded via url.UserPassword and cannot break the URL or inject extra
+// components. Ports come from model.ServicePort(svcType) — the single source of
+// truth shared with the Docker readiness probe — not from literals.
 func connStringsForService(svc model.EnvironmentService) []string {
 	host := svc.Name // DNS alias on the per-run network.
-	switch model.DetectServiceType(svc.Image) {
+	svcType := model.DetectServiceType(svc.Image)
+	port := model.ServicePort(svcType)
+	hostport := host + ":" + strconv.Itoa(port)
+
+	switch svcType {
 	case model.ServiceTypePostgres:
 		user := envOr(svc.Env, "POSTGRES_USER", "postgres")
 		pass := envOr(svc.Env, "POSTGRES_PASSWORD", "postgres")
 		db := envOr(svc.Env, "POSTGRES_DB", user)
-		return []string{
-			"DATABASE_URL=postgres://" + user + ":" + pass + "@" + host + ":5432/" + db,
+		u := url.URL{
+			Scheme: "postgres",
+			User:   url.UserPassword(user, pass),
+			Host:   hostport,
+			Path:   "/" + db,
 		}
+		return []string{"DATABASE_URL=" + u.String()}
 	case model.ServiceTypeMySQL, model.ServiceTypeMariaDB:
 		user := envOr(svc.Env, "MYSQL_USER", "root")
 		pass := envOr(svc.Env, "MYSQL_PASSWORD", envOr(svc.Env, "MYSQL_ROOT_PASSWORD", ""))
 		db := envOr(svc.Env, "MYSQL_DATABASE", "")
-		creds := user
-		if pass != "" {
-			creds = user + ":" + pass
+		u := url.URL{
+			Scheme: "mysql",
+			User:   userInfo(user, pass),
+			Host:   hostport,
+			Path:   "/" + db,
 		}
-		return []string{
-			"DATABASE_URL=mysql://" + creds + "@" + host + ":3306/" + db,
-		}
+		return []string{"DATABASE_URL=" + u.String()}
 	case model.ServiceTypeRedis:
 		pass := envOr(svc.Env, "REDIS_PASSWORD", "")
-		auth := ""
+		u := url.URL{
+			Scheme: "redis",
+			Host:   hostport,
+			Path:   "/0",
+		}
+		// Redis AUTH with no username: userinfo is ":<password>".
 		if pass != "" {
-			auth = ":" + pass + "@"
+			u.User = url.UserPassword("", pass)
 		}
-		return []string{
-			"REDIS_URL=redis://" + auth + host + ":6379/0",
-		}
+		return []string{"REDIS_URL=" + u.String()}
 	case model.ServiceTypeMongo:
 		user := envOr(svc.Env, "MONGO_INITDB_ROOT_USERNAME", "")
 		pass := envOr(svc.Env, "MONGO_INITDB_ROOT_PASSWORD", "")
-		creds := ""
-		if user != "" {
-			creds = user
-			if pass != "" {
-				creds = user + ":" + pass
-			}
-			creds += "@"
+		u := url.URL{
+			Scheme: "mongodb",
+			User:   userInfo(user, pass),
+			Host:   hostport,
 		}
-		return []string{
-			"MONGODB_URL=mongodb://" + creds + host + ":27017",
-		}
+		return []string{"MONGODB_URL=" + u.String()}
 	case model.ServiceTypeElasticsearch:
-		return []string{
-			"ELASTICSEARCH_URL=http://" + host + ":9200",
-		}
+		u := url.URL{Scheme: "http", Host: hostport}
+		return []string{"ELASTICSEARCH_URL=" + u.String()}
 	case model.ServiceTypeMailHog:
 		return []string{
 			"SMTP_HOST=" + host,
-			"SMTP_PORT=1025",
+			"SMTP_PORT=" + strconv.Itoa(port),
 		}
 	default:
 		// Unknown type: no auto connection string (still DNS-reachable).
 		return nil
+	}
+}
+
+// userInfo builds the URL userinfo for a service that authenticates with an
+// optional user + optional password. Returns nil (no userinfo) when no user is
+// set, user-only when there is no password, and user:password otherwise. The
+// password is always percent-encoded by url.UserPassword.
+func userInfo(user, pass string) *url.Userinfo {
+	switch {
+	case user == "":
+		return nil
+	case pass == "":
+		return url.User(user)
+	default:
+		return url.UserPassword(user, pass)
 	}
 }
 

--- a/backend/internal/adapter/action/agent_run_environment.go
+++ b/backend/internal/adapter/action/agent_run_environment.go
@@ -1,0 +1,127 @@
+package action
+
+import (
+	"context"
+	stderrors "errors"
+
+	"github.com/google/uuid"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	apperrors "github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// resolveEnvironment fetches the project's single Environment for the run path.
+//
+// Back-compat is HARD: a project that has no Environment yields NotFound from the
+// repository, which is NOT an error here — it returns (nil, nil) so the run
+// behaves exactly as it did before Environments existed (no sidecars, no extra
+// env, no run network). Any OTHER error is propagated and fails the run.
+func (a *AgentRunAction) resolveEnvironment(ctx context.Context, projectID uuid.UUID) (*model.Environment, error) {
+	env, err := a.environmentRepo.GetByProjectID(ctx, projectID)
+	if err != nil {
+		var de *apperrors.DomainError
+		if stderrors.As(err, &de) && de.Category == apperrors.CategoryNotFound {
+			// No Environment for this project: legacy behaviour.
+			return nil, nil
+		}
+		return nil, err
+	}
+	return env, nil
+}
+
+// buildConnStrings derives one or more "KEY=value" connection-string env entries
+// per sidecar service in env, keyed by the service type detected from its image.
+// The hostname is the service Name (its DNS alias on the per-run network), and
+// credentials are read from the service's own Env using the conventional keys
+// each image honours, falling back to sensible defaults when absent.
+//
+// Returns nil when env is nil or declares no services, so a project without an
+// Environment injects no extra env and stays byte-for-byte identical to before.
+// Unknown service types produce no auto connection string (documented limit):
+// such services are still reachable by DNS on the run network, but the run is
+// expected to configure them itself.
+func buildConnStrings(env *model.Environment) []string {
+	if env == nil || len(env.Services) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(env.Services))
+	for _, svc := range env.Services {
+		out = append(out, connStringsForService(svc)...)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// connStringsForService returns the connection-string env entries for a single
+// service, or nil when its type is unknown.
+func connStringsForService(svc model.EnvironmentService) []string {
+	host := svc.Name // DNS alias on the per-run network.
+	switch model.DetectServiceType(svc.Image) {
+	case model.ServiceTypePostgres:
+		user := envOr(svc.Env, "POSTGRES_USER", "postgres")
+		pass := envOr(svc.Env, "POSTGRES_PASSWORD", "postgres")
+		db := envOr(svc.Env, "POSTGRES_DB", user)
+		return []string{
+			"DATABASE_URL=postgres://" + user + ":" + pass + "@" + host + ":5432/" + db,
+		}
+	case model.ServiceTypeMySQL, model.ServiceTypeMariaDB:
+		user := envOr(svc.Env, "MYSQL_USER", "root")
+		pass := envOr(svc.Env, "MYSQL_PASSWORD", envOr(svc.Env, "MYSQL_ROOT_PASSWORD", ""))
+		db := envOr(svc.Env, "MYSQL_DATABASE", "")
+		creds := user
+		if pass != "" {
+			creds = user + ":" + pass
+		}
+		return []string{
+			"DATABASE_URL=mysql://" + creds + "@" + host + ":3306/" + db,
+		}
+	case model.ServiceTypeRedis:
+		pass := envOr(svc.Env, "REDIS_PASSWORD", "")
+		auth := ""
+		if pass != "" {
+			auth = ":" + pass + "@"
+		}
+		return []string{
+			"REDIS_URL=redis://" + auth + host + ":6379/0",
+		}
+	case model.ServiceTypeMongo:
+		user := envOr(svc.Env, "MONGO_INITDB_ROOT_USERNAME", "")
+		pass := envOr(svc.Env, "MONGO_INITDB_ROOT_PASSWORD", "")
+		creds := ""
+		if user != "" {
+			creds = user
+			if pass != "" {
+				creds = user + ":" + pass
+			}
+			creds += "@"
+		}
+		return []string{
+			"MONGODB_URL=mongodb://" + creds + host + ":27017",
+		}
+	case model.ServiceTypeElasticsearch:
+		return []string{
+			"ELASTICSEARCH_URL=http://" + host + ":9200",
+		}
+	case model.ServiceTypeMailHog:
+		return []string{
+			"SMTP_HOST=" + host,
+			"SMTP_PORT=1025",
+		}
+	default:
+		// Unknown type: no auto connection string (still DNS-reachable).
+		return nil
+	}
+}
+
+// envOr returns env[key] when present and non-empty, otherwise def.
+func envOr(env map[string]string, key, def string) string {
+	if env != nil {
+		if v, ok := env[key]; ok && v != "" {
+			return v
+		}
+	}
+	return def
+}

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -351,6 +352,88 @@ func (m *mockTemplateRenderer) Render(templateContent string, _ *model.TemplateC
 	return "rendered: " + templateContent[:min(20, len(templateContent))], nil
 }
 
+// mockEnvironmentRepo is an EnvironmentRepository mock. By default GetByProjectID
+// returns NotFound, modelling a project with no Environment (legacy behaviour).
+type mockEnvironmentRepo struct {
+	getByProjectIDFn func(ctx context.Context, projectID uuid.UUID) (*model.Environment, error)
+}
+
+func (m *mockEnvironmentRepo) Create(_ context.Context, e *model.Environment) (*model.Environment, error) {
+	return e, nil
+}
+func (m *mockEnvironmentRepo) GetByID(_ context.Context, id uuid.UUID) (*model.Environment, error) {
+	return nil, errors.NewNotFound("environment", id)
+}
+func (m *mockEnvironmentRepo) GetByProjectID(ctx context.Context, projectID uuid.UUID) (*model.Environment, error) {
+	if m.getByProjectIDFn != nil {
+		return m.getByProjectIDFn(ctx, projectID)
+	}
+	return nil, errors.NewNotFound("environment", projectID)
+}
+func (m *mockEnvironmentRepo) Update(_ context.Context, e *model.Environment) (*model.Environment, error) {
+	return e, nil
+}
+func (m *mockEnvironmentRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
+
+// mockSidecarManager is a SidecarManager mock. launchFn defaults to a guard that
+// FAILS the test if Launch is ever called: the back-compat golden test relies on
+// Launch staying untouched when a project has no Environment.
+type mockSidecarManager struct {
+	t *testing.T
+
+	launchFn func(ctx context.Context, runID uuid.UUID, env *model.Environment) (*port.SidecarContext, error)
+
+	mu           sync.Mutex
+	launchCalls  int
+	cleanupCalls int
+	stopCalls    int
+}
+
+func (m *mockSidecarManager) Launch(ctx context.Context, runID uuid.UUID, env *model.Environment) (*port.SidecarContext, error) {
+	m.mu.Lock()
+	m.launchCalls++
+	m.mu.Unlock()
+	if m.launchFn != nil {
+		return m.launchFn(ctx, runID, env)
+	}
+	if m.t != nil {
+		m.t.Errorf("SidecarManager.Launch must not be called when project has no Environment")
+	}
+	return nil, fmt.Errorf("unexpected Launch call")
+}
+
+func (m *mockSidecarManager) Stop(_ context.Context, _ *port.SidecarContext) error {
+	m.mu.Lock()
+	m.stopCalls++
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *mockSidecarManager) Cleanup(_ context.Context, _ *port.SidecarContext) error {
+	m.mu.Lock()
+	m.cleanupCalls++
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *mockSidecarManager) ListOrphanNetworks(_ context.Context) ([]model.NetworkInfo, error) {
+	return nil, nil
+}
+
+func (m *mockSidecarManager) GC(_ context.Context, _ time.Duration) error { return nil }
+
+func (m *mockSidecarManager) getLaunchCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.launchCalls
+}
+
+func (m *mockSidecarManager) getCleanupCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.cleanupCalls
+}
+
 // --- Test fixture ---
 
 // mockCostRepo is a no-op CostRepository for use in AgentRunAction tests.
@@ -415,13 +498,15 @@ type agentRunFixture struct {
 	run     *model.Run
 	runStep *model.RunStep
 
-	containerMgr *mockContainerManager
-	logStreamer  *mockLogStreamer
-	eventPub     *mockEventPublisher
-	storyRepo    *mockStoryRepo
-	projectRepo  *mockProjectRepo
-	runRepo      *mockRunRepo
-	costSvc      *service.CostService
+	containerMgr    *mockContainerManager
+	logStreamer     *mockLogStreamer
+	eventPub        *mockEventPublisher
+	storyRepo       *mockStoryRepo
+	projectRepo     *mockProjectRepo
+	runRepo         *mockRunRepo
+	environmentRepo *mockEnvironmentRepo
+	sidecarMgr      *mockSidecarManager
+	costSvc         *service.CostService
 
 	action *action.AgentRunAction
 }
@@ -514,6 +599,12 @@ func newAgentRunFixture(t *testing.T) *agentRunFixture {
 	}
 	f.runRepo = &mockRunRepo{}
 
+	// Default: project has no Environment (GetByProjectID -> NotFound) and the
+	// SidecarManager guards against any Launch call. This is the legacy path the
+	// back-compat golden test pins.
+	f.environmentRepo = &mockEnvironmentRepo{}
+	f.sidecarMgr = &mockSidecarManager{t: t}
+
 	// Create a real TemplateRenderer
 	renderer := &mockTemplateRenderer{}
 
@@ -534,6 +625,8 @@ func newAgentRunFixture(t *testing.T) *agentRunFixture {
 		f.storyRepo,
 		f.projectRepo,
 		f.runRepo,
+		f.environmentRepo,
+		f.sidecarMgr,
 		renderer,
 		f.costSvc,
 		agentCfg,
@@ -1009,6 +1102,184 @@ func TestAgentRunAction_ModelFallback(t *testing.T) {
 			t.Errorf("expected no MODEL env var when model is not in metadata, got %q", env)
 		}
 	}
+}
+
+// TestAgentRunAction_NoEnvironment_GoldenBackCompat is the cardinal back-compat
+// gate. A run whose project has NO Environment (GetByProjectID -> NotFound) must
+// produce ContainerOpts STRICTLY identical to the pre-P2c2c behaviour: no extra
+// connection-string env, no ExtraNetworks, and the SidecarManager is never asked
+// to Launch. The guard mockSidecarManager fails the test if Launch is called.
+func TestAgentRunAction_NoEnvironment_GoldenBackCompat(t *testing.T) {
+	f := newAgentRunFixture(t)
+	runCtx := f.newRunContext()
+
+	if err := f.action.Execute(context.Background(), runCtx); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// SidecarManager.Launch must NOT have been called.
+	if got := f.sidecarMgr.getLaunchCalls(); got != 0 {
+		t.Fatalf("expected 0 Launch calls for a project with no Environment, got %d", got)
+	}
+	// No Environment -> no sidecar teardown either.
+	if got := f.sidecarMgr.getCleanupCalls(); got != 0 {
+		t.Fatalf("expected 0 Cleanup calls for a project with no Environment, got %d", got)
+	}
+
+	f.containerMgr.mu.Lock()
+	createCalls := f.containerMgr.createCalls
+	f.containerMgr.mu.Unlock()
+	if len(createCalls) != 1 {
+		t.Fatalf("expected 1 create call, got %d", len(createCalls))
+	}
+	opts := createCalls[0]
+
+	// Golden invariant 1: ExtraNetworks empty (container is single-homed exactly
+	// like before P2c2c).
+	if len(opts.ExtraNetworks) != 0 {
+		t.Errorf("expected empty ExtraNetworks, got %v", opts.ExtraNetworks)
+	}
+	// Golden invariant 2: NetworkName unchanged (the shared agent network only).
+	if opts.NetworkName != "test-network" {
+		t.Errorf("expected NetworkName test-network, got %q", opts.NetworkName)
+	}
+	// Golden invariant 3: no connection-string env leaked in.
+	for _, key := range []string{"DATABASE_URL", "REDIS_URL", "MONGODB_URL", "ELASTICSEARCH_URL", "SMTP_HOST", "SMTP_PORT"} {
+		for _, e := range opts.Env {
+			if strings.HasPrefix(e, key+"=") {
+				t.Errorf("expected no %s in env for a project with no Environment, got %q", key, e)
+			}
+		}
+	}
+
+	// Golden invariant 4: the env slice equals the legacy set, field-by-field.
+	// Build the expected legacy env exactly as createContainer would with no
+	// extraEnv, sort both, and compare element-by-element.
+	wantEnv := []string{
+		"REPO_URL=https://github.com/test/repo",
+		"BRANCH_NAME=feat/s-42-test",
+		"STORY_KEY=S-42",
+		"PROMPT_CONTENT=" + envValue(opts.Env, "PROMPT_CONTENT"),
+		"PROMPT=" + envValue(opts.Env, "PROMPT"),
+		"GIT_TOKEN=" + envValue(opts.Env, "GIT_TOKEN"),
+		"GIT_PROVIDER=" + envValue(opts.Env, "GIT_PROVIDER"),
+		"GITHUB_TOKEN=" + envValue(opts.Env, "GITHUB_TOKEN"),
+		"CLAUDE_MD_CONTENT=" + envValue(opts.Env, "CLAUDE_MD_CONTENT"),
+		"CLAUDE_CODE_OAUTH_TOKEN=" + envValue(opts.Env, "CLAUDE_CODE_OAUTH_TOKEN"),
+	}
+	gotEnv := append([]string(nil), opts.Env...)
+	sort.Strings(gotEnv)
+	sort.Strings(wantEnv)
+	if len(gotEnv) != len(wantEnv) {
+		t.Fatalf("env length mismatch: got %d (%v), want %d (%v)", len(gotEnv), gotEnv, len(wantEnv), wantEnv)
+	}
+	for i := range gotEnv {
+		if gotEnv[i] != wantEnv[i] {
+			t.Errorf("env[%d] mismatch:\n got=%q\nwant=%q", i, gotEnv[i], wantEnv[i])
+		}
+	}
+
+	// Golden invariant 5: labels unchanged.
+	if opts.Labels["managed_by"] != "hopeitworks" ||
+		opts.Labels["run_id"] != f.runID.String() ||
+		opts.Labels["step_id"] != f.stepID.String() ||
+		opts.Labels["story_key"] != "S-42" {
+		t.Errorf("labels changed: %v", opts.Labels)
+	}
+	// Golden invariant 6: resource limits unchanged.
+	if opts.Memory != 4294967296 || opts.CPUs != 2.0 {
+		t.Errorf("resource limits changed: memory=%d cpus=%f", opts.Memory, opts.CPUs)
+	}
+}
+
+// TestAgentRunAction_WithEnvironment_SidecarWiring proves the live path: a project
+// WITH an Environment (one postgres service) launches sidecars, injects
+// DATABASE_URL, dual-homes the agent container on the run network, and tears the
+// sidecars down via the deferred Cleanup even when a later step fails.
+func TestAgentRunAction_WithEnvironment_SidecarWiring(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	runNetwork := "hopeitworks-run-" + f.runID.String()
+	env := &model.Environment{
+		ProjectID: f.projectID,
+		Services: []model.EnvironmentService{
+			{
+				Name:  "db",
+				Image: "postgres:16",
+				Env: map[string]string{
+					"POSTGRES_USER":     "app",
+					"POSTGRES_PASSWORD": "secret",
+					"POSTGRES_DB":       "appdb",
+				},
+			},
+		},
+	}
+	f.environmentRepo.getByProjectIDFn = func(_ context.Context, _ uuid.UUID) (*model.Environment, error) {
+		return env, nil
+	}
+	f.sidecarMgr.launchFn = func(_ context.Context, runID uuid.UUID, gotEnv *model.Environment) (*port.SidecarContext, error) {
+		if gotEnv != env {
+			t.Errorf("Launch received unexpected environment")
+		}
+		return &port.SidecarContext{
+			RunID:        runID,
+			NetworkName:  runNetwork,
+			ContainerIDs: map[string]string{"db": "sidecar-db"},
+			ServiceAddrs: map[string]string{"db": "db"},
+		}, nil
+	}
+
+	// Make a later step fail to prove the deferred Cleanup still runs.
+	f.containerMgr.startFn = func(_ context.Context, _ string) error {
+		return fmt.Errorf("docker start error")
+	}
+
+	runCtx := f.newRunContext()
+	if err := f.action.Execute(context.Background(), runCtx); err == nil {
+		t.Fatal("expected error from start failure, got nil")
+	}
+
+	// Launch was called exactly once.
+	if got := f.sidecarMgr.getLaunchCalls(); got != 1 {
+		t.Fatalf("expected 1 Launch call, got %d", got)
+	}
+	// Cleanup runs even though a later step failed (deferred teardown).
+	if got := f.sidecarMgr.getCleanupCalls(); got != 1 {
+		t.Fatalf("expected 1 Cleanup call (deferred), got %d", got)
+	}
+
+	f.containerMgr.mu.Lock()
+	createCalls := f.containerMgr.createCalls
+	f.containerMgr.mu.Unlock()
+	if len(createCalls) != 1 {
+		t.Fatalf("expected 1 create call, got %d", len(createCalls))
+	}
+	opts := createCalls[0]
+
+	// DATABASE_URL injected from the postgres service.
+	wantURL := "postgres://app:secret@db:5432/appdb"
+	if got := envValue(opts.Env, "DATABASE_URL"); got != wantURL {
+		t.Errorf("expected DATABASE_URL=%q, got %q", wantURL, got)
+	}
+
+	// Dual-homing: keeps shared NetworkName AND attaches to the run network.
+	if opts.NetworkName != "test-network" {
+		t.Errorf("expected shared NetworkName test-network, got %q", opts.NetworkName)
+	}
+	if len(opts.ExtraNetworks) != 1 || opts.ExtraNetworks[0] != runNetwork {
+		t.Errorf("expected ExtraNetworks=[%s], got %v", runNetwork, opts.ExtraNetworks)
+	}
+}
+
+// envValue returns the value of the first KEY=value entry matching key, or "".
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			return e[len(prefix):]
+		}
+	}
+	return ""
 }
 
 func (m *mockStoryRepo) CountByEpicGroupedByStatus(_ context.Context, _ uuid.UUID) (model.StoryCounts, error) {

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -22,6 +22,11 @@ import (
 
 const testContainerID = "container-123"
 
+const (
+	testNetwork  = "test-network"
+	testStoryKey = "S-42"
+)
+
 // testLogger creates a silent logger for tests.
 func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -527,7 +532,7 @@ func newAgentRunFixture(t *testing.T) *agentRunFixture {
 	f.story = &model.Story{
 		ID:                 f.storyID,
 		ProjectID:          f.projectID,
-		Key:                "S-42",
+		Key:                testStoryKey,
 		Title:              "Test Story",
 		Objective:          strPtr("Implement feature X"),
 		Scope:              &backendScope,
@@ -615,7 +620,7 @@ func newAgentRunFixture(t *testing.T) *agentRunFixture {
 	agentCfg := action.AgentConfig{
 		DefaultMemory: 4294967296,
 		DefaultCPUs:   2.0,
-		NetworkName:   "test-network",
+		NetworkName:   testNetwork,
 		LogTailLines:  50,
 	}
 
@@ -685,8 +690,8 @@ func TestAgentRunAction_HappyPath(t *testing.T) {
 	if opts.Image != "hopeitworks/agent:latest" {
 		t.Errorf("expected image %q, got %q", "hopeitworks/agent:latest", opts.Image)
 	}
-	if opts.NetworkName != "test-network" {
-		t.Errorf("expected network %q, got %q", "test-network", opts.NetworkName)
+	if opts.NetworkName != testNetwork {
+		t.Errorf("expected network %q, got %q", testNetwork, opts.NetworkName)
 	}
 	if opts.Memory != 4294967296 {
 		t.Errorf("expected memory 4294967296, got %d", opts.Memory)
@@ -705,7 +710,7 @@ func TestAgentRunAction_HappyPath(t *testing.T) {
 	if opts.Labels["step_id"] != f.stepID.String() {
 		t.Errorf("expected step_id label %s, got %s", f.stepID, opts.Labels["step_id"])
 	}
-	if opts.Labels["story_key"] != "S-42" {
+	if opts.Labels["story_key"] != testStoryKey {
 		t.Errorf("expected story_key label S-42, got %s", opts.Labels["story_key"])
 	}
 
@@ -729,7 +734,7 @@ func TestAgentRunAction_HappyPath(t *testing.T) {
 	if envMap["BRANCH_NAME"] != "feat/s-42-test" {
 		t.Errorf("expected BRANCH_NAME feat/s-42-test, got %q", envMap["BRANCH_NAME"])
 	}
-	if envMap["STORY_KEY"] != "S-42" {
+	if envMap["STORY_KEY"] != testStoryKey {
 		t.Errorf("expected STORY_KEY S-42, got %q", envMap["STORY_KEY"])
 	}
 	if _, ok := envMap["PROMPT_CONTENT"]; !ok {
@@ -1141,7 +1146,7 @@ func TestAgentRunAction_NoEnvironment_GoldenBackCompat(t *testing.T) {
 		t.Errorf("expected empty ExtraNetworks, got %v", opts.ExtraNetworks)
 	}
 	// Golden invariant 2: NetworkName unchanged (the shared agent network only).
-	if opts.NetworkName != "test-network" {
+	if opts.NetworkName != testNetwork {
 		t.Errorf("expected NetworkName test-network, got %q", opts.NetworkName)
 	}
 	// Golden invariant 3: no connection-string env leaked in.
@@ -1184,7 +1189,7 @@ func TestAgentRunAction_NoEnvironment_GoldenBackCompat(t *testing.T) {
 	if opts.Labels["managed_by"] != "hopeitworks" ||
 		opts.Labels["run_id"] != f.runID.String() ||
 		opts.Labels["step_id"] != f.stepID.String() ||
-		opts.Labels["story_key"] != "S-42" {
+		opts.Labels["story_key"] != testStoryKey {
 		t.Errorf("labels changed: %v", opts.Labels)
 	}
 	// Golden invariant 6: resource limits unchanged.
@@ -1264,7 +1269,7 @@ func TestAgentRunAction_WithEnvironment_SidecarWiring(t *testing.T) {
 	}
 
 	// Dual-homing: keeps shared NetworkName AND attaches to the run network.
-	if opts.NetworkName != "test-network" {
+	if opts.NetworkName != testNetwork {
 		t.Errorf("expected shared NetworkName test-network, got %q", opts.NetworkName)
 	}
 	if len(opts.ExtraNetworks) != 1 || opts.ExtraNetworks[0] != runNetwork {

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -1268,6 +1269,90 @@ func TestAgentRunAction_WithEnvironment_SidecarWiring(t *testing.T) {
 	}
 	if len(opts.ExtraNetworks) != 1 || opts.ExtraNetworks[0] != runNetwork {
 		t.Errorf("expected ExtraNetworks=[%s], got %v", runNetwork, opts.ExtraNetworks)
+	}
+}
+
+// TestAgentRunAction_ConnString_EscapesCredentials proves the connection-string
+// builder percent-encodes user-controlled credentials. A POSTGRES_PASSWORD made
+// of URL-reserved characters (@ : / # ?) must yield a DATABASE_URL that parses
+// cleanly with url.Parse and whose userinfo round-trips back to the exact
+// password — no broken URL, no injected components.
+func TestAgentRunAction_ConnString_EscapesCredentials(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	const rawPass = "p@s:w/rd#?x"
+	env := &model.Environment{
+		ProjectID: f.projectID,
+		Services: []model.EnvironmentService{
+			{
+				Name:  "db",
+				Image: "postgres:16",
+				Env: map[string]string{
+					"POSTGRES_USER":     "app",
+					"POSTGRES_PASSWORD": rawPass,
+					"POSTGRES_DB":       "appdb",
+				},
+			},
+		},
+	}
+	f.environmentRepo.getByProjectIDFn = func(_ context.Context, _ uuid.UUID) (*model.Environment, error) {
+		return env, nil
+	}
+	f.sidecarMgr.launchFn = func(_ context.Context, runID uuid.UUID, _ *model.Environment) (*port.SidecarContext, error) {
+		return &port.SidecarContext{
+			RunID:        runID,
+			NetworkName:  "hopeitworks-run-" + runID.String(),
+			ContainerIDs: map[string]string{"db": "sidecar-db"},
+			ServiceAddrs: map[string]string{"db": "db"},
+		}, nil
+	}
+
+	if err := f.action.Execute(context.Background(), f.newRunContext()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	f.containerMgr.mu.Lock()
+	createCalls := f.containerMgr.createCalls
+	f.containerMgr.mu.Unlock()
+	if len(createCalls) != 1 {
+		t.Fatalf("expected 1 create call, got %d", len(createCalls))
+	}
+
+	raw := envValue(createCalls[0].Env, "DATABASE_URL")
+	if raw == "" {
+		t.Fatal("expected DATABASE_URL to be set")
+	}
+	// The raw env value must NOT contain the unescaped password verbatim — the
+	// reserved characters must be percent-encoded.
+	if strings.Contains(raw, rawPass) {
+		t.Errorf("expected password to be percent-encoded, but raw URL contains it verbatim: %q", raw)
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("DATABASE_URL must be parsable, got error: %v (url=%q)", err, raw)
+	}
+	if parsed.Scheme != "postgres" {
+		t.Errorf("expected scheme postgres, got %q", parsed.Scheme)
+	}
+	if parsed.Host != "db:5432" {
+		t.Errorf("expected host db:5432, got %q", parsed.Host)
+	}
+	if parsed.Path != "/appdb" {
+		t.Errorf("expected path /appdb, got %q", parsed.Path)
+	}
+	if parsed.User == nil {
+		t.Fatal("expected userinfo in DATABASE_URL")
+	}
+	if parsed.User.Username() != "app" {
+		t.Errorf("expected username app, got %q", parsed.User.Username())
+	}
+	gotPass, ok := parsed.User.Password()
+	if !ok {
+		t.Fatal("expected a password in userinfo")
+	}
+	if gotPass != rawPass {
+		t.Errorf("password did not round-trip: got %q, want %q", gotPass, rawPass)
 	}
 }
 

--- a/backend/internal/adapter/docker/sidecar_manager.go
+++ b/backend/internal/adapter/docker/sidecar_manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -41,56 +40,36 @@ const (
 	defaultTeardownTimeout = 30 * time.Second
 )
 
-// serviceProfile holds the per-type knowledge needed to probe and (later, in
-// P2c2c) build connection strings for a sidecar. It is keyed by a detected
-// service type derived from the image name.
-type serviceProfile struct {
-	// healthTest is the Docker HEALTHCHECK command for this service type. Empty
-	// means "no sensible healthcheck" -> fall back to running + grace delay.
-	healthTest []string
-	// port is the service's default listen port, factored here for reuse by
-	// P2c2c connection-string injection.
-	port int
-}
-
-// serviceProfiles maps a detected service type to its probe/port profile. It is
-// intentionally small and additive; unknown types fall back to a running check.
+// serviceHealthTests is the Docker HEALTHCHECK command for each known service
+// type. It is the Docker-specific facet of a service profile; the type detection
+// and default ports live in the domain (model.DetectServiceType / model.ServicePort)
+// so the mapping is not duplicated between this readiness probe and the run-path
+// connection-string injection (action.buildConnStrings). An empty/absent entry
+// means "no sensible healthcheck" -> fall back to running + grace delay.
 //
-// TODO(P2c2c): probe creds (redis AUTH / mariadb-admin). These probes assume no
-// auth: a redis configured with requirepass returns NOAUTH (false unhealthy),
-// and mysqladmin is deprecated on recent MariaDB (use mariadb-admin). The real
-// fix injects the service credentials into the probe, which is part of the
-// connection-string work in P2c2c.
-var serviceProfiles = map[string]serviceProfile{
-	"postgres": {healthTest: []string{"CMD-SHELL", "pg_isready -U postgres || pg_isready"}, port: 5432},
-	"redis":    {healthTest: []string{"CMD", "redis-cli", "ping"}, port: 6379},
-	"mysql":    {healthTest: []string{"CMD-SHELL", "mysqladmin ping -h 127.0.0.1 --silent"}, port: 3306},
-	"mariadb":  {healthTest: []string{"CMD-SHELL", "mysqladmin ping -h 127.0.0.1 --silent"}, port: 3306},
-	"mongo":    {healthTest: []string{"CMD-SHELL", "mongosh --eval 'db.runCommand({ping:1})' || mongo --eval 'db.runCommand({ping:1})'"}, port: 27017},
+// TODO: probe creds (redis AUTH / mariadb-admin). These probes assume no auth: a
+// redis configured with requirepass returns NOAUTH (false unhealthy), and
+// mysqladmin is deprecated on recent MariaDB (use mariadb-admin). The real fix
+// injects the service credentials into the probe.
+var serviceHealthTests = map[string][]string{
+	model.ServiceTypePostgres: {"CMD-SHELL", "pg_isready -U postgres || pg_isready"},
+	model.ServiceTypeRedis:    {"CMD", "redis-cli", "ping"},
+	model.ServiceTypeMySQL:    {"CMD-SHELL", "mysqladmin ping -h 127.0.0.1 --silent"},
+	model.ServiceTypeMariaDB:  {"CMD-SHELL", "mysqladmin ping -h 127.0.0.1 --silent"},
+	model.ServiceTypeMongo:    {"CMD-SHELL", "mongosh --eval 'db.runCommand({ping:1})' || mongo --eval 'db.runCommand({ping:1})'"},
 }
 
-// servicePort returns the default listen port for a detected service type, or
-// 0 when unknown. Factored here for reuse by P2c2c connection-string injection.
+// servicePort returns the default listen port for a detected service type, or 0
+// when unknown. Thin wrapper over the domain's single source of truth.
 func servicePort(svcType string) int {
-	return serviceProfiles[svcType].port
+	return model.ServicePort(svcType)
 }
 
 // detectServiceType maps an image reference to a known service type, or "" when
-// unknown. It matches on the repository segment of the image (ignoring registry
-// host and tag), e.g. "docker.io/library/postgres:16" -> "postgres".
+// unknown. Thin wrapper over the domain's single source of truth so detection is
+// not duplicated across adapters.
 func detectServiceType(image string) string {
-	ref := image
-	if i := strings.LastIndex(ref, "/"); i >= 0 {
-		ref = ref[i+1:]
-	}
-	if i := strings.IndexAny(ref, ":@"); i >= 0 {
-		ref = ref[:i]
-	}
-	ref = strings.ToLower(ref)
-	if _, ok := serviceProfiles[ref]; ok {
-		return ref
-	}
-	return ""
+	return model.DetectServiceType(image)
 }
 
 // SidecarManager orchestrates Environment sidecars over the injected
@@ -432,12 +411,12 @@ func (s *SidecarManager) GC(ctx context.Context, olderThan time.Duration) error 
 // healthcheckFor returns the HEALTHCHECK config for a service type, or nil when
 // no sensible healthcheck exists (readiness then falls back to running+grace).
 func healthcheckFor(svcType string, interval time.Duration) *model.ContainerHealthcheck {
-	profile, ok := serviceProfiles[svcType]
-	if !ok || len(profile.healthTest) == 0 {
+	test, ok := serviceHealthTests[svcType]
+	if !ok || len(test) == 0 {
 		return nil
 	}
 	return &model.ContainerHealthcheck{
-		Test:        profile.healthTest,
+		Test:        test,
 		Interval:    interval,
 		Timeout:     3 * time.Second,
 		Retries:     3,

--- a/backend/internal/adapter/docker/sidecar_manager.go
+++ b/backend/internal/adapter/docker/sidecar_manager.go
@@ -59,12 +59,6 @@ var serviceHealthTests = map[string][]string{
 	model.ServiceTypeMongo:    {"CMD-SHELL", "mongosh --eval 'db.runCommand({ping:1})' || mongo --eval 'db.runCommand({ping:1})'"},
 }
 
-// servicePort returns the default listen port for a detected service type, or 0
-// when unknown. Thin wrapper over the domain's single source of truth.
-func servicePort(svcType string) int {
-	return model.ServicePort(svcType)
-}
-
 // detectServiceType maps an image reference to a known service type, or "" when
 // unknown. Thin wrapper over the domain's single source of truth so detection is
 // not duplicated across adapters.

--- a/backend/internal/adapter/docker/sidecar_manager_test.go
+++ b/backend/internal/adapter/docker/sidecar_manager_test.go
@@ -508,6 +508,8 @@ func TestSidecarListOrphanNetworks(t *testing.T) {
 }
 
 func TestServicePort(t *testing.T) {
+	// Ports are owned by the domain (single source of truth); the docker package
+	// no longer wraps them. Assert against model.ServicePort directly.
 	cases := map[string]int{
 		"postgres": 5432,
 		"redis":    6379,
@@ -515,8 +517,8 @@ func TestServicePort(t *testing.T) {
 		"":         0, // unknown
 	}
 	for svcType, want := range cases {
-		if got := servicePort(svcType); got != want {
-			t.Errorf("servicePort(%q) = %d, want %d", svcType, got, want)
+		if got := model.ServicePort(svcType); got != want {
+			t.Errorf("model.ServicePort(%q) = %d, want %d", svcType, got, want)
 		}
 	}
 }

--- a/backend/internal/domain/model/service_type.go
+++ b/backend/internal/domain/model/service_type.go
@@ -1,0 +1,56 @@
+package model
+
+import "strings"
+
+// Service type identifiers for sidecar services declared in an Environment. The
+// type is detected from the service image name (registry/tag stripped) and is the
+// single key both the Docker readiness probe (sidecar_manager) and the run-path
+// connection-string injection (agent_run) hang their per-type knowledge off of.
+// Keeping detection + default ports here (domain, infra-free) avoids duplicating
+// the mapping across adapters.
+const (
+	ServiceTypePostgres      = "postgres"
+	ServiceTypeRedis         = "redis"
+	ServiceTypeMySQL         = "mysql"
+	ServiceTypeMariaDB       = "mariadb"
+	ServiceTypeMongo         = "mongo"
+	ServiceTypeElasticsearch = "elasticsearch"
+	ServiceTypeMailHog       = "mailhog"
+)
+
+// servicePorts is the default listen port for each known service type. It is the
+// single source of truth for ports, reused by the Docker readiness probe and the
+// connection-string builder.
+var servicePorts = map[string]int{
+	ServiceTypePostgres:      5432,
+	ServiceTypeRedis:         6379,
+	ServiceTypeMySQL:         3306,
+	ServiceTypeMariaDB:       3306,
+	ServiceTypeMongo:         27017,
+	ServiceTypeElasticsearch: 9200,
+	ServiceTypeMailHog:       1025,
+}
+
+// DetectServiceType maps an image reference to a known service type, or "" when
+// unknown. It matches on the repository segment of the image (ignoring registry
+// host and tag/digest), e.g. "docker.io/library/postgres:16" -> "postgres".
+func DetectServiceType(image string) string {
+	ref := image
+	if i := strings.LastIndex(ref, "/"); i >= 0 {
+		ref = ref[i+1:]
+	}
+	if i := strings.IndexAny(ref, ":@"); i >= 0 {
+		ref = ref[:i]
+	}
+	ref = strings.ToLower(ref)
+	if _, ok := servicePorts[ref]; ok {
+		return ref
+	}
+	return ""
+}
+
+// ServicePort returns the default listen port for a detected service type, or 0
+// when the type is unknown.
+func ServicePort(svcType string) int {
+	return servicePorts[svcType]
+}


### PR DESCRIPTION
## P2c2c — Câblage live de l'Environment (sidecars + conn-strings)
Câble la fondation P2c2a/b dans le chemin d'exécution des agents. **Pas l'exécution des Commands** (→ P2c2d, Option A).

### Livré
- `agent_run.go` : résout l'environment du projet (`environmentRepo.GetByProjectID`, **NotFound→nil**) ; si présent et services non vides → `sidecarMgr.Launch` (réseau isolé + sidecars + readiness) + **`defer Cleanup`** (teardown garanti, ctx détaché) ; injecte les conn-strings dans l'env du container agent ; **dual-homing** du container agent (réseau partagé pour callback + réseau du run pour joindre les sidecars).
- Conn-strings construites via **`net/url`** (creds échappés) : `DATABASE_URL`/`REDIS_URL`/`MONGODB_URL`/`ELASTICSEARCH_URL`/`SMTP_*`, hostname = `service.Name` (DNS), ports via `model.ServicePort` (SoT partagée).
- Refactor : détection de type de service liftée dans `model/service_type.go` (partagée probe readiness ↔ conn-strings, zéro duplication).
- `main.go` : instancie `DockerSidecarManager`, câble `environmentRepo` + `sidecarMgr`.

### Invariant cardinal — back-compat (prouvé)
Un projet **sans** environment → `extraEnv=nil`, `ExtraNetworks` vide, **aucun `Launch`** → `ContainerOpts` **byte-identiques** à avant P2c2c. Test golden `TestAgentRunAction_NoEnvironment_GoldenBackCompat` (comparaison champ-par-champ + guard qui échoue si Launch est appelé).

### Review adversariale renforcée (chemin live) → 0 blocker
4 dimensions : back-compat **PASS** (golden airtight), correction live **PASS** (defer Cleanup garanti, fail-fast, ordre LIFO cleanupContainer→RemoveNetwork). Findings corrigés : **échappement URL des creds** (net/url, testé avec password à caractères spéciaux) + **SoT ports** (model.ServicePort, wrapper mort supprimé).

### Follow-ups (non bloquants, documentés)
- **P2c2f** : câbler le GC périodique (ListOrphanNetworks/GC déjà implémentés mais pas ordonnancés — seul filet hors `defer` aujourd'hui).
- ScrubHandler slog : élargir aux clés `*_URL` (les conn-strings ne sont pas loggées dans ce diff, risque latent).
- Défauts creds mysql/mongo, golden mode-callback : edge, à raffiner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)