### PR TITLE
feat(runtime): P2c2d — run Environment commands in ephemeral containers (Option A)

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -289,7 +289,7 @@ func run() error {
 			agentRunAction := actionadapter.NewAgentRunAction(
 				containerMgr, logStreamer, eventRepo,
 				storyRepo, projectRepo, runRepo,
-				environmentRepo, sidecarMgr,
+				environmentRepo, sidecarMgr, stackRepo,
 				handlebarsRenderer, costSvc, agentCfg, logger,
 				apiKeySvc, containerTokenStore, callbackStatusStore,
 				cfg.Docker.CallbackBaseURL,

--- a/backend/internal/adapter/action/agent_run.go
+++ b/backend/internal/adapter/action/agent_run.go
@@ -41,6 +41,7 @@ type AgentRunAction struct {
 	runRepo         port.RunRepository
 	environmentRepo port.EnvironmentRepository
 	sidecarMgr      port.SidecarManager
+	stackRepo       port.StackRepository
 	renderer        port.TemplateRenderer
 	costSvc         *service.CostService
 	config          AgentConfig
@@ -59,6 +60,11 @@ type AgentRunAction struct {
 // Environment with sidecar services, sidecarMgr brings them up on an isolated per-run
 // network and their connection strings are injected into the agent container. Both are
 // nil-safe at the call sites; a project without an Environment behaves exactly as before.
+//
+// stackRepo resolves the image that runs the Environment's setup commands (build/migrate/
+// seed/test): it is keyed by the Environment's first Stack, falling back to the agent
+// image when the Environment declares no stack. It is nil-safe: when there are no commands
+// to run it is never consulted.
 func NewAgentRunAction(
 	containerMgr port.ContainerManager,
 	logStreamer port.LogStreamer,
@@ -68,6 +74,7 @@ func NewAgentRunAction(
 	runRepo port.RunRepository,
 	environmentRepo port.EnvironmentRepository,
 	sidecarMgr port.SidecarManager,
+	stackRepo port.StackRepository,
 	renderer port.TemplateRenderer,
 	costSvc *service.CostService,
 	config AgentConfig,
@@ -86,6 +93,7 @@ func NewAgentRunAction(
 		runRepo:         runRepo,
 		environmentRepo: environmentRepo,
 		sidecarMgr:      sidecarMgr,
+		stackRepo:       stackRepo,
 		renderer:        renderer,
 		costSvc:         costSvc,
 		config:          config,
@@ -195,6 +203,15 @@ func (a *AgentRunAction) Execute(ctx context.Context, runCtx *model.RunContext) 
 	// nil when there is no Environment — extraEnv stays nil and the container env
 	// is byte-for-byte identical to the pre-Environment behaviour.
 	extraEnv := buildConnStrings(env)
+
+	// 6b. Run the Environment's setup commands (build → migrate → seed → test)
+	// against the ready sidecars, BEFORE the agent container starts. No-op when
+	// env==nil or env.Commands is empty (no ephemeral container is created). On
+	// failure we return immediately: the deferred sidecar Cleanup runs and no
+	// agent container is ever created.
+	if err := a.runEnvironmentCommands(ctx, env, sidecarCtx, project, branchName, agentImage, extraEnv); err != nil {
+		return fmt.Errorf("run environment commands: %w", err)
+	}
 
 	// 7. Create container
 	containerID, err := a.createContainer(ctx, runCtx, project, story, agentImage, prompt, branchName, extraEnv, sidecarCtx)
@@ -317,27 +334,23 @@ func (a *AgentRunAction) createContainer(
 	}
 
 	// Resolve git token dynamically from project config
-	tokenEnvName := "GITHUB_TOKEN"
-	if project.GitTokenEnv != nil && *project.GitTokenEnv != "" {
-		tokenEnvName = *project.GitTokenEnv
-	}
-	gitToken := os.Getenv(tokenEnvName)
+	gitToken := os.Getenv(gitTokenEnvName(project))
 
 	// Resolve role from step config and build per-run CLAUDE.md context.
 	role := resolveRole(runCtx)
 
 	env := []string{
-		"REPO_URL=" + repoURL,
-		"BRANCH_NAME=" + branchName,
+		envPrefixRepoURL + repoURL,
+		envPrefixBranchName + branchName,
 		"STORY_KEY=" + story.Key,
 		// PROMPT_CONTENT is consumed by the legacy shell entrypoint (agent/entrypoint.sh).
 		// PROMPT is consumed by the agent-runtime Go binary in callback mode (config.Load).
 		// Inject both so either image variant receives the rendered prompt under the name it reads.
 		"PROMPT_CONTENT=" + prompt,
 		"PROMPT=" + prompt,
-		"GIT_TOKEN=" + gitToken,
-		"GIT_PROVIDER=" + project.GitProvider,
-		"GITHUB_TOKEN=" + gitToken,
+		envPrefixGitToken + gitToken,
+		envPrefixGitProvider + project.GitProvider,
+		envPrefixGitHubToken + gitToken,
 		// CLAUDE_MD_CONTENT is written to /workspace/repo/.claude/CLAUDE.md by the agent-runtime,
 		// giving Claude Code role-aware project context for every run.
 		// priorFailureContext appends a "Previous attempt" block when there is a prior
@@ -411,10 +424,10 @@ func (a *AgentRunAction) createContainer(
 		CPUs:        a.config.DefaultCPUs,
 		Env:         env,
 		Labels: map[string]string{
-			"managed_by": "hopeitworks",
-			"run_id":     runCtx.Run.ID.String(),
-			"step_id":    runCtx.RunStep.ID.String(),
-			"story_key":  story.Key,
+			labelManagedBy: labelValueManaged,
+			labelRunID:     runCtx.Run.ID.String(),
+			"step_id":      runCtx.RunStep.ID.String(),
+			"story_key":    story.Key,
 		},
 	}
 

--- a/backend/internal/adapter/action/agent_run.go
+++ b/backend/internal/adapter/action/agent_run.go
@@ -209,7 +209,7 @@ func (a *AgentRunAction) Execute(ctx context.Context, runCtx *model.RunContext) 
 	// env==nil or env.Commands is empty (no ephemeral container is created). On
 	// failure we return immediately: the deferred sidecar Cleanup runs and no
 	// agent container is ever created.
-	if err := a.runEnvironmentCommands(ctx, env, sidecarCtx, project, branchName, agentImage, extraEnv); err != nil {
+	if err := a.runEnvironmentCommands(ctx, env, sidecarCtx, project, runCtx.Run.ID, branchName, agentImage, extraEnv); err != nil {
 		return fmt.Errorf("run environment commands: %w", err)
 	}
 
@@ -424,10 +424,10 @@ func (a *AgentRunAction) createContainer(
 		CPUs:        a.config.DefaultCPUs,
 		Env:         env,
 		Labels: map[string]string{
-			labelManagedBy: labelValueManaged,
-			labelRunID:     runCtx.Run.ID.String(),
-			"step_id":      runCtx.RunStep.ID.String(),
-			"story_key":    story.Key,
+			model.LabelManagedBy: model.LabelManagedByValue,
+			model.LabelRunID:     runCtx.Run.ID.String(),
+			"step_id":            runCtx.RunStep.ID.String(),
+			"story_key":          story.Key,
 		},
 	}
 

--- a/backend/internal/adapter/action/agent_run_commands.go
+++ b/backend/internal/adapter/action/agent_run_commands.go
@@ -1,0 +1,308 @@
+package action
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+)
+
+// Environment command keys, run in this FIXED conventional order (never the
+// non-deterministic map iteration). Each key is optional: a command absent from
+// env.Commands is skipped.
+const (
+	cmdKeyBuild   = "build"
+	cmdKeyMigrate = "migrate"
+	cmdKeySeed    = "seed"
+	cmdKeyTest    = "test"
+)
+
+// commandOrder is the canonical execution order for Environment setup commands.
+var commandOrder = []string{cmdKeyBuild, cmdKeyMigrate, cmdKeySeed, cmdKeyTest}
+
+// ephemeralWorkdir is where the repo is cloned inside the ephemeral command
+// container before each Environment command runs.
+const ephemeralWorkdir = "/workspace/repo"
+
+// gitProviderGitea is the provider key whose token is injected as "oauth2:<token>".
+const gitProviderGitea = "gitea"
+
+// Env var KEY= prefixes and label values shared between the agent container and
+// the ephemeral command container. Declared as constants because goconst (which
+// does NOT skip _test.go) flags any literal repeated three or more times.
+const (
+	envPrefixRepoURL     = "REPO_URL="
+	envPrefixBranchName  = "BRANCH_NAME="
+	envPrefixGitToken    = "GIT_TOKEN="
+	envPrefixGitProvider = "GIT_PROVIDER="
+	envPrefixGitHubToken = "GITHUB_TOKEN="
+
+	labelManagedBy    = "managed_by"
+	labelValueManaged = "hopeitworks"
+	labelRunID        = "run_id"
+
+	defaultGitTokenEnv = "GITHUB_TOKEN"
+)
+
+// cmdShell is the shell used to drive the clone-then-run one-liner.
+var cmdShell = []string{"sh", "-lc"}
+
+// commandRunTimeout bounds a single Environment command (clone + command). It is
+// generous: builds and migrations can be slow, but the run must never hang
+// indefinitely on a stuck command.
+const commandRunTimeout = 30 * time.Minute
+
+// runEnvironmentCommands executes the project's Environment setup commands
+// (build → migrate → seed → test) AFTER the sidecars are ready and BEFORE the
+// agent container starts. Each present command runs in its own EPHEMERAL
+// container (Option A: no agent-runtime change) attached to the run network,
+// with the sidecar connection strings and the same git env the agent receives.
+//
+// The repo is cloned inside the ephemeral container exactly the way the
+// agent-runtime clones it (authenticated URL, same branch, shallow), so the
+// command sees the project's Makefile/migrations. The clone is throwaway; only
+// the side effect on the sidecar (migrated/seeded DB) persists.
+//
+// Fail-fast: the first command with a non-zero exit code returns an error that
+// fails the run; no further command runs and the agent container is never
+// created. Every ephemeral container is removed best-effort regardless of
+// outcome.
+//
+// Nil-safety / back-compat: env == nil or len(env.Commands) == 0 is a no-op —
+// no ephemeral container is created and behaviour is strictly unchanged.
+func (a *AgentRunAction) runEnvironmentCommands(
+	ctx context.Context,
+	env *model.Environment,
+	sidecarCtx *port.SidecarContext,
+	project *model.Project,
+	branchName, agentImage string,
+	extraEnv []string,
+) error {
+	if env == nil || len(env.Commands) == 0 {
+		return nil
+	}
+
+	image, err := a.resolveCommandImage(ctx, env, agentImage)
+	if err != nil {
+		return fmt.Errorf("resolve command image: %w", err)
+	}
+
+	gitEnv := a.gitEnv(project)
+	cloneURL, err := authenticatedRepoURL(project)
+	if err != nil {
+		return fmt.Errorf("build authenticated repo url: %w", err)
+	}
+
+	for _, key := range commandOrder {
+		command, ok := env.Commands[key]
+		if !ok || strings.TrimSpace(command) == "" {
+			continue // optional command: skip when absent or blank
+		}
+		if err := a.runOneCommand(ctx, key, command, image, cloneURL, branchName, gitEnv, extraEnv, sidecarCtx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runOneCommand launches a single ephemeral container that clones the repo and
+// runs command, waits for it, and removes the container. A non-zero exit code is
+// returned as an error (fail-fast) with the last log lines for diagnosis.
+func (a *AgentRunAction) runOneCommand(
+	ctx context.Context,
+	key, command, image, cloneURL, branchName string,
+	gitEnv, extraEnv []string,
+	sidecarCtx *port.SidecarContext,
+) error {
+	cctx, cancel := context.WithTimeout(ctx, commandRunTimeout)
+	defer cancel()
+
+	// Clone the repo (replicating the agent-runtime clone) then run the command
+	// from the workdir. The authenticated URL is passed via an env var so it
+	// never appears in the container's argv / process list.
+	script := "git clone --depth 1 --branch \"$BRANCH_NAME\" \"$HOPEITWORKS_CLONE_URL\" " + ephemeralWorkdir +
+		" || git clone --depth 1 \"$HOPEITWORKS_CLONE_URL\" " + ephemeralWorkdir +
+		"; cd " + ephemeralWorkdir + " && " + command
+
+	cmdEnv := make([]string, 0, len(gitEnv)+len(extraEnv)+2)
+	cmdEnv = append(cmdEnv, gitEnv...)
+	cmdEnv = append(cmdEnv, extraEnv...)
+	cmdEnv = append(cmdEnv, "BRANCH_NAME="+branchName)
+	cmdEnv = append(cmdEnv, "HOPEITWORKS_CLONE_URL="+cloneURL)
+
+	opts := model.ContainerOpts{
+		Image:  image,
+		Env:    cmdEnv,
+		Memory: a.config.DefaultMemory,
+		CPUs:   a.config.DefaultCPUs,
+		Cmd:    append(append([]string(nil), cmdShell...), script),
+		Labels: a.commandLabels(sidecarCtx, key),
+	}
+	// Attach the ephemeral container to the run network so it reaches the
+	// sidecars by their DNS alias, exactly like the agent container does.
+	if sidecarCtx != nil && sidecarCtx.NetworkName != "" {
+		opts.NetworkName = sidecarCtx.NetworkName
+	}
+
+	a.logger.Info("running environment command",
+		"command_key", key, "image", image, "network", opts.NetworkName)
+
+	containerID, err := a.containerMgr.Create(cctx, opts)
+	if err != nil {
+		return fmt.Errorf("create %s command container: %w", key, err)
+	}
+	defer a.removeEphemeral(containerID)
+
+	if err := a.containerMgr.Start(cctx, containerID); err != nil {
+		return fmt.Errorf("start %s command container: %w", key, err)
+	}
+
+	exitCode, err := a.containerMgr.Wait(cctx, containerID)
+	if err != nil {
+		return fmt.Errorf("wait %s command container: %w", key, err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("environment command %q failed with exit code %d%s",
+			key, exitCode, a.commandLogTail(containerID))
+	}
+
+	a.logger.Info("environment command succeeded", "command_key", key)
+	return nil
+}
+
+// commandLabels builds the labels for an ephemeral command container so it is
+// attributable to the run and never mistaken for a sidecar or the agent.
+func (a *AgentRunAction) commandLabels(sidecarCtx *port.SidecarContext, key string) map[string]string {
+	labels := map[string]string{
+		labelManagedBy: labelValueManaged,
+		"role":         "env_command",
+		"command_key":  key,
+	}
+	if sidecarCtx != nil {
+		labels[labelRunID] = sidecarCtx.RunID.String()
+	}
+	return labels
+}
+
+// commandLogTail returns a best-effort, scrubbed tail of the ephemeral
+// container's logs for inclusion in a fail-fast error. It returns "" when logs
+// cannot be retrieved so the error message stays clean.
+func (a *AgentRunAction) commandLogTail(containerID string) string {
+	logCh, doneCh, err := a.logStreamer.StreamLogs(
+		context.Background(), containerID, "", "")
+	if err != nil {
+		return ""
+	}
+	const maxLines = 20
+	tail := make([]string, 0, maxLines)
+	for ev := range logCh {
+		if len(tail) >= maxLines {
+			tail = tail[1:]
+		}
+		tail = append(tail, ev.Message)
+	}
+	// Drain doneCh without blocking: the LogStreamer may or may not send an exit
+	// code once logCh is closed, and this is a best-effort diagnostic path.
+	select {
+	case <-doneCh:
+	default:
+	}
+	if len(tail) == 0 {
+		return ""
+	}
+	return ": " + strings.Join(tail, " | ")
+}
+
+// removeEphemeral stops and removes an ephemeral command container on a bounded,
+// detached context so cleanup runs even when the run's context is cancelled.
+func (a *AgentRunAction) removeEphemeral(containerID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := a.containerMgr.Stop(ctx, containerID); err != nil {
+		a.logger.Warn("failed to stop ephemeral command container",
+			"container_id", containerID, "error", err)
+	}
+	if err := a.containerMgr.Remove(ctx, containerID); err != nil {
+		a.logger.Warn("failed to remove ephemeral command container",
+			"container_id", containerID, "error", err)
+	}
+}
+
+// resolveCommandImage resolves the image that runs the Environment commands.
+// Preference: the Environment's first Stack (env.Stacks[0]) via the stack
+// catalogue. Fallback: the agent's effective image (the same image the run's
+// agent container uses) when no stack is declared or the stack repo is absent.
+// The fallback guarantees the command image always carries a usable toolchain.
+func (a *AgentRunAction) resolveCommandImage(ctx context.Context, env *model.Environment, agentImage string) (string, error) {
+	if len(env.Stacks) > 0 && a.stackRepo != nil {
+		key := env.Stacks[0]
+		stack, err := a.stackRepo.GetByKey(ctx, key)
+		if err != nil {
+			return "", fmt.Errorf("lookup stack %q: %w", key, err)
+		}
+		if stack != nil && stack.ImageRef != "" {
+			return stack.ImageRef, nil
+		}
+	}
+	if agentImage != "" {
+		return agentImage, nil
+	}
+	return "", fmt.Errorf("no stack declared and no fallback agent image available")
+}
+
+// gitEnv returns the git-related env entries the agent container also receives,
+// so the ephemeral command container clones identically. It mirrors the env set
+// built in createContainer (REPO_URL, GIT_TOKEN, GIT_PROVIDER, GITHUB_TOKEN),
+// resolving the token from the project-configured token env var.
+func (a *AgentRunAction) gitEnv(project *model.Project) []string {
+	repoURL := ""
+	if project.RepoURL != nil {
+		repoURL = *project.RepoURL
+	}
+	gitToken := os.Getenv(gitTokenEnvName(project))
+	return []string{
+		envPrefixRepoURL + repoURL,
+		envPrefixGitToken + gitToken,
+		envPrefixGitProvider + project.GitProvider,
+		envPrefixGitHubToken + gitToken,
+	}
+}
+
+// gitTokenEnvName resolves the OS env var name holding the git token for the
+// project, defaulting to GITHUB_TOKEN when the project does not override it.
+func gitTokenEnvName(project *model.Project) string {
+	if project.GitTokenEnv != nil && *project.GitTokenEnv != "" {
+		return *project.GitTokenEnv
+	}
+	return defaultGitTokenEnv
+}
+
+// authenticatedRepoURL builds the authenticated clone URL exactly the way the
+// agent-runtime does (agent-runtime/internal/git/clone.go#injectToken):
+//   - gitea:  https://oauth2:<token>@host/...
+//   - github: https://<token>@host/...  (also the default)
+//
+// The token is read from the project-configured env var. Building it here (not
+// in the in-container shell) keeps the token out of the command argv; it is
+// passed to the container via an env var instead.
+func authenticatedRepoURL(project *model.Project) (string, error) {
+	if project.RepoURL == nil || *project.RepoURL == "" {
+		return "", fmt.Errorf("project has no repo URL")
+	}
+	token := os.Getenv(gitTokenEnvName(project))
+	parsed, err := url.Parse(*project.RepoURL)
+	if err != nil {
+		return "", fmt.Errorf("parse repo URL: %w", err)
+	}
+	if project.GitProvider == gitProviderGitea {
+		parsed.User = url.UserPassword("oauth2", token)
+	} else {
+		parsed.User = url.User(token)
+	}
+	return parsed.String(), nil
+}

--- a/backend/internal/adapter/action/agent_run_commands.go
+++ b/backend/internal/adapter/action/agent_run_commands.go
@@ -2,14 +2,18 @@ package action
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"net/url"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
 	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	apperrors "github.com/zakari/hopeitworks/backend/pkg/errors"
 )
 
 // Environment command keys, run in this FIXED conventional order (never the
@@ -42,11 +46,11 @@ const (
 	envPrefixGitProvider = "GIT_PROVIDER="
 	envPrefixGitHubToken = "GITHUB_TOKEN="
 
-	labelManagedBy    = "managed_by"
-	labelValueManaged = "hopeitworks"
-	labelRunID        = "run_id"
-
 	defaultGitTokenEnv = "GITHUB_TOKEN"
+
+	// cloneURLEnv is the env var carrying the authenticated clone URL into the
+	// ephemeral command container, keeping the token out of the command argv.
+	cloneURLEnv = "HOPEITWORKS_CLONE_URL"
 )
 
 // cmdShell is the shell used to drive the clone-then-run one-liner.
@@ -80,6 +84,7 @@ func (a *AgentRunAction) runEnvironmentCommands(
 	env *model.Environment,
 	sidecarCtx *port.SidecarContext,
 	project *model.Project,
+	runID uuid.UUID,
 	branchName, agentImage string,
 	extraEnv []string,
 ) error {
@@ -98,59 +103,89 @@ func (a *AgentRunAction) runEnvironmentCommands(
 		return fmt.Errorf("build authenticated repo url: %w", err)
 	}
 
+	spec := commandSpec{
+		image:      image,
+		cloneURL:   cloneURL,
+		branchName: branchName,
+		gitEnv:     gitEnv,
+		extraEnv:   extraEnv,
+		runID:      runID,
+		sidecarCtx: sidecarCtx,
+	}
 	for _, key := range commandOrder {
 		command, ok := env.Commands[key]
 		if !ok || strings.TrimSpace(command) == "" {
 			continue // optional command: skip when absent or blank
 		}
-		if err := a.runOneCommand(ctx, key, command, image, cloneURL, branchName, gitEnv, extraEnv, sidecarCtx); err != nil {
+		if err := a.runOneCommand(ctx, key, command, spec); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
+// commandSpec carries the invariant inputs shared by every ephemeral command
+// container in a run, so runOneCommand keeps a small signature.
+type commandSpec struct {
+	image      string
+	cloneURL   string
+	branchName string
+	gitEnv     []string
+	extraEnv   []string
+	runID      uuid.UUID
+	sidecarCtx *port.SidecarContext
+}
+
 // runOneCommand launches a single ephemeral container that clones the repo and
 // runs command, waits for it, and removes the container. A non-zero exit code is
-// returned as an error (fail-fast) with the last log lines for diagnosis.
-func (a *AgentRunAction) runOneCommand(
-	ctx context.Context,
-	key, command, image, cloneURL, branchName string,
-	gitEnv, extraEnv []string,
-	sidecarCtx *port.SidecarContext,
-) error {
+// returned as a fail-fast error.
+//
+// SECURITY: the returned error carries ONLY the command key and exit code —
+// never the container's stdout/stderr. That error propagates through Execute to
+// the pipeline executor, which persists it to run.error_message AND broadcasts
+// it over SSE; a command that dumps its env (printenv / set -x / CI tooling)
+// would otherwise leak the git token and DB passwords into a persisted, public
+// channel. The log tail is emitted server-side via slog only.
+func (a *AgentRunAction) runOneCommand(ctx context.Context, key, command string, spec commandSpec) error {
 	cctx, cancel := context.WithTimeout(ctx, commandRunTimeout)
 	defer cancel()
 
 	// Clone the repo (replicating the agent-runtime clone) then run the command
-	// from the workdir. The authenticated URL is passed via an env var so it
-	// never appears in the container's argv / process list.
-	script := "git clone --depth 1 --branch \"$BRANCH_NAME\" \"$HOPEITWORKS_CLONE_URL\" " + ephemeralWorkdir +
-		" || git clone --depth 1 \"$HOPEITWORKS_CLONE_URL\" " + ephemeralWorkdir +
-		"; cd " + ephemeralWorkdir + " && " + command
+	// from the workdir. STRICT semantics: `set -e` makes the clone failure abort
+	// the script, so a clone error (network/auth/missing branch) NEVER silently
+	// falls back to the default branch — migrate/seed must run against the exact
+	// requested branch or not at all. The authenticated URL is passed via an env
+	// var so it never appears in the container's argv / process list.
+	script := "set -e; git clone --depth 1 --branch \"$BRANCH_NAME\" \"$" + cloneURLEnv + "\" " + ephemeralWorkdir +
+		"; cd " + ephemeralWorkdir + "; " + command
 
-	cmdEnv := make([]string, 0, len(gitEnv)+len(extraEnv)+2)
-	cmdEnv = append(cmdEnv, gitEnv...)
-	cmdEnv = append(cmdEnv, extraEnv...)
-	cmdEnv = append(cmdEnv, "BRANCH_NAME="+branchName)
-	cmdEnv = append(cmdEnv, "HOPEITWORKS_CLONE_URL="+cloneURL)
+	cmdEnv := make([]string, 0, len(spec.gitEnv)+len(spec.extraEnv)+2)
+	cmdEnv = append(cmdEnv, spec.gitEnv...)
+	cmdEnv = append(cmdEnv, spec.extraEnv...)
+	cmdEnv = append(cmdEnv, envPrefixBranchName+spec.branchName)
+	cmdEnv = append(cmdEnv, cloneURLEnv+"="+spec.cloneURL)
 
 	opts := model.ContainerOpts{
-		Image:  image,
+		Image:  spec.image,
 		Env:    cmdEnv,
 		Memory: a.config.DefaultMemory,
 		CPUs:   a.config.DefaultCPUs,
-		Cmd:    append(append([]string(nil), cmdShell...), script),
-		Labels: a.commandLabels(sidecarCtx, key),
+		// Override BOTH entrypoint and command: stack/agent images bake
+		// ENTRYPOINT ["agent-runtime"], so setting only Cmd would run
+		// `agent-runtime sh -lc <script>` and never execute the shell. Setting
+		// Entrypoint to the shell replaces the image entrypoint entirely.
+		Entrypoint: append([]string(nil), cmdShell...),
+		Cmd:        []string{script},
+		Labels:     a.commandLabels(spec.runID, key),
 	}
 	// Attach the ephemeral container to the run network so it reaches the
 	// sidecars by their DNS alias, exactly like the agent container does.
-	if sidecarCtx != nil && sidecarCtx.NetworkName != "" {
-		opts.NetworkName = sidecarCtx.NetworkName
+	if spec.sidecarCtx != nil && spec.sidecarCtx.NetworkName != "" {
+		opts.NetworkName = spec.sidecarCtx.NetworkName
 	}
 
 	a.logger.Info("running environment command",
-		"command_key", key, "image", image, "network", opts.NetworkName)
+		"command_key", key, "image", spec.image, "network", opts.NetworkName)
 
 	containerID, err := a.containerMgr.Create(cctx, opts)
 	if err != nil {
@@ -167,8 +202,10 @@ func (a *AgentRunAction) runOneCommand(
 		return fmt.Errorf("wait %s command container: %w", key, err)
 	}
 	if exitCode != 0 {
-		return fmt.Errorf("environment command %q failed with exit code %d%s",
-			key, exitCode, a.commandLogTail(containerID))
+		// Server-side diagnostic ONLY: the tail goes to slog (scrubbed by the
+		// ScrubHandler), never into the returned/propagated error.
+		a.logCommandTail(containerID, key, exitCode)
+		return fmt.Errorf("environment command %q failed with exit code %d", key, exitCode)
 	}
 
 	a.logger.Info("environment command succeeded", "command_key", key)
@@ -176,27 +213,30 @@ func (a *AgentRunAction) runOneCommand(
 }
 
 // commandLabels builds the labels for an ephemeral command container so it is
-// attributable to the run and never mistaken for a sidecar or the agent.
-func (a *AgentRunAction) commandLabels(sidecarCtx *port.SidecarContext, key string) map[string]string {
-	labels := map[string]string{
-		labelManagedBy: labelValueManaged,
-		"role":         "env_command",
-		"command_key":  key,
+// attributable to the run and reapable by GC. run_id is ALWAYS stamped — a
+// project with commands but no sidecar services still reaches this path, and an
+// unlabelled container would be invisible to the GC reaper.
+func (a *AgentRunAction) commandLabels(runID uuid.UUID, key string) map[string]string {
+	return map[string]string{
+		model.LabelManagedBy:  model.LabelManagedByValue,
+		model.LabelRole:       model.RoleEnvCommand,
+		model.LabelCommandKey: key,
+		model.LabelRunID:      runID.String(),
 	}
-	if sidecarCtx != nil {
-		labels[labelRunID] = sidecarCtx.RunID.String()
-	}
-	return labels
 }
 
-// commandLogTail returns a best-effort, scrubbed tail of the ephemeral
-// container's logs for inclusion in a fail-fast error. It returns "" when logs
-// cannot be retrieved so the error message stays clean.
-func (a *AgentRunAction) commandLogTail(containerID string) string {
-	logCh, doneCh, err := a.logStreamer.StreamLogs(
-		context.Background(), containerID, "", "")
+// logCommandTail emits a best-effort tail of the ephemeral container's logs to
+// slog for SERVER-SIDE diagnosis only. It is never returned to the caller, so it
+// cannot reach run.error_message / SSE. slog's ScrubHandler additionally redacts
+// token/secret/password-shaped fields. Bounded by its own short timeout so a
+// stuck log stream never blocks the fail-fast path.
+func (a *AgentRunAction) logCommandTail(containerID, key string, exitCode int) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	logCh, doneCh, err := a.logStreamer.StreamLogs(ctx, containerID, "", "")
 	if err != nil {
-		return ""
+		return
 	}
 	const maxLines = 20
 	tail := make([]string, 0, maxLines)
@@ -213,9 +253,12 @@ func (a *AgentRunAction) commandLogTail(containerID string) string {
 	default:
 	}
 	if len(tail) == 0 {
-		return ""
+		return
 	}
-	return ": " + strings.Join(tail, " | ")
+	a.logger.Warn("environment command failed",
+		"command_key", key,
+		"exit_code", exitCode,
+		"log_tail", strings.Join(tail, "\n"))
 }
 
 // removeEphemeral stops and removes an ephemeral command container on a bounded,
@@ -236,23 +279,37 @@ func (a *AgentRunAction) removeEphemeral(containerID string) {
 // resolveCommandImage resolves the image that runs the Environment commands.
 // Preference: the Environment's first Stack (env.Stacks[0]) via the stack
 // catalogue. Fallback: the agent's effective image (the same image the run's
-// agent container uses) when no stack is declared or the stack repo is absent.
-// The fallback guarantees the command image always carries a usable toolchain.
+// agent container uses) when no stack is declared OR the declared stack key is
+// not catalogued (typo / not seeded). The fallback guarantees the command image
+// always carries a usable toolchain.
+//
+// A NotFound from the stack repo is NOT fatal — it degrades to the agent image
+// fallback (with a Warn). Any other repo error (transient DB failure, etc.) is
+// propagated and fails the run, so a flaky lookup is not silently masked.
 func (a *AgentRunAction) resolveCommandImage(ctx context.Context, env *model.Environment, agentImage string) (string, error) {
 	if len(env.Stacks) > 0 && a.stackRepo != nil {
 		key := env.Stacks[0]
 		stack, err := a.stackRepo.GetByKey(ctx, key)
-		if err != nil {
-			return "", fmt.Errorf("lookup stack %q: %w", key, err)
-		}
-		if stack != nil && stack.ImageRef != "" {
+		switch {
+		case err == nil && stack != nil && stack.ImageRef != "":
 			return stack.ImageRef, nil
+		case err != nil && isNotFound(err):
+			a.logger.Warn("environment stack not catalogued, falling back to agent image",
+				"stack_key", key)
+		case err != nil:
+			return "", fmt.Errorf("lookup stack %q: %w", key, err)
 		}
 	}
 	if agentImage != "" {
 		return agentImage, nil
 	}
 	return "", fmt.Errorf("no stack declared and no fallback agent image available")
+}
+
+// isNotFound reports whether err is (or wraps) a NotFound DomainError.
+func isNotFound(err error) bool {
+	var de *apperrors.DomainError
+	return stderrors.As(err, &de) && de.Category == apperrors.CategoryNotFound
 }
 
 // gitEnv returns the git-related env entries the agent container also receives,

--- a/backend/internal/adapter/action/agent_run_commands_test.go
+++ b/backend/internal/adapter/action/agent_run_commands_test.go
@@ -1,0 +1,342 @@
+package action_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+)
+
+// Labels and env keys asserted repeatedly across these tests. Declared as
+// constants because goconst (which does NOT skip _test.go in this config) flags
+// any string literal repeated three or more times.
+const (
+	labelRole       = "role"
+	labelCommandKey = "command_key"
+	roleEnvCommand  = "env_command"
+	keyGITTOKEN     = "GIT_TOKEN="
+
+	stackImageRef = "ghcr.io/hopeitworks/go@sha256:deadbeef"
+	agentImageRef = "hopeitworks/agent:latest"
+)
+
+// envWithCommands returns an Environment that has a postgres service (so sidecars
+// launch) and the given commands map.
+func envWithCommands(projectID uuid.UUID, commands map[string]string, stacks []string) *model.Environment {
+	return &model.Environment{
+		ProjectID: projectID,
+		Stacks:    stacks,
+		Services: []model.EnvironmentService{
+			{
+				Name:  "db",
+				Image: "postgres:16",
+				Env: map[string]string{
+					"POSTGRES_USER":     "app",
+					"POSTGRES_PASSWORD": "secret",
+					"POSTGRES_DB":       "appdb",
+				},
+			},
+		},
+		Commands: commands,
+	}
+}
+
+// wireEnvironment makes the fixture's repos serve env and a successful sidecar
+// launch returning a run network. It returns the run network name.
+func wireEnvironment(f *agentRunFixture, env *model.Environment) string {
+	runNetwork := "hopeitworks-run-" + f.runID.String()
+	f.environmentRepo.getByProjectIDFn = func(_ context.Context, _ uuid.UUID) (*model.Environment, error) {
+		return env, nil
+	}
+	f.sidecarMgr.launchFn = func(_ context.Context, runID uuid.UUID, _ *model.Environment) (*port.SidecarContext, error) {
+		return &port.SidecarContext{
+			RunID:        runID,
+			NetworkName:  runNetwork,
+			ContainerIDs: map[string]string{"db": "sidecar-db"},
+			ServiceAddrs: map[string]string{"db": "db"},
+		}, nil
+	}
+	return runNetwork
+}
+
+// commandCreateCalls returns only the ephemeral command Create calls (role=env_command).
+func commandCreateCalls(f *agentRunFixture) []model.ContainerOpts {
+	f.containerMgr.mu.Lock()
+	defer f.containerMgr.mu.Unlock()
+	var out []model.ContainerOpts
+	for _, c := range f.containerMgr.createCalls {
+		if c.Labels[labelRole] == roleEnvCommand {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// agentCreateCalls returns only the non-command (agent) Create calls.
+func agentCreateCalls(f *agentRunFixture) []model.ContainerOpts {
+	f.containerMgr.mu.Lock()
+	defer f.containerMgr.mu.Unlock()
+	var out []model.ContainerOpts
+	for _, c := range f.containerMgr.createCalls {
+		if c.Labels[labelRole] != roleEnvCommand {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// idForCommand encodes the command key into a container id so waitFn can map an
+// id back to its command and decide the exit code.
+func idForCommand(opts model.ContainerOpts) string {
+	if k := opts.Labels[labelCommandKey]; k != "" {
+		return "cmd-" + k
+	}
+	return testContainerID
+}
+
+// TestRunEnvironmentCommands_Order proves the commands run in the FIXED
+// conventional order build → migrate → seed → test and that a command absent
+// from env.Commands is skipped.
+func TestRunEnvironmentCommands_Order(t *testing.T) {
+	f := newAgentRunFixture(t)
+	// Provide commands out of map order, and omit "migrate" to prove it is skipped.
+	env := envWithCommands(f.projectID, map[string]string{
+		cmdTest():  "make test",
+		cmdBuild(): "make build",
+		cmdSeed():  "make seed",
+	}, nil)
+	wireEnvironment(f, env)
+
+	f.containerMgr.createFn = func(_ context.Context, opts model.ContainerOpts) (string, error) {
+		return idForCommand(opts), nil
+	}
+
+	if err := f.action.Execute(context.Background(), f.newRunContext()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	cmds := commandCreateCalls(f)
+	if len(cmds) != 3 {
+		t.Fatalf("expected 3 command containers (build, seed, test), got %d", len(cmds))
+	}
+	gotOrder := []string{
+		cmds[0].Labels[labelCommandKey],
+		cmds[1].Labels[labelCommandKey],
+		cmds[2].Labels[labelCommandKey],
+	}
+	wantOrder := []string{cmdBuild(), cmdSeed(), cmdTest()}
+	for i := range wantOrder {
+		if gotOrder[i] != wantOrder[i] {
+			t.Errorf("command order[%d]: got %q, want %q (full=%v)", i, gotOrder[i], wantOrder[i], gotOrder)
+		}
+	}
+
+	// The agent container is still created after the commands succeed.
+	if len(agentCreateCalls(f)) != 1 {
+		t.Errorf("expected 1 agent container created after commands, got %d", len(agentCreateCalls(f)))
+	}
+}
+
+// TestRunEnvironmentCommands_FailFast proves that a command exiting non-zero
+// fails the run, stops further commands, and never creates the agent container.
+func TestRunEnvironmentCommands_FailFast(t *testing.T) {
+	f := newAgentRunFixture(t)
+	env := envWithCommands(f.projectID, map[string]string{
+		cmdBuild():   "make build",
+		cmdMigrate(): "make migrate",
+		cmdSeed():    "make seed",
+	}, nil)
+	wireEnvironment(f, env)
+
+	f.containerMgr.createFn = func(_ context.Context, opts model.ContainerOpts) (string, error) {
+		return idForCommand(opts), nil
+	}
+	// migrate fails with exit code 2; build succeeds.
+	f.containerMgr.waitFn = func(_ context.Context, containerID string) (int, error) {
+		if containerID == "cmd-"+cmdMigrate() {
+			return 2, nil
+		}
+		return 0, nil
+	}
+
+	err := f.action.Execute(context.Background(), f.newRunContext())
+	if err == nil {
+		t.Fatal("expected fail-fast error from migrate, got nil")
+	}
+	if !strings.Contains(err.Error(), cmdMigrate()) || !strings.Contains(err.Error(), "exit code 2") {
+		t.Errorf("expected error to mention migrate and exit code 2, got: %v", err)
+	}
+
+	// build ran, migrate ran (and failed), seed must NOT have run.
+	cmds := commandCreateCalls(f)
+	keys := make([]string, len(cmds))
+	for i, c := range cmds {
+		keys[i] = c.Labels[labelCommandKey]
+	}
+	if len(keys) != 2 || keys[0] != cmdBuild() || keys[1] != cmdMigrate() {
+		t.Errorf("expected [build migrate] before fail-fast, got %v", keys)
+	}
+
+	// The agent container must NOT have been created.
+	if got := len(agentCreateCalls(f)); got != 0 {
+		t.Errorf("expected 0 agent containers after a failed command, got %d", got)
+	}
+	// Sidecars are still torn down (deferred Cleanup).
+	if got := f.sidecarMgr.getCleanupCalls(); got != 1 {
+		t.Errorf("expected 1 sidecar Cleanup after fail-fast, got %d", got)
+	}
+}
+
+// TestRunEnvironmentCommands_EnvWithServicesNoCommands proves that an
+// Environment WITH services but WITHOUT commands launches sidecars but runs NO
+// ephemeral command container (no-op).
+func TestRunEnvironmentCommands_EnvWithServicesNoCommands(t *testing.T) {
+	f := newAgentRunFixture(t)
+	env := envWithCommands(f.projectID, nil, nil) // services present, commands nil
+	wireEnvironment(f, env)
+
+	if err := f.action.Execute(context.Background(), f.newRunContext()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Launch was called (services exist) but no command container was created.
+	if got := f.sidecarMgr.getLaunchCalls(); got != 1 {
+		t.Errorf("expected 1 Launch call, got %d", got)
+	}
+	if got := len(commandCreateCalls(f)); got != 0 {
+		t.Errorf("expected 0 ephemeral command containers when commands is empty, got %d", got)
+	}
+	// The agent container is still created.
+	if got := len(agentCreateCalls(f)); got != 1 {
+		t.Errorf("expected 1 agent container, got %d", got)
+	}
+}
+
+// TestRunEnvironmentCommands_NoEnvNoOp proves that with no Environment at all,
+// no command container is created (back-compat) — Launch is never called.
+func TestRunEnvironmentCommands_NoEnvNoOp(t *testing.T) {
+	f := newAgentRunFixture(t)
+	// Default fixture: GetByProjectID -> NotFound, sidecarMgr guards Launch.
+	if err := f.action.Execute(context.Background(), f.newRunContext()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got := len(commandCreateCalls(f)); got != 0 {
+		t.Errorf("expected 0 ephemeral command containers with no Environment, got %d", got)
+	}
+}
+
+// TestRunEnvironmentCommands_ConnStringAndGitEnv proves the ephemeral command
+// container receives the sidecar conn-strings AND the same git env the agent
+// gets, and is attached to the run network.
+func TestRunEnvironmentCommands_ConnStringAndGitEnv(t *testing.T) {
+	f := newAgentRunFixture(t)
+	env := envWithCommands(f.projectID, map[string]string{cmdMigrate(): "make migrate"}, nil)
+	runNetwork := wireEnvironment(f, env)
+
+	f.containerMgr.createFn = func(_ context.Context, opts model.ContainerOpts) (string, error) {
+		return idForCommand(opts), nil
+	}
+
+	if err := f.action.Execute(context.Background(), f.newRunContext()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	cmds := commandCreateCalls(f)
+	if len(cmds) != 1 {
+		t.Fatalf("expected 1 command container, got %d", len(cmds))
+	}
+	opts := cmds[0]
+
+	// Conn-string injected.
+	if got := envValue(opts.Env, "DATABASE_URL"); got != "postgres://app:secret@db:5432/appdb" {
+		t.Errorf("expected DATABASE_URL injected into command container, got %q", got)
+	}
+	// Same git env the agent gets.
+	if got := envValue(opts.Env, "REPO_URL"); got != testAgentRepoURL {
+		t.Errorf("expected REPO_URL in command container, got %q", got)
+	}
+	for _, key := range []string{keyGITTOKEN, "GIT_PROVIDER=", "GITHUB_TOKEN="} {
+		if !hasEnvKey(opts.Env, key) {
+			t.Errorf("expected git env %q in command container", key)
+		}
+	}
+	// Attached to the run network so it reaches the sidecars.
+	if opts.NetworkName != runNetwork {
+		t.Errorf("expected command container on run network %q, got %q", runNetwork, opts.NetworkName)
+	}
+	// Has a Cmd override that clones then runs the command.
+	if len(opts.Cmd) < 3 || opts.Cmd[0] != "sh" {
+		t.Fatalf("expected sh -lc Cmd override, got %v", opts.Cmd)
+	}
+	if !strings.Contains(opts.Cmd[2], "git clone") || !strings.Contains(opts.Cmd[2], "make migrate") {
+		t.Errorf("expected Cmd to clone then run the command, got %q", opts.Cmd[2])
+	}
+}
+
+// TestRunEnvironmentCommands_ImageResolution proves the command image is the
+// stack image when a stack is declared, and falls back to the agent image when
+// it is not.
+func TestRunEnvironmentCommands_ImageResolution(t *testing.T) {
+	t.Run("stack image when stack declared", func(t *testing.T) {
+		f := newAgentRunFixture(t)
+		env := envWithCommands(f.projectID, map[string]string{cmdBuild(): "make build"}, []string{model.StackKeyGo})
+		wireEnvironment(f, env)
+		f.stackRepo.getByKeyFn = func(_ context.Context, key string) (*model.Stack, error) {
+			if key != model.StackKeyGo {
+				return nil, fmt.Errorf("unexpected stack key %q", key)
+			}
+			return &model.Stack{Key: key, ImageRef: stackImageRef}, nil
+		}
+		f.containerMgr.createFn = func(_ context.Context, opts model.ContainerOpts) (string, error) {
+			return idForCommand(opts), nil
+		}
+
+		if err := f.action.Execute(context.Background(), f.newRunContext()); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		cmds := commandCreateCalls(f)
+		if len(cmds) != 1 || cmds[0].Image != stackImageRef {
+			t.Errorf("expected command image %q from stack, got %v", stackImageRef, cmds)
+		}
+	})
+
+	t.Run("agent image fallback when no stack", func(t *testing.T) {
+		f := newAgentRunFixture(t)
+		env := envWithCommands(f.projectID, map[string]string{cmdBuild(): "make build"}, nil)
+		wireEnvironment(f, env)
+		f.containerMgr.createFn = func(_ context.Context, opts model.ContainerOpts) (string, error) {
+			return idForCommand(opts), nil
+		}
+
+		runCtx := f.newRunContext()
+		runCtx.Metadata["agent_image"] = agentImageRef
+		if err := f.action.Execute(context.Background(), runCtx); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		cmds := commandCreateCalls(f)
+		if len(cmds) != 1 || cmds[0].Image != agentImageRef {
+			t.Errorf("expected command image to fall back to agent image %q, got %v", agentImageRef, cmds)
+		}
+	})
+}
+
+// hasEnvKey reports whether env has any entry starting with key (a KEY= prefix).
+func hasEnvKey(env []string, key string) bool {
+	for _, e := range env {
+		if strings.HasPrefix(e, key) {
+			return true
+		}
+	}
+	return false
+}
+
+// Command-key helpers keep the literal command keys in one place; goconst does
+// not skip test files, so reusing these avoids repeated string literals.
+func cmdBuild() string   { return "build" }
+func cmdMigrate() string { return "migrate" }
+func cmdSeed() string    { return "seed" }
+func cmdTest() string    { return "test" }

--- a/backend/internal/adapter/action/agent_run_commands_test.go
+++ b/backend/internal/adapter/action/agent_run_commands_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
 	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
 )
 
 // Labels and env keys asserted repeatedly across these tests. Declared as
@@ -268,12 +269,38 @@ func TestRunEnvironmentCommands_ConnStringAndGitEnv(t *testing.T) {
 	if opts.NetworkName != runNetwork {
 		t.Errorf("expected command container on run network %q, got %q", runNetwork, opts.NetworkName)
 	}
-	// Has a Cmd override that clones then runs the command.
-	if len(opts.Cmd) < 3 || opts.Cmd[0] != "sh" {
-		t.Fatalf("expected sh -lc Cmd override, got %v", opts.Cmd)
+
+	// BLOCKER #1 regression guard: the ENTRYPOINT must be overridden to the
+	// shell. Stack/agent images bake ENTRYPOINT ["agent-runtime"]; without this
+	// override Docker would run `agent-runtime sh -lc <script>` and the command
+	// would NEVER execute (and agent-runtime would receive the token+conn-strings
+	// in env). The shell goes in Entrypoint, the script in Cmd[0].
+	wantEntrypoint := []string{"sh", "-lc"}
+	if len(opts.Entrypoint) != len(wantEntrypoint) {
+		t.Fatalf("expected Entrypoint %v, got %v", wantEntrypoint, opts.Entrypoint)
 	}
-	if !strings.Contains(opts.Cmd[2], "git clone") || !strings.Contains(opts.Cmd[2], "make migrate") {
-		t.Errorf("expected Cmd to clone then run the command, got %q", opts.Cmd[2])
+	for i := range wantEntrypoint {
+		if opts.Entrypoint[i] != wantEntrypoint[i] {
+			t.Fatalf("expected Entrypoint %v, got %v", wantEntrypoint, opts.Entrypoint)
+		}
+	}
+	if len(opts.Cmd) != 1 {
+		t.Fatalf("expected Cmd to be a single script arg, got %v", opts.Cmd)
+	}
+	script := opts.Cmd[0]
+	if !strings.Contains(script, "git clone") || !strings.Contains(script, "make migrate") {
+		t.Errorf("expected script to clone then run the command, got %q", script)
+	}
+	// STRICT clone (#4): set -e, no silent default-branch fallback.
+	if !strings.HasPrefix(script, "set -e;") {
+		t.Errorf("expected script to start with 'set -e;' (strict clone), got %q", script)
+	}
+	if strings.Contains(script, "|| git clone") {
+		t.Errorf("script must NOT fall back to default branch on clone failure, got %q", script)
+	}
+	// The token must NOT appear in argv: the clone URL is referenced via env var.
+	if !strings.Contains(script, "$HOPEITWORKS_CLONE_URL") {
+		t.Errorf("expected clone URL referenced via env var, got %q", script)
 	}
 }
 
@@ -322,6 +349,167 @@ func TestRunEnvironmentCommands_ImageResolution(t *testing.T) {
 			t.Errorf("expected command image to fall back to agent image %q, got %v", agentImageRef, cmds)
 		}
 	})
+
+	// #3: a declared-but-uncatalogued stack key (typo / not seeded) yields a
+	// NotFound from the stack repo. That must NOT fail the run — it degrades to
+	// the agent image fallback.
+	t.Run("agent image fallback when stack NotFound", func(t *testing.T) {
+		f := newAgentRunFixture(t)
+		env := envWithCommands(f.projectID, map[string]string{cmdBuild(): "make build"}, []string{"typo-stack"})
+		wireEnvironment(f, env)
+		f.stackRepo.getByKeyFn = func(_ context.Context, key string) (*model.Stack, error) {
+			return nil, errors.NewNotFound("stack", key)
+		}
+		f.containerMgr.createFn = func(_ context.Context, opts model.ContainerOpts) (string, error) {
+			return idForCommand(opts), nil
+		}
+
+		runCtx := f.newRunContext()
+		runCtx.Metadata["agent_image"] = agentImageRef
+		if err := f.action.Execute(context.Background(), runCtx); err != nil {
+			t.Fatalf("expected NotFound to fall back, not fail the run, got %v", err)
+		}
+		cmds := commandCreateCalls(f)
+		if len(cmds) != 1 || cmds[0].Image != agentImageRef {
+			t.Errorf("expected fallback to agent image on stack NotFound, got %v", cmds)
+		}
+	})
+
+	// A non-NotFound stack repo error (transient DB failure) MUST fail the run —
+	// it is not masked by the fallback.
+	t.Run("non-NotFound stack error fails the run", func(t *testing.T) {
+		f := newAgentRunFixture(t)
+		env := envWithCommands(f.projectID, map[string]string{cmdBuild(): "make build"}, []string{model.StackKeyGo})
+		wireEnvironment(f, env)
+		f.stackRepo.getByKeyFn = func(_ context.Context, _ string) (*model.Stack, error) {
+			return nil, fmt.Errorf("connection refused")
+		}
+
+		err := f.action.Execute(context.Background(), f.newRunContext())
+		if err == nil {
+			t.Fatal("expected a non-NotFound stack error to fail the run, got nil")
+		}
+		if got := len(commandCreateCalls(f)); got != 0 {
+			t.Errorf("expected no command container when image resolution errors, got %d", got)
+		}
+		if got := len(agentCreateCalls(f)); got != 0 {
+			t.Errorf("expected no agent container when image resolution errors, got %d", got)
+		}
+	})
+}
+
+// TestRunEnvironmentCommands_ErrorOmitsLogTail is the BLOCKER #2 regression
+// guard: when a command fails, the error that PROPAGATES (and is persisted to
+// run.error_message + broadcast over SSE) must contain ONLY the command key and
+// exit code — never the container's stdout/stderr, which could carry a dumped
+// token or DB password.
+func TestRunEnvironmentCommands_ErrorOmitsLogTail(t *testing.T) {
+	f := newAgentRunFixture(t)
+	env := envWithCommands(f.projectID, map[string]string{cmdMigrate(): "make migrate"}, nil)
+	wireEnvironment(f, env)
+
+	f.containerMgr.createFn = func(_ context.Context, opts model.ContainerOpts) (string, error) {
+		return idForCommand(opts), nil
+	}
+	f.containerMgr.waitFn = func(_ context.Context, _ string) (int, error) {
+		return 1, nil // command fails
+	}
+	// The log stream emits a "secret" line that would leak if embedded in the error.
+	const secretLine = "GITHUB_TOKEN=ghp_supersecrettoken_should_never_propagate"
+	f.logStreamer.streamLogsFn = func(_ context.Context, _, _, _ string) (<-chan model.LogEvent, <-chan int, error) {
+		logCh := make(chan model.LogEvent, 1)
+		doneCh := make(chan int, 1)
+		logCh <- model.LogEvent{Message: secretLine}
+		close(logCh)
+		doneCh <- 1
+		return logCh, doneCh, nil
+	}
+
+	err := f.action.Execute(context.Background(), f.newRunContext())
+	if err == nil {
+		t.Fatal("expected fail-fast error, got nil")
+	}
+	if strings.Contains(err.Error(), secretLine) || strings.Contains(err.Error(), "ghp_") {
+		t.Fatalf("error leaked the log tail / secret: %q", err.Error())
+	}
+	// It must still carry the actionable bits.
+	if !strings.Contains(err.Error(), cmdMigrate()) || !strings.Contains(err.Error(), "exit code 1") {
+		t.Errorf("expected error to name the command and exit code, got %q", err.Error())
+	}
+}
+
+// TestRunEnvironmentCommands_RunIDLabelWithoutServices is the #5 regression
+// guard: a project with commands but NO sidecar services still stamps run_id on
+// the ephemeral container so the GC reaper can find it.
+func TestRunEnvironmentCommands_RunIDLabelWithoutServices(t *testing.T) {
+	f := newAgentRunFixture(t)
+	// Environment with a command but ZERO services -> no sidecar launch path.
+	env := &model.Environment{
+		ProjectID: f.projectID,
+		Commands:  map[string]string{cmdBuild(): "make build"},
+	}
+	f.environmentRepo.getByProjectIDFn = func(_ context.Context, _ uuid.UUID) (*model.Environment, error) {
+		return env, nil
+	}
+	f.containerMgr.createFn = func(_ context.Context, opts model.ContainerOpts) (string, error) {
+		return idForCommand(opts), nil
+	}
+
+	if err := f.action.Execute(context.Background(), f.newRunContext()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// No sidecar launch (no services), but the command still ran.
+	if got := f.sidecarMgr.getLaunchCalls(); got != 0 {
+		t.Errorf("expected 0 Launch calls (no services), got %d", got)
+	}
+	cmds := commandCreateCalls(f)
+	if len(cmds) != 1 {
+		t.Fatalf("expected 1 command container, got %d", len(cmds))
+	}
+	if got := cmds[0].Labels[model.LabelRunID]; got != f.runID.String() {
+		t.Errorf("expected run_id label %q on ephemeral container, got %q", f.runID.String(), got)
+	}
+	// No run network to attach to: NetworkName stays empty.
+	if cmds[0].NetworkName != "" {
+		t.Errorf("expected no run network without services, got %q", cmds[0].NetworkName)
+	}
+}
+
+// TestRunEnvironmentCommands_WaitError is the #7 guard: a Wait error (timeout /
+// daemon error) fails the run, creates no agent container, removes the ephemeral
+// container, and still tears down the sidecars.
+func TestRunEnvironmentCommands_WaitError(t *testing.T) {
+	f := newAgentRunFixture(t)
+	env := envWithCommands(f.projectID, map[string]string{cmdMigrate(): "make migrate"}, nil)
+	wireEnvironment(f, env)
+
+	f.containerMgr.createFn = func(_ context.Context, opts model.ContainerOpts) (string, error) {
+		return idForCommand(opts), nil
+	}
+	f.containerMgr.waitFn = func(_ context.Context, _ string) (int, error) {
+		return 0, fmt.Errorf("docker wait failed")
+	}
+
+	err := f.action.Execute(context.Background(), f.newRunContext())
+	if err == nil {
+		t.Fatal("expected error from Wait failure, got nil")
+	}
+	// The ephemeral container was removed (defer removeEphemeral -> Stop+Remove).
+	f.containerMgr.mu.Lock()
+	removeCalls := append([]string(nil), f.containerMgr.removeCalls...)
+	f.containerMgr.mu.Unlock()
+	if len(removeCalls) == 0 {
+		t.Error("expected the ephemeral command container to be removed")
+	}
+	// No agent container was created.
+	if got := len(agentCreateCalls(f)); got != 0 {
+		t.Errorf("expected 0 agent containers after a Wait error, got %d", got)
+	}
+	// Sidecars still torn down (deferred Cleanup).
+	if got := f.sidecarMgr.getCleanupCalls(); got != 1 {
+		t.Errorf("expected 1 sidecar Cleanup, got %d", got)
+	}
 }
 
 // hasEnvKey reports whether env has any entry starting with key (a KEY= prefix).

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -23,8 +23,9 @@ import (
 const testContainerID = "container-123"
 
 const (
-	testNetwork  = "test-network"
-	testStoryKey = "S-42"
+	testNetwork      = "test-network"
+	testStoryKey     = "S-42"
+	testAgentRepoURL = "https://github.com/test/repo"
 )
 
 // testLogger creates a silent logger for tests.
@@ -440,6 +441,27 @@ func (m *mockSidecarManager) getCleanupCalls() int {
 	return m.cleanupCalls
 }
 
+// mockStackRepo is a StackRepository mock. By default GetByKey returns a stack
+// with no image, so callers fall back to the agent image unless getByKeyFn is
+// set to return a real image_ref.
+type mockStackRepo struct {
+	getByKeyFn func(ctx context.Context, key string) (*model.Stack, error)
+}
+
+func (m *mockStackRepo) List(_ context.Context) ([]*model.Stack, error) { return nil, nil }
+func (m *mockStackRepo) GetByID(_ context.Context, _ uuid.UUID) (*model.Stack, error) {
+	return nil, nil
+}
+func (m *mockStackRepo) GetByKey(ctx context.Context, key string) (*model.Stack, error) {
+	if m.getByKeyFn != nil {
+		return m.getByKeyFn(ctx, key)
+	}
+	return nil, errors.NewNotFound("stack", key)
+}
+func (m *mockStackRepo) Upsert(_ context.Context, s *model.Stack) (*model.Stack, error) {
+	return s, nil
+}
+
 // --- Test fixture ---
 
 // mockCostRepo is a no-op CostRepository for use in AgentRunAction tests.
@@ -512,6 +534,7 @@ type agentRunFixture struct {
 	runRepo         *mockRunRepo
 	environmentRepo *mockEnvironmentRepo
 	sidecarMgr      *mockSidecarManager
+	stackRepo       *mockStackRepo
 	costSvc         *service.CostService
 
 	action *action.AgentRunAction
@@ -528,7 +551,7 @@ func newAgentRunFixture(t *testing.T) *agentRunFixture {
 	}
 
 	backendScope := "backend"
-	repoURL := "https://github.com/test/repo"
+	repoURL := testAgentRepoURL
 	f.story = &model.Story{
 		ID:                 f.storyID,
 		ProjectID:          f.projectID,
@@ -610,6 +633,7 @@ func newAgentRunFixture(t *testing.T) *agentRunFixture {
 	// back-compat golden test pins.
 	f.environmentRepo = &mockEnvironmentRepo{}
 	f.sidecarMgr = &mockSidecarManager{t: t}
+	f.stackRepo = &mockStackRepo{}
 
 	// Create a real TemplateRenderer
 	renderer := &mockTemplateRenderer{}
@@ -633,6 +657,7 @@ func newAgentRunFixture(t *testing.T) *agentRunFixture {
 		f.runRepo,
 		f.environmentRepo,
 		f.sidecarMgr,
+		f.stackRepo,
 		renderer,
 		f.costSvc,
 		agentCfg,
@@ -728,7 +753,7 @@ func TestAgentRunAction_HappyPath(t *testing.T) {
 	if !strings.Contains(envMap["CLAUDE_MD_CONTENT"], "Test Project") {
 		t.Errorf("expected CLAUDE_MD_CONTENT to contain project name, got: %q", envMap["CLAUDE_MD_CONTENT"])
 	}
-	if envMap["REPO_URL"] != "https://github.com/test/repo" {
+	if envMap["REPO_URL"] != testAgentRepoURL {
 		t.Errorf("expected REPO_URL, got %q", envMap["REPO_URL"])
 	}
 	if envMap["BRANCH_NAME"] != "feat/s-42-test" {
@@ -1162,7 +1187,7 @@ func TestAgentRunAction_NoEnvironment_GoldenBackCompat(t *testing.T) {
 	// Build the expected legacy env exactly as createContainer would with no
 	// extraEnv, sort both, and compare element-by-element.
 	wantEnv := []string{
-		"REPO_URL=https://github.com/test/repo",
+		"REPO_URL=" + testAgentRepoURL,
 		"BRANCH_NAME=feat/s-42-test",
 		"STORY_KEY=S-42",
 		"PROMPT_CONTENT=" + envValue(opts.Env, "PROMPT_CONTENT"),

--- a/backend/internal/adapter/docker/container_manager.go
+++ b/backend/internal/adapter/docker/container_manager.go
@@ -74,6 +74,14 @@ func (m *ContainerManager) Create(ctx context.Context, opts model.ContainerOpts)
 		Env:    opts.Env,
 		Labels: opts.Labels,
 	}
+	// Optional ENTRYPOINT/CMD overrides. Nil-safe: empty slices leave the
+	// image's own entrypoint/command untouched, preserving current behaviour.
+	if len(opts.Entrypoint) > 0 {
+		config.Entrypoint = opts.Entrypoint
+	}
+	if len(opts.Cmd) > 0 {
+		config.Cmd = opts.Cmd
+	}
 	if opts.Healthcheck != nil {
 		config.Healthcheck = &dockercontainer.HealthConfig{
 			Test:        opts.Healthcheck.Test,

--- a/backend/internal/adapter/docker/sidecar_manager.go
+++ b/backend/internal/adapter/docker/sidecar_manager.go
@@ -371,14 +371,29 @@ func (s *SidecarManager) ListOrphanNetworks(ctx context.Context) ([]model.Networ
 	return orphans, nil
 }
 
-// GC removes orphan run networks older than olderThan. Best-effort, log-only.
+// GC removes orphan run networks AND orphan ephemeral command containers older
+// than olderThan. Best-effort, log-only. The command containers are normally
+// removed by their own defer; this reaper is the safety net for when the API
+// process dies mid-command and the defer never runs (the network GC alone would
+// leave the exited command container behind).
 func (s *SidecarManager) GC(ctx context.Context, olderThan time.Duration) error {
+	cutoff := s.now().Add(-olderThan)
+
+	netErr := s.gcNetworks(ctx, cutoff)
+	cmdErr := s.gcCommandContainers(ctx, cutoff)
+	if netErr != nil {
+		return netErr
+	}
+	return cmdErr
+}
+
+// gcNetworks removes orphan run networks created before cutoff.
+func (s *SidecarManager) gcNetworks(ctx context.Context, cutoff time.Time) error {
 	orphans, err := s.ListOrphanNetworks(ctx)
 	if err != nil {
 		return err
 	}
 
-	cutoff := s.now().Add(-olderThan)
 	removed := 0
 	for _, n := range orphans {
 		if n.CreatedAt.After(cutoff) {
@@ -398,6 +413,53 @@ func (s *SidecarManager) GC(ctx context.Context, olderThan time.Duration) error 
 
 	if removed > 0 {
 		s.logger.Info("gc removed orphan networks", slog.Int("count", removed))
+	}
+	return nil
+}
+
+// gcCommandContainers reaps ephemeral env-command containers (role=env_command)
+// that are no longer running and were created before cutoff. A container still
+// running is left alone (its command may still be in flight); only exited or
+// dead ones are removed. Matched by label so it never touches sidecars or agents.
+func (s *SidecarManager) gcCommandContainers(ctx context.Context, cutoff time.Time) error {
+	filter := map[string]string{
+		labelManagedBy:  managedByLabel,
+		model.LabelRole: model.RoleEnvCommand,
+	}
+
+	all, err := s.containers.ListContainers(ctx, filter)
+	if err != nil {
+		return err
+	}
+	running, err := s.containers.ListRunningContainers(ctx, filter)
+	if err != nil {
+		return err
+	}
+	runningIDs := make(map[string]bool, len(running))
+	for _, c := range running {
+		runningIDs[c.ID] = true
+	}
+
+	removed := 0
+	for _, c := range all {
+		if runningIDs[c.ID] {
+			continue // still running: leave it
+		}
+		if c.CreatedAt.After(cutoff) {
+			continue // too recent: a run may still be starting up
+		}
+		if err := s.containers.Remove(ctx, c.ID); err != nil {
+			s.logger.Warn("gc: remove orphan command container failed",
+				slog.String("container_id", c.ID),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		removed++
+	}
+
+	if removed > 0 {
+		s.logger.Info("gc removed orphan command containers", slog.Int("count", removed))
 	}
 	return nil
 }

--- a/backend/internal/adapter/docker/sidecar_manager_test.go
+++ b/backend/internal/adapter/docker/sidecar_manager_test.go
@@ -484,6 +484,41 @@ func TestSidecarGC_Windowed(t *testing.T) {
 	}
 }
 
+// TestSidecarGC_ReapsCommandContainers proves the GC reaper removes ephemeral
+// env-command containers (role=env_command) that are exited and older than the
+// window, while leaving running ones and recently-created ones alone. This is
+// the safety net for an API crash mid-command where the defer removeEphemeral
+// never ran.
+func TestSidecarGC_ReapsCommandContainers(t *testing.T) {
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	cm := newMockCM()
+	// No networks to reap; focus on command containers.
+	cm.listNetworksFn = func() ([]model.NetworkInfo, error) { return nil, nil }
+	cm.listContainerFn = func() ([]port.ContainerInfo, error) {
+		return []port.ContainerInfo{
+			{ID: "cmd-old-exited", Labels: map[string]string{model.LabelRole: model.RoleEnvCommand}, CreatedAt: now.Add(-2 * time.Hour)},
+			{ID: "cmd-recent-exited", Labels: map[string]string{model.LabelRole: model.RoleEnvCommand}, CreatedAt: now.Add(-1 * time.Minute)},
+			{ID: "cmd-old-running", Labels: map[string]string{model.LabelRole: model.RoleEnvCommand}, CreatedAt: now.Add(-2 * time.Hour)},
+		}, nil
+	}
+	cm.listRunningFn = func() ([]port.ContainerInfo, error) {
+		return []port.ContainerInfo{
+			{ID: "cmd-old-running", Labels: map[string]string{model.LabelRole: model.RoleEnvCommand}},
+		}, nil
+	}
+	s := newTestSidecarManager(cm)
+	s.now = func() time.Time { return now }
+
+	if err := s.GC(context.Background(), 30*time.Minute); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Only the old + exited command container is reaped.
+	if len(cm.removedIDs) != 1 || cm.removedIDs[0] != "cmd-old-exited" {
+		t.Errorf("expected only 'cmd-old-exited' removed, got %v", cm.removedIDs)
+	}
+}
+
 func TestSidecarListOrphanNetworks(t *testing.T) {
 	cm := newMockCM()
 	cm.listNetworksFn = func() ([]model.NetworkInfo, error) {

--- a/backend/internal/domain/model/container.go
+++ b/backend/internal/domain/model/container.go
@@ -49,6 +49,16 @@ type ContainerOpts struct {
 	// container so readiness can be polled via ContainerInspect. Optional and
 	// nil-safe: nil means no healthcheck is configured (current behaviour).
 	Healthcheck *ContainerHealthcheck
+
+	// Entrypoint overrides the image's ENTRYPOINT. Optional and nil-safe: an
+	// empty/nil slice leaves the image entrypoint untouched (current behaviour).
+	Entrypoint []string
+
+	// Cmd overrides the image's CMD. Optional and nil-safe: an empty/nil slice
+	// leaves the image command untouched (current behaviour). Used to run an
+	// ephemeral one-shot command (e.g. an Environment build/migrate/seed step)
+	// in an otherwise stock stack image.
+	Cmd []string
 }
 
 // ContainerHealthcheck describes a Docker HEALTHCHECK probe for a container.

--- a/backend/internal/domain/model/container_labels.go
+++ b/backend/internal/domain/model/container_labels.go
@@ -1,0 +1,26 @@
+package model
+
+// Container bookkeeping labels shared across the run path and the Docker
+// substrate so the same key/value is used where a label is STAMPED (the action
+// that launches ephemeral command containers) and where it is MATCHED (the GC
+// reaper that finds orphans). Centralising them in the domain avoids a literal
+// drifting between the two packages.
+const (
+	// LabelManagedBy / LabelManagedByValue mark every container/network the
+	// platform owns, so GC can scope its sweeps to platform-managed objects.
+	LabelManagedBy      = "managed_by"
+	LabelManagedByValue = "hopeitworks"
+
+	// LabelRunID ties a container/network to its run for attribution and GC.
+	LabelRunID = "run_id"
+
+	// LabelRole distinguishes the kind of container within a run. RoleEnvCommand
+	// marks the ephemeral one-shot containers that run an Environment setup
+	// command (build/migrate/seed/test); the GC reaper matches on it.
+	LabelRole      = "role"
+	RoleEnvCommand = "env_command"
+
+	// LabelCommandKey records which Environment command key (build/migrate/…) an
+	// ephemeral command container ran, for diagnostics.
+	LabelCommandKey = "command_key"
+)


### PR DESCRIPTION
## P2c2d — Exécution des `env.Commands` du projet (Option A)
Dernier maillon de P2c2. Avant le harness, exécute les commandes du projet (build→migrate→seed→test) sur le réseau du run, avec les conn-strings, en fail-fast. **Option A** = container éphémère orchestré par le backend, **zéro changement agent-runtime**.

### Livré
- `ContainerOpts.Cmd`/`Entrypoint` (nil-safe) + application dans l'adapter docker.
- `runEnvironmentCommands` (agent_run_commands.go) : pour chaque commande présente (ordre fixe), lève un container éphémère = **image stack du projet** (`env.Stacks[0]`→catalogue, fallback image agent), attaché au réseau du run, env = conn-strings + env git, clone du repo (token en env, jamais argv), `sh -lc`, Wait exit code, **fail-fast**, cleanup en defer (ctx détaché). Placé après `Launch`, avant `createContainer`.
- GC étendu : reape aussi les containers éphémères orphelins `role=env_command`.

### Review adversariale renforcée (chemin live) → 2 BLOCKERS trouvés + corrigés
1. **Entrypoint non overridé** (les images ont `ENTRYPOINT ["agent-runtime"]` → la commande ne tournait jamais) → `Entrypoint=["sh","-lc"]` + test de garde.
2. **Fuite de secrets** (tail brut persisté en DB + broadcasté SSE) → l'erreur propagée ne contient que `command %q failed with exit code %d` ; tail en `slog.Warn` serveur uniquement → test plantant un `ghp_…` vérifie son absence.
Should-fix corrigés : NotFound stack→fallback image agent ; clone strict `set -e` (plus de fallback branche silencieux) ; `run_id` toujours stampé ; GC reaper containers éphémères ; test Wait-error.

### Back-compat (gate)
`env=nil` OU `len(Commands)==0` ⇒ no-op total (0 container éphémère) ; golden `TestAgentRunAction_NoEnvironment_GoldenBackCompat` vert. golangci-lint v1.64.8 = 0 finding, build/vet/test -short verts.

> **À valider par un vrai run Docker** avant de s'appuyer dessus (les containers éphémères ne sont pas exécutables en CI/devcontainer) : présence de `sh`/`git` dans l'image, exécution réelle des commandes. Inerte tant qu'aucun projet ne déclare d'Environment.Commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)