### PR TITLE
fix(run): stamp stage on retry steps (board v1 — dette D1)

### DIFF
--- a/backend/internal/adapter/action/incremental_retry.go
+++ b/backend/internal/adapter/action/incremental_retry.go
@@ -78,7 +78,7 @@ func (a *IncrementalRetryAction) Execute(ctx context.Context, runCtx *model.RunC
 		retryType = "full"
 	}
 
-	// 6. Create new RunStep
+	// 6. Create new RunStep — carry StageID/StageName from parent (D1 fix).
 	newStep := &model.RunStep{
 		ID:           uuid.New(),
 		RunID:        parent.RunID,
@@ -89,6 +89,8 @@ func (a *IncrementalRetryAction) Execute(ctx context.Context, runCtx *model.RunC
 		RetryCount:   parent.RetryCount + 1,
 		RetryType:    &retryType,
 		ParentStepID: &parent.ID,
+		StageID:      parent.StageID,
+		StageName:    parent.StageName,
 	}
 	created, err := a.runRepo.CreateRetryRunStep(ctx, newStep)
 	if err != nil {

--- a/backend/internal/adapter/action/incremental_retry_test.go
+++ b/backend/internal/adapter/action/incremental_retry_test.go
@@ -362,6 +362,42 @@ func TestIncrementalRetryAction_CustomRetryPolicy(t *testing.T) {
 	}
 }
 
+// TestIncrementalRetryAction_StageStampedFromParent verifies that a retry step
+// carries the StageID and StageName of the parent step (Dette D1 fix).
+func TestIncrementalRetryAction_StageStampedFromParent(t *testing.T) {
+	t.Parallel()
+
+	const wantStageID = "stage-dev"
+	const wantStageName = "Development"
+
+	parent := makeParentStep(0, "error", "")
+	parent.StageID = wantStageID
+	parent.StageName = wantStageName
+
+	agentRun := &retryMockAgentRun{}
+	repo := &retryMockRunRepo{
+		getRunStepFn: func(_ context.Context, _ uuid.UUID) (*model.RunStep, error) {
+			return parent, nil
+		},
+	}
+
+	a := action.NewIncrementalRetryAction(repo, agentRun, testLogger())
+	if err := a.Execute(context.Background(), buildRetryRunCtx(parent.ID, nil)); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	createdStep := repo.createdStep
+	if createdStep == nil {
+		t.Fatal("expected a retry step to be created")
+	}
+	if createdStep.StageID != wantStageID {
+		t.Errorf("retry step StageID = %q; want %q", createdStep.StageID, wantStageID)
+	}
+	if createdStep.StageName != wantStageName {
+		t.Errorf("retry step StageName = %q; want %q", createdStep.StageName, wantStageName)
+	}
+}
+
 func (m *retryMockRunRepo) GetLatestRunByStory(_ context.Context, _ uuid.UUID) (*model.LatestRun, error) {
 	return nil, nil
 }

--- a/backend/internal/adapter/postgres/run_repo.go
+++ b/backend/internal/adapter/postgres/run_repo.go
@@ -416,6 +416,12 @@ func (r *RunRepo) CreateRetryRunStep(ctx context.Context, step *model.RunStep) (
 	if step.ParentStepID != nil {
 		params.ParentStepID = pgtype.UUID{Bytes: *step.ParentStepID, Valid: true}
 	}
+	if step.StageID != "" {
+		params.StageID = pgtype.Text{String: step.StageID, Valid: true}
+	}
+	if step.StageName != "" {
+		params.StageName = pgtype.Text{String: step.StageName, Valid: true}
+	}
 
 	row, err := r.queries.CreateRetryRunStep(ctx, params)
 	if err != nil {

--- a/backend/internal/adapter/postgres/run_steps.sql.go
+++ b/backend/internal/adapter/postgres/run_steps.sql.go
@@ -31,9 +31,9 @@ func (q *Queries) AppendRunStepLogTail(ctx context.Context, arg AppendRunStepLog
 const createRetryRunStep = `-- name: CreateRetryRunStep :one
 INSERT INTO run_steps (
     id, run_id, step_name, step_order, action, status,
-    retry_count, retry_type, parent_step_id
+    retry_count, retry_type, parent_step_id, stage_id, stage_name
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
 RETURNING id, run_id, step_name, step_order, action, status, started_at, completed_at, error_message, container_id, log_tail, created_at, retry_count, retry_type, parent_step_id, stage_id, stage_name
 `
@@ -48,6 +48,8 @@ type CreateRetryRunStepParams struct {
 	RetryCount   int32       `json:"retry_count"`
 	RetryType    pgtype.Text `json:"retry_type"`
 	ParentStepID pgtype.UUID `json:"parent_step_id"`
+	StageID      pgtype.Text `json:"stage_id"`
+	StageName    pgtype.Text `json:"stage_name"`
 }
 
 func (q *Queries) CreateRetryRunStep(ctx context.Context, arg CreateRetryRunStepParams) (RunStep, error) {
@@ -61,6 +63,8 @@ func (q *Queries) CreateRetryRunStep(ctx context.Context, arg CreateRetryRunStep
 		arg.RetryCount,
 		arg.RetryType,
 		arg.ParentStepID,
+		arg.StageID,
+		arg.StageName,
 	)
 	var i RunStep
 	err := row.Scan(

--- a/backend/internal/domain/service/run_service.go
+++ b/backend/internal/domain/service/run_service.go
@@ -834,7 +834,7 @@ func (s *RunService) RetryStep(ctx context.Context, runID, stepID uuid.UUID) (*m
 		retryType = "full"
 	}
 
-	// 6. Create the retry step
+	// 6. Create the retry step — carry StageID/StageName from parent (D1 fix).
 	newStep := &model.RunStep{
 		ID:           uuid.New(),
 		RunID:        runID,
@@ -845,6 +845,8 @@ func (s *RunService) RetryStep(ctx context.Context, runID, stepID uuid.UUID) (*m
 		RetryCount:   retryCount,
 		RetryType:    &retryType,
 		ParentStepID: &rootStepID,
+		StageID:      step.StageID,
+		StageName:    step.StageName,
 	}
 	_, err = s.runRepo.CreateRetryRunStep(ctx, newStep)
 	if err != nil {

--- a/backend/internal/domain/service/run_service_test.go
+++ b/backend/internal/domain/service/run_service_test.go
@@ -1806,6 +1806,78 @@ func TestRetryStep_MaxRetriesExceeded(t *testing.T) {
 	}
 }
 
+// TestRetryStep_StageStampedFromParent verifies that a retry step carries the
+// StageID and StageName of its parent step (Dette D1 fix).
+func TestRetryStep_StageStampedFromParent(t *testing.T) {
+	runID := uuid.New()
+	stepID := uuid.New()
+	projectID := uuid.New()
+	errMsg := "agent failed"
+
+	const wantStageID = "stage-dev"
+	const wantStageName = "Development"
+
+	var capturedStep *model.RunStep
+
+	runRepo := &mockRunRepo{
+		getRunFn: func(_ context.Context, id uuid.UUID) (*model.Run, error) {
+			return &model.Run{
+				ID:        id,
+				ProjectID: projectID,
+				Status:    model.RunStatusFailed,
+			}, nil
+		},
+		getRunStepFn: func(_ context.Context, id uuid.UUID) (*model.RunStep, error) {
+			return &model.RunStep{
+				ID:           id,
+				RunID:        runID,
+				StepName:     "implement",
+				StepOrder:    0,
+				Action:       "agent_run",
+				Status:       model.StepStatusFailed,
+				ErrorMessage: &errMsg,
+				RetryCount:   0,
+				StageID:      wantStageID,
+				StageName:    wantStageName,
+			}, nil
+		},
+		listRetryStepsByParentFn: func(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+			return nil, nil // no existing retries
+		},
+		updateRunStatusFn: func(_ context.Context, id uuid.UUID, status model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
+			return &model.Run{ID: id, ProjectID: projectID, Status: status}, nil
+		},
+		createRetryRunStepFn: func(_ context.Context, step *model.RunStep) (*model.RunStep, error) {
+			capturedStep = step
+			return step, nil
+		},
+		listRunStepsByRunFn: func(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+			return []*model.RunStep{
+				{ID: stepID, Status: model.StepStatusFailed},
+			}, nil
+		},
+	}
+
+	jobQueue := &mockJobQueue{
+		enqueueExecuteRunFn: func(_ context.Context, _ uuid.UUID) error { return nil },
+	}
+
+	svc := NewRunService(runRepo, newMockProjectRepoForService(), nil, nil, jobQueue)
+	_, err := svc.RetryStep(context.Background(), runID, stepID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if capturedStep == nil {
+		t.Fatal("createRetryRunStepFn was not called")
+	}
+	if capturedStep.StageID != wantStageID {
+		t.Errorf("retry step StageID = %q; want %q", capturedStep.StageID, wantStageID)
+	}
+	if capturedStep.StageName != wantStageName {
+		t.Errorf("retry step StageName = %q; want %q", capturedStep.StageName, wantStageName)
+	}
+}
+
 func TestListRunsByStory_ProgressPopulated(t *testing.T) {
 	storyID := uuid.New()
 	run1ID := uuid.New()

--- a/backend/queries/run_steps.sql
+++ b/backend/queries/run_steps.sql
@@ -32,9 +32,9 @@ RETURNING *;
 -- name: CreateRetryRunStep :one
 INSERT INTO run_steps (
     id, run_id, step_name, step_order, action, status,
-    retry_count, retry_type, parent_step_id
+    retry_count, retry_type, parent_step_id, stage_id, stage_name
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
 RETURNING *;
 


### PR DESCRIPTION
Dette board v1 : `CreateRetryRunStep` laissait `stage_id`/`stage_name` à NULL → un step rejoué perdait son stage. **Deux** chemins de retry corrigés (`RetryStep` dans run_service.go + `IncrementalRetryAction`), stage copié du step parent. + tests. go build/vet/test/-race/golangci-lint verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)