### PR TITLE
feat(api): CRUD /projects/{id}/environment

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -45,6 +45,8 @@ tags:
     description: Cost tracking and observability endpoints
   - name: api-keys
     description: User API key management endpoints
+  - name: environments
+    description: Project environment (execution composition) endpoints
 
 paths:
   # ── Auth ────────────────────────────────────────────────────────────────
@@ -1306,6 +1308,65 @@ paths:
                       $ref: "#/components/schemas/Stack"
         "401":
           $ref: "#/components/responses/Unauthorized"
+
+  /projects/{projectId}/environment:
+    get:
+      operationId: getProjectEnvironment
+      summary: Get the project's execution environment
+      description: Returns the project's single execution environment (stacks, services, commands). Returns 404 when absent.
+      tags: [environments]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+      responses:
+        "200":
+          description: The project environment
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Environment"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    put:
+      operationId: putProjectEnvironment
+      summary: Upsert the project's execution environment
+      description: >
+        Creates the environment when absent, replaces it when present (one per project).
+        Use source "declared" when not importing from a repo file.
+      tags: [environments]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EnvironmentInput"
+      responses:
+        "200":
+          description: Environment created or updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Environment"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    delete:
+      operationId: deleteProjectEnvironment
+      summary: Delete the project's execution environment
+      tags: [environments]
+      parameters:
+        - $ref: "#/components/parameters/ProjectIdPath"
+      responses:
+        "204":
+          description: Environment deleted
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   /agents:
     get:
@@ -3168,6 +3229,96 @@ components:
         created_at:
           type: string
           format: date-time
+
+    Environment:
+      type: object
+      required:
+        - id
+        - project_id
+        - stacks
+        - services
+        - source
+        - commands
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        project_id:
+          type: string
+          format: uuid
+        stacks:
+          type: array
+          items:
+            type: string
+          description: Stack keys (e.g. go, node, python, go-node)
+        services:
+          type: array
+          items:
+            $ref: "#/components/schemas/EnvironmentService"
+        source:
+          type: string
+          enum: [devcontainer, compose, makefile, declared]
+          description: Where the run composition is derived from
+        commands:
+          type: object
+          additionalProperties:
+            type: string
+          description: Named commands to run (test, migrate, seed, …)
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    EnvironmentService:
+      type: object
+      required:
+        - name
+        - image
+        - env
+      properties:
+        name:
+          type: string
+          description: Sidecar service name (e.g. postgres, redis)
+        image:
+          type: string
+          description: Docker image reference for the sidecar
+        env:
+          type: object
+          additionalProperties:
+            type: string
+          description: Environment variables injected into the sidecar
+
+    EnvironmentInput:
+      type: object
+      required:
+        - stacks
+        - services
+        - source
+        - commands
+      properties:
+        stacks:
+          type: array
+          items:
+            type: string
+          description: Stack keys (e.g. go, node, python, go-node)
+        services:
+          type: array
+          items:
+            $ref: "#/components/schemas/EnvironmentService"
+        source:
+          type: string
+          enum: [devcontainer, compose, makefile, declared]
+          default: declared
+          description: Where the run composition is derived from
+        commands:
+          type: object
+          additionalProperties:
+            type: string
+          description: Named commands to run (test, migrate, seed, …)
 
     Agent:
       type: object

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -173,6 +173,8 @@ func run() error {
 	// (P2c2c): when a project has an Environment with sidecar services, they are brought
 	// up per-run and their connection strings injected into the agent container.
 	environmentRepo := pgadapter.NewEnvironmentRepo(queries)
+	environmentService := service.NewEnvironmentService(environmentRepo)
+	environmentHandler := handler.NewEnvironmentHandler(environmentService)
 
 	// Template renderer (Handlebars engine for prompt templates)
 	handlebarsRenderer := hbadapter.NewRenderer()
@@ -438,7 +440,7 @@ func run() error {
 	epicRunService := service.NewEpicRunService(epicRunRepo, storyRepo, epicRepo, schedulerService, parallelGroupExecutor, eventRepo, logger)
 	epicRunHandler := handler.NewEpicRunHandler(epicRunService)
 
-	server := handler.NewServer(authHandler, projectHandler, userHandler, profileHandler, epicHandler, storyHandler, agentHandler, stackHandler, runHandler, pipelineConfigHandler, hitlHandler, costHandler, notificationHandler, epicRunHandler)
+	server := handler.NewServer(authHandler, projectHandler, userHandler, profileHandler, epicHandler, storyHandler, agentHandler, stackHandler, runHandler, pipelineConfigHandler, hitlHandler, costHandler, notificationHandler, epicRunHandler, environmentHandler)
 
 	// Project user handler
 	projectUserHandler := handler.NewProjectUserHandler(projectUserService)

--- a/backend/internal/api/handler/environment_handler.go
+++ b/backend/internal/api/handler/environment_handler.go
@@ -1,0 +1,106 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+)
+
+// EnvironmentHandler implements the project environment HTTP handlers.
+type EnvironmentHandler struct {
+	service *service.EnvService
+}
+
+// NewEnvironmentHandler creates a new EnvironmentHandler.
+func NewEnvironmentHandler(svc *service.EnvService) *EnvironmentHandler {
+	return &EnvironmentHandler{service: svc}
+}
+
+// GetProjectEnvironment handles GET /projects/{projectId}/environment.
+func (h *EnvironmentHandler) GetProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
+	env, err := h.service.GetByProject(r.Context(), projectId)
+	if err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toAPIEnvironment(env))
+}
+
+// PutProjectEnvironment handles PUT /projects/{projectId}/environment (upsert).
+func (h *EnvironmentHandler) PutProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
+	var req EnvironmentInput
+	if !decodeJSONBody(w, r, &req) {
+		return
+	}
+
+	input := service.UpsertEnvironmentInput{
+		Stacks:   req.Stacks,
+		Services: inputServicesToModel(req.Services),
+		Source:   string(req.Source),
+		Commands: req.Commands,
+	}
+
+	env, err := h.service.Upsert(r.Context(), projectId, input)
+	if err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toAPIEnvironment(env))
+}
+
+// DeleteProjectEnvironment handles DELETE /projects/{projectId}/environment.
+func (h *EnvironmentHandler) DeleteProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
+	if err := h.service.Delete(r.Context(), projectId); err != nil {
+		writeErrorResponse(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// toAPIEnvironment converts a domain Environment to the generated API Environment type.
+func toAPIEnvironment(e *model.Environment) Environment {
+	services := make([]EnvironmentService, len(e.Services))
+	for i, svc := range e.Services {
+		env := make(map[string]string, len(svc.Env))
+		for k, v := range svc.Env {
+			env[k] = v
+		}
+		services[i] = EnvironmentService{
+			Name:  svc.Name,
+			Image: svc.Image,
+			Env:   env,
+		}
+	}
+	commands := make(map[string]string, len(e.Commands))
+	for k, v := range e.Commands {
+		commands[k] = v
+	}
+	return Environment{
+		Id:        e.ID,
+		ProjectId: e.ProjectID,
+		Stacks:    e.Stacks,
+		Services:  services,
+		Source:    EnvironmentSource(e.Source),
+		Commands:  commands,
+		CreatedAt: e.CreatedAt,
+		UpdatedAt: e.UpdatedAt,
+	}
+}
+
+// inputServicesToModel converts API EnvironmentService slice to domain model slice.
+func inputServicesToModel(apiServices []EnvironmentService) []model.EnvironmentService {
+	result := make([]model.EnvironmentService, len(apiServices))
+	for i, svc := range apiServices {
+		env := make(map[string]string, len(svc.Env))
+		for k, v := range svc.Env {
+			env[k] = v
+		}
+		result[i] = model.EnvironmentService{
+			Name:  svc.Name,
+			Image: svc.Image,
+			Env:   env,
+		}
+	}
+	return result
+}

--- a/backend/internal/api/handler/environment_handler.go
+++ b/backend/internal/api/handler/environment_handler.go
@@ -18,8 +18,8 @@ func NewEnvironmentHandler(svc *service.EnvService) *EnvironmentHandler {
 }
 
 // GetProjectEnvironment handles GET /projects/{projectId}/environment.
-func (h *EnvironmentHandler) GetProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
-	env, err := h.service.GetByProject(r.Context(), projectId)
+func (h *EnvironmentHandler) GetProjectEnvironment(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath) {
+	env, err := h.service.GetByProject(r.Context(), projectID)
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
@@ -28,7 +28,7 @@ func (h *EnvironmentHandler) GetProjectEnvironment(w http.ResponseWriter, r *htt
 }
 
 // PutProjectEnvironment handles PUT /projects/{projectId}/environment (upsert).
-func (h *EnvironmentHandler) PutProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
+func (h *EnvironmentHandler) PutProjectEnvironment(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath) {
 	var req EnvironmentInput
 	if !decodeJSONBody(w, r, &req) {
 		return
@@ -41,7 +41,7 @@ func (h *EnvironmentHandler) PutProjectEnvironment(w http.ResponseWriter, r *htt
 		Commands: req.Commands,
 	}
 
-	env, err := h.service.Upsert(r.Context(), projectId, input)
+	env, err := h.service.Upsert(r.Context(), projectID, input)
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
@@ -50,8 +50,8 @@ func (h *EnvironmentHandler) PutProjectEnvironment(w http.ResponseWriter, r *htt
 }
 
 // DeleteProjectEnvironment handles DELETE /projects/{projectId}/environment.
-func (h *EnvironmentHandler) DeleteProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
-	if err := h.service.Delete(r.Context(), projectId); err != nil {
+func (h *EnvironmentHandler) DeleteProjectEnvironment(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath) {
+	if err := h.service.Delete(r.Context(), projectID); err != nil {
 		writeErrorResponse(w, err)
 		return
 	}

--- a/backend/internal/api/handler/environment_handler_test.go
+++ b/backend/internal/api/handler/environment_handler_test.go
@@ -1,0 +1,246 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/api/middleware"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+const envResource = "environment"
+
+// mockEnvRepo is a hand-written mock of port.EnvironmentRepository for handler tests.
+type mockEnvRepo struct {
+	envs      map[uuid.UUID]*model.Environment
+	byProject map[uuid.UUID]*model.Environment
+}
+
+var _ port.EnvironmentRepository = (*mockEnvRepo)(nil)
+
+func newMockEnvRepo() *mockEnvRepo {
+	return &mockEnvRepo{
+		envs:      make(map[uuid.UUID]*model.Environment),
+		byProject: make(map[uuid.UUID]*model.Environment),
+	}
+}
+
+func (m *mockEnvRepo) Create(_ context.Context, e *model.Environment) (*model.Environment, error) {
+	if _, exists := m.byProject[e.ProjectID]; exists {
+		return nil, errors.NewConflict(envResource, e.ProjectID.String())
+	}
+	e.ID = uuid.New()
+	e.CreatedAt = time.Now()
+	e.UpdatedAt = time.Now()
+	m.envs[e.ID] = e
+	m.byProject[e.ProjectID] = e
+	return e, nil
+}
+
+func (m *mockEnvRepo) GetByID(_ context.Context, id uuid.UUID) (*model.Environment, error) {
+	e, ok := m.envs[id]
+	if !ok {
+		return nil, errors.NewNotFound(envResource, id)
+	}
+	return e, nil
+}
+
+func (m *mockEnvRepo) GetByProjectID(_ context.Context, projectID uuid.UUID) (*model.Environment, error) {
+	e, ok := m.byProject[projectID]
+	if !ok {
+		return nil, errors.NewNotFound(envResource, projectID)
+	}
+	return e, nil
+}
+
+func (m *mockEnvRepo) Update(_ context.Context, e *model.Environment) (*model.Environment, error) {
+	e.UpdatedAt = time.Now()
+	m.envs[e.ID] = e
+	m.byProject[e.ProjectID] = e
+	return e, nil
+}
+
+func (m *mockEnvRepo) Delete(_ context.Context, id uuid.UUID) error {
+	e, ok := m.envs[id]
+	if !ok {
+		return errors.NewNotFound(envResource, id)
+	}
+	delete(m.byProject, e.ProjectID)
+	delete(m.envs, id)
+	return nil
+}
+
+func setupEnvironmentHandler() (*EnvironmentHandler, *mockEnvRepo) {
+	repo := newMockEnvRepo()
+	svc := service.NewEnvironmentService(repo)
+	h := NewEnvironmentHandler(svc)
+	return h, repo
+}
+
+func TestGetProjectEnvironment_Found(t *testing.T) {
+	h, repo := setupEnvironmentHandler()
+	projectID := uuid.New()
+
+	env := &model.Environment{
+		ID:        uuid.New(),
+		ProjectID: projectID,
+		Stacks:    []string{model.StackKeyGo},
+		Services:  []model.EnvironmentService{},
+		Source:    model.EnvironmentSourceDeclared,
+		Commands:  map[string]string{"test": "make test"},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	repo.envs[env.ID] = env
+	repo.byProject[projectID] = env
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+projectID.String()+"/environment", nil)
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleUser)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.GetProjectEnvironment(rec, req, projectID)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp Environment
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.ProjectId != projectID {
+		t.Errorf("expected project_id %v, got %v", projectID, resp.ProjectId)
+	}
+	if resp.Source != EnvironmentSourceDeclared {
+		t.Errorf("expected source 'declared', got %q", resp.Source)
+	}
+}
+
+func TestGetProjectEnvironment_NotFound(t *testing.T) {
+	h, _ := setupEnvironmentHandler()
+	projectID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+projectID.String()+"/environment", nil)
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleUser)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.GetProjectEnvironment(rec, req, projectID)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPutProjectEnvironment_Upsert(t *testing.T) {
+	h, _ := setupEnvironmentHandler()
+	projectID := uuid.New()
+
+	body := EnvironmentInput{
+		Stacks:   []string{model.StackKeyNode},
+		Services: []EnvironmentService{{Name: "db", Image: "postgres:16", Env: map[string]string{"POSTGRES_DB": "app"}}},
+		Source:   EnvironmentInputSourceDeclared,
+		Commands: map[string]string{"test": "npm test"},
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/projects/"+projectID.String()+"/environment",
+		bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleUser)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.PutProjectEnvironment(rec, req, projectID)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp Environment
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.ProjectId != projectID {
+		t.Errorf("expected project_id %v, got %v", projectID, resp.ProjectId)
+	}
+	if len(resp.Services) != 1 {
+		t.Errorf("expected 1 service, got %d", len(resp.Services))
+	}
+	if len(resp.Stacks) != 1 || resp.Stacks[0] != model.StackKeyNode {
+		t.Errorf("expected stacks=[node], got %v", resp.Stacks)
+	}
+}
+
+func TestPutProjectEnvironment_InvalidJSON(t *testing.T) {
+	h, _ := setupEnvironmentHandler()
+	projectID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/projects/"+projectID.String()+"/environment",
+		bytes.NewBufferString(`{invalid json}`))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleUser)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.PutProjectEnvironment(rec, req, projectID)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDeleteProjectEnvironment_NoContent(t *testing.T) {
+	h, repo := setupEnvironmentHandler()
+	projectID := uuid.New()
+
+	env := &model.Environment{
+		ID:        uuid.New(),
+		ProjectID: projectID,
+		Stacks:    []string{model.StackKeyGo},
+		Services:  []model.EnvironmentService{},
+		Source:    model.EnvironmentSourceDeclared,
+		Commands:  map[string]string{},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	repo.envs[env.ID] = env
+	repo.byProject[projectID] = env
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/projects/"+projectID.String()+"/environment", nil)
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleUser)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.DeleteProjectEnvironment(rec, req, projectID)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDeleteProjectEnvironment_NotFound(t *testing.T) {
+	h, _ := setupEnvironmentHandler()
+	projectID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/projects/"+projectID.String()+"/environment", nil)
+	ctx := middleware.SetUserContext(req.Context(), uuid.New(), model.RoleUser)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.DeleteProjectEnvironment(rec, req, projectID)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/backend/internal/api/handler/gen_server.go
+++ b/backend/internal/api/handler/gen_server.go
@@ -93,6 +93,22 @@ const (
 	CreateStoryRequestScopeShared   CreateStoryRequestScope = "shared"
 )
 
+// Defines values for EnvironmentSource.
+const (
+	EnvironmentSourceCompose      EnvironmentSource = "compose"
+	EnvironmentSourceDeclared     EnvironmentSource = "declared"
+	EnvironmentSourceDevcontainer EnvironmentSource = "devcontainer"
+	EnvironmentSourceMakefile     EnvironmentSource = "makefile"
+)
+
+// Defines values for EnvironmentInputSource.
+const (
+	EnvironmentInputSourceCompose      EnvironmentInputSource = "compose"
+	EnvironmentInputSourceDeclared     EnvironmentInputSource = "declared"
+	EnvironmentInputSourceDevcontainer EnvironmentInputSource = "devcontainer"
+	EnvironmentInputSourceMakefile     EnvironmentInputSource = "makefile"
+)
+
 // Defines values for EpicStatus.
 const (
 	EpicStatusBacklog    EpicStatus = "backlog"
@@ -558,6 +574,54 @@ type CreateStoryRequest struct {
 
 // CreateStoryRequestScope defines model for CreateStoryRequest.Scope.
 type CreateStoryRequestScope string
+
+// Environment defines model for Environment.
+type Environment struct {
+	// Commands Named commands to run (test, migrate, seed, …)
+	Commands  map[string]string    `json:"commands"`
+	CreatedAt time.Time            `json:"created_at"`
+	Id        openapi_types.UUID   `json:"id"`
+	ProjectId openapi_types.UUID   `json:"project_id"`
+	Services  []EnvironmentService `json:"services"`
+
+	// Source Where the run composition is derived from
+	Source EnvironmentSource `json:"source"`
+
+	// Stacks Stack keys (e.g. go, node, python, go-node)
+	Stacks    []string  `json:"stacks"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// EnvironmentSource Where the run composition is derived from
+type EnvironmentSource string
+
+// EnvironmentInput defines model for EnvironmentInput.
+type EnvironmentInput struct {
+	// Commands Named commands to run (test, migrate, seed, …)
+	Commands map[string]string    `json:"commands"`
+	Services []EnvironmentService `json:"services"`
+
+	// Source Where the run composition is derived from
+	Source EnvironmentInputSource `json:"source"`
+
+	// Stacks Stack keys (e.g. go, node, python, go-node)
+	Stacks []string `json:"stacks"`
+}
+
+// EnvironmentInputSource Where the run composition is derived from
+type EnvironmentInputSource string
+
+// EnvironmentService defines model for EnvironmentService.
+type EnvironmentService struct {
+	// Env Environment variables injected into the sidecar
+	Env map[string]string `json:"env"`
+
+	// Image Docker image reference for the sidecar
+	Image string `json:"image"`
+
+	// Name Sidecar service name (e.g. postgres, redis)
+	Name string `json:"name"`
+}
 
 // Epic defines model for Epic.
 type Epic struct {
@@ -1729,6 +1793,9 @@ type CreateAgentJSONRequestBody = CreateAgentRequest
 // UpdateAgentJSONRequestBody defines body for UpdateAgent for application/json ContentType.
 type UpdateAgentJSONRequestBody = UpdateAgentRequest
 
+// PutProjectEnvironmentJSONRequestBody defines body for PutProjectEnvironment for application/json ContentType.
+type PutProjectEnvironmentJSONRequestBody = EnvironmentInput
+
 // CreateEpicJSONRequestBody defines body for CreateEpic for application/json ContentType.
 type CreateEpicJSONRequestBody = CreateEpicRequest
 
@@ -1928,6 +1995,15 @@ type ServerInterface interface {
 	// Get cost summary for a project
 	// (GET /projects/{projectId}/costs/summary)
 	GetProjectCostSummary(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, params GetProjectCostSummaryParams)
+	// Delete the project's execution environment
+	// (DELETE /projects/{projectId}/environment)
+	DeleteProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath)
+	// Get the project's execution environment
+	// (GET /projects/{projectId}/environment)
+	GetProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath)
+	// Upsert the project's execution environment
+	// (PUT /projects/{projectId}/environment)
+	PutProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath)
 	// Get an epic run by ID with per-story status
 	// (GET /projects/{projectId}/epic-runs/{epicRunId})
 	GetEpicRun(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, epicRunId EpicRunIdPath)
@@ -2273,6 +2349,24 @@ func (_ Unimplemented) GetProjectCostRuns(w http.ResponseWriter, r *http.Request
 // Get cost summary for a project
 // (GET /projects/{projectId}/costs/summary)
 func (_ Unimplemented) GetProjectCostSummary(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath, params GetProjectCostSummaryParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Delete the project's execution environment
+// (DELETE /projects/{projectId}/environment)
+func (_ Unimplemented) DeleteProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get the project's execution environment
+// (GET /projects/{projectId}/environment)
+func (_ Unimplemented) GetProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Upsert the project's execution environment
+// (PUT /projects/{projectId}/environment)
+func (_ Unimplemented) PutProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -3583,6 +3677,99 @@ func (siw *ServerInterfaceWrapper) GetProjectCostSummary(w http.ResponseWriter, 
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetProjectCostSummary(w, r, projectId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteProjectEnvironment operation middleware
+func (siw *ServerInterfaceWrapper) DeleteProjectEnvironment(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteProjectEnvironment(w, r, projectId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetProjectEnvironment operation middleware
+func (siw *ServerInterfaceWrapper) GetProjectEnvironment(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProjectEnvironment(w, r, projectId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PutProjectEnvironment operation middleware
+func (siw *ServerInterfaceWrapper) PutProjectEnvironment(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "projectId" -------------
+	var projectId ProjectIdPath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectId", chi.URLParam(r, "projectId"), &projectId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PutProjectEnvironment(w, r, projectId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -5819,6 +6006,15 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/projects/{projectId}/costs/summary", wrapper.GetProjectCostSummary)
 	})
 	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/projects/{projectId}/environment", wrapper.DeleteProjectEnvironment)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/projects/{projectId}/environment", wrapper.GetProjectEnvironment)
+	})
+	r.Group(func(r chi.Router) {
+		r.Put(options.BaseURL+"/projects/{projectId}/environment", wrapper.PutProjectEnvironment)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/projects/{projectId}/epic-runs/{epicRunId}", wrapper.GetEpicRun)
 	})
 	r.Group(func(r chi.Router) {
@@ -5987,232 +6183,240 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x9i24buZbgrxDaBdrGSvIjST8SNDDOo9OeTrq9djK9MzcND1V1JPG6RNYlWXZ0gwDz",
-	"D7tfOF+y4CGrilViPSRLtpPui4uOJbFI1jmHh+d9Pg0isUgFB67V4OmnQUolXYAGiZ9OZsD1aXxG9dx8",
-	"jEFFkqWaCT54an8k79+fvhwMB8x8k5pxwwGnCxg8HVD78GA4kPCPjEmIB0+1zGA4UNEcFtTMOBVyQfXg",
-	"6SDLmBmpl6l5VGnJ+Gzw+fNw8CplUdMOzG8tGwB8dAvrn2e8dQsy4x3bwBluuZOfT9+9OYd/ZKAaUWKG",
-	"EGnHtOxoznRSzHTLXTVt5RyUyGQELdtgt137F1g2EufZKbmCZcvqV+bhW27gV6HZlEXULNq0E38MiQSf",
-	"slnLrnhlxltu74zO4Mwc6NVdmZ8IzxYTkPlG/pGBXJY7SekMBv56MUxplujB06PhYME4W2QL/Nuty7iG",
-	"GUi7MMiWtU81LBRJQRK3RnB5kJfNWzg+HA4W9KPbw+Fh946k+DtEjQfH/dyCmDSf4JY4aeEl561sRG6B",
-	"hVwIqZ8vG9DyE4MkJloQJaQmk2UDYsyvl/hrAC+DSALVEF9SHd6AhrTt9ZWGtAUGCh+/LRC0kI18A39s",
-	"3QE+fMstvINFmlANLeS4SDXRbljLfnQx06229Nk8rFLBFeDF/5zG7oIwnyLBNXD8k6Zp4tjTwd+V2ewn",
-	"b5n/KWE6eDr4HwelUHFgf1UHr6QU0i5VfdnnNM7vrMHn4eCF4NOERXewcHFFRW5Jsgfj2ZjEmV0KCCwo",
-	"S/bNrn4ScsLiGPjut1UsRUaExgvGCY0iUIoU6LU3z08i4/EdQokLTaa45ufh4D2nmZ4Lyf4Jd7CHymq4",
-	"eiqFgQmdJPCKa6aXu9/Ev9GExfYaBzcmP2KlsIwytBQpSM3sUfI4on8QY6phpNkCVk/j0EhG3Yd2OGAL",
-	"c0GuMnIJMDIPk5ciugJJcByRMAUJPIIxea8gJlQRPQeS0IxHczfmZg6GCdPo6lLClDBFeJYkZG9Co6uR",
-	"ARbVZEqTxHzeH3/goV0tRAzJ6q7evHlL8CfCYuBGygHpDtyHQZTQLIaRSDM1ejz69sNgWH6pBOeg7df7",
-	"oQUtK/xkBII3wGeGoR4/eYIiQf75KPCYu9EvLbDrRG+PmgNIJFIwwPiQP/Rh8MxCZiokmSViQhOC+o4a",
-	"DFfwZgYaQs3Zcmgn1ywGWbtK8fUHdTI8OSX5eJIZPGqBCoieM2X3MBgOgBtR6G/lHCIFHokYBn8E1sf3",
-	"WwXCh4F9sw8D926ESiD0mjJ8HUIjKZQiNEmIA4t65oPIfwqXwL1SohifJZA/Y6ko37BdcVBgJ7zfnEBX",
-	"9/wb/kGTktrtmhHVNBGzDGJL3mRPAZDXr96RA/ys9sfkd8Q16CGeC5hOIdLsunZCmOHDSiTXEJOpFAsc",
-	"a6dkXGmgMRFTO9a+2drUkF/plx47q6l5lMcJTKhUBogVSSF/JjBvlsZrMqLPvkjxN6uv4WHLD3nOggKb",
-	"zqnKo+5hVTr09lMiWUwQ65+Hlp2+EEo/l0CvYnHDV3krEthlT25pB+fMAj7SRWqwMIjheoRiXeihSCh9",
-	"mam48sjR8fiJh9hYZAafxdNOrTLQy7i6jERmkVg87z/MuH50PFjVWYYDLa6Aq0vG06z2+KH5X3WObx+3",
-	"zSEyXZ/kqO8kNSIoQF4BaG239YU9OFaAEsL7iznlRnVU6kZIXwqtXauZlGb51A3EC6Cd4XO4aRr+fRft",
-	"ryxXmy74JkLpl1TTM8FCgoGh/iolHh8efzs6PB4dHfp8A8eF+ITQNLkMEujh+Oj40eMeJFp7y3yp6sxN",
-	"73aRLRZULgPH8npmnzZKPB6tzXc4HEyyeAb6MmELFjiKh73mSEEyEV8Cjxsg/t27w8On+P//qMO+UUpz",
-	"kypNpW5C5AbTetBfCK7nK+/8aPz4ybff9XrvFho5Gh8/evxk3VluAK4CyHzy7XffrzFVnbVVr7d3ZgzB",
-	"H4kdaa41lS0gJozjhWtBb+SGjZiit4eSNYY2YX/tv4vvN2OqNTTVSKtCvsOm0xU8pXjfnpyd/gLLRk5K",
-	"U3Z5BcsACOZAJL0huS1174YlCZkAAR7JZaqNDqGNNKT3fRgM1NWIcj2iKTt8NKKT6Oj40cflP7/7/odB",
-	"p0x+Bcvihq6pgArkKIYp4xATMwRFb4MFs/dh5T63EvTQVwhyG2GHQuCJ4XXdpRC63YVXLlgI2d56T7qW",
-	"q1GAJyQVMBgWqGnBrbmDG1FbKIjNStoWtamHosPki+cqxIPQLralCbSTUV/pvJmg0N/VRE8VaPgXHrrB",
-	"zIGkmZ4b7d75O6ZAdSZBVQ/HMTLJRsorpzWHnpxUpqzN1IMylaY6U1XSmNDoKhEzjzTKbxi/TKWYSVBm",
-	"27HgIYILwb0ZqL4P6AW6gJrl2jnlHJJLO9OnYn8xU5GVO29gMhfiyiznMb3i54AKYxZETh/HzBLwWWXN",
-	"lUeKeT8NMpkMng7mWqfq6cGBW2YcicUBTdmB24s6GI/HSLH19wduKDyuQN9Se7FGhfgnQiRAOT56DVyr",
-	"yylLtGUrxRN/MzqE2UOagAanU4ynlJmV/hgOmIZF+MXcF1RKulyV8X3QF3Crb6QZy86J1HzRor4kM46S",
-	"3wpzeSG4poyDJG5IwRrhI0SZBssZ0UeiyJ4DpzIDvonR0PcNYVMiFkxriPc92ra/mqslm4DkoEHVqCcf",
-	"sAIwt8plg1Hvpf2ZvEAe7ex74hqkZLG9of09M8fhPcZcu0QLC2Af9tjIjU6Iwj+9haqiQIj7zJi+bJYA",
-	"XjNdXllW8ihfpIaMGdPzbNKEDPvrABdMqPljwvQki65A2y+BVpFTPBDcMoqml8CvA55nIyWJqbVm8Wsm",
-	"BV8YZFxTydCANxdJzPgMB8yYE3PJHhcav7IfmVaQTKsS3uvTdz+/f3757rdfXv3aB1OrnP3tkpyFkNOH",
-	"oUtIxSXypRUh8fxN/sIONd8ofDPziGLOyFPuImdrFsTI1YScHSyWo5JyOl5uvYvAOvZy918jp1iFV37Q",
-	"Ts1nxKKdan3ohYSKcp1/Fxnaa1m+jqEPVDLIp09W2biC5efPht93L1W7w4pJ0VepERkSrhncmLlAoqwS",
-	"ZUqLRfUI+A/2EoAC5kh8rhkz5xlvREfKUkgYx9ncVVodgOwNBe785qlx/ihnUo1Ho9druXlCb9F6s9n9",
-	"hR6zKO1lQV2Z0z05XIFPM5TRvd58QUYRpJryCC4jyTRIRoMwiyEFHqtLC9K+t/0QI7H6WoudRlzS4MXo",
-	"8GhVx1t5zr4xuw6rXYWW4oudVq2fSiRV86eaUwlxk3LihNk2HyaC+cIONXCgcgbaCDCg1oOYZjqpcaKS",
-	"AyVixngew1PnQu3EY3V2O3uIWow+0eVKrZvbjkZHT94dHT59tJ657TY6TYPjtpzju+8O4fvHh4cjOP5h",
-	"Mnp8FD8e0e+Ovh09fvztt0+ePH58eHh4GNAMN1aNOpyc5ePffrudjZX02FeRKvdQjgxMa5gLOgn6EfsL",
-	"O3TFzbUVIgn5wTzAFk4xB4za9tdzexmqe3ny+lVsDTe1ewYjMQJRSzZCw97TaKqzLBJ4tKxKbo6LrR58",
-	"ZBEBGyB+H5pZr0x83H1n2P0Xy7UA4FcRBwAQ5TpS0GtfalAszuVAIwUobVSqbxRZCPMnJHBNnVIyJr9m",
-	"SWLd/FyQqJxBEao1jeYQjysvSo8mx9Gj+DE8mfbSUnzje8jEbH43mtH7i5eEcfQzxWSydH5lIZffKO8l",
-	"/P0WI8icKsLhGiSZAHAc5+/5aHz8KGSdb9h7aa2/5V25MjChy5By9R8gxWhCjbZrVV3DZnEsYTyGj/67",
-	"HIYs+jLjQYI4LcjgdpBc23JnNuTbnaohhub75o2RPXPAGJ8NzSeOf6Q0UxAPSWHzGBJr7hiSyMhLSQLx",
-	"/ka0MXBr9Hkrj9n3YeL9hYce/NaXGDxOaymqhY+cu7DGVV4C8awmDrWGhXl8OSAocRGvPxnyuC7Z3c48",
-	"dNttetM3TIVdzHStTYVeLaUzxmkuH7XNcFaODHiW6aAyV9ObnGf8BPUAazWs4cxI8OVpLwnrhx92Jc+Y",
-	"l4uzxPxekV687xsEGAYNwR8d3kD/JWtCRTllC/hegqYsCV2ejnm0hQB132cbxDOuo3j1HFYVbDfAq2Oy",
-	"1njsOKBvUnbmZEOzhvdWkV8+3IT5tY7decZRiu1kBquiZw5aj1Aq4ma+nRZ6sUuvkMtMiiy9tBfwLq/s",
-	"tS/X0DXUgZBlfzpxJq6AcZGzf2T5rerFsN4wPTdXWW4LhvFsPCRGBOojejdbVXz4Fy8dRCNGI6/yyvDX",
-	"kROsPVXy4tX55a+/vbv86bf3v74M68iGo6hmH1IFU+XOFqCU80DXNFcDNHL6ktjwAC+2vDMQS1hXu5t5",
-	"FR51ZopQCIHtJyFnQncGmmEOQPUNMgXyX9zHcSQW/sVih3e9hR0V2tXrjMqAJHtCJoLKeKRYDETRKeil",
-	"obgJFFqKi63VdAZESKfc/MbJRAKN5oRpgjHxoIjgl4a5kb05TfRoRjUYfcO5MJ6SlMorlB+NLIp4okQC",
-	"VYKjF7sKnSvG42D+ygSI+W1sBL1LxRJ0lv9odCzrEXKRNVMhyX/quQQ1F0n8n0RBJHisnpEbmiRRIqIr",
-	"8qPNCnJcmiSCz0ASPaec/OeCfvSeQVVrQnU0Jz+SKFtkCcUAXvMiqGYJIwbbh95fvBx7Xhlvl4PhoFg8",
-	"j1zESatXQPWJ1QALGuCazy0uImBGbiD//V//L988AqJYdojaoPmqXL2q0X1/2C/wzeG66v0u8L4amIEG",
-	"ZiJyshmTkkYMXaiCMCiPiaRMgSLUUuKlGUrMUB+w/lpTezSs6T9k3SwIoRF0xQijMvuwM6KHu5BwN4rs",
-	"eRjar0LvuDthsGKtNEQeOqxeSu52Ej9iNp02x32/5+bGiYkZlUd6l0Ho9lzJjPe5Qw1GihiD6io0TaW4",
-	"psnBPFtQjt4g66RB3KpnPraZwf6NIc9YzEZID3FJMjXDiZs39N7mkUvLZLrkpZ9pos/tyJ1JixLQiC+4",
-	"t6dunR+USFAQuiz9PbVscS4Z8uryVNmhRNMr4F5OSZpQxokFGRzY/fjHSoLKkIRyZ7sREYDHl0YfN39f",
-	"sXQwHNCJkKgr9Nv99S11A0sn25lEbioeNkuWDWYaSLehRThc2TxMgy73pwXrGurDOtvxhNVu65sd3uGg",
-	"wjFbtdz4QC7fz999dVmfOYW1mg5WvAVbiM/Y79ck4rG7gCVRZpHOJMROQMuvYuQvRiS0l7XHV3xOPg6c",
-	"pnq8ny6Eh2AcJF4RIwk0xoASZTMCxoOgY1SBvIbA1f4WqMKXuKZJZgTaXGbdyy94MSXuIj9wsVFDI+O+",
-	"v3hZDazsKQfVg5yt2xq3kMvGeXCx3QnEZGbkcl9knoO0YkXosplAeCU7i5EnjACri+k3EUXXkZ5elG+I",
-	"eRR29RuqCHyMAGK7gx5wzDgLCybaICnH8UEpphkZ98PAIfLDwKDtwyBT8YfBOMg+Vg7A6SIVUl9YM0az",
-	"sNUkM53TG7KgEhPICpkJtZp/P3n7hqDXfUG1Buk0+4kBtuqhhzZH0ta2rFDqDqrn/c1E5ZxLl6G8ypac",
-	"yWo1EAzRh6fI7smi3w43eiPDyYPJEvan9lk53CRL4hh0vkZwNuf8bJvMDSm2uncFS0ITw2OWBD4y5eLp",
-	"OmT2Yt/lop5NzwG/HXnLV+0WlBoXo9GccSiZIa5BnL2iyWcWqj6BbtYFXWKqxSLVS8Km+GUksiRGW4n5",
-	"5aOWNKoCw1M/S8tLLXe0yrHtJv0h/UI38vmHg1pEfgnIN+jROs8CF9cbNpvrGzD/ze1mqHZO0YJhHWLO",
-	"Vxs5pabgyInR6K8on1C+ao7I0/SMlNF1oor9XZjB/XWJJr+erV+Cvr1NPXgNjrkeQlaLebD6nuEL0IIt",
-	"WaI6cg3W4oLoyHV9phXBGEqDqDz/ycV9reLBajVlEHupBOYx0A2R6i3efVfMIAo4+d3+7bb3eKdHnyxB",
-	"79/Ord/Xm9FpPi+AuoeisZAxyP3Qi1UsGCHmuhok1BI3GTajN9Kcy5prCmLg3g1TRHqDM0YU0z/u5tpe",
-	"NI1PQ54ekBvE7X6CBG8UlB3bc43cXmYSe15BiDIJZ/+i1JE/i5c23Mcw7M0eesG3lvk2u7aDdvfTqQ1a",
-	"xyVsHYOZuU2l4UGUSFCgScL4FYYMYLCA6hNy22yKHw7eihiSjiT+IrWgLRkgQI4N2fGPtpEd/2TNZFIj",
-	"ma+fl1wHpMva8qbsyKsPgXw11+irTzLaSVyol7n0AFKVdhdauusI0fuIx+yXyVXieL0QzdUTtgWLU+DY",
-	"dgUD4PyhDZ5VzFO1XIb6vRAUJYrqi/7I48NGBlgZ9/i4X8K7NX7BwFsu+DZWlvbLn2pYbNHf0phKpAVB",
-	"a5kRZdDnssem5OzcaqFqvzl6paUqKxby62WY7q2O7Mhg3GTLbTHjdthoVzG5hYPTQB6hZIYVSn3USajO",
-	"SNssbJ45HajpqsUojoC2+JuR89Ecp3QuNxM7eExe47/oenO5nzFR5uW4ZjRJls+cmO1CT6h9sHm8UXX6",
-	"AdO9DW4gaPm+19vieAu3ReWicNjpZPlVuKwiOaMyDof6zmCUwDUklaANRfZOf31BHtP9MfnN2kwJXINc",
-	"WjJgefwunUFv1NnAkUbBIRjL5EUxFTmtlpQcZflaPimu0cb0lFZTU6Voh10lL/93ATpLbdG/lwZYIjVK",
-	"a0O5v9Vkuz4UnRt5VpiCpNwq4NUYCZppsRIegfg07F+TVCQsWj4lc2Hvh4jKmCRAr9G6ypTDHnlBpWQQ",
-	"E+DxSIsR8PgZAT4VMrLeNDElC8ozmhygVwEd6gnVGEcXSTtmr7TPaGdkpYqYHe77jgO3ZTudc6N1ly6o",
-	"JrA05QlWwNiQ37iiTvjGnhnTlxNJeTQf5LnWZl1P6hkMB+hOMvcIu0xFYt5hznRymb9ITzOSXxWulg/w",
-	"Mjes2GAJLUimoKR9GzR1bn22yqazD20xvyFawYo6e9QaJQ3HqdqRthWIbJB56XzKFVY4pYkKKiEbqGAN",
-	"Xr0U5MiidGQeKfxjNv/tCpYj66lLKZOenb+klmZ+CGkHO3z1UQOPS/5nXWZqW2ywRNT3328HUV5lhFRC",
-	"ZN0bVlGs10rIf3+KVJeTaV43ckx+gdRGxE1odHVjGIotucomLGF6Oe4omNAja7DVIIhxWZeWsXWB+dyM",
-	"PbND+xvxKkRdWzDIdQx1/EyTLUVXPbQoo50GqszgsiG33EnvLb9uEFZShIysHRFS6BQVyaw5OqTcfLfC",
-	"kdPPNvSMghbbVItbqxOu7sROi8dspzRMxGSU4a0O9ArkJS2iiqpb+30Oeg5W7HPPEPeMEXd82YalKVTq",
-	"6TVfdrXFizybJrdyJLjCPIVrT6KdUpa4VG4/W6EIDQ0aPOpLByN93xUBEDaKt1w8X5NMYCok2Le2Phdf",
-	"L20LTx3uKhP+66j1s83SPn/ywj27UvMX9OOlresaCqTAvi7E/l5ojHl+jUuV3mPcrmJFVsGTaqb7UThA",
-	"vjPluaNU0WpY203pry6fefJkO3B6UKWO7syW7y73ArRN7L7xDgoz6fWs/A7nrYWOJ8uSWfYSIgL+0IA0",
-	"MVmiatt30vOM95lS5Wl+vSZ1VTU6pm07x3lPJXeObdzhjk9v1RvbVW6hYC0rdXx7V3i3C/YvZNy85NoF",
-	"jNepXNzypoe3LVk8qEKhtj2P9ArCHpYHp+XkbUdmD9fHutMQ7mrRtzsqa7Qrc8dapenu3Nm8zeJ291LO",
-	"7l7rFzVVzVv74vTIfTun2D8/93uYz13Q1M7jy1YP2r9SDuSlgPVrPm4aq7ZOh4yVyLVhczHMc0yQas2e",
-	"lA05L9Yo53JZMHDY6UG+l71WmvKwa+9usfBWFXQnifsAXg2v5XBD8hFkz2n25HsSzSmGcEtV1dI43FxY",
-	"3FCljo4fdWHChYU1VPDHuD6rEkqIgF3b+lI5vjxTz+t/+2f84uhwcqyTCTtaTB6d6mjxb//8j//zv3/s",
-	"ZCp2Bx2Bi86z0or4ptzJn4vMmzLR0mVPjolNhyQ/EuTDznsAKZlKUPNnpZXiR2JrTJKUSs1ogk4dGl9T",
-	"HsEzoq5YaobYzwZl+hkpsirt7JnkmGnPCVCZMEwboTN4RjDVkvyI9p3CI3iblM2AMhg+EoXfhguETiRk",
-	"DLFNctFzH17jTjS2VBj1Tf6rQZz046WBfc4Ei5ihSp/WLtOadQjU71kuOIKNj5ztzEApuaHLmqmyMqAj",
-	"ZtXbbmXZ4IuLBFZiWOvmV6UJnc0kzNA9i9awvNGZFAmQPedxXKawX8ZtuGpc9fySQLuWR+Ojnj2nRAJN",
-	"zbrRm4e0afZ7QzEiXrIJBoxoQfYKyWRoT9LQJQwOCcozQ2LFmf2hy+PiV1zc8A8DfOGMe7OZFaoOq1ap",
-	"pzGc92gb4bzHm+k4CMr+ra2CtJPxDQsxbafwkpRCXnrh4BuXW6qW+L1UnKZqLvTaJWGKiqCr9gKQEXBb",
-	"v2Ra5snk9e4P//u//u/R4eG+TaHJXPcZbE5cuOEbWkIHec36BaTkutDvV3TK1ZdqqD5VJAetVYBqG/WO",
-	"foFlES2hlIhYkZa3dIE7WOPoGRH5/UMVUWIBBOKZuf4UKLKgSzKn10C4sI+Oe5Uj3U6vwoBDsVopyytP",
-	"u46Gs2Jw24p3eq2Yz9XUHZ96buvSbUhq6HkH1bloGTPqu3QdCip2pA53bg735XnwjjsDOcK7Fm+3SY6d",
-	"Mo8tTTJlbuNklKUEF1YeMym7mZpJMD2GyjgBhfnn5nlXVsll+a1e3Phcf7PtilgR0GzXIIoGpH07fnSL",
-	"zmybpdUE+6utnVzTREcB0+PKFb26g6FDTwthNRVOXDMaW61hZIe0kwRudxg3brnnnYciaGB7xNBtsm5b",
-	"f6sU1Bz06MjiXNzckiZ80SHYJXJ9++7ur4A16aXwnNeSPm8jwPd1bKyuerxBAl+gr+XhZn1U2688jx56",
-	"9Vo9z/gWrKhGE7ln02mZgt67PcqGqlItkfxh6VKJmF3mF03AVFsUMOgIYRaSGXBb9mgPAUaPWxOYmPpV",
-	"f4QoQ7/WL6iF5pGGCKvf5yyauzWp1oDdyN1e9o5sjvt+01Yalm60CNVNwRozJiTVMFvagLeCH7i9NK1c",
-	"+HDyIHuMmJ9mSdKvWtpa3H8GDdXpi+yLohi80X73ivg0zJLYL2PTyQQSwWeKaDHuDvvszsbY3rI70o07",
-	"VOLh4IYyzfjssiguuFadtfYAWSzF0COoM5AZ5+VTuGmK5k39S5qdZ/x3pucXuUhJk+S36eDp3/rw+e4O",
-	"VR1zhPNlevaV+uPzcHChaXS1Hc24b62NhaH+YOPWM8Y5xEOyyBLNRlRGc5vV4TVy3YvZDJS2hUPQrDkk",
-	"kCggms7216jgg6eraAiLdXu86pz5cj4PmomBbSBgrtClniORzMSIN/W61UIk0Zwy3mV9q8tP7rFhEST8",
-	"4s2pzWsRAivSRi5byfUfKfrHtpZY9vozlCjwd9lJ6at6UMBmGjKK91KANiswsSOpfZ0Yfo9DfVFm9N0I",
-	"1bUakrVWx7cx0jcUwO/bjm4TllYWqgpW6fp15XYucgzLeHnFtCLmNDuHZXFsbci/kIRq9/REZDymkoGq",
-	"NTxyV7/r4pLHpE+ZtL1o0M9DpxrrLuFVzFwZ8B4R27tv0rdef6K7KOc/HNhGPnkAZ68CZN19A9d1VvxZ",
-	"2wzuxHPQ0HpoHY9BIJo20ER0U7/Nxgb9J+PjJ5swYs+TUto3vDVaQdAYTW1E6M48npgpzXiE3MnVsSy6",
-	"ppm1VS2PZvVuWgvOtwPcSnxw9SrdLNq3rLOymRXUQ1//IN4SNy24zbs11oLkXYewjsIbrkNkR6skv8hp",
-	"Z4MZVCI7at3UgFO2MyuV0NjGn5RFm8LvvwUbXUMToDu10hXv8pu8wPiVoOElk1yRYijaV7CSyT8yMFIG",
-	"yg0u/MUWNTUjjC6UCHGVpRjOAz202RKyRqftAbs/8le48Mp05kUdSuyudivtxnfJFd4jt8eYmsY4Nqs7",
-	"hW6/Qh9pjPlcN7yzMbft5LRMbcsTQrFuAZrIZlaLyGFhlSKDmhR41KR8KqPXh7XsIhCt1KqxKU2hDccE",
-	"nyZ7CoC8fvWOHOBntb9Rk8VQsHePgtIWedj7qgl3jdmG711x4mrBXB9dyJL79O91M2GX4V+dLrMe2tfv",
-	"vdsbOm+XZ1IYQc4D0YJx38JwNGwKfO4f27zWCzfvdrV2WnOd8K+r8uHDKlJYL5G+ZhW+PxoRXC2y1Yjc",
-	"TWptbakyVu3V3U5a3sgqGM1R0A8u3f+LzA7v5NdHYX79V8b4phnjX1Jmd04deabqZtfwg8rR/tzGcbws",
-	"qkbG0wqlRbopkNoT8/IlivJabpRNxOua+nZpeb0BiFpFS9pKP2PxXZhFO1o8fanGwQ7bXzPm3qv18vU4",
-	"3Izw620l7V0smJ5vwFlcmGtRTy9eoDctU5We560AUCDvKON4W4mPu6ql0ZpQuTbsqy95j4m8ORydP8zl",
-	"rKxjnDY0cnJ2+gss7yk3ndLtYPgKlpdzFrIfv6FKk8dewmV+L1/BckhSCVP2MU+Z+zAYj8cfBpWbeTwe",
-	"f/zu+x+aFg1H3Bi4jmKYMg5xtfopdvjBFAonVQ/JjZBXVckrN1utZfB58+ZtKZrimnYdK1QPiUiBU7Yf",
-	"ELh7O0bsyt6Le4Dv9PQbmGzBUIps7T7tpOYahCiTTC8vzIx5kIK4YnCSGYZex8y//v7OidnKSOZUEcqJ",
-	"kfh+48mS2FxsYidA+w3G87pPlr6KHNv8rVNmzuznz9hnZiryPmjU1o9zD/0sUjjVvwt5pcg7oIvVup/P",
-	"7f1PTs5OCwr1n8rl8wXldGZ9ckZKM8dx/IG/c8F+6Kq2Fl8lMhlZfURmel5MahYwGzRncPzBvEnCInAd",
-	"TNx2356+MxyrYhYxRGvnHBt52D2kDszYUkCovOnJ2elgOLgGqew7Ho6PxocoG5kDkLLB08Gj8eH4EeJZ",
-	"zxF7B6ihWkuCVV8MfSIFnMbYtUrp14mY0OTEDsRoTboAw1AaLdnlEENzcGY+Nhqz/cEgvfF/YCtRbPeC",
-	"Gzw+PKy1vcPu3tYGdvB3lydsif2WZw1fdquHrX6WVijyjTPUzBDaxOHl83Dw+PCoaa0CPAfvOc30XEj2",
-	"T4jtSc09jnZimiTVmckeysTkR/c1hnvRmSpqGKvBH2aeAzPvwRT7xo/8lP/U+Qer9FJtMD+wTAaUfi7i",
-	"5VrIawNtuIv95ypPM6ri5xUKOt7aJuoNiQIoxToKrvdQzFRKNTbi2rOJ3C6zHmy/yFRaE6EbbkQwB9d9",
-	"SwSH3UTwnHrAKJn14Onf/vAJwo0htCzQ4DVCuma0qJNQEITh7h45YHhCMxFgM6r3VkTcBf4rza56of1w",
-	"a2vbWzhwfDFiQ2VRBEpNM6zjDTQG2+7yAvTohb3ZVi7J4j40t2Vx/ZW7qUsonzfnCQ0E8UbMCONY3+Ej",
-	"hhrMSC7gNxOAsJ75RgoQmS5IoIKLxwEJTsxmEBORaQ+CyXIr3E/McF6/s1zHy1m5Nngdvgb9wk4Sfrfd",
-	"09kL7x2I7VW8lVviNVRglCyJGQpcMyzf3QWzvK9aM0nkRYR2yBfqdYp6sYajnaPMfO81nquS+I7ZxJq3",
-	"hnnkh+5HXgg+TVjUdc3YNyYUiwF1EpCCPgJGpTbRzugoUP/oju+ZHuJFvsOyffAK79ye0HAB2iGyEBoy",
-	"o/oUXRQLRW0VwXOmk5FDVLuq4VVJCqga1df/CX2pZLKslMEiXtPMwdMB1sootckyH7FAwmoqjivWb6nL",
-	"iOtBm3Afdeb+dJ+ejf5tlFGItFB58fzHPoy3p5ZUZiXWO25justiCY6eDBGF6OlgshwpDenBJ/Pf0/hz",
-	"2+Xtvfrz5YVtMLuePnuBi5xRPb8zJIUQVCH524kB5qHH3Q/9KvRPIuNNckNlQ7YUlMTm0AjjTiR+Mh/z",
-	"Xma9cbg29vyOaX8hsYJEWkXhZGnb9q2LuQOvf0/4Bj+xA75SNBaXx6bi1+5Rv5GQV9CKQ1+NXjahFHu5",
-	"tol69YqZ26KTXYiM9b3esby4Do0WUs3XSqMWG1shUSze6dNoTR1PhDJnAXt6Xc5posm8KNqJrjXB0Stg",
-	"K2Ee5NFhB0UVzAN1xdIDW0pzTE4MAYDCCCCihT+vmVI9c8UJ7SfbU8seSHecxjaWuaox1QuQPuRztLLZ",
-	"B32QcLdf80HCF6wSeEnblBPgkqFVu0j1DxwyfHhkHvbVv3olM9S/Vig+L4qEEWXOBTcsly0qviots0hn",
-	"Rn3Ah23lWKIE/vr+lESUuxack2X+K5bCtWF4kyy5GpM8nD9ZEvSPxDaa37kDVw+X0WKKLlmdKus5GO0x",
-	"0nZS5zn05g6prNWCfgUJdwQG7FQeqrYYC6mPPi6Jxfu2VMa0iU72JlRHc6IlozMgjE/Ex/1GcjQgbTdF",
-	"nOWD7tDj2T3+Qkj9fHkHRgK/IUUvA0EB1G26LNMSCTkei6/++DxsEBxfYDxG2cBoFxdVZY17MjgXrT4C",
-	"+HHxCy405e4uqAoeLZByu2HZUGoVlf6xPPjErAUghgRs85Aqfl/i9yV+1zufzRrj4+aGPnYr8b1o5/Z1",
-	"y1uo6TA0GUy2D6jDuyTh+zeM5MFAdZtIlRVlAehXEl9uh4Dts7BgVs4dS9s98O+8Gw9Yxq6QjIVq12ld",
-	"4XcHrnvbyHVvsw6xZsUTfVQq2GBUabOBPUxd//FwSGyDuB+xr+i+FYipLhuCYlEBIxxPIK8gZ8T5GWV8",
-	"TE7iBeMj1EaBx6lg3EWxBbxyL+w+nttt7JYvv6i9s/VBbSF4wDz0qPuhn4ScsDgGfltysTFCITRaI/oa",
-	"VOT+QiNsd1SfO16bhvXla1mcDf+KA9x2HOC2AwBt1B+9pgxzqarkRfbcHyOn9f6vtrDAdrn7xKXY34qg",
-	"/til1F4pYnDHMrujqFW8224lFXl9E+Z1fNznoVQKwygNIbzimullD8E9J428hEIwWrSFGx18wn9P+8j2",
-	"W6Ghbj5zYje0xr1jsfQQtAHejIhmVeBhwPXwrk7TtLSB3ovi4Cx8Ngu8rj347LRZd7g3jO1K31if+d4Z",
-	"uVQ0jXtSG/gG/NXWAGsyrOeVi7xWXdgsxAhCRZqKSiFiUwZxIRGIawzdw0ILtoXu0BrbiyYjysbpCGyZ",
-	"lfEhWtOxCMKYPPcaICvbgJRHSRa7ctXVdPeYqTShS0Kx4jKLgWSKziCkaJTmjBdCbUVurdWLLV/XFXCw",
-	"QLOujaB9Pm8vXJJgWXzpu9grjYAfHh2a//5wGAwpuwNLi1+NLngQCiLJCaEglvtjpE2UG1KP7GHoOi1d",
-	"GlKNzp4vtyfV3gK//XWWjg4rjeJnpYvQvSG81szIw/9k6W7TW6I/mlOpe2L/BY7dNafBd8ZtEZeMuSVu",
-	"swM+04sOsbsQ1fRMsJAOvUqCLylLlt4JR2vT/dl94+B2LK4QTRJ4DNLV2l+P/GTG+/KeczN018QnM+7x",
-	"+V2S3tdqKfL6Jt1rjnYPT22BbClu7u94yYyPEriGpM7tb8nZVVlqt8fpykWhv+TI3ia0L1CAxB24rzan",
-	"L0hZNDKc++CT+fM84x2R6q/sqN1r76/y7eze4uKWcm0DAwSAxT0Ni3F+W6s0piBHtuy8Ksoj3Y8uwQnk",
-	"O0SLTMP+Srowwzvpot3X8gpHPGQfywOKPDLA6h92hMC3OLT4i2xJ7m35Tez8VWfJ6mqr1NLuIzHv+KBd",
-	"JH6p4Dv2kCBsmhjLncczbeYP3jzituJ5QU6FTfNXr6t+bMleVb18LtugyX5X1VoeF0T77R0ud+nTL100",
-	"YGG6yhzaRIb7RsLh3Rzle4/rcpJA3S/jcfBmt8w94WlXTpm12f0d0ci9xH7tmFXc7n4o/UQNvKXnfXAQ",
-	"01mX7vLy5PXXxYtenrxuK6jw8uS1le24iEGhOwviGag7zNU53l6BqldSinAJmWWUgGG/mARo5Asry9oy",
-	"vcAjZl45mOVdDFmSmaTpnOy9PHm9b8XjW1NkbhRtKClEMx7N71SlbibL423r0ydYShlVkGaN2jwTZ9i0",
-	"khbj/+ykaemCUGLTfwyckByxh76QDFRe28qAcY+qJY/2b0mlB58kGn8ObFvelvRQ/N2G6RZmB0w6SxIX",
-	"l0uiOUtijMIdk6LHgcrN8txg2zYQoBJb96UpxGOSe/UfH/5AmK3rauZmitBEAo2XVm/QIBeuYTbVQY+6",
-	"3eK9nKvu0Xdk1MJ+hC0Hr+i+vK0I4zsUGCx+jQppE+eGOVVhv6qUYhONnDa9c4HceMNjgbM2n4oz87Py",
-	"TXFj8qI4BTY8fU6vgXDsXo49aZH655DEQ3IzZ4lfqCw/JeVBwoqrjGfYi6ls4hk8NcWxZArXs+o2zTA4",
-	"svnY4Dv8dWraTo2jrS/vyCBuDXkyPso7Sm37iNh6AK35HdnCHJL6ER2TM/uFR+7mbNgJYyu1YkMcJnhx",
-	"EFSZKM3ho64KciJL+x6NHKdNx8Ju+69z0XYuckx9eQfDYneVJtc4E3Omk4O81lpnyGKSlHlKVggq2f4N",
-	"ZViq1AhK82xBuauEQZMxeQmKzbgLNowymYwm1Gz4xZtTrDo/TcSNwrq7fpVLV9TAq7CIpyky28B2R3kK",
-	"lLlWFAC5MTcVB4iVK8sROhKYbGNfuL283d3GkrUGIaxst8khk2er5Fn52ygTt74NprlKAO4npwuv0lyD",
-	"DzhQJKBCvdzrutfu8lvtz/egMb663S6M+6AgkXvD+7Dl4oZCu2nEchWLXb66VdA8aM9dc2PIO/bjBeAW",
-	"IKdfVxF3P06+zQmwdNkF3qUvDfZjOQef/I+93HrbJ99uQevXyibXcPaFqOFBlF4IoLadoTS7jh4UQnbl",
-	"ULolFzp8AFzoS607sB6pbsh3DnTeWC54c76DkAT0gBmP2XAVcsplft85Ii+Ax2i5re1oEyTmylNrNGyl",
-	"0fCDVkuqOw3Fh+XKoqX7TLpI6nssjJwGt9Rc3cENH+UidVdtme1jb2eVZoIdre+64MyGNPRVhiKELpDt",
-	"0GwjR2rNfDGq3HnG1fPlpiWTvqS6JB02xP4xsAjTbQW8okG5CdPOuteuMG/B8rtTDfk84/ekEjdYhs8z",
-	"/uXqvHBTKSXVRTqtjKG3X/2dpFwxFH8K17cWvp8Wo/jH5LR0jc+pIhStyJ4R2XlKuG2Ahe4S9L8PbUmm",
-	"/CNhqnS959VNS6/8gsoriAlV5Q429NCTPeeuhHhIppQl5l8hy3n3m334d+JxuV8fyvmfwRlvQ17Wc6tU",
-	"T49Q7antLllRfU3kgunGjVlJ50WCKw7xk34gfQAZ71poajMhldc9pWmXayStrRLGwWQ5yjt9dxHI8+W5",
-	"7a39VZGJe6tg4WqJsKnnpKZJptwlo+k9xqynDfurkYwUSTLK0ny3m5JLRxjPRV6A0jb6MRcutixALjYm",
-	"7yrdBMuL1t7ARVxCJUJnSCaZJlygWFHerwnG+LVfqg2xO2RvkRlQQc5p9xujef4k9+eXHpbjRUXe8p7s",
-	"G4NThtOIaRn8gMKuFAskwoQqTQrRDUm3B7H2i6b5k9Dl1xMWswlhuljlVtPIhRvzwBOJayHQYrGgIwXm",
-	"Cd9oYS8MewFMi1aOezCejYdkQqOrRMyGOc/u384xUG+kdmshcq4A2+skQlyRLCV70h3VvJu/GdS06hUs",
-	"11vSdarMw9EnSxs4hVlnoQXMrw+p3weCzBDgb/IC4dPPLJW/r5AVsJr3NyC8t1iRfF+BpG7h2r/k4owl",
-	"zGqJn/ykdpnBEGoP2hCGO7wnU5iFToCO7Pn8c+V523PRkOhd0lvX5XHAFqmQLW7ZU/x9S9fIjkizssd7",
-	"chLV9qCyJGiJt8NQcEn0Sh0RK8bYeGwpscJbWZniYZJ0hUKfZ8kVsRRVskwj7y6otFonvvG/n7x9Y77n",
-	"ekG1rvT4XoNyPyHQegU0bYWv9qh3Yje0RgzBhUtV+xJLFVgW1HDLNVmJHgYmDu/qTrr/RjSF/FQpWFAR",
-	"SJojBe4NW7uKJ1hffLkzUvmrbkFT3YIWRtP/kuj2cCAa7sjHcbf8qaP+nhOfvYJ3D8inYfmXa+hJk8RG",
-	"Lqxhnl6lhHrRgJrxAaVsVTrcShu5tS7HINk1xKUhzy32jaoHwVhBjv8jg8xMqJY8Kg2DQVufe1vn7EX3",
-	"M8+TvrFe+uPDw+pYzzccCw5mxOPqCCFX9uXMidjrIJh/hMbzOzEidpyErQZS/M70/MLgsCOiopYQ6TD4",
-	"F2sOVFAIxHH4hpv1rZneOVWazuAAk7nbwjrYbAbSepU+DF6LDwNCp1MhY8qjvGVRRGVMFNM2aiNOwCrO",
-	"C8oza7iZwVNnTFblyfnG+e/mVJsTk7qIjTyJ0H/e6DuCMK2IgtkCuHbk40rC6DlwQjMtRjS+Nvsyq0iR",
-	"zeZEZRNlaIVrHGA3o0jGNUvK3Fu3kpDYuHZM3s2ZwqNv7cfOLTHEU02rGWw+n1nlDNhqoeAvFcYwbHBC",
-	"OIt1EA4zsNAIMZUL88OFGfMV3a8Nzom3KxCBeOhn8n6tjAGRbAOhrB+3ShzoDFuXM2hYpIm5kyvJv6mE",
-	"CAVmFNwbmmwvUv2uePrPGhhahcNa7ZkXqSYl+LfWj7s2cVvfwkWqR+UOfAN6FwkU7Za9l3/QtvXqVu+v",
-	"QbQPr3CTVR97fzK7e412myzwAcrt5m8Hn/I/V6yaXcRe9LfeIrF387B3xXbX649dgeAXav2sEUIX1+p5",
-	"b9lWAw8MiYf3yF0eRCvvyo4CLb0Dl1TWC91FP+37x/gOm4VveqvdJ939ZY7VLV3K+3M+c+v5EXQdIcRr",
-	"E//dBaF1Wo8q3SuUHXlvXKvWrAJNE7iloN5ViXHEcQefzD825FHb3jgdBhhKcKTV8WweigvzhXRMSrOq",
-	"kaLsSAzrxRQbW5hMWFuDe9b+6ltQzY+MRxIWwDXW5tFoGy4yDT3j6rvSaKGLzB+IMUyMaFFEhLIpYZrc",
-	"UCz5WayMRpagfRZSLxjTH0+EJAv6ETfFMAI0AoghDgdparn8CR82FHUbou9jCzF4fABHBLHFONOMWnOI",
-	"g69jtTU7+5cSx4kkWKf38ClTmkZX3V1XnfXEAskw0qmQi5G44ZbUoitV9HwlEeVEwhQk8MgcDqWBxu4I",
-	"SoCReZSwBZ0hPdN4JHiyfGaXoJomYpYBZqohrRIF8hrkSLEYmuqSXdiXuL+2abiBQHPAHo3N3uERNhyg",
-	"ePmtGTWqILUpttgJV+UAK92X+EVOE03uqY5058188xXD6F+pzrdJdW4xY2YK0dGCw/c4Ym1J/6vo1mTe",
-	"vT/6LCzvrywgTRK3hxLV9rOH64NFa27c2+WZFFOGaXE7BWuwQLozxJuNGtkd97GF85BXK4m8+b9RxQqr",
-	"0GoNNaqCaFfKaLHKPemhTTh670SgVRzdlep5a72wmRTIHqcLrIt6YGT0BWXJfsdhOqApG13Bsp2Jvl2e",
-	"nJ3+YkbdRXNigzu7Xp/OxHnNy5OzU2JepGib78Nou8JHFfjFwntzxjUxct+QcLgGSWKI5DLVEPtoKCDe",
-	"laSQQ32wS1+IXeKefCA+pgPtSi1g8f4P5p49/CNrpEDbEIg7SsjJJUymQSoJnteDT1fQLybbI6P1hKBf",
-	"YL0Y6/zNHkJRSJ7DuQdIU6rUjZAxqkuhi/PFnPKZudLygTs6kLhMvshaRzLk/XHzkAinva/zU3Xw4VaC",
-	"N1gJ2ubr6hPrQ+/v7UFaj9bXInSzwpfqTauxmVJkbBKptwzOOxDxLHZu6826S+xYSzLKpHWnVy+Z/vY4",
-	"2pUeYHb20FQAA+Y/S8XAxgOPoyHKJNNLpBbbVOEk0/PB07/9YajC2igtLa3e9NdHZEIVkNQQ0XCQyWTw",
-	"dGDEk4PrIyQqt+LKs2VTBxvza9s2qDLF2oAtkKyOeFtQTmdgAz9Xn8xNGIFICMwjbn86jxkJTID9Qdqf",
-	"tr3KAmv7gbvtUzgDWlccR+dbVF2DTWn27dPkqR8tL1QtQBnaSr325OpkP2cLykeMj/QcRokQadkQIjAh",
-	"toBYnSRQIbplV9UCvauzncxcNGULdNAnoIIVFYySKGl0hRG7PCZiYs4RnbCE6WVoLptY0UDvuUzdsZ1c",
-	"sv38x+f/HwAA///ycK5SQnUBAA==",
+	"H4sIAAAAAAAC/+y9i3IbOZIo+isI3hsxUlySetjuhzs6YuVHe7Tt7taV7J27O+7QglVJEqsiUAOgJHMc",
+	"jth/uOcbzoftl5xAAlWFqkI9KJGS7O6JibZIogBUZiKR7/w0isQqFRy4VqPnn0YplXQFGiR+OlkA16fx",
+	"GdVL8zEGFUmWaib46Ln9kbx/f/pqNB4x801qxo1HnK5g9HxE7cOj8UjCPzImIR491zKD8UhFS1hRM+Nc",
+	"yBXVo+ejLGNmpF6n5lGlJeOL0efP49HrlEVtOzC/dWwA8NEtrH+e8c4tyIz3bANnuONO/nr67u05/CMD",
+	"1YoSM4RIO6ZjR0umk2KmO+6qbSvnoEQmI+jYBrvr2j/DupU4z07JFaw7Vr8yD99xA78KzeYsombRtp34",
+	"Y0gk+JwtOnbFKzPecXtndAFn5kA3d2V+IjxbzUDmG/lHBnJd7iSlCxj568Uwp1miR8+PxqMV42yVrfBv",
+	"ty7jGhYg7cIgO9Y+1bBSJAVJ3BrB5UFetm/h+HA8WtGPbg+Hh/07kuK/IGo9OO7nDsSk+QR3xEkHLznv",
+	"ZCNyCyzkQkj9Yt2Clp8YJDHRgighNZmtWxBjfr3EXwN4GUUSqIb4kurwBjSkXa+vNKQdMFD4+F2BoIVs",
+	"5Rv4Y+cO8OE7buEdrNKEauggx1WqiXbDOvaji5nutKXP5mGVCq4AL/4XNHYXhPkUCa6B4580TRPHng7+",
+	"S5nNfvKW+b8lzEfPR//XQSlUHNhf1cFrKYW0S1Vf9gWN8ztr9Hk8ein4PGHRPSxcXFGRW5LswXQxJXFm",
+	"lwICK8qSfbOrn4ScsTgGvvttFUuRCaHxinFCowiUIgV67c3zk8h4fI9Q4kKTOa75eTx6z2mml0Kyf8I9",
+	"7KGyGq6eSmFgQmcJvOaa6fXuN/FvNGGxvcbBjcmPWCksowwtRQpSM3uUPI7oH8SYaphotoLmaRwbyaj/",
+	"0I5HbGUuyCYjlwAT8zB5JaIrkATHEQlzkMAjmJL3CmJCFdFLIAnNeLR0Y26WYJgwja4uJcwJU4RnSUL2",
+	"ZjS6mhhgUU3mNEnM5/3pBx7a1UrEkDR39fbtLwR/IiwGbqQckO7AfRhFCc1imIg0U5Onk28+jMbll0pw",
+	"Dtp+vR9a0LLCT0YgeAt8YRjq8bNnKBLkn48Cj7kb/dICu0709qg5gEQiBQOMD/lDH0Y/WMjMhSSLRMxo",
+	"QlDfUaNxA29moCHUnC2HdnLNYpC1qxRff1Qnw5NTko8nmcGjFqiA6CVTdg+j8Qi4EYX+Xs4hUuCRiGH0",
+	"e2B9fL8mED6M7Jt9GLl3I1QCodeU4esQGkmhFKFJQhxY1A8+iPyncAncKyWK8UUC+TOWivIN2xVHBXbC",
+	"+80JtLnn3/APmpTUbteMqKaJWGQQW/ImewqAvHn9jhzgZ7U/JX9DXIMe47mA+Rwiza5rJ4QZPqxEcg0x",
+	"mUuxwrF2SsaVBhoTMbdj7ZttTA35lX7psbOamkd5nMCMSmWAWJEU8mcC82ZpvCEj+uyLFH+3+hoetvyQ",
+	"5ywosOmcqjzqHlelQ28/JZLFDLH+eWzZ6Uuh9AsJ9CoWN7zJW5HALgdySzs4Zxbwka5Sg4VRDNcTFOtC",
+	"D0VC6ctMxZVHjo6nzzzExiIz+CyedmqVgV7G1WUkMovE4nn/Ycb1k+NRU2cZj7S4Aq4uGU+z2uOH5n/V",
+	"Ob552jWHyHR9kqOhk9SIoAB5BaC13dYX9uBYAUoI7y+XlBvVUakbIX0ptHatZlKa5VM3EC+AbobP4aZt",
+	"+Hd9tN9YrjZd8E2E0q+opmeChQQDQ/1VSjw+PP5mcng8OTr0+QaOC/EJoWlyGSTQw+nR8ZOnA0i09pb5",
+	"UtWZ297tIlutqFwHjuX1wj5tlHg8Wrff4Xg0y+IF6MuErVjgKB4OmiMFyUR8CTxugfi37w4Pn+P//6MO",
+	"+1YpzU2qNJW6DZG3mNaD/kpwvWy885Pp02fffDvovTto5Gh6/OTps01nuQG4CiDz2TfffrfBVHXWVr3e",
+	"3pkxBH8kdqS51lS2gpgwjheuBb2RG27FFL09lKwxtAn76/BdfHc7plpDU420KuQ7bjtdwVOK9+3J2enP",
+	"sG7lpDRll1ewDoBgCUTSG5LbUvduWJKQGRDgkVyn2ugQ2khDet+HwUhdTSjXE5qywycTOouOjp98XP/z",
+	"2+++H/XK5FewLm7omgqoQE5imDMOMTFDUPQ2WDB7H1fucytBj32FILcR9igEnhhe110KodtdeOWChZDt",
+	"rfesb7kaBXhCUgGDcYGaDtyaO7gVtYWC2K6kbVGbeiw6TL54rkI8Cu1iW5pANxkNlc7bCQr9XW30VIGG",
+	"f+GhG8wcSJrppdHunb9jDlRnElT1cBwjk2ylvHJac+jJSWXK2kwDKFNpqjNVJY0Zja4SsfBIo/yG8ctU",
+	"ioUEZbYdCx4iuBDc24Hq+4BeoguoXa5dUs4hubQzfSr2FzMVWbnzBmZLIa7Mch7TK34OqDBmQeT0ccws",
+	"AZ9V1mw8Usz7aZTJZPR8tNQ6Vc8PDtwy00isDmjKDtxe1MF0OkWKrb8/cEPhcQX6ltqLNSrEPxMiAcrx",
+	"0WvgWl3OWaItWyme+LvRIcwe0gQ0OJ1iOqfMrPT7eMQ0rMIv5r6gUtJ1U8b3QV/Arb6Rdiw7J1L7RYv6",
+	"ksw4Sn4N5vJScE0ZB0nckII1wkeIMg2WM6KPRJE9B05lBvwlRkPfXwibE7FiWkO879G2/dVcLdkMJAcN",
+	"qkY9+YAGwNwqly1GvVf2Z/ISebSz74lrkJLF9ob298wch/cYc+0SLSyAQ9hjKzc6IQr/9BaqigIh7rNg",
+	"+rJdAnjDdHllWcmjfJEaMhZML7NZGzLsryNcMKHmjxnTsyy6Am2/BFpFTvFAcMsoml4Cvw54no2UJObW",
+	"msWvmRR8ZZBxTSVDA95SJDHjCxywYE7MJXtcaPzKfmRaQTKvSnhvTt/99f2Ly3e//fz61yGYanL2X9bk",
+	"LIScIQxdQioukS81hMTzt/kLO9T8ReGbmUcUc0aechc5W7MgRq4m5OJgtZ6UlNPzcptdBNaxl7v/WjlF",
+	"E175QTs1nxGLdqrNoRcSKsp1/l1kaK9l+TqGPlDJIJ8+WWXjCtafPxt+379U7Q4rJkVfpUZkSLhmcGPm",
+	"AomySpQpLVbVI+A/OEgACpgj8bl2zJxnvBUdKUshYRxnc1dpdQCyNxS485unxvmjnEm1Ho1Br+XmCb1F",
+	"581m9xd6zKJ0kAW1Mad7ctyATzuU0b3efkFGEaSa8gguI8k0SEaDMIshBR6rSwvSobf9GCOxhlqLnUZc",
+	"0uDF5PCoqeM1nrNvzK7Dalehpfhip1Xr5xJJ1fypllRC3KacOGG2y4eJYL6wQw0cqFyANgIMqM0gpplO",
+	"apyo5ECJWDCex/DUuVA38Vid3c4eopbX5XUVEJHFakV5rDYSaZtXY0zyiXL1c0+D0mOyYgtJNYyJAojH",
+	"5H/++397bsdyjzt07FZdk73DFchrFtVw2+njLsF7YZ8NId/6/Zu37N+WIAEvWQM0nF4hEghTJAbJct+Y",
+	"L4LCdZTLtyhbm4cs3VyBIUy0EURJF+FHVyoUsGP07StYK+dMXogx4SKGMUnXein4mCzExHxhkDic8rfj",
+	"LfMQWbyCh68CxuOSqDfzknmYPM2tqY/ytNwDjebKfUFH4z8e4TYu6SEk10NYOfgbpOW0jltS1euASmJ0",
+	"RLMDtLFrYZ3rLIaIyhBRtQTAhMNeCoNxY8KmNFZDlX2AOCBa87NFWiqUXkhQYyIhZmp/qICaW+YMCIPg",
+	"T1nUF0tU9zcdTY6evTs6fP5kM3/TXYx6LRdcOce33x7Cd08PDydw/P1s8vQofjqh3x59M3n69Jtvnj17",
+	"+vTw8PAwYBq9tW2w5yotH//mm+1srBTIhloSyz2UIwPTGukaveTDpL2Xdmjj5toKkfRebY6qHTBq29/w",
+	"RktZ9Orkzet4EeA4bSLJhQ1RtIoq+qqsjgA8WldNF06Mb7JRlJEDTjD8PjSzbkx83K805bzXLdcBgF9F",
+	"DKHb3N1FwbC10oTI4twQYtRgpc2N9xdFVsL8CQlcU2eVm5JfsySxcW5ckKicQRGqNY2WEE8rL0qPZsfR",
+	"k/gpPJsPMtP53ueQj9X8Thgn7y9eEcYx0CIms7ULrBJy/RflvYS/32IEWVJFOFyDJDMAjuP8PR9Nj5+E",
+	"3NMtey/d1XdUFhsDE7oOWRf/A6SYzKiC2Nl6DZvFsYTxGD7673IYcmnLjAcJ4rQgg7tBcmPXldmQ73ip",
+	"ST46U+0bI3vmgDG+GJtPHP9IaaaMeFkY/cfE2vvHJKI8giSBeP9WtDFyawx5K4/ZD2Hiw7XnAfzWV5k9",
+	"TmspqoOPnLu4/oD4Fi82kcc9vhwQxI2guvFkyOP6ZFg789htt+1N3zIVjrGiG20q9GopXTBOc/moa4az",
+	"cmQgtIqOKnO1vcl5xk/QEGbdZjWcpSy6LE97SVjff78reca8XJwl5veK9OJ93yLAMGiJfuwJh/FfsiZU",
+	"lFN2gO8VaMqSoCpsmUeXVt9/n93C7rOJ5XFHNqIGXh2Ttd5TxwF9n6rzpxqaNby3ivzy4TbMb3TszjOO",
+	"UmwvM2iKnjloPUKpiJv5djroxS7dIJeFFFl6aS/gXV7ZG1+uoWuoByHr4XTifDwB7xpn/8jyW9VL4rhh",
+	"emmustwZahTjMTEi0BDRu92t4MO/eOkgGjEdp8krw19HTrD2VMmL1+eXv/727vKn397/+iqsIxuO0mFD",
+	"q2Cq3NkKlHImiprmaoBGTl8RGx/nJVf1RiILG2vmZm7Co85MEQohsP0k5ELo3khrTIKrvkGmQP6L+ziN",
+	"0F5WEJYd3vcWdlRoV28yKgOS7AmZCSrjiWIxEEXnoNeG4mZQaCkuuUTTBRAhnXLzGyczCTRaEqYJJoWB",
+	"IoJfGuZG9pY00ZMF1WD0DWdAfE5SKq8KKyHiiRIJVAmOYVxV6FwxHgcTOGdAzG9TI+hdKpagCepHo2PZ",
+	"kAgXWjoXkvynXkpQS5HE/0kURILH6gdyQ5MkSkR0RX60abGOS5NE8AVIopeUk/9c0Y/eM6hqzaiOluRH",
+	"EmWrLKGYwWLNnUpjaIZ76P3Fq6ln5/R2ORqPisXz0H2ctHoFVJ9oRhjSANd8YXERATNyA/mf//5f+eYR",
+	"EMWyY9QGzVfl6lWN7rvDYZHfDtdVC3GB92ZkInpYicjJZkpKGjF0oQrCoDwmkjIFilBLiZdmKDFDfcD6",
+	"a83t0bC+75CxuCCEVtAVI4zK7MPOiB7uQsLdKLLnYWi/Cr3j/oz5irvOEHnosHo1KbaT+Riz+bw98ek9",
+	"NzdOTMyoPNWpzMKy50pmfMgdajBSBNlVV6FpKsU1TQ6W2YpyDIewUQqIW/WDj21msH9jyDMWiwnSQ1yS",
+	"TM1w4uYNvbd55NIymT556a800ed25M6kRQnoxRbc21O/zg9KJCgIXZYBD3Wbv2TIq8tTZYcSTa+Ae0mV",
+	"aUIZJxZkcGD34x8rCSpDEsqjzdDJweNLo4+bv69YOhqP6ExI1BWG7f76jrqBpZPtTCJvKx62S5YtZhpI",
+	"t6FFOFzZQgTWiTMqwbqB+rDJdjxhtd/6Zof3RGjgmK1abnwgl+/n7766rM+cwlpNDyvegi3EZ+wPaxLx",
+	"2F3AkiizSGcSYieg5Vcx8hcjEtrL2uMrPiefBk5TPeBdF8JDMBEAr4iJBBpjRKWyKXHTUTAySIG8hsDV",
+	"/gtQhS9xTZPMCLS5zLqXX/BiTtxFfuCCg8dGxn1/8aqaWTBQDqpn+di4LdxCLhvnzlK7E4jJwsjlvsi8",
+	"BGnFitBlM4PwSnYWI08YAVYX099GFN1EenpZviEmEtrVb6gi8DECiO0OBsAx4ywsmGiDpBzHB6WYZmTc",
+	"DyOHyA8jg7YPo0zFH0bTIPtoHIDTVSqkvrBmjHZhq01mOqc3ZEUlZlAXMhNqNf9+8stbgmFnK6o1SKfZ",
+	"zwyw1QA9tD2VpLZlhVJ3UD0fbiYq51y7Eh1NtuRMVs1IaEQfniK7J4t+O9zojQwnD2YL2p+6Z+Vwk6yJ",
+	"Y9D5GsHZnPOzazI3pNjq3hWsCU0Mj1kT+MiUCyjvkdmLfZeLejY9B/xu5K1fd1tQalyMRkvGoWSGuAZx",
+	"9oo2n1mo/BK6WVd0jbmGq1SvCZvjl5HIkhhtJeaXj1rSqAoMT/0sLS+14glVjm036Q8ZFruYzz8e1VLS",
+	"SkC+RY/WeRa4uN6yxVLfgPlvbjdDtXOOFgzrEHO+2sgpNQVHToxGf0X5jPKmOSLPUzdSRt+JKvZ3YQYP",
+	"1yXa/Hq2gBf69m7rwWtxzA0QsjrMg9X3DF+AFmzJGtWRa7AWF0RHruszrUgZL+YSgF3gcxMPVqsps7hK",
+	"JTBPAmpJ1erw7ruwpijg5Hf7t9ve470efbIGvX83t/5Qb0av+bwA6h6KxkLGIPdDL1axYISYazNIqCNx",
+	"IGxGb6U5lzbeFsTAvRumSHUCZ4wopn/az7W9aBqfhjw9IDeI2/0ECd4oKDu25xq5vSyl4XkFIcoknP2L",
+	"Ukf+LF7djCGGYW/20Av+Yplvu2s7aHc/ndusLVzCFvJZmNtUGh5EiQQFmiSMX2HIAAYLqCE5J+2m+PHo",
+	"FxFD0lPFpsit68qGC5BjS3mYJ9soD/Nsw2oKRjLfvDBHHZAubdmbsqewTAjkzWTbrz7LdidxoV7q7iPI",
+	"1d1daOmuI0QfIh5zWCpziePNQjSbJ2wLFqfAse0LBsD5Qxs8q5inasl89XshKEoU5Yf9kceHrQywMu7p",
+	"8bCKL9b4BSNvueDbWFnar/+tYbVFf0trLq0WBK1lRpRBn8sem5Ozc6uFqv326JWOsuRYyXaQYXqwOrIj",
+	"g3GbLbfDjNtjo21icgsHp4U8Qtl8DUp90kuozkjbLmyeOR2o7arFKI6AtvibkfPRHKd0LjcTO3hK3uC/",
+	"6HpzxQ9ioszLcc1okqx/cGK2Cz2h9sH28VM/haYTmO5tcANBy/eD3hbHW7gtKheFw04vy6/CpYnkjMo4",
+	"HOq7gEkC15BUgjYU2Tv99SV5Sven5DdrMyVwDXJtyYDl8bt0AYNRZwNHWgWHYCyTF8VUFHWwpOQoy9fy",
+	"SXGNDswbqpmaKlWr7Cp5/dsL0Flqq96+MsASqVFaW+rdNrPNh1B0buRpMAVJuVXAqzESNNOiER6B+DTs",
+	"X5NUJCxaPydLYe+HiMqYJECv0brKlMMeeUmlZBAT4PFEiwnw+AcCfC5kZL1pYk5WlGc0OUCvAjrUE6ox",
+	"ji6SdsxeaZ/RzshKFTE73PcdB27LdjrnRuuv3VNNYGlLlK+AsSXBv6FO+MaeBdOXM0l5tBzlxUbMup7U",
+	"MxqP0J1k7hF2mYrEvMOS6eQyf5GBZiS/LGotH+BVblixwRJakExBSfs2aOrc+myVrecytol0Y7SCFYVm",
+	"qTVKGo5TtSNtKxDZIPPS+ZQrrHBOExVUQm6hgrV49VKQE4vSiXmk8I/Z/LcrWE+spy6lTKpQYmI7P4S0",
+	"hx2+/qiBxyX/sy4ztS02WCLqu++2gyivNFAqIbLuDaso1osF5b8/R6rLyTQvnDwlP0NqI+JmNLq6MQzF",
+	"1hxnM5YwvZ72VAwakDXYaRDEuKxLy9j6wHxuxp7ZocONeBWiri0Y5DqGOv5Kky1FVz22KKOdBqos4LKl",
+	"uIqT3jt+vUVYSREysnFESKFT1KoFtEWHlJvvVzhy+tmGnlHQYpdqcWd1whVe2mn1tO3URouYjDK81YFe",
+	"gbykRVRRo+yAXoIV+9wzxD1jxB1ftmFpCpWCsu2XXW3xIs+mza0cCa4wT+Hak2jnlCUuldvPVihCQ4MG",
+	"j/rSwUjfd0UAhI3iLRfP1yQzmAsJ9q2tz8XXS7vCU8e7yoT/OordbbO23R+8ct2u1PwV/XhpC5uHAimw",
+	"sRmxvxcaY55f41Kl9xi3q1iRVfCkmul+FA6Q70157qnV1wxruyn91eUzz55tB06Pqtbfvdny3eVegLaN",
+	"3bfeQWEmvZmV3+G8s9L/bF0yy0FCRMAfGpAmZmtUbYdOep7xIVOqPM1v0KSuqkbPtF3nOG8q6M6xjTvc",
+	"8emtemP7yi0UrKVRyH5wixO74PBK/u1LblzBf5PS/R1venjXmv2jKhRq2/NIryDscXlwOk7edmT2cIHI",
+	"ew3hrlY9vaeyRrsyd2xUm/Xenc3brO76IPVcH7R+UVvZ2I0vTo/ct3OK/fPzsIf53AVN7Ty+rHnQ/pVy",
+	"IK8EbF70+Laxapu0iGpEro3bq0GfY4JUZ/akbMl5sUY5l8uCgcNOD/K97LXazId9e3eLhbeqoD9J3Adw",
+	"M7yWww3JR5A9p9mT70i0pBjCLVVVS+Nwc2FxQ5U6On7ShwkXFtbSwgbj+qxKKCECrPI4W5McX56p582/",
+	"/TN+eXQ4O9bJjB2tZk9OdbT6t3/+x//3//7Yy1TsDnoCF51npRPxbbmTfy0yb8pES5c9OSU2HZL8SJAP",
+	"O+8BpGQuQS1/KK0UPxJbZJmkVGpGE3Tq0Pia8gh+IOqKpWaI/WxQpn8gRValnT2THDPtOQEqE4ZpI3QB",
+	"PxBMtSQ/on2n8AjeJWUzoAyGj0Tht+ECoRMJGUNsk1z00ofXtBeNHSW2fZN/M4iTfrw0sM+ZYBEzVGlU",
+	"3mdasw6B+j3LBUew8YmznRkoJTd0XTNVVgb0xKx6260sG3xxkUAjhrVuflWa0MVCwgLds2gNyzt9SpEA",
+	"2XMex3UK+2XchqvGVc8vCfQrezI9Gth0USQBI+xJsbqlTbPfG4oR8ZLNMGBEC7JXSCZje5LGLmFwTFCe",
+	"GRMrzuyPXR4Xv+Lihn8Y4Qtn3JvNrFB1WHVKPa3hvEfbCOc9vp2Og6Ac3tsxSDsZv2Uhpu0UXpJSyEsv",
+	"HPzW5ZaqNe4vFaepWgq9cUmYoiJo014AMgJu65fMyzyZvOHL4f/89/9/dHi4b1NoMtd+DbvzF254j9X0",
+	"8prNC0jJTaE/rOiUqy/VUn2qSA7aqADVNuod/QzrIlpCKRGxIi1v7QJ3sMbRD0Tk9w9VRIkVEIgX5vpT",
+	"oMiKrsmSXgPhwj46HVSOdCflx4vKSkUuiVeedhMNp2Fw24p3eqOYz2bqjk89d3XptiQ1DLyD6ly0jBn1",
+	"XboOBRU7Uo87N4f7+jx4x52BnOBdi7fbLMdOmceWJpkyt3EyyVKCCyuPmZTtvM0kmB5DZZyAwvxz87wr",
+	"q+Sy/JoXNz433GzbECsCmu0GRNGCtG+mT+7QmvR2aTXBBqMbJ9e00VHA9Ni4ops7GDv0dBBWW+HEDaOx",
+	"1QZGdkh7SeBuh/HWPWe981AEDWyPGPpN1l3rb5WC2oMeHVmci5s70oQvOgTbJG9u3939FbAhvRSe81rS",
+	"510E+KGOjeaqx7dI4As0dj68XSPx7ivPo4dBzcbPM74FK6rRRB7YdFqmoA/uD3ZLVamWSP64dKlELC7z",
+	"iyZgqi0KGPSEMAvJDLgte7SHAKPHrQlMzP2qP0KUoV+bF9RC80hLhNXflixaujWp1rBKdbGXvSOb477f",
+	"tpWWpVstQnVTsMaMCUk1LNY24K3gB24vbSsXPpw8yB4j5udZkgyrlrYR919AS3X6IvuiKAZvtN+9Ij4N",
+	"syT2y9h0MoNE8IUiWkz7wz77szG2t+yOdOMelXg8uqFMM764LIoLblRnrTtAFksxDAjqDGTGefkUbpqi",
+	"e+HwkmbnGf8b08uLXKSkSfLbfPT870P4fH+Lxp45wvkyAxsr/v55bBs8bUczHlprY2WoP9i5/IxxDvGY",
+	"rLJEswmV0bLRHmkvZgtQ2hYOQbPmmECigGi62N+ggg+erqIjOtbt8apz5sv5PGghRraBgLlCsffVaDxy",
+	"za/Chb6ESKIlZbzP+laXn9xj4yJI+OXbU5vXIgRWpI1ctpLrP1I0UO8ssez1ZyhR4O+yl9KbelDAZhoy",
+	"ig9SgG5XYGJHUvsmMfweh/qizOi7EaprNSRrvf7vYqRvKYA/tB/rbVhaWagqWKXr18btXOQYlvHyimlF",
+	"zGl2Dsvi2NqQfyEJ1e7pmch4TCUDVWt45K5+18Ulj0mfM2l70aCfh8411l3Cq5i5MuADIrZ336V2s/5E",
+	"91HOfzyyjXzyAM5BBcj6G+du6qz4o/bZ3YnnoKX10CYeg0A0baCL9m39Nrc26D+bHj+7DSP2PCmlfcNb",
+	"oxMErdHURoTuzeOJmdKMR8idXB3LomuaWVvV8miad9NGcL4b4BrxwdWr9HbRvmWdldtZQT30DQ/iLXHT",
+	"gdu8W2MtSN51COspvOE6RPa0SvKLnPY2mEElsqfWTQ04ZTuzUgmNbfxJWbQp/P5bsNG1NAG6Vytd8S6/",
+	"yQuMXwkaXjLJFSmGon0FK5n8IwMjZaDc4MJfbFFTM8LoQokQV1mK4TwwQJstIWt02gGw+z1/hQuvTGde",
+	"1KHEbrNbaT++S67wHrk9xtS0xrEVzXnbM8ZbYz43De9szW07OS1T2/KEUKxbgCayhdUiclhYpcigJgUe",
+	"tSmf2FM5rGUXgWilVo1NaQptOCb4NNlTAOTN63fkwHZo3r9Vk8VQsPeAgtIWedj7qg13rdmG711x4mrB",
+	"XB9dyJKH9O91M2GX4V+dLrMZ2jfvvTsYOr+sz6QwgpwHohXjvoXhaNwW+Dw8tnmjF27fbbN2Wnud8K+r",
+	"8uHjKlJYL5G+YRW+31sRXC2y1Yrc29Ta2lJlrNqru510vJFVMNqjoB9duv8XmR3ey6+Pwvz6z4zx22aM",
+	"f0mZ3Tl15Jmqt7uGH1WO9ucujuNlUbUynk4ordLbAqk7MS9foiiv5UbZRLy+qe+WljcYgKhVdKStDDMW",
+	"34dZtKfF05dqHOyx/bVj7r3aLF+Pw80Ev95W0t7FiunlLTiLC3Mt6unFK/SmZarS87wTAArkPWUcbyvx",
+	"cVe1NDoTKjeGffUlHzCRN4ej84e5nJVNjNOGRk7OTn+G9QPlplO6HQxfwfpyyUL247dUafLUS7jM7+Ur",
+	"WI9JKmHOPuYpcx9G0+n0w6hyM0+n04/ffvd926LhiBsD10kMc8YhrlY/xQ4/mELhpOoxuRHyqip55War",
+	"jQw+b9/+UoqmuKZdxwrVYyJS4JTtBwTuwY4Ru7L34h7gez39BiZbMJQiW3tIO6m5BiHKJNPrCzNjHqQg",
+	"rhicZIah1zHzr39758RsZSRzqgjlxEh8v/FkTWwuNrEToP0G43ndJ0tfRY5t/tYpM2f282fsMzMXeR80",
+	"auvHuYf+KlI41X8T8kqRd0BXzbqfL+z9T07OTgsK9Z/K5fMV5XRhfXJGSjPHcfqBv3PBfuiqthZfJTIZ",
+	"WX1EZnpZTGoWMBs0Z3D6wbxJwiJwHUzcdn85fWc4VsUsYojWzjk18rB7SB2YsaWAUHnTk7PT0Xh0DVLZ",
+	"dzycHk0PUTYyByBlo+ejJ9PD6RPEs14i9g5QQ7WWBKu+GPpECjiNsWuV0m8SMaPJiR2I0Zp0BYahtFqy",
+	"yyGG5uDMfGw1ZvuDQXrjf8dWotjuBTd4fHhYa3uH3b2tDezgv1yesCX2O541fNmtHrb6WWpQ5FtnqFkg",
+	"tInDy+fx6OnhUdtaBXgO3nOa6aWQ7J8Q25OaexztxDRJqjOTPZSJyY/uawz3ogtV1DBWo9/NPAdm3oM5",
+	"9o2f+Cn/qfMPVuml2mB+ZJkMKP1CxOuNkNcF2nAX+89VnmZUxc8NCjre2ibqDYkCKMU6Cq73UMxUSjU2",
+	"4tqzidwusx5sv8hUWhOhG25EMAfXfUsEh/1E8IJ6wCiZ9ej533/3CcKNIbQs0OA1QrpmtKiTUBCE4e4e",
+	"OWB4QjsRYDOq91ZE3AX+K82uBqH9cGtr21s4cHwxYkNlUQRKzTOs4w00Btvu8gL05KW92RqXZHEfmtuy",
+	"uP7K3dQllM+35wktBPFWLAjjWN/hI4YaLEgu4LcTgLCe+VYKEJkuSKCCi6cBCU4sFhATkWkPgsl6K9xP",
+	"LHBev7Ncz8tZuTZ4Hb4B/dJOEn633dPZS+8diO1VvJVb4g1UYJSsiRkKXDMs390Hs7yvWjtJ5EWEdsgX",
+	"6nWKBrGGo52jzHzvNZ6rkviO2cSGt4Z55Pv+R14KPk9Y1HfN2DcmFIsB9RKQgiECRqU20c7oKFD/6J7v",
+	"mQHiRb7Dsn1wg3duT2i4AO0QWQgNmVF9ii6KhaLWRPCS6WTiENWtanhVkgKqRvX1f0JfKpmtK2WwiNc0",
+	"c/R8hLUySm2yzEcskNBMxXHF+i11GXE9aBMeos48nO4zsNG/jTIKkRYqL57/2Ifx9tSSyqzEesdtTHdZ",
+	"LMHRkyGiED0dzNYTpSE9+GT+exp/7rq8vVd/sb6wDWY302cvcJEzqpf3hqQQgiokfzcxwDz0tP+hX4X+",
+	"SWS8TW6obMiWgpLYHBph3IvET+Zj3stsMA43xp7fMe1PJFaQSKsonK1t275NMXfg9e8J3+AndsBXisbi",
+	"8rit+LV71N9KyCtoxaGvRi+3oRR7uXaJevWKmduik12IjPW93rO8uAmNFlLN10qjFhtbIVEs3unTaE0d",
+	"T4QyZwF7el0uaaLJsijaia41wdErYCthHuTRYQdFFcwDdcXSA1tKc0pODAGAwgggooU/r5lS/eCKE9pP",
+	"tqeWPZDuOE1tLHNVY6oXIH3M56ix2Ud9kHC3X/NBwhesEnhJ25QT4JKhVbtI9Q8cMnx4Yh721b96JTPU",
+	"vxoUnxdFwogy54Ibl8sWFV+VllmkM6M+4MO2cixRAn99f0oiyl0Lztk6/xVL4dowvFmWXE1JHs6frAn6",
+	"R2Ibze/cgc3DZbSYoktWr8p6DkZ7jLSd1HkOvblDKmu1oF9Bwj2BATuVh6otxkLqo49LYvG+LZUxbaOT",
+	"vRnV0ZJoyegCCOMz8XG/lRwNSLtNEWf5oHv0ePaPvxBSv1jfg5HAb0gxyEBQAHWbLsu0REKOx+Kr3z+P",
+	"WwTHlxiPUTYw2sVFVVnjgQzORauPAH5c/IILTbm/C6qCRwuk3G5YNpRqotI/lgefmLUAxJCAbR5Sxe8r",
+	"/L7E72bns11jfNre0MduJX4Q7dy+bnkLtR2GNoPJ9gF1eJ8k/PCGkTwYqG4TqbKiLAD9SuLL3RCwfRYW",
+	"zMq5Z2l7AP6dd+MRy9gVkrFQ7TutDX534Lq3TVz3NusQa1c80Uelgg1GlTYb2MPU9R8Px8Q2iPsR+4ru",
+	"W4GY6rIhKBYVMMLxDPIKckacX1DGp+QkXjE+QW0UeJwKxl0UW8Ar99Lu44Xdxm758svaO1sf1BaCB8xD",
+	"T/of+knIGYtj4HclFxsjFEKjNaJvQEXuLzTC9kf1ueN127C+fC2Ls/GfcYDbjgPcdgCgjfqj15RhLlWV",
+	"vMie+2PitN7/pysssFvuPnEp9nciqN93KbVXihjcs8zuKKqJd9utpCKv34Z5HR8PeSiVwjBKQwivuWZ6",
+	"PUBwz0kjL6EQjBbt4EYHn/Df0yGy/VZoqJ/PnNgNbXDvWCw9Bm2AtyOiXRV4HHA9vK/TNC9toA+iODgL",
+	"n80Cr2sPPjtt1x0eDGO70jc2Z773Ri4VTeOB1AZ+C/5qa4C1GdbzykVeqy5sFmIEoSJNRaUQsTmDuJAI",
+	"xDWG7mGhBdtCd2yN7UWTEWXjdAS2zMr4GK3pWARhSl54DZCVbUDKoySLXbnqarp7zFSa0DWhWHGZxUAy",
+	"RRcQUjRKc8ZLobYit9bqxZav6wo4WKBZ10bQPp+3Fy5JsCy+9G3slUbAD08OzX+/PwyGlN2DpcWvRhc8",
+	"CAWR5IRQEMvDMdI2yg2pR/Yw9J2WPg2pRmcv1tuTau+A3+E6S0+HlVbxs9JF6MEQXmtm5OF/tna36R3R",
+	"Hy2p1AOx/xLH7prT4DvjtohLxtwSt9kBnxlEh9hdiGp6JlhIh26S4CvKkrV3wtHa9HB23zi4HYsrRJME",
+	"HoN0tfY3Iz+Z8aG859wM3TXxyYx7fH6XpPe1Woq8vkkPmqM9wFNbIFuKm4c7XjLjkwSuIalz+ztydlWW",
+	"2h1wunJR6E85crAJ7QsUIHEH7qvb05dXZGywd/q198zWhceAfcpb7zFYqaplwGydPia4X6/Nw4D3bcWM",
+	"FdZnq3M7U0twCbJnS66OiQJ5zSJQ2FB3RXms9qckn/Dp4VPbI4DOFPBAsFfJOnaK1u2dVX+bgbP6zitE",
+	"52PkIfNI7kAtwQZ61pKtGlUCPUSPiYQ0oREowtwPqQSsWLInOLLxfFv7U/JeFcU+PoxiiBIqIf4wyrtL",
+	"aMJWqZCYRD2XYoX5cakgc5YEDRpn2a5oavsGPG+Hp1gy/Z7Ndz3k7PM+50chQt5//EDNrqdA3pG022+k",
+	"lEUTo0scfDJ/nme8J3fqtR21e3vy63w798Dk7FKukW2ILlIWodDrIomsGTMFObGNUFRRsO9hrFucQL5D",
+	"9BG07M8jj5RFvXTR7f1/jSMes9f/EcXCGmAND4RF4FscWvxFtknEtjz5dv6q+765WpNaur325h0ftdPe",
+	"L15/zz57hE0bY7n3CNvbRSjdPgekEguAnIrxoAI1jC3Zq2pQFMA2aHLYVbWZjmVgcHfl6j6jzMqgAbAw",
+	"bTKHLpHhoZFweD9H+cEjjZ0kUI8U8Dh4e6DAA+FpV2ECG7P7e6KRB4lG3jGruNv9UEYutPCWgffBQUwX",
+	"fbrLq5M3XxcvenXypqvEz6uTN1a24yIGhQEWEC9A3WP26PH2Sia+llKEi5qtowQM+8W0dCNfWFnWFo4H",
+	"HjHzykF7UTFkTRaSpkuy9+rkzb4Vj+9MkbmbrqXIHc14tLxXlbqdLI+3rU+fYHF/VEHaNWrzTJxhG2Va",
+	"jP+jk6alC0KJTUg1cEJyTBJ8loHKqy0aMO5RtebR/h2p9OCTROPPgW0U31GwAH939tAcjZgGnSQuU4RE",
+	"S5bEmBcyJUXXHZU7irnBtm1pQyU2k01TiH0z+veE2UrjZm6mCE0k0Hht9QYNcsU4TWyaSsgkarf4IOeq",
+	"f/Q9GbWwQ27HwbNoToJF3x57UQGLX6NC2lTucU5V2EExpdjWKadN71wgN77lscBZ20/FmflZ+aa4KXlZ",
+	"nAKbMLWk14AGftclHal/CUk8JjdLlvilM/NTUh4krAHOeIbdAcu20sFTUxxLpqxDAdVtmmG4fvuxwXf4",
+	"89R0nRpHW1/ekUHcGvJkfJL3ONz2EbEVajozDrOVOST1IzolZ/YLj9zN2bATxlZqLTwe+UFQZekODh91",
+	"VZATWTr0aOQ4bTsWdtt/nouuc5Fj6ss7GBa7TZrc4EwsmU4O8uqfvUH0SVJmzlohqGT7N5RZv6+QZJmt",
+	"KHe1mWgyJa9AsQV34e9RJpPJjJoNv3x7in1Q5om4UVgJ3q+77MrseDV/8TRFZhvYgC9PyjXXigIgN+am",
+	"4gCxcoWiQkcC0z/tC3cXXH08kQzN7bY5ZPL8ybxOzDYKl25ug2mvW4P7yenCq33aEpUUKFtToV7u9YHt",
+	"dvk1O8Y+aow3t9uHcR8UJHJv+BC2XNxQaDetWK5isc9X1wTNo/bctbcqvmc/XgBuAXL6tYm4h3Hy3Z4A",
+	"S5dd4F2G0uAwlnPwyf84yK23ffLtF7R+rWxyA2dfiBoeRTGgAGq7GUq76+hRIWRXDqU7cqHDR8CFvtRK",
+	"OJuR6i35zoHOW50Gb853EJKAHjHjMRuuQk49VGzuBfAYLbe1Hd0Gibny1JmfUWl9/6jVkupOQ/FhubJo",
+	"6T6TLrfnIUOsg1tqrzfkhk9ykbqv2tn2sbez2meVrT5UCbRb0tBXGYoQukC2Q7OtHKkzF9OocucZVy/W",
+	"ty3i9yVVyuqxIQ6PgUWYbivgFQ3KbZh21r1uhXkLlt+dasjnGX8glbjFMnye8S9X54WbSnHDPtLpZAyD",
+	"/ervJOWKofhTuL618P20GMU/Jaela3xJFaFoRfaMyM5Twm1LRnSXoP99bIsE5h8JU6XrPa+3XXrlV1Re",
+	"QUyoKndwSw892XPuSojHZE5ZYv4Vspx3v92Hfy8el4f1oZz/EZzxNuRlM7dK9fQI1V1sxaXPq6+JXLAA",
+	"RmtW0nlRcgGH+Ek/kD6CGixaaGpz85XXz6ttlxukUTcJ42C2nkiRwBACebE+NyO/MjJxbxVspSARNvUq",
+	"CWmSKXfJaPqAMetpy/5qJCNFkkyyNN/tbcmlJ4znIi+JbFvPmQsXm+ggF5uSd5X+tuVFa2/gIi6hEqEz",
+	"JrNMEy5QrCjv1wRj/Lov1ZbYHbK3ygyoIOe0+63RPH+Q+/NLD8vxoiLveE8OjcEpw2nEvAx+QGFXihUS",
+	"YUKVJoXohqQ7gFiHRdP8Qejy6wmLuQ1huljlTtPIhRvzyBOJayHQYrWiEwXmCd9oYS8MewHMi+bCezBd",
+	"TMdkRqOrRCzGOc8e3mA4UAGrdmshcq4AG74lQlyRLCV70h1VV9gEMdi26hWsN1vS9U7Ow9Fnaxs4hVln",
+	"oQXMr4+pAxWCzBDgb/IC4TPMLJW/r5AVsJr3NyB8sFiRfF+BpG7hGpLl4owlzGrRufyk9pnBEGqP2hCG",
+	"O3wgU5iFToCO7Pn8Y+V523PRkuhd0lvf5XFgi+G0u2VP8fctXSM7Is3KHh/ISVTbg8qSoCXeDkPBJdGN",
+	"OiJWjLHx2FJizdGyMsXjJOkKhb7IkitXXqlkmUbeXVFptU58438/+eWt+Z7rFdUaO9HcgnI/IdAGBTRt",
+	"ha8OqHdiN7RBDMGFS1X7EksVWBbUcsu1WYkeByYO7+tOevjWaIX8VClYUBFI2iMFHgxbu4on2Fx8uTdS",
+	"+bNuQVvdgg5GM/yS6PdwIBruycdxv/yppyKsE5+9EqyPyKdh+ZdrMU2TxEYubGCeblJCvWhAuB5l4XAr",
+	"beTWuhyDZNcQl4a8smxgLQjGCnL8HxlkZkK15lFpGAza+tzbOmcvup95nvSNHTyeHh5Wx3q+4VhwGGOR",
+	"1MoIIRv7cuZE7L4TzD9C4/m9GBF7TsJWAyn+xvTywuCwJ6KilhDpMPgnaw5UUAjEcfiGm82tmd45VZou",
+	"4ACTubvCOthiAdJ6lT6M3ogPI0LncyFjyqO8iV5EZUwU0zZqI07AKs4ryjNruFnAc2dMVuXJ+Yvz3y2p",
+	"NicmdREbeRKh/7zRdwRhWhEFC6xvasnHlYTRWMs202JC42uzL7OKFNliSVQ2U4ZWuMYBdjOKZFyzpMy9",
+	"dSsJia3Up+Tdkik8+tZ+7NwSYzzVtJrBVi2fXOcM2Pyn4C8VxjBucUI4i3UQDguw0AgxlQvzw4UZ8xXd",
+	"ry3OiV8aEIF47Gfyfq2MAZFsA6GsH7dKHOgM25QzaFilibmTK8m/qYQIBWYU3MfhBqqrVL8rnv6jBoZW",
+	"4TA8RjTF50gJ/m3Fi9Yn7uqku0r1pNyBb0DvIwEryFVf/lHb1qtbfSAjew1e4bbfPvb+YHb3Gu22WeAD",
+	"lNvP3w4+5X82rJp9xF70tNgisffzsHfFdjewedbp5wu1ftYIoY9rDby3bAeLR4bEwwfkLg9vQa2f+Lot",
+	"NXxJZYPQ7bKcHgPGd5bCdftb7SHp7k9zbKs5diPOZ249P4KuJ4R4Y+K/vyC0XutRpXuFsiMfjGvVmlWg",
+	"aQK3FNS7KjGOOO7gk/nHhjxq262txwBDCY60Op7NQ3FhvpBOSWlWNVKUHYlhvZhiYwuTCWtrcM/aX30L",
+	"qvmR8UjCCrjG2jwabcNFpqFnXH1XGi10kfkDMYaJES2KiFA2x55CFEt+FiujkSVon4XUC8b0xxMhyYp+",
+	"xE0xjACNAGKIw0GaWq5/wocNRd2F6IfYQgweH8ERQWwxzjSj1hzi4OtYbc3O/qXEcSIJ1uk9fMpsk7Pe",
+	"EmbOemKBZBjpXMjVRNxwS2rRlSq6kJOIciJhDhJ4ZA6H0kBjdwQlwMQ8StiKLpCeaTwRPFn/YJegmiZi",
+	"kQFmqiGtYvs1kBPFYmirS3ZhX+LhGnniBgLtage02nyHR9hwgOLlt2bUqILUpthib3aVA6x0X+IXOU20",
+	"uad60p1v55uvGEb/THW+S6pzhxkzU4iODhy+xxEbS/pfRbcm8+7D0Wdh+XBlAWmSuD2UqLafPVwfrDpz",
+	"435Zn0kxZ5gWt1OwBgukO0O82aiR3XEfWzgPebWSyJv/L6pYoQmtzlCjKoh2pYwWqzyQHtqGo/dOBGri",
+	"6L5Uzzvrhe2kQPY4XWFd1AMjo68oS/Z7DtMBTdnkCtbdTPSX9cnZ6c9m1H20yze4s+sN6ZWf17w8OTsl",
+	"5kXw0qjDaLvCRxX4xcJ7S8Y1MXLfmHC4BkliiOQ61RD7aCgg3pekkEN9tEtfiF3igXwgPqYDDbQtYPH+",
+	"D+aePf4ja6RA2xCIO0rIySVMpkEqCZ7Xg09XMCwm2yOjzYSgn2GzGOv8zR5DUUiew3kASFOq1I2QMapL",
+	"oYvz5ZLyhbnS8oE7OpC4TL7IRkcy5P1x85AIp32o81N18OFWgjdYCdr26+oTG0Lv7+1B2ozWNyJ0s8KX",
+	"6k2rsZlSZGwTqbcMznsQ8Sx27urNuk/sWEsyyqR1p9cgmf7uONqVHmB29thUAAPmP0rFwNYDj6MhyiTT",
+	"a6QW21ThJNPL0fO//26owtooLS01b/rrIzKjCkhqiGg8ymQyej4y4snB9RESlVux8WzZ1MHG/Nq2DapM",
+	"sTZgCySrI95WlNMF2MDP5pO5CSMQCYF5xN1P5zEjgQmwP0j307ZXWWBtP3C3ewpnQOuL4+h9i6prsC3N",
+	"vnuaPPWj44WqBShDW6nXnmxO9tdsRfmE8YlewiQRIi0bQgQmxBYQzUkCFaI7dlUt0Nuc7WThoik7oIM+",
+	"ARWsqGCUREmjK4zY5TERM3OO6IwlTK9Dc9nEihZ6z2Xqnu3kkm076QO/ZlJwnGHP70G0SoX12e0Hqbp8",
+	"TI0+//75/wQAAP//YveXMzODAQA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/backend/internal/api/handler/server.go
+++ b/backend/internal/api/handler/server.go
@@ -20,11 +20,12 @@ type Server struct {
 	costs          *CostHandler
 	notifications  *NotificationHandler
 	epicRuns       *EpicRunHandler
+	environment    *EnvironmentHandler
 }
 
 // NewServer creates a new Server with the given handlers.
-func NewServer(auth *AuthHandler, projects *ProjectHandler, users *UserHandler, profile *ProfileHandler, epics *EpicHandler, stories *StoryHandler, agents *AgentHandler, stacks *StackHandler, runs *RunHandler, pipelineConfig *PipelineConfigHandler, hitl *HITLHandler, costs *CostHandler, notifications *NotificationHandler, epicRuns *EpicRunHandler) *Server {
-	return &Server{auth: auth, projects: projects, users: users, profile: profile, epics: epics, stories: stories, agents: agents, stacks: stacks, runs: runs, pipelineConfig: pipelineConfig, hitl: hitl, costs: costs, notifications: notifications, epicRuns: epicRuns}
+func NewServer(auth *AuthHandler, projects *ProjectHandler, users *UserHandler, profile *ProfileHandler, epics *EpicHandler, stories *StoryHandler, agents *AgentHandler, stacks *StackHandler, runs *RunHandler, pipelineConfig *PipelineConfigHandler, hitl *HITLHandler, costs *CostHandler, notifications *NotificationHandler, epicRuns *EpicRunHandler, environment *EnvironmentHandler) *Server {
+	return &Server{auth: auth, projects: projects, users: users, profile: profile, epics: epics, stories: stories, agents: agents, stacks: stacks, runs: runs, pipelineConfig: pipelineConfig, hitl: hitl, costs: costs, notifications: notifications, epicRuns: epicRuns, environment: environment}
 }
 
 // RegisterUser delegates to AuthHandler.
@@ -435,4 +436,19 @@ func (s *Server) UpdatePromptTemplate(w http.ResponseWriter, r *http.Request, pr
 // Deprecated: use DeleteAgent instead.
 func (s *Server) DeletePromptTemplate(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath, templateID TemplateIdPath) {
 	s.agents.DeleteAgent(w, r, projectID, templateID)
+}
+
+// GetProjectEnvironment delegates to EnvironmentHandler.
+func (s *Server) GetProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
+	s.environment.GetProjectEnvironment(w, r, projectId)
+}
+
+// PutProjectEnvironment delegates to EnvironmentHandler.
+func (s *Server) PutProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
+	s.environment.PutProjectEnvironment(w, r, projectId)
+}
+
+// DeleteProjectEnvironment delegates to EnvironmentHandler.
+func (s *Server) DeleteProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
+	s.environment.DeleteProjectEnvironment(w, r, projectId)
 }

--- a/backend/internal/api/handler/server.go
+++ b/backend/internal/api/handler/server.go
@@ -439,16 +439,16 @@ func (s *Server) DeletePromptTemplate(w http.ResponseWriter, r *http.Request, pr
 }
 
 // GetProjectEnvironment delegates to EnvironmentHandler.
-func (s *Server) GetProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
-	s.environment.GetProjectEnvironment(w, r, projectId)
+func (s *Server) GetProjectEnvironment(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath) {
+	s.environment.GetProjectEnvironment(w, r, projectID)
 }
 
 // PutProjectEnvironment delegates to EnvironmentHandler.
-func (s *Server) PutProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
-	s.environment.PutProjectEnvironment(w, r, projectId)
+func (s *Server) PutProjectEnvironment(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath) {
+	s.environment.PutProjectEnvironment(w, r, projectID)
 }
 
 // DeleteProjectEnvironment delegates to EnvironmentHandler.
-func (s *Server) DeleteProjectEnvironment(w http.ResponseWriter, r *http.Request, projectId ProjectIdPath) {
-	s.environment.DeleteProjectEnvironment(w, r, projectId)
+func (s *Server) DeleteProjectEnvironment(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath) {
+	s.environment.DeleteProjectEnvironment(w, r, projectID)
 }

--- a/backend/internal/domain/service/environment_service.go
+++ b/backend/internal/domain/service/environment_service.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// field name constants used in validation error messages.
+const (
+	envFieldSource = "source"
+	envFieldStacks = "stacks"
+)
+
+// validSources is the set of allowed EnvironmentSource values.
+var validSources = map[string]bool{
+	model.EnvironmentSourceDevcontainer: true,
+	model.EnvironmentSourceCompose:      true,
+	model.EnvironmentSourceMakefile:     true,
+	model.EnvironmentSourceDeclared:     true,
+}
+
+// validStacks is the set of allowed StackKey values.
+var validStacks = map[string]bool{
+	model.StackKeyGo:     true,
+	model.StackKeyNode:   true,
+	model.StackKeyPython: true,
+	model.StackKeyGoNode: true,
+}
+
+// EnvService provides business logic for project execution environments.
+// Exactly one Environment exists per project (upsert semantics).
+type EnvService struct {
+	repo port.EnvironmentRepository
+}
+
+// NewEnvironmentService creates a new EnvService.
+func NewEnvironmentService(repo port.EnvironmentRepository) *EnvService {
+	return &EnvService{repo: repo}
+}
+
+// GetByProject returns the project's execution environment, or NotFound when absent.
+func (s *EnvService) GetByProject(ctx context.Context, projectID uuid.UUID) (*model.Environment, error) {
+	return s.repo.GetByProjectID(ctx, projectID)
+}
+
+// UpsertEnvironmentInput carries the fields that can be set when creating or
+// replacing a project's environment.
+type UpsertEnvironmentInput struct {
+	Stacks   []string
+	Services []model.EnvironmentService
+	Source   string
+	Commands map[string]string
+}
+
+// Upsert creates the environment when absent or replaces it when present.
+// An empty source defaults to "declared" before validation.
+func (s *EnvService) Upsert(ctx context.Context, projectID uuid.UUID, input UpsertEnvironmentInput) (*model.Environment, error) {
+	// Default empty source to "declared".
+	if input.Source == "" {
+		input.Source = model.EnvironmentSourceDeclared
+	}
+
+	if err := validateEnvironmentInput(input); err != nil {
+		return nil, err
+	}
+
+	existing, err := s.repo.GetByProjectID(ctx, projectID)
+	if err != nil {
+		domErr, ok := err.(*errors.DomainError)
+		if !ok || domErr.Category != errors.CategoryNotFound {
+			return nil, err
+		}
+		// Not found — create a new environment.
+		env := &model.Environment{
+			ProjectID: projectID,
+			Stacks:    input.Stacks,
+			Services:  input.Services,
+			Source:    input.Source,
+			Commands:  input.Commands,
+		}
+		return s.repo.Create(ctx, env)
+	}
+
+	// Found — update in place.
+	existing.Stacks = input.Stacks
+	existing.Services = input.Services
+	existing.Source = input.Source
+	existing.Commands = input.Commands
+	return s.repo.Update(ctx, existing)
+}
+
+// Delete removes the project's environment. Returns NotFound when absent.
+func (s *EnvService) Delete(ctx context.Context, projectID uuid.UUID) error {
+	existing, err := s.repo.GetByProjectID(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	return s.repo.Delete(ctx, existing.ID)
+}
+
+// validateEnvironmentInput validates source and stacks fields.
+func validateEnvironmentInput(input UpsertEnvironmentInput) error {
+	if !validSources[input.Source] {
+		return errors.NewValidation(envFieldSource, "must be one of: devcontainer, compose, makefile, declared")
+	}
+	for _, sk := range input.Stacks {
+		if !validStacks[sk] {
+			return errors.NewValidation(envFieldStacks, "unknown stack key: "+sk+"; must be one of: go, node, python, go-node")
+		}
+	}
+	return nil
+}

--- a/backend/internal/domain/service/environment_service_test.go
+++ b/backend/internal/domain/service/environment_service_test.go
@@ -1,0 +1,241 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// envTestMsg is a shared format string for unexpected errors.
+const (
+	envTestMsg      = "unexpected error"
+	envResourceName = "environment"
+)
+
+// mockEnvironmentRepo is a hand-written mock of port.EnvironmentRepository.
+type mockEnvironmentRepo struct {
+	envs      map[uuid.UUID]*model.Environment // keyed by environment ID
+	byProject map[uuid.UUID]*model.Environment // keyed by projectID
+}
+
+func newMockEnvironmentRepo() *mockEnvironmentRepo {
+	return &mockEnvironmentRepo{
+		envs:      make(map[uuid.UUID]*model.Environment),
+		byProject: make(map[uuid.UUID]*model.Environment),
+	}
+}
+
+func (m *mockEnvironmentRepo) Create(_ context.Context, e *model.Environment) (*model.Environment, error) {
+	if _, exists := m.byProject[e.ProjectID]; exists {
+		return nil, errors.NewConflict(envResourceName, e.ProjectID.String())
+	}
+	e.ID = uuid.New()
+	e.CreatedAt = time.Now()
+	e.UpdatedAt = time.Now()
+	m.envs[e.ID] = e
+	m.byProject[e.ProjectID] = e
+	return e, nil
+}
+
+func (m *mockEnvironmentRepo) GetByID(_ context.Context, id uuid.UUID) (*model.Environment, error) {
+	e, ok := m.envs[id]
+	if !ok {
+		return nil, errors.NewNotFound(envResourceName, id)
+	}
+	return e, nil
+}
+
+func (m *mockEnvironmentRepo) GetByProjectID(_ context.Context, projectID uuid.UUID) (*model.Environment, error) {
+	e, ok := m.byProject[projectID]
+	if !ok {
+		return nil, errors.NewNotFound(envResourceName, projectID)
+	}
+	return e, nil
+}
+
+func (m *mockEnvironmentRepo) Update(_ context.Context, e *model.Environment) (*model.Environment, error) {
+	e.UpdatedAt = time.Now()
+	m.envs[e.ID] = e
+	m.byProject[e.ProjectID] = e
+	return e, nil
+}
+
+func (m *mockEnvironmentRepo) Delete(_ context.Context, id uuid.UUID) error {
+	e, ok := m.envs[id]
+	if !ok {
+		return errors.NewNotFound(envResourceName, id)
+	}
+	delete(m.byProject, e.ProjectID)
+	delete(m.envs, id)
+	return nil
+}
+
+func TestEnvironmentService_Upsert_Creates(t *testing.T) {
+	repo := newMockEnvironmentRepo()
+	svc := NewEnvironmentService(repo)
+	projectID := uuid.New()
+
+	input := UpsertEnvironmentInput{
+		Stacks:   []string{model.StackKeyGo},
+		Services: []model.EnvironmentService{},
+		Source:   model.EnvironmentSourceDeclared,
+		Commands: map[string]string{"test": "make test"},
+	}
+
+	env, err := svc.Upsert(context.Background(), projectID, input)
+	if err != nil {
+		t.Fatalf("%s: %v", envTestMsg, err)
+	}
+	if env.ProjectID != projectID {
+		t.Errorf("expected project_id %v, got %v", projectID, env.ProjectID)
+	}
+	if env.Source != model.EnvironmentSourceDeclared {
+		t.Errorf("expected source 'declared', got %q", env.Source)
+	}
+	if len(env.Stacks) != 1 || env.Stacks[0] != model.StackKeyGo {
+		t.Errorf("expected stacks=[go], got %v", env.Stacks)
+	}
+}
+
+func TestEnvironmentService_Upsert_Updates(t *testing.T) {
+	repo := newMockEnvironmentRepo()
+	svc := NewEnvironmentService(repo)
+	projectID := uuid.New()
+
+	// First create
+	_, err := svc.Upsert(context.Background(), projectID, UpsertEnvironmentInput{
+		Stacks:   []string{model.StackKeyGo},
+		Services: []model.EnvironmentService{},
+		Source:   model.EnvironmentSourceDeclared,
+		Commands: map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Now update
+	updated, err := svc.Upsert(context.Background(), projectID, UpsertEnvironmentInput{
+		Stacks:   []string{model.StackKeyNode},
+		Services: []model.EnvironmentService{{Name: "db", Image: "postgres:16", Env: map[string]string{}}},
+		Source:   model.EnvironmentSourceCompose,
+		Commands: map[string]string{"test": "npm test"},
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Source != model.EnvironmentSourceCompose {
+		t.Errorf("expected source 'compose', got %q", updated.Source)
+	}
+	if len(updated.Stacks) != 1 || updated.Stacks[0] != model.StackKeyNode {
+		t.Errorf("expected stacks=[node], got %v", updated.Stacks)
+	}
+	if len(updated.Services) != 1 {
+		t.Errorf("expected 1 service, got %d", len(updated.Services))
+	}
+}
+
+func TestEnvironmentService_Delete(t *testing.T) {
+	repo := newMockEnvironmentRepo()
+	svc := NewEnvironmentService(repo)
+	projectID := uuid.New()
+
+	// Create an environment first
+	_, err := svc.Upsert(context.Background(), projectID, UpsertEnvironmentInput{
+		Stacks:   []string{model.StackKeyPython},
+		Services: []model.EnvironmentService{},
+		Source:   model.EnvironmentSourceDeclared,
+		Commands: map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Delete
+	if err := svc.Delete(context.Background(), projectID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	// Should be gone
+	_, err = svc.GetByProject(context.Background(), projectID)
+	if err == nil {
+		t.Fatal("expected NotFound after delete, got nil error")
+	}
+	domErr, ok := err.(*errors.DomainError)
+	if !ok || domErr.Category != errors.CategoryNotFound {
+		t.Errorf("expected not_found, got %v", err)
+	}
+}
+
+func TestEnvironmentService_Delete_NotFound(t *testing.T) {
+	repo := newMockEnvironmentRepo()
+	svc := NewEnvironmentService(repo)
+
+	err := svc.Delete(context.Background(), uuid.New())
+	if err == nil {
+		t.Fatal("expected error for non-existent environment")
+	}
+	domErr, ok := err.(*errors.DomainError)
+	if !ok || domErr.Category != errors.CategoryNotFound {
+		t.Errorf("expected not_found, got %v", err)
+	}
+}
+
+func TestEnvironmentService_Validation_BadSource(t *testing.T) {
+	repo := newMockEnvironmentRepo()
+	svc := NewEnvironmentService(repo)
+
+	_, err := svc.Upsert(context.Background(), uuid.New(), UpsertEnvironmentInput{
+		Stacks:   []string{model.StackKeyGo},
+		Services: []model.EnvironmentService{},
+		Source:   "unknown-source",
+		Commands: map[string]string{},
+	})
+	if err == nil {
+		t.Fatal("expected validation error for unknown source")
+	}
+	domErr, ok := err.(*errors.DomainError)
+	if !ok || domErr.Category != errors.CategoryValidation {
+		t.Errorf("expected validation error, got %v", err)
+	}
+}
+
+func TestEnvironmentService_Validation_BadStack(t *testing.T) {
+	repo := newMockEnvironmentRepo()
+	svc := NewEnvironmentService(repo)
+
+	_, err := svc.Upsert(context.Background(), uuid.New(), UpsertEnvironmentInput{
+		Stacks:   []string{"ruby"},
+		Services: []model.EnvironmentService{},
+		Source:   model.EnvironmentSourceDeclared,
+		Commands: map[string]string{},
+	})
+	if err == nil {
+		t.Fatal("expected validation error for unknown stack key")
+	}
+	domErr, ok := err.(*errors.DomainError)
+	if !ok || domErr.Category != errors.CategoryValidation {
+		t.Errorf("expected validation error, got %v", err)
+	}
+}
+
+func TestEnvironmentService_EmptySource_DefaultsDeclared(t *testing.T) {
+	repo := newMockEnvironmentRepo()
+	svc := NewEnvironmentService(repo)
+
+	env, err := svc.Upsert(context.Background(), uuid.New(), UpsertEnvironmentInput{
+		Stacks:   []string{model.StackKeyGoNode},
+		Services: []model.EnvironmentService{},
+		Source:   "", // empty should default to "declared"
+		Commands: map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("%s: %v", envTestMsg, err)
+	}
+	if env.Source != model.EnvironmentSourceDeclared {
+		t.Errorf("expected source 'declared' (default), got %q", env.Source)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `GET /projects/{projectId}/environment` — returns the project's execution environment (200) or 404 when absent
- Adds `PUT /projects/{projectId}/environment` — upsert semantics: creates when absent, replaces when present (200); validates source enum and stack keys (400)
- Adds `DELETE /projects/{projectId}/environment` — removes the environment (204) or 404 when absent

The `environments` table, `port.EnvironmentRepository` interface, and the postgres adapter all pre-existed from P2c1. This PR adds the missing API layer.

## Schemas

**Environment** (response): `id`, `project_id`, `stacks` (string[]), `services` (EnvironmentService[]), `source` (enum), `commands` (map<string,string>), `created_at`, `updated_at`

**EnvironmentService**: `name`, `image`, `env` (map<string,string>)

**EnvironmentInput** (request body): `stacks`, `services`, `source` (enum: devcontainer|compose|makefile|declared, default: declared), `commands`

## Design decisions

- No admin gate on PUT — mirrors `PipelineConfigHandler` (project-scoped write, not admin-only)
- Empty `source` in input defaults to `"declared"` before validation
- `EnvService` (not `EnvironmentService`) to avoid stutter with the `EnvironmentService` sidecar model type

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -short ./...` — all 27 packages pass
- [x] `go.mod` / `go.sum` unchanged
- [x] Service tests: Upsert create, Upsert update, Delete, Delete NotFound, bad source, bad stack, empty source default
- [x] Handler tests: GET 200, GET 404, PUT 200, PUT invalid JSON 400, DELETE 204, DELETE 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)