### PR TITLE
feat(agent_run): hoist token mint + fix dead revoke, real provider cost_usd, prompt audit (substrate ADR Stage 3a)

### DIFF
--- a/backend/internal/adapter/action/agent_run.go
+++ b/backend/internal/adapter/action/agent_run.go
@@ -241,6 +241,22 @@ func (a *AgentRunAction) Execute(ctx context.Context, runCtx *model.RunContext) 
 		return fmt.Errorf("run environment commands: %w", err)
 	}
 
+	// 6c. Resolve the role and mint the callback token ONCE, before either dispatch
+	// path. Hoisting the mint here (out of buildAgentEnv) means the token lifecycle
+	// is substrate-agnostic: minted once per run, then revoked with the SAME token
+	// after the callback resolves (see waitForCallback). Returns nil for legacy /
+	// non-callback runs.
+	role := resolveRole(runCtx)
+	callback, err := a.prepareCallback(ctx, runCtx, role)
+	if err != nil {
+		return fmt.Errorf("prepare callback: %w", err)
+	}
+
+	// 6d. Audit the rendered prompt on the agnostic channel (durable event bus +
+	// operational log), once, before dispatch — so every substrate and both paths
+	// audit it identically. Skipped when the prompt is empty.
+	a.auditPrompt(ctx, runCtx, prompt, role)
+
 	// 7. Substrate dispatch. When a runtime is injected (SUBSTRATE selection in
 	// main.go, DockerRuntime by default), the run is realised THROUGH
 	// port.AgentRuntime — Docker is no longer special. The callback-wait + token
@@ -248,11 +264,11 @@ func (a *AgentRunAction) Execute(ctx context.Context, runCtx *model.RunContext) 
 	// this is NOT the rejected branch-beside-Docker fork. nil keeps the legacy
 	// direct path (back-compat).
 	if a.runtime != nil {
-		return a.executeViaRuntime(ctx, runCtx, project, story, agentImage, prompt, branchName, extraEnv, sidecarCtx)
+		return a.executeViaRuntime(ctx, runCtx, project, story, agentImage, prompt, branchName, extraEnv, sidecarCtx, callback)
 	}
 
 	// 7b. Legacy direct path (unchanged) — createContainer + Start + persist + wait.
-	containerID, err := a.createContainer(ctx, runCtx, project, story, agentImage, prompt, branchName, extraEnv, sidecarCtx)
+	containerID, err := a.createContainer(ctx, runCtx, project, story, agentImage, prompt, branchName, extraEnv, sidecarCtx, callback)
 	if err != nil {
 		return fmt.Errorf("create container: %w", err)
 	}
@@ -269,7 +285,7 @@ func (a *AgentRunAction) Execute(ctx context.Context, runCtx *model.RunContext) 
 	// 10. Wait for completion using the appropriate mode
 	var exitCode int
 	if isCallbackMode {
-		exitCode, err = a.waitForCallback(ctx, runCtx)
+		exitCode, err = a.waitForCallback(ctx, runCtx, callback)
 	} else {
 		exitCode, err = a.streamAndWait(ctx, containerID, runCtx)
 	}
@@ -365,8 +381,9 @@ func (a *AgentRunAction) createContainer(
 	agentImage, prompt, branchName string,
 	extraEnv []string,
 	sidecarCtx *port.SidecarContext,
+	callback *port.CallbackSpec,
 ) (string, error) {
-	env, err := a.buildAgentEnv(ctx, runCtx, project, story, agentImage, prompt, branchName, extraEnv)
+	env, err := a.buildAgentEnv(ctx, runCtx, project, story, agentImage, prompt, branchName, extraEnv, callbackToken(callback))
 	if err != nil {
 		return "", err
 	}
@@ -410,10 +427,12 @@ func (a *AgentRunAction) executeViaRuntime(
 	agentImage, prompt, branchName string,
 	extraEnv []string,
 	sidecarCtx *port.SidecarContext,
+	callback *port.CallbackSpec,
 ) error {
-	// buildAgentEnv mints the container token (callback mode) as a side effect, so
-	// the token lifecycle is unchanged from the legacy path.
-	env, err := a.buildAgentEnv(ctx, runCtx, project, story, agentImage, prompt, branchName, extraEnv)
+	// The callback token is minted once upstream (prepareCallback) and threaded in
+	// via callback; buildAgentEnv only emits AUTH_TOKEN from it. The token lifecycle
+	// is unchanged from — and now identical to — the legacy path.
+	env, err := a.buildAgentEnv(ctx, runCtx, project, story, agentImage, prompt, branchName, extraEnv, callbackToken(callback))
 	if err != nil {
 		return fmt.Errorf("build agent env: %w", err)
 	}
@@ -433,6 +452,7 @@ func (a *AgentRunAction) executeViaRuntime(
 		Memory:       a.config.DefaultMemory,
 		CPUs:         a.config.DefaultCPUs,
 		Network:      buildRunNetwork(sidecarCtx),
+		Callback:     callback,
 	}
 
 	handle, err := a.runtime.Launch(ctx, spec)
@@ -459,7 +479,7 @@ func (a *AgentRunAction) executeViaRuntime(
 	isCallbackMode := a.isCallbackMode(runtimeKind, agentImage)
 	var exitCode int
 	if isCallbackMode {
-		exitCode, err = a.waitForCallback(ctx, runCtx)
+		exitCode, err = a.waitForCallback(ctx, runCtx, callback)
 	} else {
 		exitCode, err = a.streamAndWait(ctx, handle.ID, runCtx)
 	}
@@ -497,10 +517,16 @@ func (a *AgentRunAction) buildAgentLabels(runCtx *model.RunContext, story *model
 
 // buildAgentEnv assembles the full KEY=value environment for one agent run: the
 // repo/branch/prompt base block, the resolved git token, and either the
-// callback-mode auth block (API_KEY, minted AUTH_TOKEN, CALLBACK_URL/PROVIDER/
-// RUN_ID/STEP_ID, MODEL) or the legacy OAuth block, followed by any sidecar
-// connection strings in extraEnv. The slice order is preserved exactly, so the
-// resulting env is byte-for-byte identical to the previous inline assembly.
+// callback-mode auth block (API_KEY, the AUTH_TOKEN minted upstream by
+// prepareCallback, CALLBACK_URL/PROVIDER/RUN_ID/STEP_ID, MODEL) or the legacy
+// OAuth block, followed by any sidecar connection strings in extraEnv. The slice
+// order is preserved exactly, so the resulting env is byte-for-byte identical to
+// the previous inline assembly.
+//
+// authToken is the per-run callback token minted once in Execute (prepareCallback)
+// and threaded in; it is "" for legacy/non-callback runs. buildAgentEnv no longer
+// mints the token itself — the mint is hoisted so it happens once per run for all
+// substrates and the matching revoke can run with the same token.
 func (a *AgentRunAction) buildAgentEnv(
 	ctx context.Context,
 	runCtx *model.RunContext,
@@ -508,6 +534,7 @@ func (a *AgentRunAction) buildAgentEnv(
 	story *model.Story,
 	agentImage, prompt, branchName string,
 	extraEnv []string,
+	authToken string,
 ) ([]string, error) {
 	repoURL := ""
 	if project.RepoURL != nil {
@@ -557,20 +584,12 @@ func (a *AgentRunAction) buildAgentEnv(
 			}
 		}
 
-		// Generate a short-lived container token for callback auth. The token is bound
-		// to the agent so the fetch-at-startup bundle endpoint can resolve this agent's
-		// capabilities server-side. agentID is uuid.Nil when no agent is bound, which
-		// yields an empty bundle (back-compat: behaves exactly as before).
-		if a.tokenStore != nil {
-			agentID := uuid.Nil
-			if id := extractAgentID(runCtx); id != nil {
-				agentID = *id
-			}
-			token, tokenErr := a.tokenStore.Create(ctx, runCtx.Run.ID, runCtx.RunStep.ID, agentID, role, 2*time.Hour)
-			if tokenErr != nil {
-				return nil, fmt.Errorf("create container token: %w", tokenErr)
-			}
-			env = append(env, "AUTH_TOKEN="+token)
+		// AUTH_TOKEN for callback auth. The token is minted ONCE upstream in Execute
+		// (prepareCallback) and threaded in, so the same token can be revoked after
+		// the callback resolves. Empty when no tokenStore is configured (back-compat:
+		// behaves exactly as before).
+		if authToken != "" {
+			env = append(env, "AUTH_TOKEN="+authToken)
 		}
 
 		env = append(env,
@@ -599,6 +618,105 @@ func (a *AgentRunAction) buildAgentEnv(
 	env = append(env, extraEnv...)
 
 	return env, nil
+}
+
+// prepareCallback mints the per-run callback token ONCE and returns the typed
+// CallbackSpec carried on the RunSpec, so the lifecycle — mint at launch, revoke
+// after the callback resolves — runs identically on every substrate.
+//
+// It returns (nil, nil) for non-callback runs: when callback mode is off
+// (statusStore nil or a non-callback runtime kind) there is no token to mint and
+// the legacy OAuth env is used. Gated on tokenStore != nil so a callback-capable
+// run with no token store still launches (back-compat: AUTH_TOKEN simply absent).
+func (a *AgentRunAction) prepareCallback(ctx context.Context, runCtx *model.RunContext, role string) (*port.CallbackSpec, error) {
+	runtimeKind, _ := runCtx.Metadata["runtime_kind"].(string)
+	agentImage, _ := runCtx.Metadata["agent_image"].(string)
+	if !a.isCallbackMode(runtimeKind, agentImage) {
+		return nil, nil
+	}
+
+	var token string
+	if a.tokenStore != nil {
+		// Bind the token to the agent so the fetch-at-startup bundle endpoint can
+		// resolve this agent's capabilities server-side. agentID is uuid.Nil when no
+		// agent is bound, which yields an empty bundle (back-compat).
+		agentID := uuid.Nil
+		if id := extractAgentID(runCtx); id != nil {
+			agentID = *id
+		}
+		t, err := a.tokenStore.Create(ctx, runCtx.Run.ID, runCtx.RunStep.ID, agentID, role, 2*time.Hour)
+		if err != nil {
+			return nil, fmt.Errorf("create container token: %w", err)
+		}
+		token = t
+	}
+
+	return &port.CallbackSpec{
+		URL:       a.callbackURL,
+		AuthToken: token,
+		RunID:     runCtx.Run.ID,
+		StepID:    runCtx.RunStep.ID,
+	}, nil
+}
+
+// callbackToken returns the minted auth token from a CallbackSpec, or "" when
+// there is no callback (legacy/non-callback run).
+func callbackToken(callback *port.CallbackSpec) string {
+	if callback == nil {
+		return ""
+	}
+	return callback.AuthToken
+}
+
+// auditPrompt makes the rendered prompt auditable through the substrate-agnostic
+// channel, independent of which substrate runs the agent or the (Docker-only)
+// log stream. It does two things:
+//   - Durable audit: publishes the prompt on the Postgres event bus as a LogEvent
+//     of Type "prompt" (→ events table + SSE). This survives the retirement of the
+//     Docker log-stream mechanism (Stage 5).
+//   - Operational signal: a structured Info log carrying only run/step/agent/role
+//     and the prompt length (the prompt body stays out of the bounded log_tail).
+//
+// A prompt is a rendered task template, not a secret. The ScrubHandler still
+// redacts any token-shaped field on the slog signal; the durable event-bus audit
+// is intentionally non-redacted (see in-body comment). An empty prompt is skipped
+// (no empty event).
+func (a *AgentRunAction) auditPrompt(ctx context.Context, runCtx *model.RunContext, prompt, role string) {
+	if prompt == "" {
+		return
+	}
+
+	agentID := ""
+	if id := extractAgentID(runCtx); id != nil {
+		agentID = id.String()
+	}
+
+	a.logger.Info("agent prompt dispatched",
+		"run_id", runCtx.Run.ID,
+		"step_id", runCtx.RunStep.ID,
+		"agent_id", agentID,
+		"role", role,
+		"prompt_len", len(prompt),
+	)
+
+	// Durable audit on the agnostic event bus — same mechanism as publishLogEvent,
+	// with Type "prompt" so consumers can distinguish it from container stdout.
+	//
+	// The prompt is published NON-redacted to the event bus (Postgres events table
+	// + SSE) ON PURPOSE: this is the auditable record of what the agent was asked to
+	// do (Decision #2, ADR §7#2). The ScrubHandler only wraps slog, not the event
+	// bus, so it does not touch this — which is intended; the prompt is a rendered
+	// task template, not a secret.
+	//
+	// The role is carried on the operational slog above, not duplicated into the
+	// LogEvent (no model field added — avoids scope creep). An event-bus consumer
+	// recovers the role by joining on run_id/step_id.
+	a.publishLogEvent(ctx, runCtx, model.LogEvent{
+		RunID:   runCtx.Run.ID.String(),
+		StepID:  runCtx.RunStep.ID.String(),
+		Message: prompt,
+		Type:    eventTypePrompt,
+	})
 }
 
 // streamAndWait starts log streaming, waits for container exit, and handles log tail.
@@ -795,24 +913,33 @@ func (a *AgentRunAction) isCallbackMode(runtimeKind, agentImage string) bool {
 // waitForCallback waits for the agent container to report its exit status via
 // the HTTP callback endpoint. Logs and cost events arrive asynchronously via
 // separate callback endpoints and do not flow through this method.
-func (a *AgentRunAction) waitForCallback(ctx context.Context, runCtx *model.RunContext) (int, error) {
+//
+// It REVOKES the callback token — the real one minted in Execute (prepareCallback)
+// and carried on callback — on EVERY exit path (success, WaitForStatus error,
+// timeout, cancel, panic) via defer, so the token dies with the run instead of
+// lingering until its 2h TTL. (Before Stage 3a the revoke was dead: it looked the
+// token up via a stub that always returned none.)
+func (a *AgentRunAction) waitForCallback(ctx context.Context, runCtx *model.RunContext, callback *port.CallbackSpec) (int, error) {
 	stepID := runCtx.RunStep.ID
+
+	// Revoke via defer, registered BEFORE WaitForStatus, so it fires on every exit
+	// path — including a WaitForStatus error, timeout, or context cancellation, none
+	// of which would reach a post-wait revoke. Bounded, detached context so it runs
+	// even when ctx is already cancelled.
+	if a.tokenStore != nil && callback != nil && callback.AuthToken != "" {
+		defer func() {
+			revokeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if revokeErr := a.tokenStore.Revoke(revokeCtx, callback.AuthToken); revokeErr != nil {
+				a.logger.Warn("failed to revoke container token",
+					"step_id", stepID, "error", revokeErr)
+			}
+		}()
+	}
 
 	exitCode, errMsg, err := a.statusStore.WaitForStatus(ctx, stepID, 2*time.Hour)
 	if err != nil {
 		return -1, err
-	}
-
-	// Revoke the container token after completion
-	if a.tokenStore != nil {
-		revokeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if tokenStr, ok := a.findContainerToken(runCtx); ok {
-			if revokeErr := a.tokenStore.Revoke(revokeCtx, tokenStr); revokeErr != nil {
-				a.logger.Warn("failed to revoke container token",
-					"step_id", stepID, "error", revokeErr)
-			}
-		}
 	}
 
 	if errMsg != "" {
@@ -821,14 +948,6 @@ func (a *AgentRunAction) waitForCallback(ctx context.Context, runCtx *model.RunC
 	}
 
 	return exitCode, nil
-}
-
-// findContainerToken looks for the AUTH_TOKEN in the run context metadata.
-// This is a best-effort lookup used to revoke tokens after completion.
-func (a *AgentRunAction) findContainerToken(_ *model.RunContext) (string, bool) {
-	// The token is not stored in metadata; revocation is handled by TTL expiry.
-	// This method exists as a hook for future token tracking if needed.
-	return "", false
 }
 
 // resolveProvider resolves the AI provider for the current step from run context metadata.

--- a/backend/internal/adapter/action/agent_run_commands.go
+++ b/backend/internal/adapter/action/agent_run_commands.go
@@ -51,6 +51,10 @@ const (
 	// cloneURLEnv is the env var carrying the authenticated clone URL into the
 	// ephemeral command container, keeping the token out of the command argv.
 	cloneURLEnv = "HOPEITWORKS_CLONE_URL"
+
+	// eventTypePrompt tags the durable prompt-audit LogEvent published on the
+	// agnostic event bus, so consumers distinguish it from container stdout.
+	eventTypePrompt = "prompt"
 )
 
 // cmdShell is the shell used to drive the clone-then-run one-liner.

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -2,6 +2,7 @@ package action_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -1769,27 +1770,192 @@ func newCallbackRuntimeAction(
 }
 
 // mockTokenStore is a minimal port.ContainerTokenStore for the callback-mode
-// runtime-dispatch test. Create returns a fixed token; Revoke records the call.
+// runtime-dispatch tests. Create returns a fixed token and remembers it; Revoke
+// records every token it was asked to revoke, so a test can prove the run revokes
+// the SAME token Create minted (the dead-revoke fix).
 type mockTokenStore struct {
-	mu           sync.Mutex
-	createdCalls int
-	revokedCalls int
+	mu            sync.Mutex
+	createdCalls  int
+	createdTokens []string
+	revokedTokens []string
 }
+
+const testMintedToken = "token-abc"
 
 func (m *mockTokenStore) Create(_ context.Context, _, _, _ uuid.UUID, _ string, _ time.Duration) (string, error) {
 	m.mu.Lock()
 	m.createdCalls++
+	m.createdTokens = append(m.createdTokens, testMintedToken)
 	m.mu.Unlock()
-	return "token-abc", nil
+	return testMintedToken, nil
 }
 
 func (m *mockTokenStore) Validate(_ context.Context, _ string) (*model.ContainerToken, error) {
 	return nil, nil
 }
 
-func (m *mockTokenStore) Revoke(_ context.Context, _ string) error {
+func (m *mockTokenStore) Revoke(_ context.Context, token string) error {
 	m.mu.Lock()
-	m.revokedCalls++
+	m.revokedTokens = append(m.revokedTokens, token)
 	m.mu.Unlock()
 	return nil
+}
+
+func (m *mockTokenStore) createCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.createdCalls
+}
+
+func (m *mockTokenStore) revokedTokenList() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.revokedTokens))
+	copy(out, m.revokedTokens)
+	return out
+}
+
+// TestAgentRunAction_CallbackToken_MintedOnceAndRevoked is the Stage 3a proof that
+// the dead token-revoke is fixed. A callback-mode run via the runtime path must:
+//   - mint the callback token EXACTLY once (Create), and
+//   - revoke EXACTLY that token once (Revoke) after the callback resolves.
+//
+// Before Stage 3a the revoke never fired: it resolved the token through a stub
+// that always returned none, so the token only died at its 2h TTL.
+func TestAgentRunAction_CallbackToken_MintedOnceAndRevoked(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	fakeRT := &mockAgentRuntime{}
+	statusStore := &mockCallbackStatusStore{exitCode: 0}
+	tokenStore := &mockTokenStore{}
+
+	act := newCallbackRuntimeAction(f, statusStore, tokenStore, fakeRT)
+
+	runCtx := f.newRunContext()
+	runCtx.Metadata["runtime_kind"] = model.RuntimeKindClaudeCode
+
+	if err := act.Execute(context.Background(), runCtx); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	// Mint exactly once.
+	if got := tokenStore.createCount(); got != 1 {
+		t.Fatalf("expected Create to be called once, got %d", got)
+	}
+
+	// Revoke exactly once, with the SAME token Create minted.
+	revoked := tokenStore.revokedTokenList()
+	if len(revoked) != 1 {
+		t.Fatalf("expected exactly 1 Revoke call, got %d (%v)", len(revoked), revoked)
+	}
+	if revoked[0] != testMintedToken {
+		t.Errorf("expected Revoke to use the minted token %q, got %q", testMintedToken, revoked[0])
+	}
+
+	// The minted token must also reach the harness via RunSpec.Env (AUTH_TOKEN) and
+	// the typed RunSpec.Callback mirror.
+	spec := fakeRT.lastSpec(t)
+	if got := envValue(spec.Env, "AUTH_TOKEN"); got != testMintedToken {
+		t.Errorf("expected AUTH_TOKEN=%q in RunSpec.Env, got %q", testMintedToken, got)
+	}
+	if spec.Callback == nil {
+		t.Fatal("expected RunSpec.Callback to be set in callback mode")
+	}
+	if spec.Callback.AuthToken != testMintedToken {
+		t.Errorf("expected RunSpec.Callback.AuthToken=%q, got %q", testMintedToken, spec.Callback.AuthToken)
+	}
+	if spec.Callback.RunID != f.runID || spec.Callback.StepID != f.stepID {
+		t.Errorf("RunSpec.Callback ids mismatch: run=%s step=%s", spec.Callback.RunID, spec.Callback.StepID)
+	}
+}
+
+// TestAgentRunAction_CallbackToken_RevokedOnWaitError proves the revoke fires even
+// when WaitForStatus FAILS (error / timeout / cancel). The revoke is deferred
+// before the wait, so a failed run still revokes its token with the SAME value
+// Create minted — the token never lingers to its 2h TTL on the error path.
+func TestAgentRunAction_CallbackToken_RevokedOnWaitError(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	fakeRT := &mockAgentRuntime{}
+	// WaitForStatus returns an error: the run must fail, yet the token is revoked.
+	statusStore := &mockCallbackStatusStore{waitErr: fmt.Errorf("status wait timed out")}
+	tokenStore := &mockTokenStore{}
+
+	act := newCallbackRuntimeAction(f, statusStore, tokenStore, fakeRT)
+
+	runCtx := f.newRunContext()
+	runCtx.Metadata["runtime_kind"] = model.RuntimeKindClaudeCode
+
+	if err := act.Execute(context.Background(), runCtx); err == nil {
+		t.Fatal("expected error from WaitForStatus failure, got nil")
+	}
+
+	// Minted once.
+	if got := tokenStore.createCount(); got != 1 {
+		t.Fatalf("expected Create to be called once, got %d", got)
+	}
+
+	// Revoked once with the minted token, despite the wait error (deferred revoke).
+	revoked := tokenStore.revokedTokenList()
+	if len(revoked) != 1 {
+		t.Fatalf("expected exactly 1 Revoke call on the error path, got %d (%v)", len(revoked), revoked)
+	}
+	if revoked[0] != testMintedToken {
+		t.Errorf("expected Revoke to use the minted token %q on the error path, got %q", testMintedToken, revoked[0])
+	}
+}
+
+// TestAgentRunAction_AuditsPromptOnEventBus proves the prompt is auditable on the
+// substrate-agnostic event bus: a run publishes exactly one LogEvent of Type
+// "prompt" whose Message is the rendered prompt, independent of the substrate.
+func TestAgentRunAction_AuditsPromptOnEventBus(t *testing.T) {
+	f := newAgentRunFixture(t)
+	runCtx := f.newRunContext()
+
+	if err := f.action.Execute(context.Background(), runCtx); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// The mockTemplateRenderer renders "rendered: <first 20 chars of template>".
+	wantPrompt := "rendered: " + runCtx.Metadata["template_content"].(string)[:20]
+
+	var promptEvents []model.LogEvent
+	for _, e := range f.eventPub.getEvents() {
+		var le model.LogEvent
+		if err := json.Unmarshal(e.Payload, &le); err != nil {
+			continue
+		}
+		if le.Type == "prompt" {
+			promptEvents = append(promptEvents, le)
+		}
+	}
+
+	if len(promptEvents) != 1 {
+		t.Fatalf("expected exactly 1 prompt-audit event, got %d", len(promptEvents))
+	}
+	if promptEvents[0].Message != wantPrompt {
+		t.Errorf("prompt-audit Message mismatch:\n got=%q\nwant=%q", promptEvents[0].Message, wantPrompt)
+	}
+}
+
+// TestAgentRunAction_NoPromptAudit_WhenEmpty proves an empty rendered prompt is
+// NOT audited (no empty event pollutes the bus).
+func TestAgentRunAction_NoPromptAudit_WhenEmpty(t *testing.T) {
+	f := newAgentRunFixture(t)
+	runCtx := f.newRunContext()
+	delete(runCtx.Metadata, "template_content") // empty prompt
+
+	if err := f.action.Execute(context.Background(), runCtx); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	for _, e := range f.eventPub.getEvents() {
+		var le model.LogEvent
+		if err := json.Unmarshal(e.Payload, &le); err != nil {
+			continue
+		}
+		if le.Type == "prompt" {
+			t.Errorf("expected no prompt-audit event for an empty prompt, got %q", le.Message)
+		}
+	}
 }

--- a/backend/internal/api/handler/agent_callback_handler.go
+++ b/backend/internal/api/handler/agent_callback_handler.go
@@ -20,10 +20,12 @@ type LogCallbackRequest struct {
 }
 
 // CostCallbackRequest is the request body for the cost callback endpoint.
+// InputTokens/OutputTokens are int64 to match agent-runtime's costPayload wire type.
 type CostCallbackRequest struct {
-	InputTokens  int    `json:"input_tokens"`
-	OutputTokens int    `json:"output_tokens"`
-	Model        string `json:"model"`
+	InputTokens  int64   `json:"input_tokens"`
+	OutputTokens int64   `json:"output_tokens"`
+	Model        string  `json:"model"`
+	CostUSD      float64 `json:"cost_usd"`
 }
 
 // StatusCallbackRequest is the request body for the status callback endpoint.
@@ -134,9 +136,10 @@ func (h *AgentCallbackHandler) HandleCost(w http.ResponseWriter, r *http.Request
 
 	costEvents := []model.CostEvent{
 		{
-			InputTokens:  int64(req.InputTokens),
-			OutputTokens: int64(req.OutputTokens),
+			InputTokens:  req.InputTokens,
+			OutputTokens: req.OutputTokens,
 			Model:        req.Model,
+			CostUSD:      req.CostUSD,
 		},
 	}
 

--- a/backend/internal/api/handler/agent_callback_handler_test.go
+++ b/backend/internal/api/handler/agent_callback_handler_test.go
@@ -1,0 +1,260 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// testCallbackLogger returns a silent logger for the cost callback tests.
+func testCallbackLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// --- Mocks scoped to the agent callback handler tests ---
+
+// recordingCostRepoForCallback captures every InsertCostRecord so a test can
+// assert what CostUSD the cost callback ultimately persisted.
+type recordingCostRepoForCallback struct {
+	inserts []model.CostRecord
+}
+
+func (m *recordingCostRepoForCallback) InsertCostRecord(_ context.Context, r *model.CostRecord) (*model.CostRecord, error) {
+	m.inserts = append(m.inserts, *r)
+	r.ID = uuid.New()
+	return r, nil
+}
+func (m *recordingCostRepoForCallback) GetCostByRunStep(_ context.Context, _ uuid.UUID) (*model.CostRecord, error) {
+	return nil, errors.NewNotFound("cost_record", uuid.Nil)
+}
+func (m *recordingCostRepoForCallback) SumCostByProject(_ context.Context, _ uuid.UUID, _ time.Time) (float64, int64, int64, error) {
+	return 0, 0, 0, nil
+}
+func (m *recordingCostRepoForCallback) SumCostByRun(_ context.Context, _ uuid.UUID) (float64, error) {
+	return 0, nil
+}
+func (m *recordingCostRepoForCallback) SumCostByStory(_ context.Context, _ uuid.UUID) (float64, int64, int64, int, error) {
+	return 0, 0, 0, 0, nil
+}
+func (m *recordingCostRepoForCallback) ListCostsByProjectByStory(_ context.Context, _ uuid.UUID, _ time.Time) ([]model.StoryCostBreakdown, error) {
+	return nil, nil
+}
+func (m *recordingCostRepoForCallback) ListCostsByProjectByRun(_ context.Context, _ uuid.UUID, _ time.Time) ([]model.RunCostBreakdown, error) {
+	return nil, nil
+}
+func (m *recordingCostRepoForCallback) ListCostsByProjectByModel(_ context.Context, _ uuid.UUID, _ time.Time) ([]model.CostByModel, error) {
+	return nil, nil
+}
+func (m *recordingCostRepoForCallback) ListStepCostsByRun(_ context.Context, _ uuid.UUID) ([]model.StepCostBreakdown, error) {
+	return nil, nil
+}
+func (m *recordingCostRepoForCallback) ListDailyCostsByProject(_ context.Context, _ uuid.UUID, _ time.Time) ([]model.CostDataPoint, error) {
+	return nil, nil
+}
+func (m *recordingCostRepoForCallback) ListCostsByProjectByRunPaginated(_ context.Context, _ uuid.UUID, _ time.Time, _, _ int32) ([]model.RunCostRow, error) {
+	return nil, nil
+}
+func (m *recordingCostRepoForCallback) CountCostsByProjectByRun(_ context.Context, _ uuid.UUID, _ time.Time) (int64, error) {
+	return 0, nil
+}
+func (m *recordingCostRepoForCallback) ListByProjectByAgent(_ context.Context, _ uuid.UUID) ([]model.AgentCostBreakdown, error) {
+	return nil, nil
+}
+func (m *recordingCostRepoForCallback) ListCostsByRunByRole(_ context.Context, _ uuid.UUID) ([]model.RoleCostBreakdown, error) {
+	return nil, nil
+}
+func (m *recordingCostRepoForCallback) SumTokensByRun(_ context.Context, _ uuid.UUID) (int64, int64, error) {
+	return 0, 0, nil
+}
+
+// runRepoForCallback is a RunRepository mock whose GetRunStep/GetRun resolve the
+// fixed step+run the cost callback needs (the run carries the project id).
+type runRepoForCallback struct {
+	step *model.RunStep
+	run  *model.Run
+}
+
+func (m *runRepoForCallback) CreateRun(_ context.Context, run *model.Run) (*model.Run, error) {
+	return run, nil
+}
+func (m *runRepoForCallback) GetRun(_ context.Context, id uuid.UUID) (*model.Run, error) {
+	if m.run != nil && m.run.ID == id {
+		return m.run, nil
+	}
+	return nil, errors.NewNotFound("run", id)
+}
+func (m *runRepoForCallback) GetActiveRunByStory(_ context.Context, _ uuid.UUID) (*model.Run, error) {
+	return nil, nil
+}
+func (m *runRepoForCallback) GetLatestRunByStory(_ context.Context, _ uuid.UUID) (*model.LatestRun, error) {
+	return nil, nil
+}
+func (m *runRepoForCallback) GetLatestRunsByStories(_ context.Context, _ []uuid.UUID) (map[uuid.UUID]*model.LatestRun, error) {
+	return map[uuid.UUID]*model.LatestRun{}, nil
+}
+func (m *runRepoForCallback) GetDAGNodeRunInfoByStories(_ context.Context, _ []uuid.UUID) (map[uuid.UUID]model.DAGNodeRunInfo, error) {
+	return map[uuid.UUID]model.DAGNodeRunInfo{}, nil
+}
+func (m *runRepoForCallback) ListRunsByProject(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *runRepoForCallback) ListRunsByStory(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *runRepoForCallback) UpdateRunStatus(_ context.Context, id uuid.UUID, status model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
+	return &model.Run{ID: id, Status: status}, nil
+}
+func (m *runRepoForCallback) UpdateRunMetadata(_ context.Context, _ uuid.UUID, _ map[string]interface{}) error {
+	return nil
+}
+func (m *runRepoForCallback) CountRunsByProject(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+func (m *runRepoForCallback) CountRunsByStory(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+func (m *runRepoForCallback) CreateRunStep(_ context.Context, step *model.RunStep) (*model.RunStep, error) {
+	return step, nil
+}
+func (m *runRepoForCallback) GetRunStep(_ context.Context, id uuid.UUID) (*model.RunStep, error) {
+	if m.step != nil && m.step.ID == id {
+		return m.step, nil
+	}
+	return nil, errors.NewNotFound("run_step", id)
+}
+func (m *runRepoForCallback) ListRunStepsByRun(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+	return nil, nil
+}
+func (m *runRepoForCallback) UpdateRunStepStatus(_ context.Context, id uuid.UUID, status model.StepStatus, _, _ *time.Time, _ *string) (*model.RunStep, error) {
+	return &model.RunStep{ID: id, Status: status}, nil
+}
+func (m *runRepoForCallback) UpdateRunStepContainerInfo(_ context.Context, id uuid.UUID, _ *string, _ *string) (*model.RunStep, error) {
+	return &model.RunStep{ID: id}, nil
+}
+func (m *runRepoForCallback) CreateRetryRunStep(_ context.Context, step *model.RunStep) (*model.RunStep, error) {
+	return step, nil
+}
+func (m *runRepoForCallback) ListRetryStepsByParent(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+	return nil, nil
+}
+func (m *runRepoForCallback) AppendStepLogTail(_ context.Context, _ uuid.UUID, _ string) error {
+	return nil
+}
+
+// noopEventPublisherForCallback is a no-op EventPublisher for the cost callback,
+// which does not publish events.
+type noopEventPublisherForCallback struct{}
+
+func (m *noopEventPublisherForCallback) Publish(_ context.Context, _ model.Event) error {
+	return nil
+}
+
+// noopStatusStoreForCallback is a no-op CallbackStatusStore; the cost callback
+// never touches it.
+type noopStatusStoreForCallback struct{}
+
+func (m *noopStatusStoreForCallback) WaitForStatus(_ context.Context, _ uuid.UUID, _ time.Duration) (int, string, error) {
+	return 0, "", nil
+}
+func (m *noopStatusStoreForCallback) SetStatus(_ context.Context, _ uuid.UUID, _ int, _ string) error {
+	return nil
+}
+
+// TestHandleCost_ProviderCostUSD_ReachesRecordStepCost proves the cost callback
+// threads the provider-real cost_usd from the request body all the way into the
+// persisted CostRecord — so the agent/provider cost is what gets stored, not a
+// pricing-table derivation.
+func TestHandleCost_ProviderCostUSD_ReachesRecordStepCost(t *testing.T) {
+	runID := uuid.New()
+	stepID := uuid.New()
+	projectID := uuid.New()
+
+	costRepo := &recordingCostRepoForCallback{}
+	costSvc := service.NewCostService(costRepo, nil, nil, nil, testCallbackLogger())
+
+	runRepo := &runRepoForCallback{
+		step: &model.RunStep{ID: stepID, RunID: runID},
+		run:  &model.Run{ID: runID, ProjectID: projectID},
+	}
+
+	h := NewAgentCallbackHandler(
+		&noopEventPublisherForCallback{},
+		costSvc,
+		&noopStatusStoreForCallback{},
+		runRepo,
+	)
+
+	body := `{"input_tokens":1000,"output_tokens":500,"model":"claude-opus-4-6","cost_usd":0.05}`
+	rec := callbackRequest(t, h.HandleCost, runID, stepID, body)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, costRepo.inserts, 1, "expected one cost record to be persisted")
+
+	inserted := costRepo.inserts[0]
+	// The provider-real 0.05 must be persisted verbatim (not the ~22.5 pricing
+	// derivation for these tokens on opus).
+	assert.Equal(t, 0.05, inserted.CostUSD)
+	assert.Equal(t, stepID, inserted.RunStepID)
+	assert.Equal(t, projectID, inserted.ProjectID)
+	assert.Equal(t, int64(1000), inserted.TokensInput)
+	assert.Equal(t, int64(500), inserted.TokensOutput)
+}
+
+// TestHandleCost_NoCostUSD_FallsBackToPricing proves a cost callback that omits
+// cost_usd (legacy agent) falls back to the pricing-table derivation.
+func TestHandleCost_NoCostUSD_FallsBackToPricing(t *testing.T) {
+	runID := uuid.New()
+	stepID := uuid.New()
+	projectID := uuid.New()
+
+	costRepo := &recordingCostRepoForCallback{}
+	costSvc := service.NewCostService(costRepo, nil, nil, nil, testCallbackLogger())
+
+	runRepo := &runRepoForCallback{
+		step: &model.RunStep{ID: stepID, RunID: runID},
+		run:  &model.Run{ID: runID, ProjectID: projectID},
+	}
+
+	h := NewAgentCallbackHandler(
+		&noopEventPublisherForCallback{},
+		costSvc,
+		&noopStatusStoreForCallback{},
+		runRepo,
+	)
+
+	// No cost_usd field → 0 → pricing fallback. 1M in + 100k out on opus = 22.5.
+	body := `{"input_tokens":1000000,"output_tokens":100000,"model":"claude-opus-4-6"}`
+	rec := callbackRequest(t, h.HandleCost, runID, stepID, body)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, costRepo.inserts, 1)
+	assert.InDelta(t, 22.5, costRepo.inserts[0].CostUSD, 0.001)
+}
+
+// callbackRequest issues a POST to the given handler with the runId/stepId chi
+// URL params populated, returning the recorder.
+func callbackRequest(t *testing.T, h http.HandlerFunc, runID, stepID uuid.UUID, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/internal/agent/callback/runs/"+runID.String()+"/steps/"+stepID.String()+"/cost", bytes.NewBufferString(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("runId", runID.String())
+	rctx.URLParams.Add("stepId", stepID.String())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	return rec
+}

--- a/backend/internal/domain/model/cost_record.go
+++ b/backend/internal/domain/model/cost_record.go
@@ -36,6 +36,9 @@ type CostEvent struct {
 	InputTokens  int64
 	OutputTokens int64
 	Model        string
+	// CostUSD is the real cost reported by the agent/provider for this event.
+	// 0 = not reported → the cost falls back to the pricing table (ComputeCostUSD).
+	CostUSD float64
 }
 
 // Pricing holds input and output pricing per million tokens.

--- a/backend/internal/domain/port/agent_runtime.go
+++ b/backend/internal/domain/port/agent_runtime.go
@@ -3,6 +3,8 @@ package port
 import (
 	"context"
 
+	"github.com/google/uuid"
+
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
 )
 
@@ -45,6 +47,24 @@ type RunSpec struct {
 	Entrypoint []string
 	Cmd        []string
 	Workdir    string
+
+	// NEW (Stage 3a) — typed callback contract for callback-mode runs. The Action
+	// mints the token and fills this once (substrate-agnostic) so the lifecycle —
+	// mint at launch, revoke after the callback resolves — runs identically on
+	// every substrate. nil for legacy (non-callback) runs. The auth values ALSO
+	// live in Env (AUTH_TOKEN/CALLBACK_URL/RUN_ID/STEP_ID) for the harness; this is
+	// the typed mirror the adapter MAY use directly.
+	Callback *CallbackSpec
+}
+
+// CallbackSpec is the typed callback contract carried on a RunSpec. The Action
+// mints the AuthToken (per agent/role) and fills this; the adapter MAY use the
+// typed fields, but the actual values also live in RunSpec.Env for the harness.
+type CallbackSpec struct {
+	URL       string
+	AuthToken string
+	RunID     uuid.UUID
+	StepID    uuid.UUID
 }
 
 // RunNetwork is the agnostic description of the per-run isolated network the

--- a/backend/internal/domain/service/cost_service.go
+++ b/backend/internal/domain/service/cost_service.go
@@ -46,8 +46,11 @@ func (s *CostService) RecordStepCost(ctx context.Context, stepID, projectID uuid
 		return nil
 	}
 
-	// Aggregate all events
+	// Aggregate all events. reportedCost sums the provider-real cost_usd carried by
+	// each event; anyReported flags that at least one event reported a real cost.
 	var totalInput, totalOutput int64
+	var reportedCost float64
+	var anyReported bool
 	modelName := events[0].Model
 	for _, e := range events {
 		totalInput += e.InputTokens
@@ -55,15 +58,27 @@ func (s *CostService) RecordStepCost(ctx context.Context, stepID, projectID uuid
 		if e.Model != "" {
 			modelName = e.Model
 		}
+		reportedCost += e.CostUSD
+		if e.CostUSD > 0 {
+			anyReported = true
+		}
 	}
 
-	// Compute cost
-	costUSD, known := model.ComputeCostUSD(modelName, totalInput, totalOutput)
-	if !known {
-		s.logger.Warn("unknown model for cost computation, cost set to zero",
-			"model", modelName,
-			"step_id", stepID,
-		)
+	// Cost source: prefer the provider-real cost reported by the agent. The pricing
+	// table is only the FALLBACK for events that did not report a real cost (legacy
+	// runs, providers that don't surface cost).
+	var costUSD float64
+	if anyReported {
+		costUSD = reportedCost
+	} else {
+		var known bool
+		costUSD, known = model.ComputeCostUSD(modelName, totalInput, totalOutput)
+		if !known {
+			s.logger.Warn("unknown model for cost computation, cost set to zero",
+				"model", modelName,
+				"step_id", stepID,
+			)
+		}
 	}
 
 	record := &model.CostRecord{

--- a/backend/internal/domain/service/cost_service_test.go
+++ b/backend/internal/domain/service/cost_service_test.go
@@ -366,6 +366,66 @@ func TestRecordStepCost_UnknownModel_ZeroCost(t *testing.T) {
 	assert.Nil(t, inserted.AgentID)
 }
 
+// TestRecordStepCost_ProviderReportedCost_WinsOverPricing proves the provider-real
+// cost_usd carried on the events is persisted verbatim and does NOT get replaced
+// by the pricing-table derivation (Decision #1: pricing is a fallback only).
+func TestRecordStepCost_ProviderReportedCost_WinsOverPricing(t *testing.T) {
+	costRepo := &mockCostRepo{}
+	svc := newTestCostService(costRepo, nil, nil, nil)
+
+	// A known model whose pricing derivation would be far from the reported cost,
+	// so we can assert the reported value (not the derived one) is persisted.
+	events := []model.CostEvent{
+		{InputTokens: 1_000_000, OutputTokens: 100_000, Model: "claude-opus-4-6", CostUSD: 0.0123},
+	}
+
+	err := svc.RecordStepCost(context.Background(), uuid.New(), uuid.New(), events, nil)
+	require.NoError(t, err)
+	require.Len(t, costRepo.insertCalls, 1)
+
+	inserted := costRepo.insertCalls[0]
+	// Provider-real cost wins: exactly the reported value, not 15.0+7.5 from pricing.
+	assert.Equal(t, 0.0123, inserted.CostUSD)
+}
+
+// TestRecordStepCost_ProviderReportedCost_Aggregated proves multiple events with
+// real cost_usd are summed into the persisted record.
+func TestRecordStepCost_ProviderReportedCost_Aggregated(t *testing.T) {
+	costRepo := &mockCostRepo{}
+	svc := newTestCostService(costRepo, nil, nil, nil)
+
+	events := []model.CostEvent{
+		{InputTokens: 100, OutputTokens: 50, Model: "claude-opus-4-6", CostUSD: 0.01},
+		{InputTokens: 200, OutputTokens: 75, Model: "claude-opus-4-6", CostUSD: 0.02},
+	}
+
+	err := svc.RecordStepCost(context.Background(), uuid.New(), uuid.New(), events, nil)
+	require.NoError(t, err)
+	require.Len(t, costRepo.insertCalls, 1)
+
+	assert.InDelta(t, 0.03, costRepo.insertCalls[0].CostUSD, 1e-9)
+}
+
+// TestRecordStepCost_NoReportedCost_FallsBackToPricing proves that when no event
+// reports a real cost (CostUSD == 0, the legacy stream path), the cost falls back
+// to the pricing-table derivation.
+func TestRecordStepCost_NoReportedCost_FallsBackToPricing(t *testing.T) {
+	costRepo := &mockCostRepo{}
+	svc := newTestCostService(costRepo, nil, nil, nil)
+
+	// CostUSD intentionally omitted (0) → fallback to ComputeCostUSD.
+	events := []model.CostEvent{
+		{InputTokens: 1_000_000, OutputTokens: 100_000, Model: "claude-opus-4-6"},
+	}
+
+	err := svc.RecordStepCost(context.Background(), uuid.New(), uuid.New(), events, nil)
+	require.NoError(t, err)
+	require.Len(t, costRepo.insertCalls, 1)
+
+	// 15*1 + 75*0.1 = 22.5 from the pricing table.
+	assert.InDelta(t, 22.5, costRepo.insertCalls[0].CostUSD, 0.001)
+}
+
 func TestRecordStepCost_MultipleEvents_Aggregated(t *testing.T) {
 	costRepo := &mockCostRepo{}
 	svc := newTestCostService(costRepo, nil, nil, nil)


### PR DESCRIPTION
## Stage 3a — Agnostic callback lifecycle: token, cost, audit (substrate ADR)

Part of Stage 3 of `docs/agent-substrate-abstraction-adr.md` (Decisions §7 #1 cost, #2 logs/prompt). Hardens the substrate-agnostic Action. Crash reconciliation (§2d) follows as Stage 3b.

### Token lifecycle — mint once, **fix the dead revoke**
- The callback token mint is **hoisted out of `buildAgentEnv` into `Execute` (`prepareCallback`)** — minted **once** per run, for all substrates, before either dispatch path. `buildAgentEnv` now takes `authToken` and only emits `AUTH_TOKEN`.
- **The dead revoke is fixed.** Before, `findContainerToken` always returned `("", false)`, so `Revoke` never ran and the token lived to its 2h TTL. Now `waitForCallback` revokes the **real** minted token carried on `port.CallbackSpec`, **via `defer`** so it fires on *every* exit path (success, `WaitForStatus` error, timeout, cancel). `findContainerToken` is deleted.
- New `CallbackSpec{URL, AuthToken, RunID, StepID}` on `RunSpec` (additive) — the typed callback contract the Action fills and adapters may use.

### Real provider cost (`cost_usd`) — Decision #1
- `CostCallbackRequest` (now `int64` tokens, matching `agent-runtime`'s `costPayload`) + `model.CostEvent` gain `cost_usd`; `HandleCost` threads it.
- `RecordStepCost` **prefers the provider-real reported cost**; the pricing table (`ComputeCostUSD`) stays the **fallback** for events that report no cost (legacy runs / providers without cost). No schema change (`cost_records.cost_usd` already exists).

### Prompt audit — Decision #2
- `auditPrompt` publishes the rendered prompt on the **agnostic Postgres event bus** (`LogEvent` type `prompt` → events table + SSE) + an operational `slog` line (prompt length only). Once, in `Execute`, before dispatch → every substrate and both paths audit identically. Survives the Stage 5 retirement of the Docker log-stream. The prompt is audit data (intentionally unredacted on the bus, per Decision #2).

### Tests
- Golden `TestAgentRunAction_NoEnvironment_GoldenBackCompat` stays byte-identical & green (non-callback fixture → `prepareCallback` nil → legacy env).
- `CallbackToken_MintedOnceAndRevoked`: `Create` once, `Revoke` once **with the same token**. `CallbackToken_RevokedOnWaitError`: revoke fires even when `WaitForStatus` errors (proves the `defer`).
- Cost: provider-reported wins over pricing; zero-reported falls back. `HandleCost` threads `cost_usd` to the persisted record.
- Prompt audit: a `prompt`-typed event carrying the prompt is published.

### Adversarial review applied
4-dim review × verify: token lifecycle, revoke fix, cost source, and audit all confirmed correct. Fixes applied: `int64` wire types, **revoke-on-all-paths via defer**, audit-data + role comments.

### Verification
`golangci-lint` (v1.64.8) exit 0; `go build`/`vet`/`go test ./... -short` green.

### Definition of Done
Back + tests + lint ✅. **openapi/front/Playwright/docs — N/A**: `cost_usd` rides the *internal* callback route (not in `openapi.yaml`); prompt audit feeds an existing SSE event; nothing user-visible new (more accurate cost is transparent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)