### PR TITLE
feat(agent_run): dispatch via port.AgentRuntime, DockerRuntime injected by default (substrate ADR Stage 2)

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -220,16 +220,13 @@ func run() error {
 		logger.Warn("docker container manager unavailable, timeout enforcer and orphan cleaner disabled", "error", err)
 	}
 
-	// Substrate selection (P3a). The substrate is the execution backend that
-	// realises an agent run via port.AgentRuntime. Docker is the live default and
-	// the ONLY substrate wired into the agent_run flow below. The microsandbox
-	// adapter is a scaffold: selecting it logs the choice and constructs the
-	// (inert) AgentRuntime, but does NOT intercept execution — live runs still go
-	// through the Docker ContainerManager. This switch never touches the Docker
-	// wiring; it only records intent. The returned AgentRuntime is the scaffold
-	// adapter (microsandbox) or nil (docker); P3a does not consume it on the live
-	// path, so it is intentionally discarded here.
-	_ = selectSubstrate(cfg.Substrate.Kind, stackRepo, logger)
+	// Substrate selection. The substrate is the execution backend that realises an
+	// agent run via port.AgentRuntime. selectSubstrate returns the alternative
+	// adapter (microsandbox) when SUBSTRATE selects one, or nil for the Docker
+	// default. As of Stage 2 the live agent_run flow dispatches THROUGH the port:
+	// when nil here, the agent_run wiring below injects docker.Runtime so Docker is
+	// an adapter behind the port, not a special path.
+	agentRuntime := selectSubstrate(cfg.Substrate.Kind, stackRepo, logger)
 
 	// HITL repository (created early because hitl_gate action needs it)
 	hitlRepo := pgadapter.NewHITLRepo(queries)
@@ -300,6 +297,16 @@ func run() error {
 				LogTailLines:  50,
 			}
 			sidecarMgr = dockeradapter.NewDockerSidecarManager(containerMgr, logger)
+
+			// Default substrate = Docker-as-adapter: when no alternative substrate
+			// was selected (SUBSTRATE=docker), route the live path through
+			// DockerRuntime. It emits byte-identical ContainerOpts, so behaviour is
+			// unchanged — Docker is no longer a special path, it is an adapter behind
+			// the port.
+			if agentRuntime == nil {
+				agentRuntime = dockeradapter.NewRuntime(containerMgr, agentCfg.NetworkName, logger)
+			}
+
 			agentRunAction := actionadapter.NewAgentRunAction(
 				containerMgr, logStreamer, eventRepo,
 				storyRepo, projectRepo, runRepo,
@@ -307,6 +314,7 @@ func run() error {
 				handlebarsRenderer, costSvc, agentCfg, logger,
 				apiKeySvc, containerTokenStore, callbackStatusStore,
 				cfg.Docker.CallbackBaseURL,
+				actionadapter.WithAgentRuntime(agentRuntime),
 			)
 			actionReg.Register(agentRunAction)
 			logger.Info("agent_run action registered")
@@ -574,24 +582,25 @@ func stackCatalogueFromConfig(entries []pkgconfig.StackConfig, logger *slog.Logg
 }
 
 // selectSubstrate logs the configured execution substrate and, for the
-// microsandbox kind, constructs the AgentRuntime adapter. The adapter is NOT yet
-// wired into the live agent_run flow, so live execution always uses the Docker
-// ContainerManager regardless of this selection (the agent_run → AgentRuntime
-// migration is the deferred P3c). This function records intent and constructs
-// the adapter only — it never alters the Docker wiring. Returns the AgentRuntime
-// when one is constructed (microsandbox), or nil for the docker default (the
-// live path needs no extra adapter).
+// microsandbox kind, constructs its AgentRuntime adapter. As of Stage 2 of the
+// substrate-abstraction migration the returned runtime IS wired into the live
+// agent_run flow: the caller injects it via WithAgentRuntime and Execute
+// dispatches through port.AgentRuntime. Returns the alternative adapter
+// (microsandbox) when one is selected, or nil for the docker default — nil tells
+// the caller to inject docker.Runtime, so Docker is an adapter behind the port,
+// not a special path.
 //
-// The adapter's live half (Launch/Wait/Stop) is real only in a binary built
-// with `-tags microsandbox` on a KVM/HVF host (P3b); the default build returns
-// microsandbox.ErrNotBuilt. enabled=true lets the tagged build launch microVMs;
-// the fallback build ignores it.
+// The microsandbox adapter's live half (Launch/Wait/Stop) is real only in a
+// binary built with `-tags microsandbox` on a KVM/HVF host (P3b); the default
+// build returns microsandbox.ErrNotBuilt, so selecting microsandbox without that
+// build fails the run clearly rather than silently falling back to Docker.
+// enabled=true lets the tagged build launch microVMs; the fallback build ignores it.
 func selectSubstrate(kind string, stacks port.StackRepository, logger *slog.Logger) port.AgentRuntime {
 	switch kind {
 	case pkgconfig.SubstrateMicrosandbox:
 		logger.Info("substrate selected", "substrate", pkgconfig.SubstrateMicrosandbox)
 		rt := microsandboxadapter.NewRuntime(true, stacks, logger)
-		logger.Warn("microsandbox runtime constructed but not wired into live agent_run (P3c); live execution still uses Docker. Live microVM ops require a binary built with -tags microsandbox on a KVM host",
+		logger.Warn("microsandbox runtime is wired into live agent_run; live microVM ops require a binary built with -tags microsandbox on a KVM host, else Launch returns ErrNotBuilt and the run fails clearly",
 			"substrate", pkgconfig.SubstrateMicrosandbox)
 		return rt
 	default:

--- a/backend/internal/adapter/action/agent_run.go
+++ b/backend/internal/adapter/action/agent_run.go
@@ -50,6 +50,29 @@ type AgentRunAction struct {
 	tokenStore      port.ContainerTokenStore
 	statusStore     port.CallbackStatusStore
 	callbackURL     string
+
+	// runtime, when non-nil, is the execution substrate the run is realised on
+	// (port.AgentRuntime). main.go injects docker.Runtime by DEFAULT (Docker is no
+	// longer special — it is an adapter behind the port), and may inject an
+	// alternative substrate (e.g. microsandbox) under SUBSTRATE selection. When nil
+	// the Action drives the ContainerManager directly via the legacy path, kept
+	// byte-identical for back-compat. Set via WithAgentRuntime.
+	runtime port.AgentRuntime
+}
+
+// Option configures optional behaviour of an AgentRunAction without widening the
+// (already large) NewAgentRunAction positional signature. The legacy path uses no
+// options; its constructor call-sites stay unchanged (variadic empty).
+type Option func(*AgentRunAction)
+
+// WithAgentRuntime selects the execution substrate the run dispatches through.
+// When set, Execute realises the run via this port.AgentRuntime (Launch/Wait/Stop
+// — Docker-as-adapter by default) while keeping callback-wait + token mint/revoke
+// + the outcome model in the Action. Passing nil is a no-op (legacy direct path).
+func WithAgentRuntime(rt port.AgentRuntime) Option {
+	return func(a *AgentRunAction) {
+		a.runtime = rt
+	}
 }
 
 // NewAgentRunAction creates a new agent run action.
@@ -83,8 +106,9 @@ func NewAgentRunAction(
 	tokenStore port.ContainerTokenStore,
 	statusStore port.CallbackStatusStore,
 	callbackURL string,
+	opts ...Option,
 ) *AgentRunAction {
-	return &AgentRunAction{
+	a := &AgentRunAction{
 		containerMgr:    containerMgr,
 		logStreamer:     logStreamer,
 		eventPub:        eventPub,
@@ -103,6 +127,10 @@ func NewAgentRunAction(
 		statusStore:     statusStore,
 		callbackURL:     callbackURL,
 	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
 }
 
 // Name returns the action identifier.
@@ -213,7 +241,17 @@ func (a *AgentRunAction) Execute(ctx context.Context, runCtx *model.RunContext) 
 		return fmt.Errorf("run environment commands: %w", err)
 	}
 
-	// 7. Create container
+	// 7. Substrate dispatch. When a runtime is injected (SUBSTRATE selection in
+	// main.go, DockerRuntime by default), the run is realised THROUGH
+	// port.AgentRuntime — Docker is no longer special. The callback-wait + token
+	// mint/revoke + outcome model stay in the Action (see executeViaRuntime), so
+	// this is NOT the rejected branch-beside-Docker fork. nil keeps the legacy
+	// direct path (back-compat).
+	if a.runtime != nil {
+		return a.executeViaRuntime(ctx, runCtx, project, story, agentImage, prompt, branchName, extraEnv, sidecarCtx)
+	}
+
+	// 7b. Legacy direct path (unchanged) — createContainer + Start + persist + wait.
 	containerID, err := a.createContainer(ctx, runCtx, project, story, agentImage, prompt, branchName, extraEnv, sidecarCtx)
 	if err != nil {
 		return fmt.Errorf("create container: %w", err)
@@ -351,6 +389,98 @@ func (a *AgentRunAction) createContainer(
 	}
 
 	return a.containerMgr.Create(ctx, opts)
+}
+
+// executeViaRuntime realises the agent run THROUGH port.AgentRuntime instead of
+// driving the Docker ContainerManager directly. Docker is no longer special: the
+// injected runtime (docker.Runtime by default, microsandbox under SUBSTRATE) owns
+// only Launch/Stop/Wait, while THIS Action keeps the substrate-agnostic outcome
+// model — callback-wait in callback mode, streamAndWait in legacy mode — plus the
+// token mint (inside buildAgentEnv) and persistContainerID timing.
+//
+// It deliberately does NOT read result.ExitCode off the runtime's Wait as the
+// outcome source: that was the rejected P3c branch-beside-Docker fork, which let
+// substrate runs skip callback-wait and token-revoke. Here the outcome flows from
+// exactly the same place as the legacy path.
+func (a *AgentRunAction) executeViaRuntime(
+	ctx context.Context,
+	runCtx *model.RunContext,
+	project *model.Project,
+	story *model.Story,
+	agentImage, prompt, branchName string,
+	extraEnv []string,
+	sidecarCtx *port.SidecarContext,
+) error {
+	// buildAgentEnv mints the container token (callback mode) as a side effect, so
+	// the token lifecycle is unchanged from the legacy path.
+	env, err := a.buildAgentEnv(ctx, runCtx, project, story, agentImage, prompt, branchName, extraEnv)
+	if err != nil {
+		return fmt.Errorf("build agent env: %w", err)
+	}
+
+	runtimeKind, _ := runCtx.Metadata["runtime_kind"].(string)
+	modelID, _ := runCtx.Metadata["model"].(string)
+
+	spec := port.RunSpec{
+		RuntimeKind:  runtimeKind,
+		Model:        modelID,
+		Provider:     resolveProvider(runCtx),
+		Image:        agentImage,
+		Prompt:       prompt,
+		Env:          env,
+		Labels:       a.buildAgentLabels(runCtx, story),
+		Capabilities: model.CapabilitySpec{}, // materialised by the harness at startup (fetch-at-startup)
+		Memory:       a.config.DefaultMemory,
+		CPUs:         a.config.DefaultCPUs,
+		Network:      buildRunNetwork(sidecarCtx),
+	}
+
+	handle, err := a.runtime.Launch(ctx, spec)
+	if err != nil {
+		return fmt.Errorf("launch agent on substrate: %w", err)
+	}
+	// Teardown guaranteed, mirroring the legacy defer cleanupContainer. A detached
+	// context lets Stop run even when ctx is already cancelled.
+	defer func() {
+		if stopErr := a.runtime.Stop(context.Background(), handle); stopErr != nil {
+			a.logger.Warn("failed to stop agent substrate handle",
+				"run_id", runCtx.Run.ID, "handle", handle.ID, "error", stopErr)
+		}
+	}()
+
+	// Persist the substrate handle as the run-step container id (same timing as the
+	// legacy path persists it after Start), so the out-of-band reapers keep working.
+	a.persistContainerID(ctx, runCtx.RunStep.ID, handle.ID)
+
+	// OUTCOME — IDENTICAL to the legacy path. We do NOT read result.ExitCode off the
+	// runtime's Wait as the outcome (that is the rejected P3c fork). In callback mode
+	// the callback channel is the source of truth (waitForCallback); in legacy mode
+	// we streamAndWait on the handle id (= container id for Docker).
+	isCallbackMode := a.isCallbackMode(runtimeKind, agentImage)
+	var exitCode int
+	if isCallbackMode {
+		exitCode, err = a.waitForCallback(ctx, runCtx)
+	} else {
+		exitCode, err = a.streamAndWait(ctx, handle.ID, runCtx)
+	}
+	if err != nil {
+		return fmt.Errorf("stream/wait: %w", err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("agent exited with code %d", exitCode)
+	}
+	return nil
+}
+
+// buildRunNetwork maps the per-run sidecar network onto the agnostic
+// port.RunNetwork. nil/empty sidecarCtx => zero RunNetwork (no extra attachment),
+// so a project without an Environment yields a launch byte-identical to the
+// single-homed legacy case.
+func buildRunNetwork(sidecarCtx *port.SidecarContext) port.RunNetwork {
+	if sidecarCtx != nil && sidecarCtx.NetworkName != "" {
+		return port.RunNetwork{Name: sidecarCtx.NetworkName}
+	}
+	return port.RunNetwork{}
 }
 
 // buildAgentLabels returns the bookkeeping labels stamped onto the agent

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -1423,3 +1423,373 @@ func (m *mockRunRepo) UpdateRunMetadata(_ context.Context, _ uuid.UUID, _ map[st
 func (m *mockRunRepo) AppendStepLogTail(_ context.Context, _ uuid.UUID, _ string) error {
 	return nil
 }
+
+// --- Substrate dispatch (Stage 2) test infrastructure ---
+
+// testSubstrateHandleID is the run handle the fake substrate returns from Launch.
+// Defined once so the assertions (persistContainerID, streamAndWait target, Stop
+// arg) all reference the same literal (goconst).
+const testSubstrateHandleID = "sub-123"
+
+// mockAgentRuntime is a fake port.AgentRuntime that records the RunSpec it was
+// asked to Launch and counts Launch/Wait/Stop, so the dispatch path can be
+// asserted without any real container backend. waitExitCode lets a test prove
+// that the runtime's own Wait is IGNORED as the outcome source in callback mode.
+type mockAgentRuntime struct {
+	mu sync.Mutex
+
+	launchSpecs []port.RunSpec
+	waitCalls   int
+	stopHandles []port.RunHandle
+
+	launchErr    error
+	waitExitCode int
+	waitErr      error
+}
+
+func (m *mockAgentRuntime) Provision(_ context.Context, _ model.CapabilitySpec) (model.ProvisionResult, error) {
+	return model.ProvisionResult{}, nil
+}
+
+func (m *mockAgentRuntime) Launch(_ context.Context, spec port.RunSpec) (port.RunHandle, error) {
+	m.mu.Lock()
+	m.launchSpecs = append(m.launchSpecs, spec)
+	m.mu.Unlock()
+	if m.launchErr != nil {
+		return port.RunHandle{}, m.launchErr
+	}
+	return port.RunHandle{ID: testSubstrateHandleID}, nil
+}
+
+func (m *mockAgentRuntime) Wait(_ context.Context, _ port.RunHandle) (port.RunResult, error) {
+	m.mu.Lock()
+	m.waitCalls++
+	m.mu.Unlock()
+	if m.waitErr != nil {
+		return port.RunResult{}, m.waitErr
+	}
+	return port.RunResult{ExitCode: m.waitExitCode}, nil
+}
+
+func (m *mockAgentRuntime) Stop(_ context.Context, h port.RunHandle) error {
+	m.mu.Lock()
+	m.stopHandles = append(m.stopHandles, h)
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *mockAgentRuntime) SupportedCapabilities() model.CapabilitySet {
+	return model.CapabilitySet{}
+}
+
+func (m *mockAgentRuntime) launchCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.launchSpecs)
+}
+
+func (m *mockAgentRuntime) stopCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.stopHandles)
+}
+
+func (m *mockAgentRuntime) waitCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.waitCalls
+}
+
+func (m *mockAgentRuntime) lastSpec(t *testing.T) port.RunSpec {
+	t.Helper()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.launchSpecs) == 0 {
+		t.Fatalf("Launch was never called")
+	}
+	return m.launchSpecs[len(m.launchSpecs)-1]
+}
+
+// mockCallbackStatusStore is a fake port.CallbackStatusStore. WaitForStatus
+// returns the configured exit code / error message, recording that it was
+// consulted — used to prove the callback channel (not the runtime's Wait) is the
+// outcome source in callback mode.
+type mockCallbackStatusStore struct {
+	mu sync.Mutex
+
+	waitCalls int
+	exitCode  int
+	errMsg    string
+	waitErr   error
+}
+
+func (m *mockCallbackStatusStore) WaitForStatus(_ context.Context, _ uuid.UUID, _ time.Duration) (int, string, error) {
+	m.mu.Lock()
+	m.waitCalls++
+	m.mu.Unlock()
+	if m.waitErr != nil {
+		return -1, "", m.waitErr
+	}
+	return m.exitCode, m.errMsg, nil
+}
+
+func (m *mockCallbackStatusStore) SetStatus(_ context.Context, _ uuid.UUID, _ int, _ string) error {
+	return nil
+}
+
+func (m *mockCallbackStatusStore) waitCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.waitCalls
+}
+
+// envHas reports whether env contains a KEY=value entry for the given key.
+func envHas(env []string, key string) bool {
+	prefix := key + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAgentRunAction_RuntimeDispatch_Legacy proves the legacy-mode run is realised
+// THROUGH the injected port.AgentRuntime: Launch is called once with a RunSpec
+// carrying the buildAgentEnv output / labels / resources / empty Network, the
+// substrate handle is persisted as the container id, the outcome comes from
+// streamAndWait (legacy, statusStore nil), Stop is deferred, and the Docker
+// ContainerManager.Create is NEVER called directly on this path.
+func TestAgentRunAction_RuntimeDispatch_Legacy(t *testing.T) {
+	f := newAgentRunFixture(t)
+	fakeRT := &mockAgentRuntime{}
+
+	// Rebuild the action with the runtime injected (legacy mode: statusStore nil,
+	// no runtime_kind metadata → isCallbackMode false → streamAndWait).
+	action := newRuntimeAction(f, nil, nil, "", fakeRT)
+
+	runCtx := f.newRunContext()
+	if err := action.Execute(context.Background(), runCtx); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Launch called exactly once.
+	if got := fakeRT.launchCount(); got != 1 {
+		t.Fatalf("expected 1 Launch call, got %d", got)
+	}
+	spec := fakeRT.lastSpec(t)
+
+	// The Docker ContainerManager.Create must NOT be called on the runtime path.
+	f.containerMgr.mu.Lock()
+	createCalls := len(f.containerMgr.createCalls)
+	f.containerMgr.mu.Unlock()
+	if createCalls != 0 {
+		t.Fatalf("expected 0 direct containerMgr.Create calls on the runtime path, got %d", createCalls)
+	}
+
+	// RunSpec.Env carries what buildAgentEnv produced (base block present).
+	for _, key := range []string{"REPO_URL", "STORY_KEY", "PROMPT", "CLAUDE_MD_CONTENT"} {
+		if !envHas(spec.Env, key) {
+			t.Errorf("expected RunSpec.Env to contain %s=, env=%v", key, spec.Env)
+		}
+	}
+
+	// RunSpec.Labels match buildAgentLabels.
+	if spec.Labels["managed_by"] != model.LabelManagedByValue ||
+		spec.Labels["run_id"] != f.runID.String() ||
+		spec.Labels["step_id"] != f.stepID.String() ||
+		spec.Labels["story_key"] != testStoryKey {
+		t.Errorf("RunSpec.Labels mismatch: %v", spec.Labels)
+	}
+
+	// Resources copied from AgentConfig.
+	if spec.Memory != 4294967296 || spec.CPUs != 2.0 {
+		t.Errorf("RunSpec resources mismatch: memory=%d cpus=%f", spec.Memory, spec.CPUs)
+	}
+
+	// No Environment → zero RunNetwork (byte-identical to single-homed legacy).
+	if spec.Network.Name != "" {
+		t.Errorf("expected empty RunNetwork.Name with no Environment, got %q", spec.Network.Name)
+	}
+
+	// Image threaded through.
+	if spec.Image != "hopeitworks/agent:latest" {
+		t.Errorf("expected RunSpec.Image hopeitworks/agent:latest, got %q", spec.Image)
+	}
+
+	// persistContainerID received the substrate handle id.
+	f.runRepo.mu.Lock()
+	var persistedHandle bool
+	for _, c := range f.runRepo.containerInfoCalls {
+		if c.ContainerID != nil && *c.ContainerID == testSubstrateHandleID {
+			persistedHandle = true
+		}
+	}
+	f.runRepo.mu.Unlock()
+	if !persistedHandle {
+		t.Errorf("expected persistContainerID(%q) to be called with the substrate handle", testSubstrateHandleID)
+	}
+
+	// Stop deferred once on the handle.
+	if got := fakeRT.stopCount(); got != 1 {
+		t.Errorf("expected 1 Stop call (deferred teardown), got %d", got)
+	}
+	if len(fakeRT.stopHandles) == 1 && fakeRT.stopHandles[0].ID != testSubstrateHandleID {
+		t.Errorf("expected Stop on handle %q, got %q", testSubstrateHandleID, fakeRT.stopHandles[0].ID)
+	}
+}
+
+// TestAgentRunAction_RuntimeDispatch_CallbackWaitNotSkipped is the anti-drift
+// guard. In callback mode the outcome MUST come from the callback channel
+// (statusStore.WaitForStatus), NOT from the runtime's own Wait — proving the
+// rejected P3c fork (read result.ExitCode off the substrate, skipping
+// callback-wait + token-revoke) has not been reintroduced.
+//
+// The fake runtime's Wait is rigged to return a NON-zero exit code; the callback
+// reports 0. The run must succeed (callback wins) and statusStore.WaitForStatus
+// must have been consulted.
+func TestAgentRunAction_RuntimeDispatch_CallbackWaitNotSkipped(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	// Rig the runtime so its OWN Wait would fail the run if it were the outcome
+	// source (exit 1). It must be ignored in callback mode.
+	fakeRT := &mockAgentRuntime{waitExitCode: 1, waitErr: nil}
+
+	// Callback channel says exit 0 (success).
+	statusStore := &mockCallbackStatusStore{exitCode: 0}
+
+	// apiKeySvc is nil: the fixture runCtx carries no UserID (uuid.Nil), so
+	// buildAgentEnv never resolves an API key. tokenStore IS exercised (the token
+	// mint stays in buildAgentEnv).
+	tokenStore := &mockTokenStore{}
+
+	action := newCallbackRuntimeAction(f, statusStore, tokenStore, fakeRT)
+
+	runCtx := f.newRunContext()
+	// claude_code runtime_kind → callback mode (with statusStore set).
+	runCtx.Metadata["runtime_kind"] = model.RuntimeKindClaudeCode
+
+	if err := action.Execute(context.Background(), runCtx); err != nil {
+		t.Fatalf("expected success (callback reports exit 0), got %v", err)
+	}
+
+	// The callback channel WAS consulted: outcome came from the callback.
+	if got := statusStore.waitCount(); got != 1 {
+		t.Fatalf("expected statusStore.WaitForStatus to be consulted once (callback = outcome source), got %d", got)
+	}
+
+	// The runtime's own Wait was NOT used as the outcome source. (The dispatch does
+	// not call runtime.Wait at all in callback mode; assert it was not consulted.)
+	if got := fakeRT.waitCount(); got != 0 {
+		t.Errorf("expected runtime.Wait NOT to be the outcome source in callback mode, but it was called %d times", got)
+	}
+
+	// Launch + Stop still happen exactly once (substrate lifecycle preserved).
+	if got := fakeRT.launchCount(); got != 1 {
+		t.Errorf("expected 1 Launch call, got %d", got)
+	}
+	if got := fakeRT.stopCount(); got != 1 {
+		t.Errorf("expected 1 Stop call (deferred teardown), got %d", got)
+	}
+}
+
+// newRuntimeAction builds an AgentRunAction from the fixture's mocks plus the
+// supplied auth/callback wiring and an injected runtime. Keeps the long positional
+// constructor in one place for the Stage 2 runtime-path tests.
+func newRuntimeAction(
+	f *agentRunFixture,
+	apiKeySvc *service.APIKeyService,
+	tokenStore port.ContainerTokenStore,
+	callbackURL string,
+	rt port.AgentRuntime,
+) *action.AgentRunAction {
+	agentCfg := action.AgentConfig{
+		DefaultMemory: 4294967296,
+		DefaultCPUs:   2.0,
+		NetworkName:   testNetwork,
+		LogTailLines:  50,
+	}
+	return action.NewAgentRunAction(
+		f.containerMgr,
+		f.logStreamer,
+		f.eventPub,
+		f.storyRepo,
+		f.projectRepo,
+		f.runRepo,
+		f.environmentRepo,
+		f.sidecarMgr,
+		f.stackRepo,
+		&mockTemplateRenderer{},
+		f.costSvc,
+		agentCfg,
+		testLogger(),
+		apiKeySvc,
+		tokenStore,
+		nil, // statusStore set by withStatusStore when callback mode is wanted
+		callbackURL,
+		action.WithAgentRuntime(rt),
+	)
+}
+
+// newCallbackRuntimeAction builds an AgentRunAction wired for callback mode (a
+// status store set so isCallbackMode is satisfied) with a runtime injected. Used
+// by the anti-drift test that proves callback-wait is the outcome source.
+func newCallbackRuntimeAction(
+	f *agentRunFixture,
+	statusStore port.CallbackStatusStore,
+	tokenStore port.ContainerTokenStore,
+	rt port.AgentRuntime,
+) *action.AgentRunAction {
+	agentCfg := action.AgentConfig{
+		DefaultMemory: 4294967296,
+		DefaultCPUs:   2.0,
+		NetworkName:   testNetwork,
+		LogTailLines:  50,
+	}
+	return action.NewAgentRunAction(
+		f.containerMgr,
+		f.logStreamer,
+		f.eventPub,
+		f.storyRepo,
+		f.projectRepo,
+		f.runRepo,
+		f.environmentRepo,
+		f.sidecarMgr,
+		f.stackRepo,
+		&mockTemplateRenderer{},
+		f.costSvc,
+		agentCfg,
+		testLogger(),
+		nil, // apiKeySvc — not needed: fixture runCtx has no UserID
+		tokenStore,
+		statusStore,
+		"http://callback",
+		action.WithAgentRuntime(rt),
+	)
+}
+
+// mockTokenStore is a minimal port.ContainerTokenStore for the callback-mode
+// runtime-dispatch test. Create returns a fixed token; Revoke records the call.
+type mockTokenStore struct {
+	mu           sync.Mutex
+	createdCalls int
+	revokedCalls int
+}
+
+func (m *mockTokenStore) Create(_ context.Context, _, _, _ uuid.UUID, _ string, _ time.Duration) (string, error) {
+	m.mu.Lock()
+	m.createdCalls++
+	m.mu.Unlock()
+	return "token-abc", nil
+}
+
+func (m *mockTokenStore) Validate(_ context.Context, _ string) (*model.ContainerToken, error) {
+	return nil, nil
+}
+
+func (m *mockTokenStore) Revoke(_ context.Context, _ string) error {
+	m.mu.Lock()
+	m.revokedCalls++
+	m.mu.Unlock()
+	return nil
+}


### PR DESCRIPTION
## Stage 2 — Substrate dispatch via the port (substrate ADR)

Third stage of `docs/agent-substrate-abstraction-adr.md`. The **live** `agent_run` path now dispatches **through** `port.AgentRuntime`. Docker is no longer special — it becomes an adapter behind the port, injected by default.

### What lands
- **Additive `WithAgentRuntime(rt) Option`** + a `runtime` field on `AgentRunAction`. The constructor gains a trailing variadic `opts ...Option`; all existing 16-arg call-sites (incl. the golden fixture) stay valid.
- **`Execute` dispatch**: `if a.runtime != nil { return executeViaRuntime(...) }` else the legacy direct path (byte-identical, unchanged).
- **`executeViaRuntime`**: builds an agnostic `RunSpec` (env via `buildAgentEnv`, labels via `buildAgentLabels`, `Memory`/`CPUs` from config, run-network via `buildRunNetwork(sidecarCtx)`), `Launch`es, `defer`s `Stop` teardown, `persistContainerID(handle.ID)`, then **keeps the exact same outcome model** — `waitForCallback` in callback mode, `streamAndWait(handle.ID)` in legacy mode. It **never** reads `result.ExitCode` off `runtime.Wait` as the outcome.
- **`main.go`**: `selectSubstrate` returns the microsandbox adapter or nil; when nil (SUBSTRATE=docker, the default) the live path injects `dockeradapter.NewRuntime(containerMgr, agentNetwork, logger)`. The runtime is threaded via `WithAgentRuntime`.

### NOT the rejected P3c fork
The ADR rejects the branch-beside-Docker fork (Alternative A) because its substrate branch only read `result.ExitCode` and skipped callback-wait + token-revoke. Here the **token mint stays in `buildAgentEnv`**, **callback-wait stays the outcome source**, and the legacy path is untouched — Docker runs *through* the port, it does not sit beside it.

### Tests
- Golden `TestAgentRunAction_NoEnvironment_GoldenBackCompat` stays green (fixture injects no runtime → legacy path, the regression oracle).
- `TestAgentRunAction_RuntimeDispatch_Legacy`: proves the runtime path Launches once with the correct `RunSpec` (env/labels/resources/zero-network), persists the handle id, never calls `containerMgr.Create` directly, defers exactly one `Stop`.
- `TestAgentRunAction_RuntimeDispatch_CallbackWaitNotSkipped` (anti-drift): rigs `runtime.Wait`→exit 1 but the callback→exit 0; the run **succeeds** and `runtime.Wait` is never consulted as outcome — the definitive guard against re-introducing the P3c fork.

### Adversarial review applied
Reinforced live-path review (4 dims × verify): anti-drift confirmed sound, wiring correct, golden green, lint clean. One fix applied — refreshed the now-stale `selectSubstrate` godoc/warn-log (it claimed "not wired / still uses Docker", false as of Stage 2).

### Verification
`golangci-lint run` (v1.64.8) exit 0; `go build`/`vet`/`go test ./... -short` green.

### Definition of Done
Back + tests + lint ✅. openapi / front / Playwright / docs — **N/A**: internal execution wiring, Docker behaviour byte-identical, nothing user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)