### PR TITLE
test(e2e)+docs: close board v1 DoD debt — Playwright specs + product.md

### DIFF
--- a/docs/product.md
+++ b/docs/product.md
@@ -1,6 +1,6 @@
 # hopeitworks — Vision Produit
 
-*Maintenu par François. Dernière mise à jour : 2026-02-28.*
+*Maintenu par François. Dernière mise à jour : 2026-06-23.*
 
 ## Vision
 
@@ -58,7 +58,11 @@ Project → Epic → Story → Run → Step
 - Inviter des membres, gérer les permissions par projet
 
 ### Stories et Epics
-- Board de stories avec filtrage par statut
+- Board dont les colonnes sont **dérivées des stages du pipeline** du projet, avec un toggle de vue :
+  - **Macro** : le cycle de vie (Backlog → Running → In Review → Done → Failed)
+  - **Détail** : une colonne par stage du pipeline (dans l'ordre), encadrée par les voies Backlog et Done/Failed
+  - Une carte se place dans son `current_stage`, avancé en temps réel par le runtime
+- Sélecteur d'epic et filtrage des stories
 - Import de stories depuis des fichiers markdown
 - Éditeur de stories (création et édition dans l'UI)
 - Epics avec calcul de DAG et visualisation des dépendances
@@ -66,7 +70,11 @@ Project → Epic → Story → Run → Step
 
 ### Exécution de pipeline
 - Lancement d'une story : container Docker → agent code → branche → PR
-- Pipeline configurable par projet (groupes d'étapes, agents, modèles, prompts)
+- Pipeline configurable par projet (groupes d'étapes = stages, agents, modèles, prompts)
+- **Politique de transition par stage** (configurée dans l'éditeur de pipeline) :
+  - **auto** : la carte avance seule au stage suivant
+  - **manual** : la carte est parquée idle à l'entrée du stage, l'utilisateur la démarre via le bouton **Go** sur le board
+  - **gate** : validation humaine (HITL) avant d'avancer
 - Pause/reprise d'une exécution en cours
 - Annulation d'un run
 - Retry d'un step en échec depuis l'UI
@@ -86,6 +94,11 @@ Project → Epic → Story → Run → Step
 - Pause automatique aux checkpoints configurés
 - Visualisation du diff pour approbation
 - Approuver ou rejeter avec raison
+
+### Probes et halt-gate (sécurité runtime)
+- **Guards** configurables par stage dans l'éditeur de pipeline : un probe (`log_silence` = heartbeat, `wallclock` = timeout, `cost_batch` = budget cumulé), un seuil, et une politique `on_fail` (halt-gate par défaut, sinon fail/retry)
+- En cas de breach, le runtime **parque** la carte sur un **halt-gate** plutôt que de la laisser dériver : le run est suspendu avec une raison structurée (valeur observée vs seuil)
+- Vue **Triage des halt-gates** (`/halts`) : les runs parqués sont listés et **groupés par raison de probe**, chaque carte affichant le contexte (story, stage, mesure) et les actions de résolution — **resume** (relancer le step), **override** (accepter et avancer), **skip** (passer outre), **send back** (revenir à un stage antérieur), **abort** (échouer la carte) — plus un **Resume all** par groupe
 
 ### Suivi des coûts
 - Tracking des tokens et coûts par étape, run, story et agent

--- a/frontend/e2e/tests/board-stage.spec.ts
+++ b/frontend/e2e/tests/board-stage.spec.ts
@@ -1,0 +1,288 @@
+import { test, expect } from './fixtures'
+
+// ── Board "Stage" redesign ────────────────────────────────────────────────────
+// Covers the user-visible behaviour of the stage-pipeline board refonte:
+//   - the détail view derives one column per pipeline stage (the macro view shows
+//     the lifecycle), and a card sits in its `current_stage` column;
+//   - a card idle in a `manual` stage shows a "Go · start stage" affordance that
+//     POSTs to the stage/start endpoint;
+//   - a fresh Backlog card shows "Go" which opens the launch confirm dialog.
+//
+// The suite is fully mocked (see ./fixtures) so it runs without a backend. The
+// board fetches three endpoints we stub here: the pipeline config (stage columns),
+// the epics list (epic selector + auto-select), and the stories of the first epic.
+
+const PROJECT_ID = 'p1'
+
+const mockProject = {
+  id: PROJECT_ID,
+  name: 'Test Project',
+  description: 'A test project',
+  owner_id: 'u1',
+  git_provider: 'github',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const mockEpics = [
+  {
+    id: 'e1',
+    project_id: PROJECT_ID,
+    name: 'User Authentication',
+    description: 'Implement user authentication',
+    status: 'in_progress',
+    story_counts: { backlog: 1, running: 1, done: 1, failed: 0 },
+    created_at: '2026-01-15T10:00:00Z',
+    updated_at: '2026-01-15T10:00:00Z',
+  },
+]
+
+// Pipeline groups become the détail board's stage columns (in order). The
+// `transition` policy drives the manual-idle affordance.
+const mockPipelineConfig = {
+  project_id: PROJECT_ID,
+  groups: [
+    { id: 'g-setup', name: 'Setup', transition: 'auto', steps: [] },
+    { id: 'g-dev', name: 'Development', transition: 'auto', steps: [] },
+    { id: 'g-review', name: 'Review', transition: 'manual', steps: [] },
+    { id: 'g-merge', name: 'Merge', transition: 'gate', steps: [] },
+  ],
+  updated_at: '2026-02-15T10:30:00Z',
+}
+
+// Stories spread across lifecycle states + a manual-idle card parked at "Review".
+const mockStories = [
+  {
+    id: 'story-backlog',
+    epic_id: 'e1',
+    project_id: PROJECT_ID,
+    key: 'S-01',
+    title: 'Backlog story',
+    status: 'backlog',
+    created_at: '2026-01-15T10:00:00Z',
+    updated_at: '2026-01-15T10:00:00Z',
+  },
+  {
+    id: 'story-running',
+    epic_id: 'e1',
+    project_id: PROJECT_ID,
+    key: 'S-02',
+    title: 'Running in Development',
+    status: 'running',
+    current_stage: 'Development',
+    latest_run: {
+      id: 'run-2',
+      status: 'running',
+      current_step: {
+        id: 'st-2',
+        name: 'implement',
+        action_type: 'agent_run',
+        status: 'running',
+        index: 0,
+        total: 1,
+      },
+    },
+    created_at: '2026-01-15T10:00:00Z',
+    updated_at: '2026-01-15T10:00:00Z',
+  },
+  {
+    id: 'story-manual-idle',
+    epic_id: 'e1',
+    project_id: PROJECT_ID,
+    key: 'S-03',
+    title: 'Parked at manual Review',
+    status: 'running',
+    // Parked at the entry of the manual "Review" stage: run paused, no waiting_approval
+    // step → the board surfaces the "Go · start stage" affordance.
+    current_stage: 'Review',
+    latest_run: { id: 'run-3', status: 'paused', current_step: null },
+    created_at: '2026-01-15T10:00:00Z',
+    updated_at: '2026-01-15T10:00:00Z',
+  },
+  {
+    id: 'story-done',
+    epic_id: 'e1',
+    project_id: PROJECT_ID,
+    key: 'S-04',
+    title: 'Completed story',
+    status: 'done',
+    latest_run: { id: 'run-4', status: 'completed' },
+    created_at: '2026-01-15T10:00:00Z',
+    updated_at: '2026-01-15T10:00:00Z',
+  },
+]
+
+/** Stub auth + project + pipeline + epics + stories so the board renders fully. */
+async function setupBoardMocks(
+  page: import('@playwright/test').Page,
+  opts: { stories?: typeof mockStories } = {},
+) {
+  await page.route('**/api/v1/auth/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: '1', email: 'admin@test.com', name: 'Admin', role: 'admin' }),
+    })
+  })
+
+  await page.route('**/api/v1/projects/p1', async (route) => {
+    // Let sub-resource routes (/epics, /stories, /pipeline) fall through to their handlers.
+    const url = route.request().url()
+    if (url.includes('/epics') || url.includes('/stories') || url.includes('/pipeline')) {
+      return route.fallback()
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockProject),
+    })
+  })
+
+  await page.route('**/api/v1/projects/p1/pipeline', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockPipelineConfig),
+    })
+  })
+
+  await page.route('**/api/v1/projects/p1/epics*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: mockEpics, pagination: { total: 1, page: 1, per_page: 20 } }),
+    })
+  })
+
+  await page.route('**/api/v1/projects/p1/stories*', async (route) => {
+    // The stage/start POST lives under /stories/{id}/stage/start — never answer it here.
+    if (route.request().url().includes('/stage/')) return route.fallback()
+    const stories = opts.stories ?? mockStories
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: stories,
+        pagination: { total: stories.length, page: 1, per_page: 50 },
+      }),
+    })
+  })
+}
+
+test.describe('Board — Stage view', () => {
+  test('détail view renders one column per pipeline stage with cards in their current_stage', async ({
+    page,
+  }) => {
+    await setupBoardMocks(page)
+    await page.goto('/projects/p1/board')
+
+    await expect(page.getByRole('heading', { name: 'Story Board' })).toBeVisible()
+    // First epic auto-selected → its stories load.
+    await expect(page.getByText('Running in Development')).toBeVisible()
+
+    // Switch from the macro lifecycle to the détail (per-stage) view.
+    await page.getByRole('button', { name: 'Détail' }).click()
+
+    // Détail columns = Backlog entry lane + one lane per pipeline stage + Done/Failed.
+    // Each stage in the pipeline config becomes its own column header.
+    await expect(page.getByText('Setup', { exact: true })).toBeVisible()
+    await expect(page.getByText('Development', { exact: true })).toBeVisible()
+    await expect(page.getByText('Review', { exact: true })).toBeVisible()
+    await expect(page.getByText('Merge', { exact: true })).toBeVisible()
+    // Entry + terminal lanes flank the stage columns.
+    await expect(page.getByText('Backlog', { exact: true })).toBeVisible()
+    await expect(page.getByText('Done', { exact: true })).toBeVisible()
+    await expect(page.getByText('Failed', { exact: true })).toBeVisible()
+
+    // A card sits in the column matching its current_stage. Each board column is a
+    // fixed-width lane (min-w-[240px]); assert co-location by selecting the lane that
+    // holds the "Development" header and checking it carries S-02 but not the S-03 card
+    // (which is parked in the "Review" stage).
+    const columns = page.locator('div.min-w-\\[240px\\]')
+    const devColumn = columns.filter({ has: page.getByText('Development', { exact: true }) })
+    await expect(devColumn).toHaveCount(1)
+    await expect(devColumn).toContainText('Running in Development')
+    await expect(devColumn).not.toContainText('Parked at manual Review')
+
+    const reviewColumn = columns.filter({ has: page.getByText('Review', { exact: true }) })
+    await expect(reviewColumn).toContainText('Parked at manual Review')
+  })
+
+  test('macro view shows the lifecycle columns', async ({ page }) => {
+    await setupBoardMocks(page)
+    await page.goto('/projects/p1/board')
+
+    // Default view is macro (lifecycle). Force it in case localStorage persisted détail.
+    await page.getByRole('button', { name: 'Macro' }).click()
+
+    await expect(page.getByText('Backlog', { exact: true })).toBeVisible()
+    await expect(page.getByText('Running', { exact: true })).toBeVisible()
+    await expect(page.getByText('In Review', { exact: true })).toBeVisible()
+    await expect(page.getByText('Done', { exact: true })).toBeVisible()
+    await expect(page.getByText('Failed', { exact: true })).toBeVisible()
+  })
+
+  test('a manual-idle card shows "Go · start stage" and starts the stage', async ({ page }) => {
+    await setupBoardMocks(page)
+
+    let startCalled = false
+    let startUrl = ''
+    await page.route(
+      '**/api/v1/projects/p1/stories/story-manual-idle/stage/start',
+      async (route) => {
+        startCalled = true
+        startUrl = route.request().url()
+        expect(route.request().method()).toBe('POST')
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ id: 'run-3', status: 'running', story_id: 'story-manual-idle' }),
+        })
+      },
+    )
+
+    await page.goto('/projects/p1/board')
+
+    // The parked manual-stage card shows the explicit start-stage label.
+    const goButton = page.getByRole('button', { name: 'Go: S-03' })
+    await expect(goButton).toHaveText(/Go · start stage/)
+
+    await goButton.click()
+
+    await expect(page.getByText('Stage started')).toBeVisible()
+    expect(startCalled).toBe(true)
+    expect(startUrl).toContain('/projects/p1/stories/story-manual-idle/stage/start')
+  })
+
+  test('a Backlog card shows "Go" which opens the launch confirm dialog', async ({ page }) => {
+    await setupBoardMocks(page)
+    await page.goto('/projects/p1/board')
+
+    const goButton = page.getByRole('button', { name: 'Go: S-01' })
+    await expect(goButton).toBeVisible()
+    await expect(goButton).toHaveText('Go')
+
+    await goButton.click()
+
+    // Backlog "Go" launches a fresh run via the confirm dialog, not a direct POST.
+    await expect(page.getByText('Launch Story Run')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Confirm' })).toBeVisible()
+  })
+
+  test('shows the empty state when the project has no epics', async ({ page }) => {
+    await setupBoardMocks(page)
+    await page.route('**/api/v1/projects/p1/epics*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [], pagination: { total: 0, page: 1, per_page: 20 } }),
+      })
+    })
+
+    await page.goto('/projects/p1/board')
+
+    await expect(
+      page.getByText('No epics found. Import stories to get started.'),
+    ).toBeVisible()
+  })
+})

--- a/frontend/e2e/tests/halt-gate-triage.spec.ts
+++ b/frontend/e2e/tests/halt-gate-triage.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect } from './fixtures'
+
+// ── Halt-gate triage (/halts) ─────────────────────────────────────────────────
+// A guard probe (timeout / heartbeat / cost) can park a run on a "halt-gate". The
+// /halts view lists every parked halt grouped by probe reason, with the resolution
+// actions (resume / override / skip / send back / abort) on each card and a
+// "Resume all" bulk action per group.
+//
+// Fully mocked (see ./fixtures): GET /probe-halts lists the parked halts;
+// POST /hitl-requests/{id}/resolve resolves a single halt.
+
+// Two probe reasons → two groups (log_silence ×2, cost_batch ×1).
+const mockHalts = [
+  {
+    id: 'h-1',
+    run_step_id: 'rs-1',
+    run_id: 'run-1',
+    project_id: 'p1',
+    story_key: 'S-01',
+    story_title: 'Implement auth',
+    step_name: 'implement',
+    stage_name: 'Development',
+    halt_reason: { probe: 'log_silence', observed: 240, threshold: 120, unit: 'seconds' },
+    created_at: '2026-02-15T10:00:00Z',
+  },
+  {
+    id: 'h-2',
+    run_step_id: 'rs-2',
+    run_id: 'run-2',
+    project_id: 'p1',
+    story_key: 'S-02',
+    story_title: 'Add profile page',
+    step_name: 'review',
+    stage_name: 'Review',
+    halt_reason: { probe: 'log_silence', observed: 300, threshold: 120, unit: 'seconds' },
+    created_at: '2026-02-15T10:05:00Z',
+  },
+  {
+    id: 'h-3',
+    run_step_id: 'rs-3',
+    run_id: 'run-3',
+    project_id: 'p1',
+    story_key: 'S-03',
+    story_title: 'Build pipeline',
+    step_name: 'implement',
+    stage_name: 'Development',
+    halt_reason: { probe: 'cost_batch', observed: 12.5, threshold: 10, unit: 'usd' },
+    created_at: '2026-02-15T10:10:00Z',
+  },
+]
+
+async function setupAuthMock(page: import('@playwright/test').Page) {
+  await page.route('**/api/v1/auth/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: '1', email: 'admin@test.com', name: 'Admin', role: 'admin' }),
+    })
+  })
+}
+
+test.describe('Halt-gate triage', () => {
+  test('lists parked halts grouped by probe reason with resolution actions', async ({ page }) => {
+    await setupAuthMock(page)
+    await page.route('**/api/v1/probe-halts*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: mockHalts, total: mockHalts.length }),
+      })
+    })
+
+    await page.goto('/halts')
+
+    await expect(page.getByRole('heading', { name: 'Halt-gate triage' })).toBeVisible()
+
+    // One card per parked halt.
+    await expect(page.getByTestId('halt-gate-card-item')).toHaveCount(3)
+
+    // Grouped by probe reason → a "Resume all" bulk action per group (2 groups).
+    await expect(page.getByTestId('halt-group-bulk-resume')).toHaveCount(2)
+
+    // Each card surfaces the structured halt context + the resolution actions.
+    const firstCard = page.getByTestId('halt-gate-card-item').first()
+    await expect(firstCard.getByTestId('halt-gate-story')).toHaveText('S-01')
+    await expect(firstCard.getByTestId('halt-gate-stage')).toHaveText('Development')
+    await expect(firstCard.getByTestId('halt-gate-description')).toContainText('240')
+    await expect(firstCard.getByTestId('halt-gate-resume')).toBeVisible()
+    await expect(firstCard.getByTestId('halt-gate-override')).toBeVisible()
+    await expect(firstCard.getByTestId('halt-gate-skip')).toBeVisible()
+    await expect(firstCard.getByTestId('halt-gate-send-back')).toBeVisible()
+    await expect(firstCard.getByTestId('halt-gate-abort')).toBeVisible()
+  })
+
+  test('resuming a halt POSTs the resolve action and removes the card', async ({ page }) => {
+    await setupAuthMock(page)
+    await page.route('**/api/v1/probe-halts*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: mockHalts, total: mockHalts.length }),
+      })
+    })
+
+    let resolvedId = ''
+    let resolvedAction = ''
+    await page.route('**/api/v1/hitl-requests/*/resolve', async (route) => {
+      expect(route.request().method()).toBe('POST')
+      const body = route.request().postDataJSON()
+      resolvedAction = body.action
+      resolvedId = route.request().url()
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'resolved' }),
+      })
+    })
+
+    await page.goto('/halts')
+    await expect(page.getByTestId('halt-gate-card-item')).toHaveCount(3)
+
+    // Resolve the first halt by resuming it.
+    await page.getByTestId('halt-gate-card-item').first().getByTestId('halt-gate-resume').click()
+
+    // Success toast + the resolved card is dropped from the list.
+    await expect(page.getByText('S-01 resolved')).toBeVisible()
+    await expect(page.getByTestId('halt-gate-card-item')).toHaveCount(2)
+
+    expect(resolvedAction).toBe('resume')
+    expect(resolvedId).toContain('/hitl-requests/h-1/resolve')
+  })
+
+  test('shows the empty state when no runs are parked', async ({ page }) => {
+    await setupAuthMock(page)
+    await page.route('**/api/v1/probe-halts*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [], total: 0 }),
+      })
+    })
+
+    await page.goto('/halts')
+
+    await expect(page.getByText('No parked halts')).toBeVisible()
+    await expect(page.getByTestId('halt-gate-card-item')).toHaveCount(0)
+  })
+
+  test('shows an error with retry when the halts fetch fails', async ({ page }) => {
+    await setupAuthMock(page)
+    let callCount = 0
+    await page.route('**/api/v1/probe-halts*', async (route) => {
+      callCount++
+      if (callCount === 1) {
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: { code: 'INTERNAL', message: 'boom' } }),
+        })
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: mockHalts, total: mockHalts.length }),
+        })
+      }
+    })
+
+    await page.goto('/halts')
+
+    await expect(page.getByText('Failed to load probe halts')).toBeVisible()
+    await page.getByRole('button', { name: 'Retry' }).click()
+
+    await expect(page.getByTestId('halt-gate-card-item')).toHaveCount(3)
+  })
+})

--- a/frontend/e2e/tests/pipeline-config-transitions-guards.spec.ts
+++ b/frontend/e2e/tests/pipeline-config-transitions-guards.spec.ts
@@ -1,0 +1,227 @@
+import { test, expect } from './fixtures'
+
+// ── Pipeline config — transition policy + guards ──────────────────────────────
+// The stage refonte adds two per-stage controls to the pipeline editor:
+//   - a transition policy Select (auto = advances alone, manual = waits for a Go,
+//     gate = HITL validation);
+//   - a Guards editor where probes (log_silence / wallclock / cost_batch) are
+//     configured with a threshold and an on_fail policy (halt-gate by default).
+// Editing either marks the config dirty (enables Save) and is persisted via PUT.
+//
+// Fully mocked (see ./fixtures): GET/PUT /projects/proj-1/pipeline.
+
+const mockPipelineConfig = {
+  project_id: 'proj-1',
+  groups: [
+    {
+      id: 'g-dev',
+      name: 'Development',
+      transition: 'auto',
+      steps: [
+        {
+          id: 's-dev-1',
+          name: 'implement',
+          action_type: 'agent_run',
+          model: 'claude-opus-4-6',
+          auto_approve: false,
+          retry_policy: { max_retries: 2, retry_type: 'on-failure' },
+        },
+      ],
+      guards: [],
+    },
+    {
+      id: 'g-review',
+      name: 'Review',
+      transition: 'gate',
+      steps: [
+        {
+          id: 's-review-1',
+          name: 'code-review',
+          action_type: 'agent_run',
+          model: 'claude-sonnet-4-6',
+          auto_approve: false,
+          retry_policy: { max_retries: 1, retry_type: 'on-failure' },
+        },
+      ],
+      // A stage already carrying one guard so we can assert it renders.
+      guards: [{ kind: 'log_silence', threshold: 120, on_fail: 'halt-gate' }],
+    },
+  ],
+  updated_at: '2026-02-15T10:30:00Z',
+}
+
+function setupAuthMock(page: import('@playwright/test').Page) {
+  return page.route('**/api/v1/auth/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: '1', email: 'admin@test.com', name: 'Admin User', role: 'admin' }),
+    })
+  })
+}
+
+function setupProjectMock(page: import('@playwright/test').Page) {
+  return page.route('**/api/v1/projects/proj-1', async (route) => {
+    if (route.request().url().includes('/pipeline') || route.request().url().includes('/agents')) {
+      return route.fallback()
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'proj-1',
+        name: 'Test Project',
+        owner_id: 'u1',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      }),
+    })
+  })
+}
+
+/** Capture the PUT body so we can assert what was persisted. */
+function setupPipelineMock(
+  page: import('@playwright/test').Page,
+  onPut: (body: { groups: typeof mockPipelineConfig.groups }) => void,
+) {
+  return page.route('**/api/v1/projects/proj-1/pipeline', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockPipelineConfig),
+      })
+    } else if (route.request().method() === 'PUT') {
+      const body = route.request().postDataJSON()
+      onPut(body)
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...mockPipelineConfig,
+          groups: body.groups,
+          updated_at: new Date().toISOString(),
+        }),
+      })
+    }
+  })
+}
+
+test.describe('Pipeline config — transitions & guards', () => {
+  test('each stage exposes a transition policy with auto/manual/gate options', async ({ page }) => {
+    await setupAuthMock(page)
+    await setupProjectMock(page)
+    await setupPipelineMock(page, () => {})
+
+    await page.goto('/projects/proj-1/pipeline')
+
+    await expect(page.getByTestId('pipeline-group-card')).toHaveCount(2)
+
+    // One transition Select per stage.
+    const selects = page.getByTestId('transition-select')
+    await expect(selects).toHaveCount(2)
+
+    // The hint spells out what each policy means.
+    await expect(page.getByTestId('transition-hint').first()).toContainText('auto = avance seule')
+
+    // The three policies are offered.
+    await selects.first().click()
+    await expect(page.getByRole('option', { name: 'Auto' })).toBeVisible()
+    await expect(page.getByRole('option', { name: 'Manual' })).toBeVisible()
+    await expect(page.getByRole('option', { name: 'Gate' })).toBeVisible()
+  })
+
+  test('setting a stage to manual marks dirty and persists the policy', async ({ page }) => {
+    await setupAuthMock(page)
+    await setupProjectMock(page)
+    let putBody: { groups: typeof mockPipelineConfig.groups } | null = null
+    await setupPipelineMock(page, (body) => {
+      putBody = body
+    })
+
+    await page.goto('/projects/proj-1/pipeline')
+
+    await expect(page.getByTestId('save-config-btn')).toBeDisabled()
+
+    // Set the first stage (Development) from auto → manual.
+    await page.getByTestId('transition-select').first().click()
+    await page.getByRole('option', { name: 'Manual' }).click()
+
+    // Editing the policy enables Save.
+    await expect(page.getByTestId('save-config-btn')).toBeEnabled()
+
+    await page.getByTestId('save-config-btn').click()
+    await expect(page.getByText('Configuration saved')).toBeVisible()
+
+    // The persisted payload carries the new policy on the first stage.
+    expect(putBody).not.toBeNull()
+    expect(putBody!.groups[0]!.transition).toBe('manual')
+  })
+
+  test('renders an existing guard and lets an admin add a guard to a stage', async ({ page }) => {
+    await setupAuthMock(page)
+    await setupProjectMock(page)
+    let putBody: { groups: typeof mockPipelineConfig.groups } | null = null
+    await setupPipelineMock(page, (body) => {
+      putBody = body
+    })
+
+    await page.goto('/projects/proj-1/pipeline')
+
+    // The Development stage starts with no guards (empty hint); Review has one.
+    const groups = page.getByTestId('pipeline-group-card')
+    await expect(groups.nth(0).getByTestId('guard-empty')).toBeVisible()
+    await expect(groups.nth(1).getByTestId('guard-row')).toHaveCount(1)
+
+    // Add a guard to the Development stage.
+    await groups.nth(0).getByTestId('add-guard').click()
+
+    const devGuardRow = groups.nth(0).getByTestId('guard-row')
+    await expect(devGuardRow).toHaveCount(1)
+
+    // A fresh guard defaults to log_silence / halt-gate; the on_fail Select offers
+    // the halt-gate, fail and retry policies.
+    await devGuardRow.getByTestId('guard-on-fail-select').click()
+    await expect(page.getByRole('option', { name: 'Halt-gate' })).toBeVisible()
+    await expect(page.getByRole('option', { name: 'Fail' })).toBeVisible()
+    await expect(page.getByRole('option', { name: 'Retry' })).toBeVisible()
+    // Close the overlay without changing the value.
+    await page.getByRole('option', { name: 'Halt-gate' }).click()
+
+    await expect(page.getByTestId('save-config-btn')).toBeEnabled()
+    await page.getByTestId('save-config-btn').click()
+    await expect(page.getByText('Configuration saved')).toBeVisible()
+
+    // The persisted payload added a guard to the first stage.
+    expect(putBody).not.toBeNull()
+    expect(putBody!.groups[0]!.guards).toHaveLength(1)
+    expect(putBody!.groups[0]!.guards![0]!.kind).toBe('log_silence')
+    expect(putBody!.groups[0]!.guards![0]!.on_fail).toBe('halt-gate')
+  })
+
+  test('changing a guard kind re-homes its threshold and persists', async ({ page }) => {
+    await setupAuthMock(page)
+    await setupProjectMock(page)
+    let putBody: { groups: typeof mockPipelineConfig.groups } | null = null
+    await setupPipelineMock(page, (body) => {
+      putBody = body
+    })
+
+    await page.goto('/projects/proj-1/pipeline')
+
+    // The Review stage's existing guard is log_silence. Switch it to cost_batch.
+    const reviewGuard = page.getByTestId('pipeline-group-card').nth(1).getByTestId('guard-row')
+    await reviewGuard.getByTestId('guard-kind-select').click()
+    await page.getByRole('option', { name: 'Cost batch' }).click()
+
+    // Unit label flips to USD for a cost guard.
+    await expect(reviewGuard.getByTestId('guard-unit')).toHaveText('USD')
+
+    await expect(page.getByTestId('save-config-btn')).toBeEnabled()
+    await page.getByTestId('save-config-btn').click()
+    await expect(page.getByText('Configuration saved')).toBeVisible()
+
+    expect(putBody).not.toBeNull()
+    expect(putBody!.groups[1]!.guards![0]!.kind).toBe('cost_batch')
+  })
+})


### PR DESCRIPTION
Comble la dette DoD de la refonte board (INC 1-5, déjà mergée) : les 2 cases manquantes du nouveau Definition of Done.

**E2E Playwright** (suite mockée `frontend/e2e/tests/`, runnable via `npm run test:e2e`, 13 tests verts) :
- `board-stage.spec.ts` — colonnes dérivées des stages + toggle macro/détail, carte dans son `current_stage`, Go manual-stage (POST `/stage/start`) vs Go backlog (dialog launch).
- `halt-gate-triage.spec.ts` — `/halts` groupé par raison + actions de résolution (resume/override/skip/send-back/abort) + bulk + resolve (POST `/hitl-requests/{id}/resolve`).
- `pipeline-config-transitions-guards.spec.ts` — éditeur transition (auto/manual/gate) + GuardEditor (kind/threshold/on_fail) + persistance PUT `/pipeline`.

**docs/product.md** : comportement user-visible (colonnes/stages + toggle, politiques de transition, sous-section probes & halt-gate).

Note : e2e non gaté en CI (run local). Aucun code applicatif touché. Périmètre `frontend/e2e/` + `docs/product.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)