### PR TITLE
docs(board): telemetry capabilities + contract + INC5/D1 plan

### DIFF
--- a/docs/agent-runtime-telemetry-contract.md
+++ b/docs/agent-runtime-telemetry-contract.md
@@ -1,0 +1,141 @@
+# Contrat de télémétrie sortante `AgentRuntime` — proposition
+
+> **Statut : PROPOSITION, à coordonner avec le chantier runtime** (`agent-runtime-capabilities-plan.md`, édité en parallèle — **ne pas modifier leur fichier**). Cet artefact lève le **gap G1** identifié dans `board-pipeline-agents-model.md` §9 et débloque **INC 4b** (`board-pipeline-v1-build.md`). Il est cadré par la recherche `runtime-telemetry-capabilities.md` (ce que les outils savent émettre, juin 2026).
+>
+> **Principe.** Le runtime/adapter **émet** un petit jeu d'événements **normalisés** ; un ingesteur board les traduit en `events` (Postgres, append-only) ; l'évaluateur de policy (probes/guards) **réagit**. Le domaine ne contient que de la *policy* (seuils + actions) ; l'émission et le substrat sont *runtime/adapter*. Jamais d'infra dans le domaine.
+
+## 1. Frontière (qui produit quoi)
+
+| Émis par | Événements | Nature |
+|---|---|---|
+| **Adapter** (depuis le flux natif de l'outil) | `ToolCallEvent`, `UsageDelta`, `UsageTotal` | normalisés, poussés live |
+| **Board (ingesteur)** | `FileTouchEvent` | **dérivé** de `ToolCallEvent` |
+| **Substrat / orchestrateur** | `ResourceSample` | cgroups v2 / cAdvisor / metrics-server |
+| **Board (watchdog)** | `Heartbeat` | **synthétisé** sur le gap d'events |
+
+> Ce qui rend le contrat *agnostique* : `FileTouchEvent` et `Heartbeat` ne sont **pas** des champs que l'adapter doit fournir (dérivé / synthétisé). Et `resource_metrics` n'est demandé à **aucun** outil — c'est du substrat (confirmé : ❌ chez les 10 runtimes étudiés).
+
+## 2. Les événements (wire shape)
+
+Champs communs à tout event : `run_id`, `step_id`, `ts` (RFC3339, source-side).
+
+```go
+// — Adapter-normalized (poussés depuis le container pendant le run) —
+
+ToolCallEvent {           // → probe loop-detection (INC 4b)
+  tool_use_id  string     // corrèle started/completed, dédup les appels parallèles
+  tool_name    string
+  phase        string     // "started" | "completed"
+  args         any?       // optionnel (peut être tronqué/omis par policy de contenu)
+  result_summary string?  // optionnel
+  success      bool?      // sur "completed"
+  duration_ms  int?       // sur "completed"
+}
+
+UsageDelta {              // → probe cost-mid-run (INC 4b). Émis per-step où dispo.
+  tokens { input, output, cache_read, cache_creation, reasoning? }  // OBLIGATOIRE
+  cost_usd     float?     // optionnel + flag estimate (estimation client-side)
+  model        string
+  step_id      string
+}
+
+UsageTotal {              // réconciliation finale. TOUT adapter peut l'émettre.
+  tokens { ... }
+  cost_usd     float?     // estimate
+  model_breakdown map<string, {tokens, cost_usd?}>
+}
+
+// — Runtime-owned (PAS depuis l'outil) —
+
+ResourceSample {          // → probe resource-pressure (INC 4b). Échantillonné par le substrat.
+  cpu_pct      float
+  mem_bytes    int
+  io_read_bytes, io_write_bytes int
+}
+
+Heartbeat {               // → probe liveness (INC 4b). Synthétisé par le watchdog.
+  last_event_ts string
+  state         string    // "alive" | "stalled"
+}
+
+// — Dérivé board-side, PAS un champ d'adapter —
+
+FileTouchEvent {          // → probe blast-radius (INC 4b). Projeté depuis ToolCallEvent (edit/write/read).
+  path         string
+  op           string     // "read" | "write" | "edit"
+  tool_use_id  string
+}
+```
+
+Règles : **tokens = monnaie portable**, `cost_usd` toujours optionnel + flaggé estimate (Claude `total_cost_usd` et opencode sont des estimations client-side). Le contrat est *event-normalized* ; le **transport est au choix de l'adapter**.
+
+## 3. Transport — extension du protocole callback existant
+
+Le mécanisme existe déjà : `agent_callback_handler.go` reçoit aujourd'hui `…/logs`, `…/cost`, `…/status` (POST depuis le container) et les écrit dans `events` (`log.emitted`) / `cost_records`. On **étend** ce canal, on n'en invente pas un autre :
+
+| Endpoint inbound (`/internal/agent/callback/runs/{runId}/steps/{stepId}/…`) | Porte | Statut |
+|---|---|---|
+| `logs` | (existant) liveness de secours | ✅ existe |
+| `cost` | → `UsageDelta` (per-step) + un POST final `UsageTotal` | ⚙️ existe, à appeler **plus souvent** + flag final |
+| `tools` | → `ToolCallEvent` | 🆕 nouvel endpoint |
+| `status` | terminal | ✅ existe |
+
+- `FileTouchEvent` : **dérivé dans l'ingesteur** quand un `ToolCallEvent` porte un outil edit/write/read — pas d'endpoint.
+- `ResourceSample` : échantillonné par l'orchestrateur/watchdog (lecture cgroups du container), pas un callback agent.
+- `Heartbeat` : synthétisé board-side (watchdog sur `max(last_event_ts)` tous events confondus) — généralise le `log_silence` déjà livré par INC 4a.
+
+Chaque callback inbound → écrit dans `events` (le pont « callback → events » nommé en §9) → SSE + évaluateur de policy.
+
+## 4. Mapping par adapter (nos 2 réels + plancher)
+
+| Event | **Claude Code** (2.1.186) | **opencode** (1.17.9) | Plancher / autres |
+|---|---|---|---|
+| `ToolCallEvent` | `stream-json` blocs `tool_use`/`tool_result` ; hook `PostToolUse` ; OTEL `claude_code.tool_result` (`tool_use_id`) | SSE `message.part.updated` (parts tool) ; hooks plugin `tool.execute.before/after` | Codex `exec --json` item.* ; Cursor `tool_call` ; **Aider ❌** |
+| `UsageDelta` | OTEL `claude_code.api_request` (cost/tokens **par requête**) ou usage per-message (SDK/stream-json) | part `step_finish` (tokens+cost) via SSE/`run --format json` | Codex `turn.completed` ; Crush `step_finish` ; sinon fin de run |
+| `UsageTotal` | message `result` final (`total_cost_usd` + `modelUsage`) | **session API** (évite le flush-race #26855) | tous |
+| `FileTouchEvent` *(dérivé)* | depuis tool `Edit`/`Write`/`Read` (+ hook `file_path`, `lines_of_code.count`) | events natifs `file.edited`/`file.watcher.updated` ou tool parts | depuis tool-calls partout |
+| `ResourceSample` *(substrat)* | cgroups v2 / cAdvisor / metrics-server | idem | idem |
+| `Heartbeat` *(synthèse)* | watchdog + hint stream-stall (2.1.185) | watchdog + `session.status`/`idle` + `GET /global/health` | watchdog |
+
+**Stratégie d'émission recommandée par adapter :**
+- **Claude Code** : `--output-format stream-json` (tool/text/cost live sur stdout) **+** hook `PostToolUse` (POST `…/tools` + file_path) **+** appel `…/cost` par `api_request`. Optionnel : OTLP vers sidecar collector en dual-path.
+- **opencode** : `opencode serve` (HTTP+SSE) ; un **hook plugin `event` catch-all** = point de forwarding unique vers les callbacks ; lire le cost final via session API.
+- **Aider = plancher assumé** : seulement `UsageTotal` (scrappé) + `FileTouchEvent` via git-diff → adapter dégradé, on ne baisse pas le contrat à son niveau.
+
+## 5. Câblage event → probe INC 4b
+
+| Probe INC 4b | Consomme | Bloqué ? |
+|---|---|---|
+| loop-detection | `ToolCallEvent` (répétition même tool/args) | 🟢 dispo pour nos 2 adapters (stream-json / SSE) |
+| blast-radius | `FileTouchEvent` (hors `target_files`/`scope`) | 🟢 dérivé de ToolCallEvent |
+| cost mid-run | `UsageDelta` (cumul > ceiling) | 🟢 per-request (Claude) / per-step (opencode) |
+| resource-pressure | `ResourceSample` (> seuils) | 🟢 **indépendant de l'agent** (cgroups) |
+| liveness | `Heartbeat` (`state=stalled`) | ✅ déjà couvert (INC 4a `log_silence`, à généraliser) |
+
+→ **Aucune probe n'attend une capacité manquante des outils.** Le travail est : (a) le nouvel endpoint `…/tools` + dérivation `FileTouchEvent` + `ResourceSample` (cgroups) côté board ; (b) faire **forwarder** au binaire les tool-calls + cost per-step (petit, il parse déjà le stream) ; (c) formaliser le contrat sur le port.
+
+## 6. Surface du port `AgentRuntime` (à acter avec le chantier runtime)
+
+Le port reste `Launch/Wait/Stop/Provision/SupportedCapabilities`. **Proposition** : garder le **protocole callback HTTP comme contrat de télémétrie** (mécanisme prouvé), et que le port **garantisse** qu'un adapter, run vivant, POST les events normalisés ci-dessus. Deux variantes à trancher ensemble :
+- **(A, recommandé)** le contrat = les endpoints callback étendus (`…/tools`, `…/cost` enrichi) ; le port documente la garantie d'émission. Changement minimal.
+- **(B)** ajouter une méthode `Emit`/stream typée au port. Plus pur, plus de surface.
+
+`SupportedCapabilities` devrait déclarer **quels events un adapter sait émettre** (ex. Aider = `{UsageTotal, FileTouch(git)}` seulement) → les probes activables se dérivent des capacités de l'adapter.
+
+## 7. Points de coordination / questions ouvertes
+
+- **G2 — contrat `Stop()`** : doit être **gracieux/non-corrompant** (pas d'écriture partielle) pour que le halt-gate laisse un run reprenable. À pin avec le runtime.
+- **Version pinning** : opencode bugs #26855 (flush cost final) / #27966 (régression SSE) → pinner une version connue-bonne ; OTEL natif opencode **non confirmé** (plugins communautaires).
+- **Auth en container** : Claude `total_cost_usd` = estimation (vraie facturation via Usage/Cost API) ; usage SDK plan abonnement = **crédit séparé depuis 2026-06-15** → auth API-key/Bedrock/Vertex, pas le login claude.ai.
+- **Dual-path OTLP optionnel** : Claude/Codex/Goose ont un OTLP natif (W3C `traceparent` → spans imbriqués sous l'orchestrateur). Utile en *complément* d'observabilité, mais **le callback reste le contrat canonique** (tous les outils n'ont pas d'OTEL → ne pas en dépendre pour les probes).
+
+## 8. Découpage d'implémentation (INC 4b)
+
+| Côté | Travail |
+|---|---|
+| **Binaire `agent-runtime/`** (à faire **pendant** la refonte runtime) | forwarder `ToolCallEvent` (déjà dans le stream-json parsé) + `UsageDelta` per-step (appeler `…/cost` plus souvent) + `UsageTotal` final |
+| **Substrat / orchestrateur** (board, indépendant du binaire) | `ResourceSample` depuis cgroups ; généraliser le watchdog `Heartbeat` à tous les events |
+| **Ingesteur board** | endpoint `…/tools` → `events` ; dériver `FileTouchEvent` ; alimenter les probes/guards (INC 4a en place) |
+| **Port** | acter variante A/B + `SupportedCapabilities` par event |
+
+> **Ordonnancement** : (b) substrat + ingesteur = livrables board-side **maintenant** (INC 4a les a amorcés). (a) forwarding binaire = à intégrer dans la refonte runtime pour ne pas builder deux fois. La spec ci-dessus est l'artefact à poser dans la discussion runtime.

--- a/docs/board-pipeline-v1-build.md
+++ b/docs/board-pipeline-v1-build.md
@@ -135,6 +135,23 @@ v1 démontrable = **INC 1 + INC 2** (« les colonnes du board reflètent enfin l
 
 ---
 
+## INC 5 — Config UI : transition policy + guards (écart INC 3/4a)
+
+**Goal.** Combler le trou de configuration découvert à l'audit front : le moteur enforce `transition` (INC 3) et les `guards` (INC 4a), mais le pipeline editor ne permet ni de **définir** la policy d'un stage, ni de **configurer** une probe. Sans ça, tout stage reste `auto` et aucune probe n'est activable depuis l'UI → features livrées mais dormantes. **Frontend only — backend + schéma OpenAPI (`transition`, `Guard` avec `on_fail`) supportent déjà tout.**
+
+**Fichiers :** `frontend/src/views/PipelineConfigView.vue`, `frontend/src/features/pipeline/PipelineGroupCard.vue` (+ `PipelineStepCard.vue` si guards au niveau step), `frontend/src/stores/pipelineConfig.ts`.
+
+1. **Éditeur de transition policy** : sur chaque stage (PipelineGroupCard), un Select `auto | manual | gate` (défaut `auto`, hint « auto = avance seule, manual = attend Go, gate = HITL »). Store : `updateGroupTransition(groupId, value)` → `isDirty`. Persisté par le `PUT /pipeline` existant.
+2. **Éditeur de guards** : sur le stage (et/ou step), affordance « + Guard » + liste éditable. Par guard : `kind` (log_silence | wallclock | cost_batch), `threshold` (log_silence, secondes) / `max` (wallclock s, cost_batch USD selon kind), `on_fail` (halt-gate | fail | retry, défaut halt-gate). Store : `addGuard/removeGuard/updateGuard`. Types depuis le schéma généré (`Guard`). Persisté par `PUT /pipeline`.
+3. Tests unitaires des nouvelles fonctions store + rendu des contrôles.
+
+**Hors scope :** aucun backend ; pas d'affichage des breaches dans le run detail (volontaire). **Verify :** front build + type-check + lint + vitest verts. **▶ CC :** branche `feat/board-config-ui` depuis develop ; commits locaux, pas de push.
+
+## Dette D1 — retry steps stampent le stage (backend)
+
+**Goal.** `CreateRetryRunStep` laisse `stage_id`/`stage_name` à NULL (flaggé par l'agent INC 1) → un step rejoué perd son stage. Stamper le stage du step parent.
+**Fichiers :** `backend/internal/domain/service/run_service.go` (+ repo/sqlc si besoin) — là où le retry step est créé ; copier `StageID`/`StageName` depuis le `ParentStepID`. **Verify :** go build/vet/test -short + golangci-lint ; test : un step rejoué porte le stage du parent. **▶ CC :** branche `fix/retry-step-stage-stamp` depuis develop ; commits locaux, pas de push.
+
 ## Ordre de lancement recommandé
 
 1. **INC 1** (keystone) → merge develop.

--- a/docs/runtime-telemetry-capabilities.md
+++ b/docs/runtime-telemetry-capabilities.md
@@ -1,0 +1,84 @@
+# Capacités de télémétrie des runtimes — recherche (juin 2026)
+
+> Recherche web (workflow `runtime-telemetry-capabilities`, 5 agents, sourcée) sur ce que les **versions récentes** de Claude Code, OpenCode et concurrents intégrables savent émettre, pour cadrer le **contrat de télémétrie sortante** du port `AgentRuntime` (débloque INC 4b / gap G1 — voir `board-pipeline-agents-model.md` §9 et `board-pipeline-v1-build.md` §INC 4).
+>
+> 5 signaux visés (= probes INC 4b) : **incremental_cost** (cost mid-run), **tool_call_events** (loop detection), **files_touched** (blast-radius), **resource_metrics** (resource-pressure), **heartbeat_progress** (liveness).
+
+## 1. Matrice de capacités
+
+✅ natif & streamé live · 🟡 partiel / per-step-pas-per-timer / synthétisable · ❌ pas fourni par l'outil
+
+| Runtime (version mi-2026) | incremental_cost | tool_call_events | files_touched | resource_metrics | heartbeat |
+|---|:---:|:---:|:---:|:---:|:---:|
+| **Claude Code** CLI 2.1.186 + Agent SDK | ✅ | ✅ | ✅ | ❌ | 🟡 |
+| **opencode** v1.17.9 (serve/run) | ✅¹ | ✅ | ✅ | ❌ | 🟡 |
+| **Codex CLI** v0.142 | ✅² | ✅ | ✅ | ❌ | 🟡 |
+| **Goose** v1.38 | 🟡 (fin de run) | ✅ | 🟡 | ❌ | 🟡 |
+| **Aider** v0.86 | 🟡 (texte) | ❌ | 🟡 (git diff) | ❌ | ❌ |
+| **Cursor CLI** (rolling) | 🟡 (final) | ✅ | ✅ | ❌ | 🟡 |
+| **Amp Neo** | ❌ | ✅ | 🟡 | ❌ | 🟡 |
+| **Cline CLI** 2.0 | 🟡 (résumé) | ✅ | 🟡 | ❌ | 🟡 |
+| **Crush** | ✅ (step_finish) | 🟡 | 🟡 | ❌ | 🟡 |
+| **Continue CLI** | ? | ✅ | ✅ | ❌ | 🟡 |
+
+¹ per-step `step_finish`, mais bug #26855 (flush final) → lire le cost final via session API, pas l'EOF stdout. ² per-turn `turn.completed` + métrique OTel `codex.turn.token_usage`.
+
+> **Invariant dur : `resource_metrics` = ❌ partout.** Aucun agent de code n'émet CPU/mem/IO. **C'est structurellement une affaire de substrat** (cgroups v2 / cAdvisor / Docker stats / metrics-server), pas de l'outil ni de l'adapter.
+
+## 2. LCD (commun) vs adapter-specific
+
+- **`tool_call_events`** — le signal le plus fort, natif et structuré partout sauf Aider. → **port commun.**
+- **`files_touched`** — **dérivé des tool-calls** (un edit = un tool-call). Événements dédiés là où natif (Claude `PostToolUse` file_path, opencode `file.edited`, Codex `file changes`, Cursor `writeToolCall`), projeté depuis les tool-calls ailleurs. → **vue dérivée, pas un champ de contrat séparé** (maximise la couverture).
+- **`incremental_cost`** — **scinder** : un `UsageDelta` per-step que le tier fort remplit live (Claude `api_request`, opencode/Crush `step_finish`, Codex `turn.completed`) + un `UsageTotal` final que **tout le monde** peut émettre. Jamais exiger un cost **périodique sur timer** : personne ne l'émet.
+- **`heartbeat`** — personne n'a de keepalive content-free sur timer fixe. → **synthétisé par la couche runtime** (watchdog sur le timestamp du dernier event). C'est déjà ce que fait INC 4a (`log_silence`).
+- **`resource_metrics`** — **substrat**, jamais l'adapter (cgroups v2 / cAdvisor / metrics-server).
+- **Cost en devise** = estimation client-side (Claude `total_cost_usd`, opencode) → **les tokens sont la monnaie portable**, le $ reste best-effort/flaggé estimate.
+
+## 3. Contrat de télémétrie `AgentRuntime` recommandé
+
+Un petit jeu d'**événements normalisés** (l'adapter traduit le flux natif de chaque outil) + 2 signaux **runtime-owned** :
+
+```
+Adapter-normalized (poussés live) :
+  ToolCallEvent  { ts, tool_use_id, tool_name, phase:started|completed, args?, result_summary?, success?, duration_ms? }
+        → loop-detection. Universel sauf Aider.
+  FileTouchEvent { ts, path, op:read|write|edit, tool_use_id }
+        → blast-radius. DÉRIVÉ de ToolCallEvent (edit/write/read).
+  UsageDelta     { ts, tokens:{input,output,cache_read,cache_creation,reasoning?}, cost_usd?, model, step_id }
+        → cost-mid-run. Per-step où supporté. Tokens obligatoires, cost optionnel+flag estimate.
+  UsageTotal     { tokens{...}, cost_usd?, model_breakdown }
+        → réconciliation finale. EVERY adapter peut l'émettre.
+
+Runtime-owned (substrat / synthèse, PAS l'outil) :
+  ResourceSample { ts, cpu_pct, mem_bytes, io_read/write_bytes }   → resource-pressure. cgroups v2 / cAdvisor.
+  Heartbeat      { ts, last_event_ts, state:alive|stalled }        → liveness. Watchdog sur gap d'events (= INC 4a).
+```
+
+Règles : contrat **event-normalized**, transport au choix de l'adapter (Claude stream-json + OTLP ; opencode SSE `/event` ; Codex/Goose `--json` ; Cursor/Cline/Amp NDJSON). `files_touched` et `heartbeat` ne sont **pas** des champs d'adapter (l'un dérivé, l'autre synthétisé) — c'est ça qui garde le contrat agnostique. **Aider = le plancher** (seulement `UsageTotal` scrappé + git-diff) → adapter dégradé assumé, on ne baisse pas le contrat à son niveau.
+
+## 4. Implications pour INC 4b (le déblocage réel)
+
+La recherche **réduit** le périmètre « bloqué » que j'avais annoncé :
+
+- **resource-pressure** : **pas bloqué sur l'agent du tout** — c'est du **cgroups au niveau substrat**. Buildable indépendamment de la refonte runtime. (Aligné sur l'invariant projet : runtime = isolation/ressources.)
+- **Pour nos 2 adapters réels (claude_code, opencode)** : tool-calls, files (dérivés) et **cost incrémental sont déjà dans les flux émis aujourd'hui** — Claude via `stream-json` / OTEL `api_request` (per-request) ; opencode via SSE `step_finish` (per-step). Le binaire lit déjà ces flux → c'est **« forwarder plus de l'existant »**, pas une nouvelle capacité.
+- **heartbeat** : déjà couvert par INC 4a (`log_silence`).
+
+> **Donc le vrai bloqueur d'INC 4b n'est pas « le runtime ne peut pas émettre »** — les outils émettent déjà. C'est : (a) **normaliser** ces 4 events sur le port `AgentRuntime`, (b) faire **forwarder** au binaire agent les tool-calls + UsageDelta (petit), (c) **brancher cgroups** pour le resource. Aucune dépendance à une nouvelle capacité des outils. La seule raison d'attendre = le binaire runtime est en cours de refonte → **définir le contrat maintenant** et implémenter le forwarding dans cette refonte, pas après.
+
+## 5. Capacités 2026 à exploiter (nos 2 adapters)
+
+- **Claude Code** : `stream-json` + `--include-partial-messages` (deltas), OTEL `claude_code.api_request` (cost/tokens **par requête**), hook `PostToolUse` (file_path), event OTEL `tool_result` (corrélé `tool_use_id`), `--bare` (runs déterministes CI), hint stream-stall (2.1.185). **Stratégie d'émission** : stream-json stdout **+** OTLP vers sidecar **+** hook PostToolUse pour pousser files_touched + heartbeat synthétique.
+- **opencode** : `opencode serve` (HTTP + SSE, **le meilleur modèle d'embedding** : lancer une fois, piloter via OpenAPI typé), 80+ events bus, hook plugin `event` (catch-all) = **point de forwarding unique**, SDKs TS/Python/Go. **Lire le cost final via session API** (évite le bug #26855).
+- **Transverse** : **MCP universel** (sauf Aider) = injection de capacités (pas un canal de télémétrie). Propagation **W3C `traceparent`** (Claude, opencode, Codex) = les spans agent s'imbriquent sous le span orchestrateur gratuitement.
+
+## 6. À vérifier / faible confiance (les versions bougent vite)
+
+- **Lot « Concurrents B » (Cline/Crush/Continue/Cursor/Amp) = confiance moyenne** → provisoire.
+- **opencode** : pinner une version connue-bonne (bug #26855 flush cost final ; #27966 régression SSE `/event` ~1.14.42+). **OTEL natif NON confirmé** → plugins communautaires uniquement.
+- **Claude** : `total_cost_usd` = estimation client-side (vraie facturation via Usage/Cost API) ; **usage SDK sur plan abonnement = crédit séparé depuis 2026-06-15** → préférer auth API-key/Bedrock/Vertex en container ; export de traces encore **beta**.
+- **Continue CLI = EOL** (racheté par Cursor, repo read-only) → pas un choix d'avenir.
+- **Cursor CLI** : non-versionné/rolling ; hooks file-edit **IDE-only** en CLI (utiliser l'event write tool-call). **Aider** : API Python non-officielle/instable → ne pas builder d'adapter dessus.
+
+## Sources principales
+Claude Code : code.claude.com/docs (headless, agent-sdk/observability, monitoring-usage), anthropics/claude-code CHANGELOG. opencode : opencode.ai/docs (server, plugins, sdk), sst/opencode issues #26855/#14246/#27966. Codex : developers.openai.com/codex. Goose : github.com/block/goose (cf. caveat org `aaif-goose` vs `block`). Cursor : cursor.com/docs/cli. Cline : docs.cline.bot. (Liste complète des URLs dans le résultat workflow.)


### PR DESCRIPTION
Restaure 2 docs de planning aspirés par mégarde dans un stash (`git stash -u`) pendant un nettoyage : `runtime-telemetry-capabilities.md` (recherche web des capacités runtimes) et `agent-runtime-telemetry-contract.md` (spec du contrat de télémétrie `AgentRuntime` / gap G1). Ajoute aussi INC 5 + Dette D1 au build plan. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)