### PR TITLE
feat(runtime): P3a — microsandbox substrate scaffold (inert, config-selected)

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -20,6 +20,7 @@ import (
 	gitadapter "github.com/zakari/hopeitworks/backend/internal/adapter/git"
 	hbadapter "github.com/zakari/hopeitworks/backend/internal/adapter/handlebars"
 	memoryadapter "github.com/zakari/hopeitworks/backend/internal/adapter/memory"
+	microsandboxadapter "github.com/zakari/hopeitworks/backend/internal/adapter/microsandbox"
 	pgadapter "github.com/zakari/hopeitworks/backend/internal/adapter/postgres"
 	riveradapter "github.com/zakari/hopeitworks/backend/internal/adapter/river"
 	smtpadapter "github.com/zakari/hopeitworks/backend/internal/adapter/smtp"
@@ -216,6 +217,17 @@ func run() error {
 	if err != nil {
 		logger.Warn("docker container manager unavailable, timeout enforcer and orphan cleaner disabled", "error", err)
 	}
+
+	// Substrate selection (P3a). The substrate is the execution backend that
+	// realises an agent run via port.AgentRuntime. Docker is the live default and
+	// the ONLY substrate wired into the agent_run flow below. The microsandbox
+	// adapter is a scaffold: selecting it logs the choice and constructs the
+	// (inert) AgentRuntime, but does NOT intercept execution — live runs still go
+	// through the Docker ContainerManager. This switch never touches the Docker
+	// wiring; it only records intent. The returned AgentRuntime is the scaffold
+	// adapter (microsandbox) or nil (docker); P3a does not consume it on the live
+	// path, so it is intentionally discarded here.
+	_ = selectSubstrate(cfg.Substrate.Kind, stackRepo, logger)
 
 	// HITL repository (created early because hitl_gate action needs it)
 	hitlRepo := pgadapter.NewHITLRepo(queries)
@@ -540,6 +552,28 @@ func stackCatalogueFromConfig(entries []pkgconfig.StackConfig, logger *slog.Logg
 		out = append(out, model.Stack{Key: e.Key, ImageRef: e.ImageRef, Toolchain: toolchain})
 	}
 	return out
+}
+
+// selectSubstrate logs the configured execution substrate and, for the
+// microsandbox kind, constructs the scaffold AgentRuntime adapter (P3a). The
+// adapter is intentionally inert: it is NOT wired into the live agent_run flow,
+// so live execution always uses the Docker ContainerManager regardless of this
+// selection. This function records intent only — it never alters the Docker
+// wiring. Returns the AgentRuntime when one is constructed (microsandbox), or
+// nil for the docker default (the live path needs no extra adapter).
+func selectSubstrate(kind string, stacks port.StackRepository, logger *slog.Logger) port.AgentRuntime {
+	switch kind {
+	case pkgconfig.SubstrateMicrosandbox:
+		logger.Info("substrate selected", "substrate", pkgconfig.SubstrateMicrosandbox)
+		// enabled=false: even a constructed adapter stays a stub in P3a.
+		rt := microsandboxadapter.NewRuntime(false, stacks, logger)
+		logger.Warn("microsandbox runtime is scaffold-only (P3a): live execution still uses Docker",
+			"substrate", pkgconfig.SubstrateMicrosandbox)
+		return rt
+	default:
+		logger.Info("substrate selected", "substrate", pkgconfig.SubstrateDocker)
+		return nil
+	}
 }
 
 // startTokenCleanup launches a goroutine that periodically purges expired revoked tokens.

--- a/backend/cmd/api/main_test.go
+++ b/backend/cmd/api/main_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	microsandboxadapter "github.com/zakari/hopeitworks/backend/internal/adapter/microsandbox"
+	pkgconfig "github.com/zakari/hopeitworks/backend/pkg/config"
+)
+
+// quietLogger discards output so factory tests don't spam the test log.
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestSelectSubstrate(t *testing.T) {
+	t.Run("docker default returns nil (live path needs no extra adapter)", func(t *testing.T) {
+		got := selectSubstrate(pkgconfig.SubstrateDocker, nil, quietLogger())
+		if got != nil {
+			t.Fatalf("selectSubstrate(docker) = %T, want nil", got)
+		}
+	})
+
+	t.Run("unknown kind falls through to docker default (returns nil)", func(t *testing.T) {
+		// validate() rejects unknown kinds at load time; the factory itself
+		// defaults defensively so it never panics on an unexpected value.
+		got := selectSubstrate("k8s", nil, quietLogger())
+		if got != nil {
+			t.Fatalf("selectSubstrate(unknown) = %T, want nil", got)
+		}
+	})
+
+	t.Run("microsandbox constructs the scaffold AgentRuntime", func(t *testing.T) {
+		got := selectSubstrate(pkgconfig.SubstrateMicrosandbox, nil, quietLogger())
+		if got == nil {
+			t.Fatal("selectSubstrate(microsandbox) = nil, want a scaffold adapter")
+		}
+		if _, ok := got.(*microsandboxadapter.Runtime); !ok {
+			t.Fatalf("selectSubstrate(microsandbox) = %T, want *microsandbox.Runtime", got)
+		}
+	})
+}

--- a/backend/internal/adapter/microsandbox/runtime.go
+++ b/backend/internal/adapter/microsandbox/runtime.go
@@ -1,0 +1,214 @@
+// Package microsandbox is the scaffold of the microVM substrate adapter. It
+// implements the target domain port port.AgentRuntime, but is INERT in P3a:
+//
+//   - It is NOT wired into the live agent_run flow (which still drives the
+//     Docker ContainerManager directly). The factory in main.go only logs the
+//     selected substrate; selecting "microsandbox" does not intercept execution.
+//   - Its microVM operations (Launch/Wait/Stop) are STUBS returning
+//     ErrNotImplemented — real microVM execution lands in P3b and requires a KVM
+//     host plus the microsandbox Go SDK (deliberately NOT a dependency yet).
+//
+// What IS real and testable here:
+//
+//   - SupportedCapabilities — pure data declaring which agnostic capability
+//     kinds a microVM substrate can translate.
+//   - Provision — the agnostic→supported triage with warn+skip (an unsupported
+//     capability degrades the run, never blocks it). The native translation is a
+//     TODO; the filtering is fully covered by tests.
+//   - ResolveImage — pure helper composing a launch image from a RunSpec via the
+//     stack catalogue (StackRef-by-key first, free-form spec.Image fallback),
+//     mirroring the RunService image-resolution invariant.
+package microsandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+)
+
+// Compile-time guarantee that Runtime satisfies the target runtime port.
+var _ port.AgentRuntime = (*Runtime)(nil)
+
+// ErrNotImplemented is the sentinel returned by the live-execution stubs
+// (Launch/Wait/Stop). Real microVM execution is P3b and requires a KVM host plus
+// the microsandbox Go SDK; until then these operations are intentionally absent.
+var ErrNotImplemented = errors.New("microsandbox: live execution not implemented (P3a scaffold, real microVM lands in P3b on a KVM host)")
+
+// Reasons recorded in ProvisionWarning for capabilities a microVM substrate
+// cannot (yet) translate. Kept as constants for goconst and reuse in tests.
+const (
+	reasonMCPStdioUnsupported = "stdio MCP servers require an in-image binary; not yet translated by the microsandbox substrate"
+	reasonUnknownTransport    = "unknown MCP transport"
+
+	transportHTTP  = "http"
+	transportStdio = "stdio"
+)
+
+// Runtime is the microsandbox (microVM) substrate adapter. In P3a it is a
+// scaffold: it satisfies port.AgentRuntime so the rest of the system can target
+// the stable port, but only Provision/SupportedCapabilities carry real logic.
+//
+// The name is intentionally Runtime (not MicrosandboxRuntime) — the package
+// qualifier already conveys the substrate, so callers write microsandbox.Runtime
+// without stutter.
+type Runtime struct {
+	// enabled gates the live-execution stubs. Even when enabled, P3a returns
+	// ErrNotImplemented; the flag exists so P3b can flip behaviour without
+	// changing the factory contract.
+	enabled bool
+	logger  *slog.Logger
+	// stacks resolves a stack key to its catalogued image. Optional: when nil,
+	// ResolveImage falls back to the free-form RunSpec.Image, preserving the
+	// image-only invariant.
+	stacks port.StackRepository
+}
+
+// NewRuntime constructs the scaffold microVM adapter. stacks may be nil (image
+// resolution then falls back to the free-form RunSpec.Image).
+func NewRuntime(enabled bool, stacks port.StackRepository, logger *slog.Logger) *Runtime {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Runtime{enabled: enabled, logger: logger, stacks: stacks}
+}
+
+// SupportedCapabilities declares, as pure data, which agnostic capability kinds a
+// microVM substrate can translate to its native mechanism.
+//
+// A microVM runs a normal Pod-expressible workload (the harness + materialised
+// capabilities on disk), so it supports the same on-disk capabilities as the
+// container substrate: skills (files), HTTP MCP servers (network) and tool
+// policy (CLI flags). Stdio MCP servers need an in-image binary and stronger
+// in-VM process plumbing, which the scaffold does not translate yet — hence
+// warn+skip in Provision.
+func (r *Runtime) SupportedCapabilities() model.CapabilitySet {
+	return model.CapabilitySet{
+		Skills:          true,
+		MCPServersHTTP:  true,
+		MCPServersStdio: false,
+		ToolPolicy:      true,
+	}
+}
+
+// Provision applies the agnostic capability spec to the (eventual) microVM-native
+// mechanism. P3a performs only the triage: every supported capability is recorded
+// as Applied; every unsupported one is recorded as a ProvisionWarning. It NEVER
+// returns a blocking error for an unsupported capability (warn+skip invariant).
+//
+// The actual native materialisation (skills onto the VM disk, .mcp.json, harness
+// tool flags) is P3b — marked TODO below. The triage itself is fully testable.
+func (r *Runtime) Provision(_ context.Context, spec model.CapabilitySpec) (model.ProvisionResult, error) {
+	supported := r.SupportedCapabilities()
+	var res model.ProvisionResult
+
+	// Skills: on-disk files, supported by any Pod-expressible substrate.
+	for _, skill := range spec.Skills {
+		ref := capabilityRef(model.CapabilityKindSkill, skill.Name)
+		if supported.Skills {
+			// TODO(P3b): materialise skill files onto the microVM workdir.
+			res.Applied = append(res.Applied, ref)
+		} else {
+			res.Warnings = append(res.Warnings, model.ProvisionWarning{
+				Capability: ref,
+				Reason:     "skills not supported by this substrate",
+			})
+		}
+	}
+
+	// MCP servers: HTTP = network service (supported); stdio = in-image binary
+	// (not yet translated by the microVM scaffold).
+	for _, srv := range spec.MCPServers {
+		ref := capabilityRef(model.CapabilityKindMCPServer, srv.Name)
+		switch srv.Transport {
+		case transportHTTP:
+			if supported.MCPServersHTTP {
+				// TODO(P3b): write .mcp.json into the microVM workdir.
+				res.Applied = append(res.Applied, ref)
+			} else {
+				res.Warnings = append(res.Warnings, model.ProvisionWarning{
+					Capability: ref,
+					Reason:     "http MCP servers not supported by this substrate",
+				})
+			}
+		case transportStdio:
+			// Always warn+skip in P3a (MCPServersStdio is false).
+			res.Warnings = append(res.Warnings, model.ProvisionWarning{
+				Capability: ref,
+				Reason:     reasonMCPStdioUnsupported,
+			})
+		default:
+			res.Warnings = append(res.Warnings, model.ProvisionWarning{
+				Capability: ref,
+				Reason:     fmt.Sprintf("%s: %q", reasonUnknownTransport, srv.Transport),
+			})
+		}
+	}
+
+	// Tool policy: harness allow/deny flags, supported.
+	if spec.ToolPolicy != nil {
+		ref := capabilityRef(model.CapabilityKindToolPolicy, "")
+		if supported.ToolPolicy {
+			// TODO(P3b): pass allow/deny lists to the in-VM harness.
+			res.Applied = append(res.Applied, ref)
+		} else {
+			res.Warnings = append(res.Warnings, model.ProvisionWarning{
+				Capability: ref,
+				Reason:     "tool policy not supported by this substrate",
+			})
+		}
+	}
+
+	r.logger.Debug("microsandbox: provision triage (scaffold)",
+		"applied", len(res.Applied), "warnings", len(res.Warnings))
+	return res, nil
+}
+
+// Launch is a P3a stub. Real microVM launch (clone + harness + capabilities) lands
+// in P3b and requires a KVM host plus the microsandbox Go SDK.
+func (r *Runtime) Launch(_ context.Context, _ port.RunSpec) (port.RunHandle, error) {
+	return port.RunHandle{}, ErrNotImplemented
+}
+
+// Wait is a P3a stub. See ErrNotImplemented.
+func (r *Runtime) Wait(_ context.Context, _ port.RunHandle) (port.RunResult, error) {
+	return port.RunResult{}, ErrNotImplemented
+}
+
+// Stop is a P3a stub. See ErrNotImplemented.
+func (r *Runtime) Stop(_ context.Context, _ port.RunHandle) error {
+	return ErrNotImplemented
+}
+
+// ResolveImage composes the effective launch image for a run, mirroring the
+// RunService invariant: a catalogued stack (resolved by key via the stack
+// catalogue) wins; otherwise the free-form spec.Image is used as-is. This is a
+// pure helper (no microVM I/O) so it is unit-testable in isolation.
+//
+// spec.Image may carry either a stack key (e.g. "go") or a free-form image
+// reference. When the stack catalogue is configured and the value matches a
+// catalogued key, the catalogued (digest-pinned) ImageRef is returned.
+func (r *Runtime) ResolveImage(ctx context.Context, spec port.RunSpec) (string, error) {
+	if r.stacks != nil && spec.Image != "" {
+		if stack, err := r.stacks.GetByKey(ctx, spec.Image); err == nil && stack != nil {
+			return stack.ImageRef, nil
+		}
+	}
+	if spec.Image == "" {
+		return "", fmt.Errorf("microsandbox: no image resolvable from run spec (empty image, no matching stack)")
+	}
+	return spec.Image, nil
+}
+
+// capabilityRef formats a stable "kind/name" reference for Applied/Warnings
+// entries. An empty name (e.g. tool policy is singular per run) yields just the
+// kind.
+func capabilityRef(kind, name string) string {
+	if name == "" {
+		return kind
+	}
+	return kind + "/" + name
+}

--- a/backend/internal/adapter/microsandbox/runtime_test.go
+++ b/backend/internal/adapter/microsandbox/runtime_test.go
@@ -1,0 +1,235 @@
+package microsandbox
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+)
+
+// Test-only constants to satisfy goconst (literals reused ≥3×).
+const (
+	skillName    = "review-checklist"
+	httpMCPName  = "search"
+	stdioMCPName = "secret-fetcher"
+)
+
+// compile-time conformance is also asserted in runtime.go via the package-level
+// var; this test makes the guarantee visible to the test suite too.
+func TestRuntime_ImplementsAgentRuntime(_ *testing.T) {
+	var _ port.AgentRuntime = NewRuntime(false, nil, nil)
+}
+
+func TestRuntime_SupportedCapabilities(t *testing.T) {
+	got := NewRuntime(false, nil, nil).SupportedCapabilities()
+	want := model.CapabilitySet{
+		Skills:          true,
+		MCPServersHTTP:  true,
+		MCPServersStdio: false,
+		ToolPolicy:      true,
+	}
+	if got != want {
+		t.Fatalf("SupportedCapabilities() = %+v, want %+v", got, want)
+	}
+}
+
+func TestRuntime_Provision_WarnSkip(t *testing.T) {
+	tests := []struct {
+		name         string
+		spec         model.CapabilitySpec
+		wantApplied  []string
+		wantWarnings []string // capability refs expected to warn
+	}{
+		{
+			name:        "empty spec applies nothing and warns nothing",
+			spec:        model.CapabilitySpec{},
+			wantApplied: nil,
+		},
+		{
+			name: "skill is supported and applied",
+			spec: model.CapabilitySpec{
+				Skills: []model.SkillSpec{{Name: skillName}},
+			},
+			wantApplied: []string{model.CapabilityKindSkill + "/" + skillName},
+		},
+		{
+			name: "http mcp server is supported and applied",
+			spec: model.CapabilitySpec{
+				MCPServers: []model.MCPServerSpec{{Name: httpMCPName, Transport: transportHTTP}},
+			},
+			wantApplied: []string{model.CapabilityKindMCPServer + "/" + httpMCPName},
+		},
+		{
+			name: "stdio mcp server is warn+skip, never error",
+			spec: model.CapabilitySpec{
+				MCPServers: []model.MCPServerSpec{{Name: stdioMCPName, Transport: transportStdio}},
+			},
+			wantWarnings: []string{model.CapabilityKindMCPServer + "/" + stdioMCPName},
+		},
+		{
+			name: "unknown transport is warn+skip",
+			spec: model.CapabilitySpec{
+				MCPServers: []model.MCPServerSpec{{Name: "weird", Transport: "grpc"}},
+			},
+			wantWarnings: []string{model.CapabilityKindMCPServer + "/weird"},
+		},
+		{
+			name: "tool policy is supported and applied",
+			spec: model.CapabilitySpec{
+				ToolPolicy: &model.ToolPolicySpec{Allow: []string{"Bash"}},
+			},
+			wantApplied: []string{model.CapabilityKindToolPolicy},
+		},
+		{
+			name: "mixed spec: applies supported, warns unsupported, never errors",
+			spec: model.CapabilitySpec{
+				Skills: []model.SkillSpec{{Name: skillName}},
+				MCPServers: []model.MCPServerSpec{
+					{Name: httpMCPName, Transport: transportHTTP},
+					{Name: stdioMCPName, Transport: transportStdio},
+				},
+				ToolPolicy: &model.ToolPolicySpec{Deny: []string{"WebFetch"}},
+			},
+			wantApplied: []string{
+				model.CapabilityKindSkill + "/" + skillName,
+				model.CapabilityKindMCPServer + "/" + httpMCPName,
+				model.CapabilityKindToolPolicy,
+			},
+			wantWarnings: []string{model.CapabilityKindMCPServer + "/" + stdioMCPName},
+		},
+	}
+
+	rt := NewRuntime(false, nil, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := rt.Provision(context.Background(), tt.spec)
+			if err != nil {
+				t.Fatalf("Provision returned error %v; warn+skip must never error", err)
+			}
+			assertRefs(t, "applied", res.Applied, tt.wantApplied)
+			gotWarnRefs := make([]string, 0, len(res.Warnings))
+			for _, w := range res.Warnings {
+				if w.Reason == "" {
+					t.Errorf("warning for %q has empty reason", w.Capability)
+				}
+				gotWarnRefs = append(gotWarnRefs, w.Capability)
+			}
+			assertRefs(t, "warnings", gotWarnRefs, tt.wantWarnings)
+		})
+	}
+}
+
+func TestRuntime_LiveStubs_ReturnNotImplemented(t *testing.T) {
+	rt := NewRuntime(true, nil, nil) // even enabled, P3a stays a stub
+	ctx := context.Background()
+
+	if _, err := rt.Launch(ctx, port.RunSpec{}); !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("Launch err = %v, want ErrNotImplemented", err)
+	}
+	if _, err := rt.Wait(ctx, port.RunHandle{}); !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("Wait err = %v, want ErrNotImplemented", err)
+	}
+	if err := rt.Stop(ctx, port.RunHandle{}); !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("Stop err = %v, want ErrNotImplemented", err)
+	}
+}
+
+func TestRuntime_ResolveImage(t *testing.T) {
+	const (
+		freeFormImage = "ghcr.io/acme/custom:1.2.3"
+		catalogueRef  = "ghcr.io/zakari/hopeitworks-go@sha256:deadbeef"
+	)
+
+	tests := []struct {
+		name    string
+		stacks  port.StackRepository
+		image   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "no catalogue: free-form image passes through",
+			image: freeFormImage,
+			want:  freeFormImage,
+		},
+		{
+			name:   "catalogue key resolves to catalogued image",
+			stacks: &stubStackRepo{byKey: map[string]*model.Stack{model.StackKeyGo: {ImageRef: catalogueRef}}},
+			image:  model.StackKeyGo,
+			want:   catalogueRef,
+		},
+		{
+			name:   "catalogue miss falls back to free-form image",
+			stacks: &stubStackRepo{byKey: map[string]*model.Stack{}},
+			image:  freeFormImage,
+			want:   freeFormImage,
+		},
+		{
+			name:    "empty image with no catalogue is an error",
+			image:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := NewRuntime(false, tt.stacks, nil)
+			got, err := rt.ResolveImage(context.Background(), port.RunSpec{Image: tt.image})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ResolveImage() expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveImage() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ResolveImage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// assertRefs compares an unordered set of refs (applied/warning) ignoring order.
+func assertRefs(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s: got %v (len %d), want %v (len %d)", label, got, len(got), want, len(want))
+	}
+	gotSet := make(map[string]int, len(got))
+	for _, g := range got {
+		gotSet[g]++
+	}
+	for _, w := range want {
+		if gotSet[w] == 0 {
+			t.Fatalf("%s: missing %q in %v", label, w, got)
+		}
+		gotSet[w]--
+	}
+}
+
+// stubStackRepo is a minimal port.StackRepository for ResolveImage tests.
+type stubStackRepo struct {
+	byKey map[string]*model.Stack
+}
+
+func (s *stubStackRepo) List(_ context.Context) ([]*model.Stack, error) { return nil, nil }
+
+func (s *stubStackRepo) GetByID(_ context.Context, _ uuid.UUID) (*model.Stack, error) {
+	return nil, errors.New("not implemented in stub")
+}
+
+func (s *stubStackRepo) GetByKey(_ context.Context, key string) (*model.Stack, error) {
+	if st, ok := s.byKey[key]; ok {
+		return st, nil
+	}
+	return nil, errors.New("stack not found")
+}
+
+func (s *stubStackRepo) Upsert(_ context.Context, st *model.Stack) (*model.Stack, error) {
+	return st, nil
+}

--- a/backend/internal/config/loader.go
+++ b/backend/internal/config/loader.go
@@ -37,6 +37,9 @@ func setDefaults(cfg *pkgconfig.Config) {
 		t := true
 		cfg.Database.AutoMigrate = &t
 	}
+	if cfg.Substrate.Kind == "" {
+		cfg.Substrate.Kind = pkgconfig.SubstrateDocker
+	}
 }
 
 func applyEnvOverrides(cfg *pkgconfig.Config) {
@@ -81,6 +84,9 @@ func applyEnvOverrides(cfg *pkgconfig.Config) {
 	if v := os.Getenv("CALLBACK_BASE_URL"); v != "" {
 		cfg.Docker.CallbackBaseURL = v
 	}
+	if v := os.Getenv("SUBSTRATE"); v != "" {
+		cfg.Substrate.Kind = v
+	}
 	if v := os.Getenv("SMTP_HOST"); v != "" {
 		cfg.SMTP.Host = v
 	}
@@ -118,6 +124,12 @@ func validate(cfg *pkgconfig.Config) error {
 	}
 	if cfg.Database.Password == "" {
 		return fmt.Errorf("database.password is required")
+	}
+	switch cfg.Substrate.Kind {
+	case pkgconfig.SubstrateDocker, pkgconfig.SubstrateMicrosandbox:
+	default:
+		return fmt.Errorf("substrate.kind must be %q or %q, got %q",
+			pkgconfig.SubstrateDocker, pkgconfig.SubstrateMicrosandbox, cfg.Substrate.Kind)
 	}
 	return nil
 }

--- a/backend/internal/config/loader_test.go
+++ b/backend/internal/config/loader_test.go
@@ -225,3 +225,68 @@ logging:
 		t.Errorf("Stacks len = %d, want 0 when section absent", len(cfg.Stacks))
 	}
 }
+
+// minimalDB is a valid database section reused by the substrate tests; defined
+// as a const so the substrate cases stay focused (and to satisfy goconst).
+const minimalDB = `
+database:
+  host: localhost
+  port: 5432
+  name: testdb
+  user: testuser
+  password: testpass
+  sslmode: disable
+
+logging:
+  level: info
+`
+
+func writeConfig(t *testing.T, yaml string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoad_SubstrateDefaultsToDocker(t *testing.T) {
+	t.Setenv("SUBSTRATE", "")
+	cfg, err := Load(writeConfig(t, minimalDB))
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Substrate.Kind != "docker" {
+		t.Errorf("Substrate.Kind = %q, want docker default", cfg.Substrate.Kind)
+	}
+}
+
+func TestLoad_SubstrateFromYAML(t *testing.T) {
+	t.Setenv("SUBSTRATE", "")
+	cfg, err := Load(writeConfig(t, minimalDB+"\nsubstrate:\n  kind: microsandbox\n"))
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Substrate.Kind != "microsandbox" {
+		t.Errorf("Substrate.Kind = %q, want microsandbox", cfg.Substrate.Kind)
+	}
+}
+
+func TestLoad_SubstrateEnvOverride(t *testing.T) {
+	t.Setenv("SUBSTRATE", "microsandbox")
+	cfg, err := Load(writeConfig(t, minimalDB))
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Substrate.Kind != "microsandbox" {
+		t.Errorf("Substrate.Kind = %q, want microsandbox from env override", cfg.Substrate.Kind)
+	}
+}
+
+func TestLoad_SubstrateInvalidRejected(t *testing.T) {
+	t.Setenv("SUBSTRATE", "k8s")
+	if _, err := Load(writeConfig(t, minimalDB)); err == nil {
+		t.Fatal("Load() should reject an unknown substrate kind")
+	}
+}

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -4,13 +4,32 @@ import "time"
 
 // Config holds the complete application configuration.
 type Config struct {
-	Server   ServerConfig   `yaml:"server"`
-	Database DatabaseConfig `yaml:"database"`
-	Docker   DockerConfig   `yaml:"docker"`
-	Log      LogConfig      `yaml:"logging"`
-	SMTP     SMTPConfig     `yaml:"smtp"`
-	Security SecurityConfig `yaml:"security"`
-	Stacks   []StackConfig  `yaml:"stacks"`
+	Server    ServerConfig    `yaml:"server"`
+	Database  DatabaseConfig  `yaml:"database"`
+	Docker    DockerConfig    `yaml:"docker"`
+	Substrate SubstrateConfig `yaml:"substrate"`
+	Log       LogConfig       `yaml:"logging"`
+	SMTP      SMTPConfig      `yaml:"smtp"`
+	Security  SecurityConfig  `yaml:"security"`
+	Stacks    []StackConfig   `yaml:"stacks"`
+}
+
+// Substrate kinds: the execution substrate that realises an agent run. "docker"
+// is the live default; "microsandbox" selects the microVM substrate, which is a
+// scaffold in P3a (selecting it does not change live execution — see main.go).
+const (
+	SubstrateDocker       = "docker"
+	SubstrateMicrosandbox = "microsandbox"
+)
+
+// SubstrateConfig selects which execution substrate the platform uses. The
+// substrate adapter (microsandbox/K8s later) implements port.AgentRuntime; the
+// Docker substrate remains the default and the only one wired into the live
+// agent_run flow until later P3 sub-phases.
+type SubstrateConfig struct {
+	// Kind is the substrate selector: "docker" (default) or "microsandbox".
+	// Override via the SUBSTRATE env var.
+	Kind string `yaml:"kind"`
 }
 
 // StackConfig is one entry of the stack catalogue: a catalogued runtime image


### PR DESCRIPTION
## P3a — Squelette d'adapter substrat microsandbox (inerte)
1ère sous-phase de P3 (substrat microVM). **Additif et inerte** : implémente le port CIBLE `port.AgentRuntime` (PAS le `ContainerManager` du flow live), n'est branché sur rien, appels microVM stubés. Validable sans KVM/Docker (build/test-only). **0 régression Docker**.

### Livré
- `internal/adapter/microsandbox/runtime.go` : `Runtime` avec `var _ port.AgentRuntime = (*Runtime)(nil)`. `SupportedCapabilities()` (données) + `Provision()` (tri agnostique→supporté, **warn+skip**). `Launch/Wait/Stop` = stubs `ErrNotImplemented` (réel = P3b, exige KVM + SDK Go microsandbox). Helper pur `ResolveImage` (StackRef sinon image, calqué sur RunService).
- Config : `SubstrateConfig{Kind}` (défaut **`docker`**) + override env `SUBSTRATE` + validation (`docker`|`microsandbox`).
- `main.go` : fabrique `selectSubstrate` qui **logue** le choix ; `docker` (défaut) → comportement strictement inchangé (retourne nil) ; `microsandbox` → adapter inerte (`enabled=false`) + Warn "scaffold-only (P3a): live execution still uses Docker". **Ne touche pas** ContainerManager/agent_run/sidecars.
- Tests : conformité interface, SupportedCapabilities, Provision warn+skip, stubs, dispatch fabrique.

### Validation
`go build`/`go vet`/`go test -short` verts ; **golangci-lint v1.64.8 = 0 finding** ; `go.mod`/`go.sum` inchangés (aucune dépendance externe nouvelle — le vrai SDK microsandbox vient en P3b). Aucun fichier du flow live modifié.

> Plan P3 complet (P3b appels microVM réels = besoin KVM ; P3c migration live→AgentRuntime) : voir mémoire / à documenter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)