### PR TITLE
feat(pipeline): config UI — stage transition policy + guards editor (INC 5)

### DIFF
--- a/frontend/src/composables/usePipelineConfig.ts
+++ b/frontend/src/composables/usePipelineConfig.ts
@@ -1,5 +1,10 @@
 import { computed, onMounted, watch } from 'vue'
-import { usePipelineConfigStore, type PipelineStep } from '@/stores/pipelineConfig'
+import {
+  usePipelineConfigStore,
+  type PipelineStep,
+  type Guard,
+  type TransitionPolicy,
+} from '@/stores/pipelineConfig'
 import type { Ref } from 'vue'
 
 /**
@@ -63,6 +68,22 @@ export function usePipelineConfig(projectId: Ref<string>) {
     store.renameGroup(groupId, name)
   }
 
+  function updateGroupTransition(groupId: string, transition: TransitionPolicy) {
+    store.updateGroupTransition(groupId, transition)
+  }
+
+  function addGuard(groupId: string, stepId?: string) {
+    store.addGuard(groupId, stepId)
+  }
+
+  function removeGuard(groupId: string, guardIndex: number, stepId?: string) {
+    store.removeGuard(groupId, guardIndex, stepId)
+  }
+
+  function updateGuard(groupId: string, guardIndex: number, guard: Guard, stepId?: string) {
+    store.updateGuard(groupId, guardIndex, guard, stepId)
+  }
+
   function addStepToGroup(groupId: string, step: PipelineStep) {
     store.addStepToGroup(groupId, step)
   }
@@ -101,6 +122,10 @@ export function usePipelineConfig(projectId: Ref<string>) {
     addGroup,
     removeGroup,
     renameGroup,
+    updateGroupTransition,
+    addGuard,
+    removeGuard,
+    updateGuard,
     addStepToGroup,
     removeStepFromGroup,
     updateStepInGroup,

--- a/frontend/src/features/pipeline/GuardEditor.vue
+++ b/frontend/src/features/pipeline/GuardEditor.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import Button from 'primevue/button'
+import Select from 'primevue/select'
+import InputNumber from 'primevue/inputnumber'
+import type { Guard, GuardKind, GuardOnFail } from '@/stores/pipelineConfig'
+
+const props = defineProps<{
+  guards: Guard[]
+  isAdmin: boolean
+}>()
+
+const emit = defineEmits<{
+  add: []
+  remove: [index: number]
+  update: [index: number, guard: Guard]
+}>()
+
+const kindOptions: { label: string; value: GuardKind }[] = [
+  { label: 'Log silence', value: 'log_silence' },
+  { label: 'Wall clock', value: 'wallclock' },
+  { label: 'Cost batch', value: 'cost_batch' },
+]
+
+const onFailOptions: { label: string; value: GuardOnFail }[] = [
+  { label: 'Halt-gate', value: 'halt-gate' },
+  { label: 'Fail', value: 'fail' },
+  { label: 'Retry', value: 'retry' },
+]
+
+/** Per-kind metadata for the numeric field rendered next to the kind Select. */
+const kindMeta: Record<GuardKind, { field: 'threshold' | 'max'; unit: string; hint: string }> = {
+  log_silence: { field: 'threshold', unit: 's', hint: 'no agent output for N seconds' },
+  wallclock: { field: 'max', unit: 's', hint: 'step running longer than N seconds' },
+  cost_batch: { field: 'max', unit: 'USD', hint: 'cumulative run cost over N USD' },
+}
+
+const guards = computed(() => props.guards)
+
+function metaFor(kind: GuardKind) {
+  return kindMeta[kind]
+}
+
+function numericValue(guard: Guard): number | null {
+  const field = kindMeta[guard.kind].field
+  return guard[field] ?? null
+}
+
+function onKindChange(index: number, guard: Guard, kind: GuardKind) {
+  if (kind === guard.kind) return
+  // Re-home the existing numeric value onto the field the new kind expects so a
+  // configured threshold isn't silently lost when switching kinds.
+  const current = numericValue(guard) ?? undefined
+  const next: Guard = { kind, on_fail: guard.on_fail }
+  if (kindMeta[kind].field === 'threshold') {
+    next.threshold = current
+  } else {
+    next.max = current
+  }
+  emit('update', index, next)
+}
+
+function onNumericChange(index: number, guard: Guard, value: number | null) {
+  const field = kindMeta[guard.kind].field
+  const next: Guard = { ...guard, [field]: value ?? undefined }
+  emit('update', index, next)
+}
+
+function onFailChange(index: number, guard: Guard, on_fail: GuardOnFail) {
+  emit('update', index, { ...guard, on_fail })
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-2" data-testid="guard-editor">
+    <div class="flex items-center justify-between">
+      <label class="text-sm font-medium">Guards</label>
+      <Button
+        v-if="isAdmin"
+        label="+ Guard"
+        text
+        size="small"
+        data-testid="add-guard"
+        @click="emit('add')"
+      />
+    </div>
+
+    <p v-if="guards.length === 0" class="text-xs opacity-60" data-testid="guard-empty">
+      No guards. Probes park the run on breach (halt-gate) by default.
+    </p>
+
+    <div
+      v-for="(guard, index) in guards"
+      :key="index"
+      class="flex flex-wrap items-center gap-2"
+      data-testid="guard-row"
+    >
+      <!-- Kind -->
+      <Select
+        :model-value="guard.kind"
+        :options="kindOptions"
+        option-label="label"
+        option-value="value"
+        :disabled="!isAdmin"
+        size="small"
+        class="w-36"
+        data-testid="guard-kind-select"
+        @update:model-value="(v: GuardKind) => onKindChange(index, guard, v)"
+      />
+
+      <!-- Kind-dependent numeric field -->
+      <div class="flex items-center gap-1">
+        <InputNumber
+          :model-value="numericValue(guard)"
+          :min="0"
+          :max-fraction-digits="metaFor(guard.kind).unit === 'USD' ? 2 : 0"
+          :disabled="!isAdmin"
+          show-buttons
+          class="w-28"
+          data-testid="guard-numeric-input"
+          @update:model-value="(v: number) => onNumericChange(index, guard, v)"
+        />
+        <span class="text-xs opacity-60" data-testid="guard-unit">{{ metaFor(guard.kind).unit }}</span>
+      </div>
+
+      <!-- on_fail -->
+      <Select
+        :model-value="guard.on_fail"
+        :options="onFailOptions"
+        option-label="label"
+        option-value="value"
+        :disabled="!isAdmin"
+        size="small"
+        class="w-32"
+        data-testid="guard-on-fail-select"
+        @update:model-value="(v: GuardOnFail) => onFailChange(index, guard, v)"
+      />
+
+      <span class="text-xs opacity-50 flex-1 min-w-0" data-testid="guard-hint">
+        {{ metaFor(guard.kind).hint }}
+      </span>
+
+      <Button
+        v-if="isAdmin"
+        icon="pi pi-trash"
+        text
+        rounded
+        size="small"
+        severity="danger"
+        aria-label="Remove guard"
+        data-testid="remove-guard"
+        @click="emit('remove', index)"
+      />
+    </div>
+  </div>
+</template>

--- a/frontend/src/features/pipeline/PipelineGroupCard.vue
+++ b/frontend/src/features/pipeline/PipelineGroupCard.vue
@@ -2,9 +2,11 @@
 import { ref, watch, nextTick, type ComponentPublicInstance } from 'vue'
 import Button from 'primevue/button'
 import InputText from 'primevue/inputtext'
+import Select from 'primevue/select'
 import { useConfirm } from 'primevue/useconfirm'
 import PipelineStepCard from './PipelineStepCard.vue'
-import type { PipelineGroup, PipelineStep } from '@/stores/pipelineConfig'
+import GuardEditor from './GuardEditor.vue'
+import type { PipelineGroup, PipelineStep, Guard, TransitionPolicy } from '@/stores/pipelineConfig'
 import type { Agent } from '@/stores/agents'
 
 const props = defineProps<{
@@ -26,7 +28,17 @@ const emit = defineEmits<{
   'move-up': [index: number]
   'move-down': [index: number]
   'reorder-step': [groupId: string, fromIndex: number, toIndex: number]
+  'update-transition': [groupId: string, transition: TransitionPolicy]
+  'add-guard': [groupId: string]
+  'remove-guard': [groupId: string, guardIndex: number]
+  'update-guard': [groupId: string, guardIndex: number, guard: Guard]
 }>()
+
+const transitionOptions: { label: string; value: TransitionPolicy }[] = [
+  { label: 'Auto', value: 'auto' },
+  { label: 'Manual', value: 'manual' },
+  { label: 'Gate', value: 'gate' },
+]
 
 const confirm = useConfirm()
 const collapsed = ref(false)
@@ -74,6 +86,10 @@ function confirmRemove() {
       emit('remove', props.group.id)
     },
   })
+}
+
+function onTransitionChange(value: TransitionPolicy) {
+  emit('update-transition', props.group.id, value)
 }
 
 function handleMoveStepUp(stepIndex: number) {
@@ -173,6 +189,41 @@ function toggleStepExpand(index: number) {
           @click="confirmRemove"
         />
       </template>
+    </div>
+
+    <!-- Stage config: transition policy + guards -->
+    <div
+      v-show="!collapsed"
+      class="flex flex-col gap-3 pl-4 mt-1 py-2"
+      data-testid="stage-config"
+    >
+      <!-- Transition policy -->
+      <div class="flex flex-wrap items-center gap-2">
+        <label class="text-sm font-medium">Transition</label>
+        <Select
+          :model-value="group.transition"
+          :options="transitionOptions"
+          option-label="label"
+          option-value="value"
+          :disabled="!isAdmin"
+          size="small"
+          class="w-32"
+          data-testid="transition-select"
+          @update:model-value="onTransitionChange"
+        />
+        <span class="text-xs opacity-50 flex-1 min-w-0" data-testid="transition-hint">
+          auto = avance seule · manual = attend un Go · gate = HITL
+        </span>
+      </div>
+
+      <!-- Guards -->
+      <GuardEditor
+        :guards="group.guards ?? []"
+        :is-admin="isAdmin"
+        @add="emit('add-guard', group.id)"
+        @remove="(i: number) => emit('remove-guard', group.id, i)"
+        @update="(i: number, guard: Guard) => emit('update-guard', group.id, i, guard)"
+      />
     </div>
 
     <!-- Steps area -->

--- a/frontend/src/features/pipeline/PipelineStepList.vue
+++ b/frontend/src/features/pipeline/PipelineStepList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import PipelineGroupCard from './PipelineGroupCard.vue'
-import type { PipelineGroup, PipelineStep } from '@/stores/pipelineConfig'
+import type { PipelineGroup, PipelineStep, Guard, TransitionPolicy } from '@/stores/pipelineConfig'
 import type { Agent } from '@/stores/agents'
 
 defineProps<{
@@ -17,6 +17,10 @@ const emit = defineEmits<{
   'remove-step': [groupId: string, stepId: string]
   'reorder-groups': [fromIndex: number, toIndex: number]
   'reorder-step': [groupId: string, fromIndex: number, toIndex: number]
+  'update-transition': [groupId: string, transition: TransitionPolicy]
+  'add-guard': [groupId: string]
+  'remove-guard': [groupId: string, guardIndex: number]
+  'update-guard': [groupId: string, guardIndex: number, guard: Guard]
 }>()
 
 function handleMoveGroupUp(index: number) {
@@ -52,6 +56,10 @@ function handleMoveGroupDown(index: number, groupCount: number) {
       @move-up="handleMoveGroupUp(index)"
       @move-down="handleMoveGroupDown(index, groups.length)"
       @reorder-step="(gId: string, from: number, to: number) => emit('reorder-step', gId, from, to)"
+      @update-transition="(gId: string, t: TransitionPolicy) => emit('update-transition', gId, t)"
+      @add-guard="emit('add-guard', $event)"
+      @remove-guard="(gId: string, i: number) => emit('remove-guard', gId, i)"
+      @update-guard="(gId: string, i: number, guard: Guard) => emit('update-guard', gId, i, guard)"
     />
   </div>
 </template>

--- a/frontend/src/features/pipeline/__tests__/GuardEditor.spec.ts
+++ b/frontend/src/features/pipeline/__tests__/GuardEditor.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, afterEach, vi, beforeAll } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+
+beforeAll(() => {
+  // PrimeVue Select uses matchMedia which is not available in jsdom
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+import GuardEditor from '../GuardEditor.vue'
+import type { Guard } from '@/stores/pipelineConfig'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function mountComponent(guards: Guard[] = [], props: Record<string, unknown> = {}) {
+  wrapper = mount(GuardEditor, {
+    props: { guards, isAdmin: true, ...props },
+    global: { plugins: [PrimeVue] },
+  })
+  return wrapper
+}
+
+describe('GuardEditor', () => {
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  describe('rendering', () => {
+    it('shows empty hint when there are no guards', () => {
+      mountComponent([])
+      expect(wrapper.find('[data-testid="guard-empty"]').exists()).toBe(true)
+      expect(wrapper.findAll('[data-testid="guard-row"]')).toHaveLength(0)
+    })
+
+    it('renders a row per guard', () => {
+      mountComponent([
+        { kind: 'log_silence', threshold: 120, on_fail: 'halt-gate' },
+        { kind: 'wallclock', max: 1800, on_fail: 'fail' },
+      ])
+      expect(wrapper.findAll('[data-testid="guard-row"]')).toHaveLength(2)
+    })
+
+    it('shows the + Guard button for admin', () => {
+      mountComponent([])
+      expect(wrapper.find('[data-testid="add-guard"]').exists()).toBe(true)
+    })
+
+    it('hides the + Guard and remove buttons for non-admin', () => {
+      mountComponent([{ kind: 'log_silence', threshold: 120, on_fail: 'halt-gate' }], {
+        isAdmin: false,
+      })
+      expect(wrapper.find('[data-testid="add-guard"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="remove-guard"]').exists()).toBe(false)
+    })
+  })
+
+  describe('per-kind unit + hint', () => {
+    it('shows seconds for log_silence', () => {
+      mountComponent([{ kind: 'log_silence', threshold: 120, on_fail: 'halt-gate' }])
+      expect(wrapper.find('[data-testid="guard-unit"]').text()).toBe('s')
+      expect(wrapper.find('[data-testid="guard-hint"]').text()).toContain('no agent output')
+    })
+
+    it('shows seconds for wallclock', () => {
+      mountComponent([{ kind: 'wallclock', max: 1800, on_fail: 'fail' }])
+      expect(wrapper.find('[data-testid="guard-unit"]').text()).toBe('s')
+      expect(wrapper.find('[data-testid="guard-hint"]').text()).toContain('running longer')
+    })
+
+    it('shows USD for cost_batch', () => {
+      mountComponent([{ kind: 'cost_batch', max: 5, on_fail: 'halt-gate' }])
+      expect(wrapper.find('[data-testid="guard-unit"]').text()).toBe('USD')
+      expect(wrapper.find('[data-testid="guard-hint"]').text()).toContain('cumulative run cost')
+    })
+  })
+
+  describe('events', () => {
+    it('emits add on + Guard click', async () => {
+      mountComponent([])
+      await wrapper.find('[data-testid="add-guard"]').trigger('click')
+      expect(wrapper.emitted('add')).toBeTruthy()
+    })
+
+    it('emits remove with index on trash click', async () => {
+      mountComponent([
+        { kind: 'log_silence', threshold: 120, on_fail: 'halt-gate' },
+        { kind: 'wallclock', max: 1800, on_fail: 'fail' },
+      ])
+      const removeButtons = wrapper.findAll('[data-testid="remove-guard"]')
+      await removeButtons[1]!.trigger('click')
+      expect(wrapper.emitted('remove')).toBeTruthy()
+      expect(wrapper.emitted('remove')![0]).toEqual([1])
+    })
+
+    it('re-homes the numeric value onto the new kind field when kind changes', () => {
+      mountComponent([{ kind: 'log_silence', threshold: 120, on_fail: 'halt-gate' }])
+      const vm = wrapper.vm as unknown as {
+        onKindChange: (i: number, g: Guard, k: Guard['kind']) => void
+      }
+      vm.onKindChange(0, { kind: 'log_silence', threshold: 120, on_fail: 'halt-gate' }, 'wallclock')
+      expect(wrapper.emitted('update')).toBeTruthy()
+      expect(wrapper.emitted('update')![0]).toEqual([
+        0,
+        { kind: 'wallclock', max: 120, on_fail: 'halt-gate' },
+      ])
+    })
+
+    it('preserves on_fail when the numeric field changes', () => {
+      mountComponent([{ kind: 'wallclock', max: 1800, on_fail: 'fail' }])
+      const vm = wrapper.vm as unknown as {
+        onNumericChange: (i: number, g: Guard, v: number | null) => void
+      }
+      vm.onNumericChange(0, { kind: 'wallclock', max: 1800, on_fail: 'fail' }, 600)
+      expect(wrapper.emitted('update')![0]).toEqual([
+        0,
+        { kind: 'wallclock', max: 600, on_fail: 'fail' },
+      ])
+    })
+
+    it('updates on_fail without touching the numeric field', () => {
+      mountComponent([{ kind: 'cost_batch', max: 5, on_fail: 'halt-gate' }])
+      const vm = wrapper.vm as unknown as {
+        onFailChange: (i: number, g: Guard, f: Guard['on_fail']) => void
+      }
+      vm.onFailChange(0, { kind: 'cost_batch', max: 5, on_fail: 'halt-gate' }, 'retry')
+      expect(wrapper.emitted('update')![0]).toEqual([
+        0,
+        { kind: 'cost_batch', max: 5, on_fail: 'retry' },
+      ])
+    })
+  })
+})

--- a/frontend/src/features/pipeline/__tests__/PipelineGroupCard.spec.ts
+++ b/frontend/src/features/pipeline/__tests__/PipelineGroupCard.spec.ts
@@ -1,7 +1,25 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
 import ConfirmationService from 'primevue/confirmationservice'
+
+beforeAll(() => {
+  // PrimeVue Select uses matchMedia which is not available in jsdom
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
 import PipelineGroupCard from '../PipelineGroupCard.vue'
 import type { PipelineGroup, PipelineStep } from '@/stores/pipelineConfig'
 import type { Agent } from '@/stores/agents'
@@ -232,6 +250,50 @@ describe('PipelineGroupCard', () => {
       await btn.trigger('click')
       expect(wrapper.emitted('move-down')).toBeTruthy()
       expect(wrapper.emitted('move-down')![0]).toEqual([1])
+    })
+  })
+
+  describe('transition policy', () => {
+    it('renders the transition select and hint', () => {
+      mountComponent({ transition: 'manual' })
+      expect(wrapper.find('[data-testid="transition-select"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="transition-hint"]').text()).toContain('manual = attend un Go')
+    })
+
+    it('emits update-transition with group id and value', () => {
+      mountComponent({ id: 'g1', transition: 'auto' })
+      // call the handler directly (PrimeVue Select internals are not under test)
+      const vm = wrapper.vm as unknown as { onTransitionChange: (v: string) => void }
+      vm.onTransitionChange('gate')
+      expect(wrapper.emitted('update-transition')).toBeTruthy()
+      expect(wrapper.emitted('update-transition')![0]).toEqual(['g1', 'gate'])
+    })
+  })
+
+  describe('guards', () => {
+    it('renders the guard editor with the stage guards', () => {
+      mountComponent({
+        guards: [{ kind: 'wallclock', max: 1800, on_fail: 'halt-gate' }],
+      })
+      expect(wrapper.find('[data-testid="guard-editor"]').exists()).toBe(true)
+      expect(wrapper.findAll('[data-testid="guard-row"]')).toHaveLength(1)
+    })
+
+    it('forwards add-guard with the group id', async () => {
+      mountComponent({ id: 'g1' })
+      await wrapper.find('[data-testid="add-guard"]').trigger('click')
+      expect(wrapper.emitted('add-guard')).toBeTruthy()
+      expect(wrapper.emitted('add-guard')![0]).toEqual(['g1'])
+    })
+
+    it('forwards remove-guard with the group id and index', async () => {
+      mountComponent({
+        id: 'g1',
+        guards: [{ kind: 'log_silence', threshold: 120, on_fail: 'halt-gate' }],
+      })
+      await wrapper.find('[data-testid="remove-guard"]').trigger('click')
+      expect(wrapper.emitted('remove-guard')).toBeTruthy()
+      expect(wrapper.emitted('remove-guard')![0]).toEqual(['g1', 0])
     })
   })
 })

--- a/frontend/src/features/pipeline/__tests__/PipelineStepList.spec.ts
+++ b/frontend/src/features/pipeline/__tests__/PipelineStepList.spec.ts
@@ -1,7 +1,25 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, beforeAll, vi } from 'vitest'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
 import ConfirmationService from 'primevue/confirmationservice'
+
+beforeAll(() => {
+  // PrimeVue Select (transition policy) uses matchMedia which jsdom lacks
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
 import PipelineStepList from '../PipelineStepList.vue'
 import type { PipelineGroup, PipelineStep } from '@/stores/pipelineConfig'
 import type { Agent } from '@/stores/agents'

--- a/frontend/src/stores/__tests__/pipelineConfig.spec.ts
+++ b/frontend/src/stores/__tests__/pipelineConfig.spec.ts
@@ -318,7 +318,152 @@ describe('usePipelineConfigStore', () => {
     })
   })
 
+  describe('transition policy', () => {
+    beforeEach(async () => {
+      mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+    })
+
+    it('updateGroupTransition sets transition and marks dirty', async () => {
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+
+      store.updateGroupTransition('dev', 'manual')
+
+      expect(store.groups[0]!.transition).toBe('manual')
+      expect(store.isDirty).toBe(true)
+    })
+
+    it('updateGroupTransition only affects the target group', async () => {
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+      store.addGroup('Review')
+      const reviewId = store.groups[1]!.id
+
+      store.updateGroupTransition(reviewId, 'gate')
+
+      expect(store.groups[0]!.transition).not.toBe('gate')
+      expect(store.groups[1]!.transition).toBe('gate')
+    })
+
+    it('updateGroupTransition does nothing when config is null', () => {
+      const store = usePipelineConfigStore()
+      store.updateGroupTransition('dev', 'gate')
+      expect(store.config).toBeNull()
+      expect(store.isDirty).toBe(false)
+    })
+  })
+
+  describe('guards', () => {
+    beforeEach(async () => {
+      mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+    })
+
+    it('addGuard appends a default guard to a stage and marks dirty', async () => {
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+
+      store.addGuard('dev')
+
+      expect(store.groups[0]!.guards).toHaveLength(1)
+      expect(store.groups[0]!.guards![0]).toEqual({
+        kind: 'log_silence',
+        threshold: 120,
+        on_fail: 'halt-gate',
+      })
+      expect(store.isDirty).toBe(true)
+    })
+
+    it('addGuard appends to existing stage guards', async () => {
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+
+      store.addGuard('dev')
+      store.addGuard('dev')
+
+      expect(store.groups[0]!.guards).toHaveLength(2)
+    })
+
+    it('updateGuard replaces the guard at index and marks dirty', async () => {
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+      store.addGuard('dev')
+
+      store.updateGuard('dev', 0, { kind: 'wallclock', max: 1800, on_fail: 'fail' })
+
+      expect(store.groups[0]!.guards![0]).toEqual({
+        kind: 'wallclock',
+        max: 1800,
+        on_fail: 'fail',
+      })
+      expect(store.isDirty).toBe(true)
+    })
+
+    it('removeGuard removes the guard at index and marks dirty', async () => {
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+      store.addGuard('dev')
+      store.updateGuard('dev', 0, { kind: 'cost_batch', max: 5, on_fail: 'halt-gate' })
+      store.addGuard('dev')
+
+      store.removeGuard('dev', 0)
+
+      expect(store.groups[0]!.guards).toHaveLength(1)
+      // the surviving guard is the second (default) one
+      expect(store.groups[0]!.guards![0]!.kind).toBe('log_silence')
+      expect(store.isDirty).toBe(true)
+    })
+
+    it('addGuard targets a step when stepId is provided', async () => {
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+
+      store.addGuard('dev', 's1')
+
+      expect(store.groups[0]!.steps[0]!.guards).toHaveLength(1)
+      // group-level guards untouched
+      expect(store.groups[0]!.guards ?? []).toHaveLength(0)
+    })
+
+    it('updateGuard and removeGuard target a step when stepId is provided', async () => {
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+      store.addGuard('dev', 's1')
+
+      store.updateGuard('dev', 0, { kind: 'wallclock', max: 600, on_fail: 'retry' }, 's1')
+      expect(store.groups[0]!.steps[0]!.guards![0]!.kind).toBe('wallclock')
+
+      store.removeGuard('dev', 0, 's1')
+      expect(store.groups[0]!.steps[0]!.guards).toHaveLength(0)
+    })
+
+    it('guard mutations do nothing when config is null', () => {
+      const store = usePipelineConfigStore()
+      store.addGuard('dev')
+      store.updateGuard('dev', 0, { kind: 'wallclock', max: 1, on_fail: 'fail' })
+      store.removeGuard('dev', 0)
+      expect(store.config).toBeNull()
+      expect(store.isDirty).toBe(false)
+    })
+  })
+
   describe('saveConfig', () => {
+    it('persists transition and guards via the PUT body', async () => {
+      mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
+
+      const store = usePipelineConfigStore()
+      await store.fetchConfig('proj-1')
+      store.updateGroupTransition('dev', 'gate')
+      store.addGuard('dev')
+
+      mockPut.mockResolvedValue({ data: { ...mockConfig, groups: store.groups }, error: undefined })
+
+      await store.saveConfig('proj-1')
+
+      const sentGroups = mockPut.mock.calls[0]![1].body.groups
+      expect(sentGroups[0].transition).toBe('gate')
+      expect(sentGroups[0].guards).toHaveLength(1)
+    })
+
     it('saves config successfully and resets isDirty', async () => {
       mockGet.mockResolvedValue({ data: mockConfig, error: undefined })
 

--- a/frontend/src/stores/pipelineConfig.ts
+++ b/frontend/src/stores/pipelineConfig.ts
@@ -8,6 +8,15 @@ export type PipelineConfig = components['schemas']['PipelineConfig']
 export type PipelineStep = components['schemas']['PipelineStep']
 export type PipelineGroup = components['schemas']['PipelineGroup']
 export type RetryPolicy = components['schemas']['RetryPolicy']
+export type Guard = components['schemas']['Guard']
+export type TransitionPolicy = PipelineGroup['transition']
+export type GuardKind = Guard['kind']
+export type GuardOnFail = Guard['on_fail']
+
+/** A fresh guard with sensible defaults (log_silence heartbeat, halt-gate on breach). */
+export function defaultGuard(): Guard {
+  return { kind: 'log_silence', threshold: 120, on_fail: 'halt-gate' }
+}
 
 /**
  * Pinia store for pipeline configuration state management.
@@ -94,6 +103,100 @@ export const usePipelineConfigStore = defineStore('pipelineConfig', () => {
       groups: config.value.groups.map((g: PipelineGroup) =>
         g.id === groupId ? { ...g, name } : g,
       ),
+    }
+    isDirty.value = true
+  }
+
+  /** Set a group's transition policy (auto | manual | gate) and mark dirty */
+  function updateGroupTransition(groupId: string, transition: TransitionPolicy) {
+    if (!config.value) return
+    config.value = {
+      ...config.value,
+      groups: config.value.groups.map((g: PipelineGroup) =>
+        g.id === groupId ? { ...g, transition } : g,
+      ),
+    }
+    isDirty.value = true
+  }
+
+  /**
+   * Add a guard to a stage (group) or, when stepId is provided, to a step.
+   * Defaults to a log_silence / halt-gate guard. Marks dirty.
+   */
+  function addGuard(groupId: string, stepId?: string) {
+    if (!config.value) return
+    const guard = defaultGuard()
+    config.value = {
+      ...config.value,
+      groups: config.value.groups.map((g: PipelineGroup) => {
+        if (g.id !== groupId) return g
+        if (stepId === undefined) {
+          return { ...g, guards: [...(g.guards ?? []), guard] }
+        }
+        return {
+          ...g,
+          steps: g.steps.map((s: PipelineStep) =>
+            s.id === stepId ? { ...s, guards: [...(s.guards ?? []), guard] } : s,
+          ),
+        }
+      }),
+    }
+    isDirty.value = true
+  }
+
+  /**
+   * Remove the guard at `guardIndex` from a stage (group) or, when stepId is
+   * provided, from a step. Marks dirty.
+   */
+  function removeGuard(groupId: string, guardIndex: number, stepId?: string) {
+    if (!config.value) return
+    const dropAt = (guards: Guard[] = []) =>
+      guards.filter((_: Guard, i: number) => i !== guardIndex)
+    config.value = {
+      ...config.value,
+      groups: config.value.groups.map((g: PipelineGroup) => {
+        if (g.id !== groupId) return g
+        if (stepId === undefined) {
+          return { ...g, guards: dropAt(g.guards) }
+        }
+        return {
+          ...g,
+          steps: g.steps.map((s: PipelineStep) =>
+            s.id === stepId ? { ...s, guards: dropAt(s.guards) } : s,
+          ),
+        }
+      }),
+    }
+    isDirty.value = true
+  }
+
+  /**
+   * Replace the guard at `guardIndex` on a stage (group) or, when stepId is
+   * provided, on a step. Marks dirty.
+   */
+  function updateGuard(
+    groupId: string,
+    guardIndex: number,
+    guard: Guard,
+    stepId?: string,
+  ) {
+    if (!config.value) return
+    const replaceAt = (guards: Guard[] = []) =>
+      guards.map((g: Guard, i: number) => (i === guardIndex ? guard : g))
+    config.value = {
+      ...config.value,
+      groups: config.value.groups.map((g: PipelineGroup) => {
+        if (g.id !== groupId) return g
+        if (stepId === undefined) {
+          return { ...g, guards: replaceAt(g.guards) }
+        }
+        return {
+          ...g,
+          steps: g.steps.map((s: PipelineStep) =>
+            s.id === stepId ? { ...s, guards: replaceAt(s.guards) } : s,
+          ),
+        }
+      }),
     }
     isDirty.value = true
   }
@@ -286,6 +389,10 @@ export const usePipelineConfigStore = defineStore('pipelineConfig', () => {
     addGroup,
     removeGroup,
     renameGroup,
+    updateGroupTransition,
+    addGuard,
+    removeGuard,
+    updateGuard,
     addStepToGroup,
     removeStepFromGroup,
     updateStepInGroup,

--- a/frontend/src/views/PipelineConfigView.vue
+++ b/frontend/src/views/PipelineConfigView.vue
@@ -13,7 +13,7 @@ import PipelineStepPalette from '@/features/pipeline/PipelineStepPalette.vue'
 import { usePipelineConfig } from '@/composables/usePipelineConfig'
 import { useAuth } from '@/composables/useAuth'
 import { useAgents } from '@/composables/useAgents'
-import type { PipelineStep } from '@/stores/pipelineConfig'
+import type { PipelineStep, Guard, TransitionPolicy } from '@/stores/pipelineConfig'
 
 const route = useRoute()
 const toast = useToast()
@@ -37,6 +37,10 @@ const {
   updateStepInGroup,
   reorderStepsInGroup,
   reorderGroups,
+  updateGroupTransition,
+  addGuard,
+  removeGuard,
+  updateGuard,
 } = usePipelineConfig(projectId)
 
 const { agents, fetchAgents } = useAgents(projectId.value)
@@ -88,6 +92,22 @@ function handleReorderGroups(fromIndex: number, toIndex: number) {
 
 function handleReorderStep(groupId: string, fromIndex: number, toIndex: number) {
   reorderStepsInGroup(groupId, fromIndex, toIndex)
+}
+
+function handleUpdateTransition(groupId: string, transition: TransitionPolicy) {
+  updateGroupTransition(groupId, transition)
+}
+
+function handleAddGuard(groupId: string) {
+  addGuard(groupId)
+}
+
+function handleRemoveGuard(groupId: string, guardIndex: number) {
+  removeGuard(groupId, guardIndex)
+}
+
+function handleUpdateGuard(groupId: string, guardIndex: number, guard: Guard) {
+  updateGuard(groupId, guardIndex, guard)
 }
 
 function handlePaletteAddStep(actionType: string) {
@@ -216,6 +236,10 @@ async function handleSave() {
           @remove-step="handleRemoveStep"
           @reorder-groups="handleReorderGroups"
           @reorder-step="handleReorderStep"
+          @update-transition="handleUpdateTransition"
+          @add-guard="handleAddGuard"
+          @remove-guard="handleRemoveGuard"
+          @update-guard="handleUpdateGuard"
         />
       </div>
 


### PR DESCRIPTION
Comble l'écart d'audit front : le moteur Stage v1 enforce `transition` et `guards`, mais l'UI ne permettait pas de les configurer (stages figés en `auto`, guards inactivables).

- Éditeur de **transition policy** (auto/manual/gate) par stage sur PipelineGroupCard
- Éditeur de **guards** (`GuardEditor.vue`) : kind (log_silence/wallclock/cost_batch) + champ selon kind + `on_fail`, au niveau stage
- Store : `updateGroupTransition`, `addGuard`/`removeGuard`/`updateGuard` ; persisté via `PUT /pipeline`
- Tests : store + GuardEditor + PipelineGroupCard

Frontend only (backend + schéma supportent déjà tout). type-check/lint/build verts, vitest 1028 tests. Guards step-level = petit follow-up (le store accepte déjà `stepId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)