### PR TITLE
docs(runtime): microsandbox microVM substrate on a Lima VM (Linux/KVM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,18 @@ The whole stack runs in Docker (frontend, API, Postgres, mail, and a filtered Do
 
 > Pipeline execution needs a Git provider with push access (`GITHUB_TOKEN`) and an LLM token for the agents. See [`docs/local-setup.md`](docs/local-setup.md) for the full setup.
 
+### Execution substrates & platform support
+
+The runtime is pluggable. The **default substrate is Docker** (`SUBSTRATE=docker`) and
+runs anywhere Docker runs — Linux, macOS, Windows.
+
+A **hardened microVM substrate (microsandbox / libkrun)** is also supported for stronger
+isolation and native nested-container fidelity (testcontainers / DinD inside the agent).
+It is **Linux-only: it requires KVM** (`/dev/kvm`). It cannot run inside Docker Desktop on
+macOS (no nested-virt passthrough). On macOS, run the stack inside a Linux VM with nested
+virtualization (Apple **M3+ / macOS 15+**) — see [`deploy/lima/README.md`](deploy/lima/README.md)
+for a one-command, reproducible setup.
+
 ### Repository layout
 
 ```

--- a/deploy/lima/README.md
+++ b/deploy/lima/README.md
@@ -1,0 +1,81 @@
+# Local microsandbox (microVM) substrate on a Linux VM
+
+The hardened agent substrate, **microsandbox** (libkrun microVMs), only runs on
+**Linux with KVM** (or macOS Apple Silicon natively). It is *embedded* — no server,
+no daemon — so it boots the microVM in the **same process** that calls it, on a host
+that has `/dev/kvm`. Two consequences:
+
+- The hopeitworks **API must run where `/dev/kvm` is** (you can't point it at a remote
+  microsandbox — there is no server mode).
+- **Docker Desktop on macOS does not expose `/dev/kvm` to containers** (no nested-virt
+  passthrough). So on macOS you run the whole stack inside a **Linux VM with nested
+  virtualization**, where `/dev/kvm` is available.
+
+Requirements for the VM path on macOS: **Apple M3+ and macOS 15+** (nested
+virtualization), via [Lima](https://lima-vm.io)'s `vz` backend. Validated on M4 Pro /
+macOS 26.5.
+
+> The default substrate is plain Docker (`SUBSTRATE=docker`), which runs anywhere
+> Docker runs. Everything below is only needed for the microsandbox substrate.
+
+## 1. Bring up the VM (reproducible)
+
+```bash
+brew install lima                 # if needed
+limactl start ./deploy/lima/microsandbox-vm.yaml --name microsandbox --tty=false
+```
+
+This provisions a Linux guest with nested-virt `/dev/kvm`, Docker, and microsandbox.
+Verify:
+
+```bash
+limactl shell microsandbox -- bash -lc 'ls -l /dev/kvm && ~/.local/bin/msb run python -- python3 -c "print(\"microVM OK\")"'
+```
+
+## 2. Run the stack inside the VM
+
+The API auto-runs its schema migrations at boot (golang-migrate), so seed **data
+only** — do **not** also run the migrations by hand (that double-applies them and
+leaves the DB `dirty`).
+
+```bash
+limactl shell microsandbox
+# --- inside the VM ---
+git clone --depth 1 -b develop https://github.com/zkarahacane/hopeitworks.git
+cd hopeitworks
+docker compose -p hopeitworks-test -f deploy/docker-compose.agent-test.yml up -d --build
+# let the API create the schema, then seed data
+docker exec -i hopeitworks-test-postgres psql -U hopeitworks -d hopeitworks_test --set ON_ERROR_STOP=1 \
+  < backend/testdata/seed.sql
+```
+
+Seed login: `admin@hopeitworks.dev` / `admin1234`.
+
+## 3. Networking — nothing to configure
+
+Lima **auto-forwards** the guest's published ports to the Mac's `localhost`. The
+agent-test API listens on `8081`, so from the Mac:
+
+```bash
+curl http://localhost:8081/healthz      # → 200
+```
+
+No `portForwards` config is required for local access. (Add a `portForwards:` block to
+the YAML only to change ports or bind to the LAN.)
+
+## Lifecycle
+
+```bash
+limactl stop microsandbox      # stop (frees RAM)
+limactl start microsandbox     # restart
+limactl delete microsandbox    # remove the VM
+```
+
+## Notes / known gotchas
+
+- **mailhog** (`mailhog/mailhog:v1.0.1`) is amd64-only and crash-loops on arm64 guests.
+  It's dev mail only — ignore it, or swap for an arm64 mail catcher.
+- Resource sizing: the VM defaults to 4 vCPU / 6 GiB. Building the Go API image inside
+  the VM is CPU/RAM heavy; bump `cpus`/`memory` in the YAML if your Mac has headroom.
+- `agent-stack.sh reset` re-applies migrations via psql and conflicts with the API's
+  boot-time auto-migration — inside the VM, prefer the data-only seed shown above.

--- a/deploy/lima/microsandbox-vm.yaml
+++ b/deploy/lima/microsandbox-vm.yaml
@@ -1,0 +1,54 @@
+# Reproducible Lima VM that can run the microsandbox (microVM) agent substrate.
+#
+# Why a VM on macOS: microsandbox uses libkrun microVMs, which need KVM (Linux) or
+# HVF (macOS). It is *embedded* (no server) and runs the microVM on the SAME host as
+# the caller — so the hopeitworks API must run where /dev/kvm lives. Docker Desktop
+# does NOT expose /dev/kvm to containers, so on macOS we run a Linux VM with nested
+# virtualization (Apple M3+/macOS 15+), where /dev/kvm becomes available.
+#
+# One command provisions a ready microVM host (KVM + Docker + microsandbox):
+#     limactl start ./deploy/lima/microsandbox-vm.yaml --name microsandbox --tty=false
+#
+# Validated 2026-06-23 on Apple M4 Pro / macOS 26.5: KVM_CREATE_VM ok and
+# `msb run python` booted a real microVM inside the guest.
+vmType: "vz"                 # Apple Virtualization.framework — required for nested virt
+rosetta:
+  enabled: false
+nestedVirtualization: true   # → /dev/kvm inside the guest (needs M3+ / macOS 15+)
+cpus: 4
+memory: "6GiB"
+disk: "40GiB"
+images:
+  - location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
+mounts: []
+provision:
+  # system: tools, Docker, and group access to /dev/kvm (root:kvm 0660) + the docker socket
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update
+      apt-get install -y cpu-checker ca-certificates curl git docker.io docker-compose-v2
+      systemctl enable --now docker
+      u="${LIMA_CIDATA_USER:-$(logname 2>/dev/null || echo lima)}"
+      # /dev/kvm is root:kvm 0660 → user must be in kvm; docker socket → docker group.
+      usermod -aG kvm "$u" || true
+      usermod -aG docker "$u" || true
+  # user: install microsandbox (libkrun) for the guest user
+  - mode: user
+    script: |
+      #!/bin/bash
+      set -eux
+      curl -fsSL https://install.microsandbox.dev | sh
+      "$HOME/.local/bin/msb" --version
+probes:
+  - description: "kvm device + docker + microsandbox available"
+    script: |
+      #!/bin/bash
+      set -eu
+      test -e /dev/kvm
+      command -v docker >/dev/null
+      test -x "$HOME/.local/bin/msb"
+    hint: "/dev/kvm missing (nested virt not active — need M3+/macOS 15+ and vmType vz), or docker/msb not installed"


### PR DESCRIPTION
## Quoi
Documente le substrat **microsandbox (microVM/libkrun)** et son chemin local sur macOS, suite à la validation réelle de cette session.

- **README principal** : note « Execution substrates & platform support » — le substrat Docker tourne partout ; le substrat microVM est **Linux/KVM-only** (pas dans Docker Desktop macOS), avec le chemin VM Linux nested-virt (M3+/macOS 15+) pointant vers `deploy/lima/`.
- **`deploy/lima/microsandbox-vm.yaml`** : VM Lima reproductible (vz + nested virt → `/dev/kvm`, Docker, microsandbox) — un seul `limactl start` (= le « refaire à la chaîne »).
- **`deploy/lima/README.md`** : runbook (monter la VM, lancer la stack dedans, pièges : seed data-only vs auto-migrate api, Lima auto-forward des ports, mailhog amd64-only).

## Validé (Apple M4 Pro / macOS 26.5)
- `/dev/kvm` fonctionnel dans l'invité (`KVM_CREATE_VM` ✓), `msb run python` a booté un microVM.
- La stack agent-test tourne **dans la VM**, joignable depuis le Mac à `localhost:8081` (Lima auto-forward, **0 conf réseau**).

Docs-only — aucun code touché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)