### PR TITLE
feat(security): role-aware RBAC tool-level for agent capabilities

### DIFF
--- a/backend/internal/adapter/action/agent_run.go
+++ b/backend/internal/adapter/action/agent_run.go
@@ -385,7 +385,7 @@ func (a *AgentRunAction) createContainer(
 			if id := extractAgentID(runCtx); id != nil {
 				agentID = *id
 			}
-			token, tokenErr := a.tokenStore.Create(ctx, runCtx.Run.ID, runCtx.RunStep.ID, agentID, 2*time.Hour)
+			token, tokenErr := a.tokenStore.Create(ctx, runCtx.Run.ID, runCtx.RunStep.ID, agentID, role, 2*time.Hour)
 			if tokenErr != nil {
 				return "", fmt.Errorf("create container token: %w", tokenErr)
 			}

--- a/backend/internal/adapter/memory/container_token_store.go
+++ b/backend/internal/adapter/memory/container_token_store.go
@@ -28,14 +28,17 @@ func NewContainerTokenStore(ctx context.Context) *ContainerTokenStore {
 }
 
 // Create generates and stores a new token for a run step bound to an agent.
+// role is the step's pipeline role (e.g. "dev", "review") used for RBAC capability filtering;
+// an empty role means the step is not role-scoped (only universal capabilities are granted).
 // Returns the token string.
-func (s *ContainerTokenStore) Create(_ context.Context, runID, stepID, agentID uuid.UUID, ttl time.Duration) (string, error) {
+func (s *ContainerTokenStore) Create(_ context.Context, runID, stepID, agentID uuid.UUID, role string, ttl time.Duration) (string, error) {
 	token := uuid.New().String()
 	ct := &model.ContainerToken{
 		Token:     token,
 		RunID:     runID,
 		StepID:    stepID,
 		AgentID:   agentID,
+		Role:      role,
 		ExpiresAt: time.Now().Add(ttl),
 	}
 	s.tokens.Store(token, ct)

--- a/backend/internal/adapter/memory/container_token_store_test.go
+++ b/backend/internal/adapter/memory/container_token_store_test.go
@@ -1,0 +1,21 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerTokenStore_PersistsRole(t *testing.T) {
+	ctx := context.Background()
+	s := NewContainerTokenStore(ctx)
+	token, err := s.Create(ctx, uuid.New(), uuid.New(), uuid.New(), "review", time.Hour)
+	require.NoError(t, err)
+	ct, err := s.Validate(ctx, token)
+	require.NoError(t, err)
+	assert.Equal(t, "review", ct.Role)
+}

--- a/backend/internal/api/handler/agent_bundle_handler.go
+++ b/backend/internal/api/handler/agent_bundle_handler.go
@@ -43,12 +43,33 @@ func (h *AgentBundleHandler) HandleBundle(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	bundle, err := h.bundleSvc.ComposeBundle(r.Context(), ct.AgentID)
+	bundle, err := h.bundleSvc.ComposeBundle(r.Context(), ct.AgentID, ct.Role)
 	if err != nil {
 		h.logger.Warn("bundle composition failed, returning empty bundle",
-			"agent_id", ct.AgentID, "step_id", ct.StepID, "error", err)
+			"agent_id", ct.AgentID, "step_id", ct.StepID, "role", ct.Role, "error", err)
 		bundle = model.RuntimeBundle{}
 	}
+
+	// Audit log: who/what/when at provision level. No secrets (names + counts only).
+	grantedServers := make([]string, 0, len(bundle.MCP.MCPServers))
+	for name := range bundle.MCP.MCPServers {
+		grantedServers = append(grantedServers, name)
+	}
+	toolsAllow, toolsDeny := 0, 0
+	if bundle.ToolPolicy != nil {
+		toolsAllow = len(bundle.ToolPolicy.Allow)
+		toolsDeny = len(bundle.ToolPolicy.Deny)
+	}
+	h.logger.Info("capability bundle composed",
+		"run_id", ct.RunID,
+		"step_id", ct.StepID,
+		"agent_id", ct.AgentID,
+		"role", ct.Role,
+		"mcp_servers", grantedServers,
+		"tools_allow", toolsAllow,
+		"tools_deny", toolsDeny,
+		"skills", len(bundle.Skills),
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/backend/internal/domain/model/capability.go
+++ b/backend/internal/domain/model/capability.go
@@ -28,6 +28,31 @@ const (
 	CapabilityScopeProject = "project"
 )
 
+// Known pipeline roles. Using constants avoids repeated string literals (goconst).
+// Roles are set in the pipeline YAML config map (e.g. role: "dev") and flow through
+// ContainerToken.Role into ComposeBundle for RBAC filtering.
+const (
+	RoleDev       = "dev"
+	RoleImplement = "implement"
+	RoleReview    = "review"
+	RoleMerge     = "merge"
+)
+
+// RoleMatches reports whether the given role is allowed by specRoles.
+// If specRoles is empty, the capability is universal (all roles).
+// If specRoles is non-empty, only listed roles match — an empty/unknown role does NOT match.
+func RoleMatches(specRoles []string, role string) bool {
+	if len(specRoles) == 0 {
+		return true
+	}
+	for _, r := range specRoles {
+		if r == role {
+			return true
+		}
+	}
+	return false
+}
+
 // Capability is a versioned, runtime-agnostic capability (skill, MCP server or
 // tool policy) that can be composed onto an agent.
 type Capability struct {
@@ -67,6 +92,9 @@ type SkillSpec struct {
 // headers (the default); "stdio" references an in-image binary for the
 // ultra-sensitive case. CredentialRef points at a secret resolved at runtime —
 // secrets are never baked nor stored in the spec in clear.
+//
+// Roles, when non-empty, restricts this server to the listed pipeline roles.
+// An empty Roles slice means the server is universal and granted to all roles.
 type MCPServerSpec struct {
 	Name          string            `json:"name"`
 	Transport     string            `json:"transport"` // "http" | "stdio"
@@ -74,12 +102,16 @@ type MCPServerSpec struct {
 	Headers       map[string]string `json:"headers,omitempty"`
 	Command       string            `json:"command,omitempty"`
 	CredentialRef string            `json:"credential_ref,omitempty"`
+	Roles         []string          `json:"roles,omitempty"`
 }
 
 // ToolPolicySpec is an allow/deny list of tools, applied per role.
+// Roles, when non-empty, restricts this policy to the listed pipeline roles.
+// An empty Roles slice means the policy is universal and applied to all roles.
 type ToolPolicySpec struct {
 	Allow []string `json:"allow"`
 	Deny  []string `json:"deny"`
+	Roles []string `json:"roles,omitempty"`
 }
 
 // CapabilitySet declares which capability kinds an adapter can translate. The

--- a/backend/internal/domain/model/container_token.go
+++ b/backend/internal/domain/model/container_token.go
@@ -13,10 +13,15 @@ import (
 // server-side (the container never names the agent itself — it cannot fetch another
 // agent's bundle/secrets). AgentID is uuid.Nil when no agent is bound, which yields
 // an empty bundle (back-compat).
+//
+// Role is the step role resolved from the pipeline config (e.g. "dev", "review", "merge").
+// An empty role means the step is not role-scoped; in that case only universal capabilities
+// (Roles == nil/empty) are included in the bundle.
 type ContainerToken struct {
 	Token     string
 	RunID     uuid.UUID
 	StepID    uuid.UUID
 	AgentID   uuid.UUID
+	Role      string // role du step, ex. "dev"/"review"/"merge" ; "" = non scopé
 	ExpiresAt time.Time
 }

--- a/backend/internal/domain/port/container_token_store.go
+++ b/backend/internal/domain/port/container_token_store.go
@@ -12,8 +12,10 @@ import (
 type ContainerTokenStore interface {
 	// Create generates and stores a new token for a run step bound to an agent.
 	// agentID may be uuid.Nil when no agent is bound (the bundle then resolves empty).
+	// role is the step's pipeline role (e.g. "dev", "review") used for RBAC capability filtering;
+	// an empty role means the step is not role-scoped (only universal capabilities are granted).
 	// Returns the token string.
-	Create(ctx context.Context, runID, stepID, agentID uuid.UUID, ttl time.Duration) (string, error)
+	Create(ctx context.Context, runID, stepID, agentID uuid.UUID, role string, ttl time.Duration) (string, error)
 
 	// Validate checks if a token is valid and returns the associated container token.
 	// Returns an error if the token is invalid or expired.

--- a/backend/internal/domain/service/bundle_service.go
+++ b/backend/internal/domain/service/bundle_service.go
@@ -41,12 +41,16 @@ func NewBundleService(
 	}
 }
 
-// ComposeBundle builds the RuntimeBundle for an agent. A nil agent id (uuid.Nil) or an
-// agent with no capabilities yields the zero-value bundle — the runtime then materialises
-// nothing and behaves exactly as before this layer existed. The returned error is reserved
-// for hard failures the caller may choose to degrade on; capability-level problems are
-// warn+skip and never surface here.
-func (s *BundleService) ComposeBundle(ctx context.Context, agentID uuid.UUID) (model.RuntimeBundle, error) {
+// ComposeBundle builds the RuntimeBundle for an agent, filtered by role.
+// A nil agent id (uuid.Nil) or an agent with no capabilities yields the zero-value
+// bundle — the runtime then materialises nothing and behaves exactly as before.
+// The returned error is reserved for hard failures the caller may choose to degrade
+// on; capability-level problems are warn+skip and never surface here.
+//
+// Fail-safe: a role of "" (empty/unknown) only receives universal capabilities
+// (Roles == nil/empty). Role-scoped capabilities (Roles non-empty) are never granted
+// to an unidentified role, ensuring the narrowest possible permission surface.
+func (s *BundleService) ComposeBundle(ctx context.Context, agentID uuid.UUID, role string) (model.RuntimeBundle, error) {
 	var bundle model.RuntimeBundle
 	if agentID == uuid.Nil {
 		return bundle, nil
@@ -71,9 +75,9 @@ func (s *BundleService) ComposeBundle(ctx context.Context, agentID uuid.UUID) (m
 		case model.CapabilityKindSkill:
 			s.addSkill(c, &bundle)
 		case model.CapabilityKindMCPServer:
-			s.addMCPServer(ctx, c, projectID, &bundle)
+			s.addMCPServer(ctx, c, projectID, role, &bundle)
 		case model.CapabilityKindToolPolicy:
-			s.addToolPolicy(c, &bundle)
+			s.addToolPolicy(c, role, &bundle)
 		default:
 			s.logger.Warn("bundle: unknown capability kind, skipping",
 				"capability_id", c.ID, "kind", c.Kind)
@@ -101,13 +105,21 @@ func (s *BundleService) addSkill(c *model.Capability, bundle *model.RuntimeBundl
 	bundle.Skills = append(bundle.Skills, skill)
 }
 
-func (s *BundleService) addMCPServer(ctx context.Context, c *model.Capability, projectID *uuid.UUID, bundle *model.RuntimeBundle) {
+func (s *BundleService) addMCPServer(ctx context.Context, c *model.Capability, projectID *uuid.UUID, role string, bundle *model.RuntimeBundle) {
 	var spec model.MCPServerSpec
 	if err := json.Unmarshal(c.Spec, &spec); err != nil {
 		s.logger.Warn("bundle: malformed mcp_server spec, skipping",
 			"capability_id", c.ID, "name", c.Name, "error", err)
 		return
 	}
+
+	// Fail-safe: an empty/unknown role does not match role-scoped capabilities.
+	if !model.RoleMatches(spec.Roles, role) {
+		s.logger.Debug("bundle: mcp_server filtered by role",
+			"capability_id", c.ID, "name", c.Name, "spec_roles", spec.Roles, "role", role)
+		return
+	}
+
 	name := spec.Name
 	if name == "" {
 		name = c.Name
@@ -140,13 +152,21 @@ func (s *BundleService) addMCPServer(ctx context.Context, c *model.Capability, p
 	bundle.MCP.MCPServers[name] = entry
 }
 
-func (s *BundleService) addToolPolicy(c *model.Capability, bundle *model.RuntimeBundle) {
+func (s *BundleService) addToolPolicy(c *model.Capability, role string, bundle *model.RuntimeBundle) {
 	var policy model.ToolPolicySpec
 	if err := json.Unmarshal(c.Spec, &policy); err != nil {
 		s.logger.Warn("bundle: malformed tool_policy spec, skipping",
 			"capability_id", c.ID, "name", c.Name, "error", err)
 		return
 	}
+
+	// Fail-safe: an empty/unknown role does not match role-scoped policies.
+	if !model.RoleMatches(policy.Roles, role) {
+		s.logger.Debug("bundle: tool_policy filtered by role",
+			"capability_id", c.ID, "name", c.Name, "spec_roles", policy.Roles, "role", role)
+		return
+	}
+
 	if bundle.ToolPolicy == nil {
 		bundle.ToolPolicy = &model.ToolPolicySpec{}
 	}

--- a/backend/internal/domain/service/bundle_service_test.go
+++ b/backend/internal/domain/service/bundle_service_test.go
@@ -100,13 +100,13 @@ func TestComposeBundle_BackCompat_Empty(t *testing.T) {
 	svc := newBundleService(caps, &mockCredentialRepo{}, agents)
 
 	t.Run("nil agent id", func(t *testing.T) {
-		b, err := svc.ComposeBundle(context.Background(), uuid.Nil)
+		b, err := svc.ComposeBundle(context.Background(), uuid.Nil, "")
 		require.NoError(t, err)
 		assert.True(t, b.IsEmpty())
 	})
 
 	t.Run("agent with no capabilities", func(t *testing.T) {
-		b, err := svc.ComposeBundle(context.Background(), agentID)
+		b, err := svc.ComposeBundle(context.Background(), agentID, "")
 		require.NoError(t, err)
 		assert.True(t, b.IsEmpty())
 	})
@@ -129,7 +129,7 @@ func TestComposeBundle_Skill(t *testing.T) {
 	agents := &mockAgentRepo{agents: map[uuid.UUID]*model.Agent{agentID: {ID: agentID}}}
 	svc := newBundleService(caps, &mockCredentialRepo{}, agents)
 
-	b, err := svc.ComposeBundle(context.Background(), agentID)
+	b, err := svc.ComposeBundle(context.Background(), agentID, "")
 	require.NoError(t, err)
 	require.Len(t, b.Skills, 1)
 	assert.Equal(t, "code-review", b.Skills[0].Name) // falls back to capability name
@@ -165,7 +165,7 @@ func TestComposeBundle_MCPServerWithCredential(t *testing.T) {
 	}}
 	svc.capRepo = caps
 
-	b, err := svc.ComposeBundle(context.Background(), agentID)
+	b, err := svc.ComposeBundle(context.Background(), agentID, "")
 	require.NoError(t, err)
 	require.Contains(t, b.MCP.MCPServers, "kanban")
 	assert.Equal(t, "http://mcp-kanban.internal/sse", b.MCP.MCPServers["kanban"].URL)
@@ -194,7 +194,7 @@ func TestComposeBundle_MissingCredential_WarnSkip(t *testing.T) {
 		agents: map[uuid.UUID]*model.Agent{agentID: {ID: agentID}},
 	})
 
-	b, err := svc.ComposeBundle(context.Background(), agentID)
+	b, err := svc.ComposeBundle(context.Background(), agentID, "")
 	require.NoError(t, err)
 	assert.Contains(t, b.MCP.MCPServers, "kanban")
 	assert.Empty(t, b.Credentials)
@@ -225,10 +225,174 @@ func TestComposeBundle_ToolPolicyAndMalformedSkipped(t *testing.T) {
 		agents: map[uuid.UUID]*model.Agent{agentID: {ID: agentID}},
 	})
 
-	b, err := svc.ComposeBundle(context.Background(), agentID)
+	b, err := svc.ComposeBundle(context.Background(), agentID, "")
 	require.NoError(t, err)
 	require.NotNil(t, b.ToolPolicy)
 	assert.Equal(t, []string{"Read", "Grep"}, b.ToolPolicy.Allow)
 	assert.Equal(t, []string{"Bash(rm:*)"}, b.ToolPolicy.Deny)
 	assert.Empty(t, b.Skills) // the malformed skill was skipped
+}
+
+func TestComposeBundle_RoleFiltering(t *testing.T) {
+	agentBase := &mockAgentRepo{agents: map[uuid.UUID]*model.Agent{}}
+
+	tests := []struct {
+		name    string
+		caps    func(agentID uuid.UUID) []*model.Capability
+		role    string
+		checkFn func(t *testing.T, b model.RuntimeBundle)
+	}{
+		{
+			name: "review role — mcp_server scopé dev filtré",
+			caps: func(_ uuid.UUID) []*model.Capability {
+				return []*model.Capability{
+					{
+						ID:   uuid.New(),
+						Kind: model.CapabilityKindMCPServer,
+						Name: "write-mcp",
+						Spec: mustSpec(t, model.MCPServerSpec{
+							Name:  "write-mcp",
+							URL:   "http://write-mcp.internal/sse",
+							Roles: []string{model.RoleDev},
+						}),
+					},
+				}
+			},
+			role: model.RoleReview,
+			checkFn: func(t *testing.T, b model.RuntimeBundle) {
+				assert.NotContains(t, b.MCP.MCPServers, "write-mcp")
+			},
+		},
+		{
+			name: "review role — mcp_server universel inclus",
+			caps: func(_ uuid.UUID) []*model.Capability {
+				return []*model.Capability{
+					{
+						ID:   uuid.New(),
+						Kind: model.CapabilityKindMCPServer,
+						Name: "read-mcp",
+						Spec: mustSpec(t, model.MCPServerSpec{
+							Name:  "read-mcp",
+							URL:   "http://read-mcp.internal/sse",
+							Roles: []string{},
+						}),
+					},
+				}
+			},
+			role: model.RoleReview,
+			checkFn: func(t *testing.T, b model.RuntimeBundle) {
+				assert.Contains(t, b.MCP.MCPServers, "read-mcp")
+			},
+		},
+		{
+			name: "dev role — mcp_server scopé dev inclus",
+			caps: func(_ uuid.UUID) []*model.Capability {
+				return []*model.Capability{
+					{
+						ID:   uuid.New(),
+						Kind: model.CapabilityKindMCPServer,
+						Name: "write-mcp",
+						Spec: mustSpec(t, model.MCPServerSpec{
+							Name:  "write-mcp",
+							URL:   "http://write-mcp.internal/sse",
+							Roles: []string{model.RoleDev},
+						}),
+					},
+				}
+			},
+			role: model.RoleDev,
+			checkFn: func(t *testing.T, b model.RuntimeBundle) {
+				assert.Contains(t, b.MCP.MCPServers, "write-mcp")
+			},
+		},
+		{
+			name: "rôle vide — seulement capacités universelles",
+			caps: func(_ uuid.UUID) []*model.Capability {
+				return []*model.Capability{
+					{
+						ID:   uuid.New(),
+						Kind: model.CapabilityKindMCPServer,
+						Name: "write-mcp",
+						Spec: mustSpec(t, model.MCPServerSpec{
+							Name:  "write-mcp",
+							URL:   "http://write-mcp.internal/sse",
+							Roles: []string{model.RoleDev},
+						}),
+					},
+					{
+						ID:   uuid.New(),
+						Kind: model.CapabilityKindMCPServer,
+						Name: "read-mcp",
+						Spec: mustSpec(t, model.MCPServerSpec{
+							Name:  "read-mcp",
+							URL:   "http://read-mcp.internal/sse",
+							Roles: []string{},
+						}),
+					},
+				}
+			},
+			role: "",
+			checkFn: func(t *testing.T, b model.RuntimeBundle) {
+				assert.NotContains(t, b.MCP.MCPServers, "write-mcp")
+				assert.Contains(t, b.MCP.MCPServers, "read-mcp")
+			},
+		},
+		{
+			name: "tool_policy scopée review appliquée à review",
+			caps: func(_ uuid.UUID) []*model.Capability {
+				return []*model.Capability{
+					{
+						ID:   uuid.New(),
+						Kind: model.CapabilityKindToolPolicy,
+						Name: "review-policy",
+						Spec: mustSpec(t, model.ToolPolicySpec{
+							Allow: []string{"Read", "Grep"},
+							Deny:  []string{"Bash", "Edit", "Write"},
+							Roles: []string{model.RoleReview},
+						}),
+					},
+				}
+			},
+			role: model.RoleReview,
+			checkFn: func(t *testing.T, b model.RuntimeBundle) {
+				require.NotNil(t, b.ToolPolicy)
+				assert.Contains(t, b.ToolPolicy.Deny, "Bash")
+			},
+		},
+		{
+			name: "tool_policy scopée review non appliquée à dev",
+			caps: func(_ uuid.UUID) []*model.Capability {
+				return []*model.Capability{
+					{
+						ID:   uuid.New(),
+						Kind: model.CapabilityKindToolPolicy,
+						Name: "review-policy",
+						Spec: mustSpec(t, model.ToolPolicySpec{
+							Allow: []string{"Read", "Grep"},
+							Deny:  []string{"Bash", "Edit", "Write"},
+							Roles: []string{model.RoleReview},
+						}),
+					},
+				}
+			},
+			role: model.RoleDev,
+			checkFn: func(t *testing.T, b model.RuntimeBundle) {
+				assert.Nil(t, b.ToolPolicy)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			agentID := uuid.New()
+			agentBase.agents[agentID] = &model.Agent{ID: agentID}
+			caps := &mockCapabilityRepo{forAgent: map[uuid.UUID][]*model.Capability{
+				agentID: tc.caps(agentID),
+			}}
+			svc := newBundleService(caps, &mockCredentialRepo{}, agentBase)
+			b, err := svc.ComposeBundle(context.Background(), agentID, tc.role)
+			require.NoError(t, err)
+			tc.checkFn(t, b)
+		})
+	}
 }


### PR DESCRIPTION
## Quoi

Réalise le contrôle **RBAC tool-level** de §3.2 du plan runtime (« un agent review ne **voit** pas les outils d'écriture »), **enforced de façon agnostique au runtime** dans le bundle backend. Les capacités restent des **données agnostiques** (décisions #1/#3) ; `agent-runtime/` est **inchangé** : il rend le bundle déjà filtré, donc ce qu'un rôle n'a pas reçu, il ne peut pas l'utiliser.

## Comment (backend-only, **aucune migration**, contrat API inchangé)

- **Le container-token porte le rôle** (le principal de sécurité porte son rôle). `ContainerTokenStore.Create(...role...)` ; `agent_run.go` passe le `role` qu'il résout déjà via `resolveRole` (chemin live, 1 ligne).
- **`MCPServerSpec.Roles` + `ToolPolicySpec.Roles`** (`[]string`, jsonb additif). Vide = universel (tous rôles) → **toute capacité pré-existante reste accordée à tous les rôles (back-compat)**.
- **`ComposeBundle(agentID, role)`** filtre via `model.RoleMatches` : un serveur MCP role-scopé non-matchant est **absent du `.mcp.json`** ; une tool_policy non-matchante n'est **pas appliquée**. **Fail-safe** : rôle vide/inconnu → uniquement les capacités universelles.
- **Audit provision-level** (agnostique, slog) dans le handler bundle : `run/step/agent/role` + noms des serveurs MCP accordés + counts allow/deny (noms + counts, **pas de secrets**) = le « qui/quoi/quand » de §3.2 au niveau provision.

## Hors scope (phase ultérieure)

Audit **par-appel** + **egress default-deny** → phase **proxy egress** (un proxy fait les deux et reste agnostique). Reporté d'autant que zéro serveur MCP n'est encore catalogué.

## Tests / validation

Filtrage rôle MCP+tool_policy (review exclut dev-scopé / inclut universel ; dev inclut dev-scopé ; rôle vide = universels seuls ; deny review appliqué à review pas à dev) + persistance du rôle dans le token. `go build/vet/test -short` + **golangci-lint v1.64.8** tous clean. `go.mod`/`go.sum`/`agent-runtime/` inchangés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)