### PR TITLE
feat(agent_run): crash reconciliation — detect substrate exit without callback status (substrate ADR Stage 3b)

### DIFF
--- a/backend/internal/adapter/action/agent_run.go
+++ b/backend/internal/adapter/action/agent_run.go
@@ -26,6 +26,9 @@ type AgentConfig struct {
 	NetworkName string
 	// LogTailLines is the number of log lines to keep for error context.
 	LogTailLines int
+	// CrashGrace bounds how long the Action waits for a callback status AFTER the
+	// substrate process has exited, before declaring a crash. 0 => default (5s).
+	CrashGrace time.Duration
 }
 
 // AgentRunAction implements model.Action for running coding agents in containers.
@@ -474,12 +477,14 @@ func (a *AgentRunAction) executeViaRuntime(
 
 	// OUTCOME — IDENTICAL to the legacy path. We do NOT read result.ExitCode off the
 	// runtime's Wait as the outcome (that is the rejected P3c fork). In callback mode
-	// the callback channel is the source of truth (waitForCallback); in legacy mode
-	// we streamAndWait on the handle id (= container id for Docker).
+	// the callback channel is the source of truth (awaitCallbackOrCrash); runtime.Wait
+	// is consulted ONLY to detect a substrate process that exits without ever reporting
+	// a callback status (crash detection, ADR §2d) — never as the outcome. In legacy
+	// mode we streamAndWait on the handle id (= container id for Docker).
 	isCallbackMode := a.isCallbackMode(runtimeKind, agentImage)
 	var exitCode int
 	if isCallbackMode {
-		exitCode, err = a.waitForCallback(ctx, runCtx, callback)
+		exitCode, err = a.awaitCallbackOrCrash(ctx, runCtx, handle, callback)
 	} else {
 		exitCode, err = a.streamAndWait(ctx, handle.ID, runCtx)
 	}
@@ -919,35 +924,142 @@ func (a *AgentRunAction) isCallbackMode(runtimeKind, agentImage string) bool {
 // timeout, cancel, panic) via defer, so the token dies with the run instead of
 // lingering until its 2h TTL. (Before Stage 3a the revoke was dead: it looked the
 // token up via a stub that always returned none.)
+//
+// This is the LEGACY callback-wait path (Execute with runtime==nil): there is no
+// substrate handle here, so it cannot watch the process for crash detection. The
+// substrate path uses awaitCallbackOrCrash instead.
 func (a *AgentRunAction) waitForCallback(ctx context.Context, runCtx *model.RunContext, callback *port.CallbackSpec) (int, error) {
 	stepID := runCtx.RunStep.ID
 
 	// Revoke via defer, registered BEFORE WaitForStatus, so it fires on every exit
 	// path — including a WaitForStatus error, timeout, or context cancellation, none
-	// of which would reach a post-wait revoke. Bounded, detached context so it runs
-	// even when ctx is already cancelled.
-	if a.tokenStore != nil && callback != nil && callback.AuthToken != "" {
-		defer func() {
-			revokeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			if revokeErr := a.tokenStore.Revoke(revokeCtx, callback.AuthToken); revokeErr != nil {
-				a.logger.Warn("failed to revoke container token",
-					"step_id", stepID, "error", revokeErr)
-			}
-		}()
-	}
+	// of which would reach a post-wait revoke.
+	defer a.revokeCallbackToken(stepID, callback)
 
 	exitCode, errMsg, err := a.statusStore.WaitForStatus(ctx, stepID, 2*time.Hour)
+	return a.finishCallbackStatus(stepID, exitCode, errMsg, err)
+}
+
+// revokeCallbackToken revokes the minted token best-effort on a bounded detached
+// context. No-op when there is no token. Shared by every callback-wait path so the
+// token dies with the run regardless of how the wait ends.
+func (a *AgentRunAction) revokeCallbackToken(stepID uuid.UUID, callback *port.CallbackSpec) {
+	if a.tokenStore == nil || callback == nil || callback.AuthToken == "" {
+		return
+	}
+	revokeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := a.tokenStore.Revoke(revokeCtx, callback.AuthToken); err != nil {
+		a.logger.Warn("failed to revoke container token", "step_id", stepID, "error", err)
+	}
+}
+
+// awaitCallbackOrCrash waits for the agent's callback status (the AUTHORITATIVE
+// outcome) while concurrently watching the substrate process via runtime.Wait for
+// CRASH DETECTION. The callback is the source of truth; runtime.Wait only tells us
+// the exec finished. If the process exits NON-ZERO WITHOUT a callback status
+// arriving within a short grace, the run is declared a crash instead of blocking on
+// the 2h status timeout (ADR §2d). A CLEAN exit (code 0) without a status is treated
+// as an in-flight callback and keeps waiting on the authoritative status (bounded by
+// the 2h WaitForStatus), never a false crash. The reverse — status arrives, Wait
+// never returns — also stays bounded by that 2h timeout.
+//
+// Concurrency: both goroutines send on buffered (cap 1) channels and both their
+// contexts are cancelled by defer, so neither leaks regardless of which path wins
+// (the buffered send never blocks even after this method returns; the deferred
+// runtime.Stop in executeViaRuntime guarantees runtime.Wait unblocks).
+func (a *AgentRunAction) awaitCallbackOrCrash(ctx context.Context, runCtx *model.RunContext, handle port.RunHandle, callback *port.CallbackSpec) (int, error) {
+	stepID := runCtx.RunStep.ID
+	defer a.revokeCallbackToken(stepID, callback)
+
+	type statusResult struct {
+		exitCode int
+		errMsg   string
+		err      error
+	}
+	statusCh := make(chan statusResult, 1)
+	statusCtx, cancelStatus := context.WithCancel(ctx)
+	defer cancelStatus()
+	go func() {
+		ec, em, err := a.statusStore.WaitForStatus(statusCtx, stepID, 2*time.Hour)
+		statusCh <- statusResult{exitCode: ec, errMsg: em, err: err}
+	}()
+
+	waitCh := make(chan port.RunResult, 1)
+	waitCtx, cancelWait := context.WithCancel(context.Background())
+	defer cancelWait()
+	go func() {
+		// This runtime.Wait(waitCtx, handle) may run CONCURRENTLY with the deferred
+		// runtime.Stop(handle) in executeViaRuntime, on the SAME handle. That is safe:
+		// the Docker client tolerates concurrent Wait+Stop on one container, and it is
+		// the expected contract for any substrate adapter (Stop is precisely what
+		// unblocks a pending Wait). So even if this goroutine is still parked in Wait
+		// when the method returns, the deferred Stop releases it and the buffered send
+		// below never blocks — no leak.
+		res, werr := a.runtime.Wait(waitCtx, handle)
+		if werr != nil {
+			a.logger.Debug("runtime wait ended with error (crash detector)", "handle", handle.ID, "error", werr)
+		}
+		waitCh <- res
+	}()
+
+	select {
+	case s := <-statusCh:
+		return a.finishCallbackStatus(stepID, s.exitCode, s.errMsg, s.err)
+	case w := <-waitCh:
+		// The substrate process exited. The AUTHORITATIVE outcome is still the
+		// callback status; runtime.Wait only signals the exec finished.
+		//
+		// ADR §2d: a crash is declared ONLY for a NON-ZERO exit without a status. A
+		// clean exit (0) without a status is treated as a delayed/in-flight callback
+		// — keep waiting on the authoritative status (bounded by the goroutine's own
+		// 2h WaitForStatus), never declaring a false crash on a clean exit.
+		if w.ExitCode == 0 {
+			s := <-statusCh
+			return a.finishCallbackStatus(stepID, s.exitCode, s.errMsg, s.err)
+		}
+		// Non-zero exit: give the (possibly in-flight) callback a brief grace, then
+		// declare a crash. A context deadline (not time.After) bounds the grace and
+		// is cleaned up by defer — no leaked timer.
+		graceCtx, cancelGrace := context.WithTimeout(context.Background(), a.crashGrace())
+		defer cancelGrace()
+		select {
+		case s := <-statusCh:
+			return a.finishCallbackStatus(stepID, s.exitCode, s.errMsg, s.err)
+		case <-graceCtx.Done():
+			// Grace elapsed. Final NON-BLOCKING check: the status may have landed in
+			// the same scheduling tick the deadline fired (select is random when both
+			// are ready). Prefer the authoritative status if it is already buffered.
+			select {
+			case s := <-statusCh:
+				return a.finishCallbackStatus(stepID, s.exitCode, s.errMsg, s.err)
+			default:
+				return -1, fmt.Errorf("agent process exited (code %d) on the substrate without reporting a callback status", w.ExitCode)
+			}
+		}
+	}
+}
+
+// finishCallbackStatus turns a WaitForStatus result into the outcome shared by
+// the legacy and substrate callback-wait paths: propagate any wait error, warn on
+// a non-empty container error message, and return the reported exit code.
+func (a *AgentRunAction) finishCallbackStatus(stepID uuid.UUID, exitCode int, errMsg string, err error) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-
 	if errMsg != "" {
-		a.logger.Warn("agent container reported error",
-			"step_id", stepID, "exit_code", exitCode, "error", errMsg)
+		a.logger.Warn("agent container reported error", "step_id", stepID, "exit_code", exitCode, "error", errMsg)
 	}
-
 	return exitCode, nil
+}
+
+// crashGrace returns the configured grace period the substrate callback-wait gives
+// an in-flight callback after the process exits, or the 5s default when unset.
+func (a *AgentRunAction) crashGrace() time.Duration {
+	if a.config.CrashGrace > 0 {
+		return a.config.CrashGrace
+	}
+	return 5 * time.Second
 }
 
 // resolveProvider resolves the AI provider for the current step from run context metadata.

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -1446,6 +1446,10 @@ type mockAgentRuntime struct {
 	launchErr    error
 	waitExitCode int
 	waitErr      error
+	// waitDelay, when > 0, makes Wait sleep before returning so a test can order it
+	// relative to the callback-status arrival (crash-detection reconciliation). Wait
+	// still honours ctx cancellation while sleeping, so it never leaks.
+	waitDelay time.Duration
 }
 
 func (m *mockAgentRuntime) Provision(_ context.Context, _ model.CapabilitySpec) (model.ProvisionResult, error) {
@@ -1462,14 +1466,24 @@ func (m *mockAgentRuntime) Launch(_ context.Context, spec port.RunSpec) (port.Ru
 	return port.RunHandle{ID: testSubstrateHandleID}, nil
 }
 
-func (m *mockAgentRuntime) Wait(_ context.Context, _ port.RunHandle) (port.RunResult, error) {
+func (m *mockAgentRuntime) Wait(ctx context.Context, _ port.RunHandle) (port.RunResult, error) {
 	m.mu.Lock()
 	m.waitCalls++
+	delay := m.waitDelay
+	waitErr := m.waitErr
+	exitCode := m.waitExitCode
 	m.mu.Unlock()
-	if m.waitErr != nil {
-		return port.RunResult{}, m.waitErr
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return port.RunResult{}, ctx.Err()
+		}
 	}
-	return port.RunResult{ExitCode: m.waitExitCode}, nil
+	if waitErr != nil {
+		return port.RunResult{}, waitErr
+	}
+	return port.RunResult{ExitCode: exitCode}, nil
 }
 
 func (m *mockAgentRuntime) Stop(_ context.Context, h port.RunHandle) error {
@@ -1495,12 +1509,6 @@ func (m *mockAgentRuntime) stopCount() int {
 	return len(m.stopHandles)
 }
 
-func (m *mockAgentRuntime) waitCount() int {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.waitCalls
-}
-
 func (m *mockAgentRuntime) lastSpec(t *testing.T) port.RunSpec {
 	t.Helper()
 	m.mu.Lock()
@@ -1522,16 +1530,39 @@ type mockCallbackStatusStore struct {
 	exitCode  int
 	errMsg    string
 	waitErr   error
+	// block, when true, makes WaitForStatus park on ctx.Done() and return ctx.Err()
+	// — modelling a status that NEVER arrives, so the substrate process exit drives
+	// the outcome (crash detection).
+	block bool
+	// delay, when > 0, holds the status back for that long before returning it —
+	// modelling a callback that lands AFTER the process exit but within the grace.
+	delay time.Duration
 }
 
-func (m *mockCallbackStatusStore) WaitForStatus(_ context.Context, _ uuid.UUID, _ time.Duration) (int, string, error) {
+func (m *mockCallbackStatusStore) WaitForStatus(ctx context.Context, _ uuid.UUID, _ time.Duration) (int, string, error) {
 	m.mu.Lock()
 	m.waitCalls++
+	block := m.block
+	delay := m.delay
+	waitErr := m.waitErr
+	exitCode := m.exitCode
+	errMsg := m.errMsg
 	m.mu.Unlock()
-	if m.waitErr != nil {
-		return -1, "", m.waitErr
+	if block {
+		<-ctx.Done()
+		return -1, "", ctx.Err()
 	}
-	return m.exitCode, m.errMsg, nil
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return -1, "", ctx.Err()
+		}
+	}
+	if waitErr != nil {
+		return -1, "", waitErr
+	}
+	return exitCode, errMsg, nil
 }
 
 func (m *mockCallbackStatusStore) SetStatus(_ context.Context, _ uuid.UUID, _ int, _ string) error {
@@ -1679,10 +1710,13 @@ func TestAgentRunAction_RuntimeDispatch_CallbackWaitNotSkipped(t *testing.T) {
 		t.Fatalf("expected statusStore.WaitForStatus to be consulted once (callback = outcome source), got %d", got)
 	}
 
-	// The runtime's own Wait was NOT used as the outcome source. (The dispatch does
-	// not call runtime.Wait at all in callback mode; assert it was not consulted.)
-	if got := fakeRT.waitCount(); got != 0 {
-		t.Errorf("expected runtime.Wait NOT to be the outcome source in callback mode, but it was called %d times", got)
+	// The runtime's own Wait exit code was NOT used as the outcome source. Stage 3b
+	// DOES consult runtime.Wait concurrently for crash detection, so it may be called
+	// — but its non-zero exit code must NOT decide the outcome. The success above
+	// (with waitExitCode=1) already proves it; here we only assert the status, not
+	// the process exit, drove the result.
+	if statusStore.exitCode != 0 {
+		t.Fatalf("test misconfigured: status exit code must be 0 to prove callback wins")
 	}
 
 	// Launch + Stop still happen exactly once (substrate lifecycle preserved).
@@ -1692,6 +1726,203 @@ func TestAgentRunAction_RuntimeDispatch_CallbackWaitNotSkipped(t *testing.T) {
 	if got := fakeRT.stopCount(); got != 1 {
 		t.Errorf("expected 1 Stop call (deferred teardown), got %d", got)
 	}
+}
+
+// testCrashGrace is the short grace the Stage 3b reconciliation tests configure so
+// a crash is declared (or a late status is awaited) in milliseconds, not the 5s
+// production default.
+const testCrashGrace = 50 * time.Millisecond
+
+// TestAgentRunAction_RuntimeDispatch_StatusWinsOverProcessExit is the anti-drift
+// guard under concurrency: even when the substrate process is OBSERVED to exit
+// first (runtime.Wait returns quickly with a non-zero exit), the callback status is
+// the source of truth. The status reports exit 0, so the run SUCCEEDS — the
+// process exit code is never read as the outcome, only used for crash detection.
+func TestAgentRunAction_RuntimeDispatch_StatusWinsOverProcessExit(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	// Process "finished" fast with a non-zero exit; if it were the outcome the run
+	// would fail. The status arrives and reports success.
+	fakeRT := &mockAgentRuntime{waitExitCode: 1}
+	statusStore := &mockCallbackStatusStore{exitCode: 0}
+	tokenStore := &mockTokenStore{}
+
+	act := newCrashGraceRuntimeAction(f, statusStore, tokenStore, fakeRT, testCrashGrace)
+
+	runCtx := f.newRunContext()
+	runCtx.Metadata["runtime_kind"] = model.RuntimeKindClaudeCode
+
+	if err := act.Execute(context.Background(), runCtx); err != nil {
+		t.Fatalf("expected success (callback status reports exit 0), got %v", err)
+	}
+
+	// The callback channel WAS the outcome source.
+	if got := statusStore.waitCount(); got != 1 {
+		t.Errorf("expected statusStore.WaitForStatus consulted once, got %d", got)
+	}
+	// Substrate lifecycle preserved: Launch + Stop once each. (runtime.Wait may or
+	// may not have returned before status won — both are fine and leak-free.)
+	if got := fakeRT.launchCount(); got != 1 {
+		t.Errorf("expected 1 Launch call, got %d", got)
+	}
+	if got := fakeRT.stopCount(); got != 1 {
+		t.Errorf("expected 1 Stop call (deferred teardown), got %d", got)
+	}
+	// Token still revoked exactly once.
+	if revoked := tokenStore.revokedTokenList(); len(revoked) != 1 || revoked[0] != testMintedToken {
+		t.Errorf("expected exactly 1 revoke of %q, got %v", testMintedToken, revoked)
+	}
+}
+
+// TestAgentRunAction_RuntimeDispatch_CrashWhenProcessExitsWithoutStatus proves the
+// crash-detection path (ADR §2d): the substrate process exits (runtime.Wait returns
+// fast) and NO callback status ever arrives (WaitForStatus parks on ctx). After the
+// short grace the run is declared a CRASH — an error — instead of blocking on the
+// 2h status timeout. The test also bounds the wall time to ~grace, proving it does
+// not wait 2h.
+func TestAgentRunAction_RuntimeDispatch_CrashWhenProcessExitsWithoutStatus(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	// Process exits fast (exit 1); status NEVER arrives (blocks until ctx done).
+	fakeRT := &mockAgentRuntime{waitExitCode: 1}
+	statusStore := &mockCallbackStatusStore{block: true}
+	tokenStore := &mockTokenStore{}
+
+	act := newCrashGraceRuntimeAction(f, statusStore, tokenStore, fakeRT, testCrashGrace)
+
+	runCtx := f.newRunContext()
+	runCtx.Metadata["runtime_kind"] = model.RuntimeKindClaudeCode
+
+	start := time.Now()
+	err := act.Execute(context.Background(), runCtx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a crash error when the process exits without a callback status, got nil")
+	}
+	if !strings.Contains(err.Error(), "without reporting a callback status") {
+		t.Errorf("expected a crash error message, got: %v", err)
+	}
+	// It must resolve in roughly the grace, NOT the 2h status timeout.
+	if elapsed > 5*time.Second {
+		t.Errorf("expected crash detection to resolve within the grace, took %v", elapsed)
+	}
+
+	// Substrate lifecycle preserved and token revoked despite the crash.
+	if got := fakeRT.stopCount(); got != 1 {
+		t.Errorf("expected 1 Stop call (deferred teardown), got %d", got)
+	}
+	if revoked := tokenStore.revokedTokenList(); len(revoked) != 1 || revoked[0] != testMintedToken {
+		t.Errorf("expected exactly 1 revoke of %q even on crash, got %v", testMintedToken, revoked)
+	}
+}
+
+// TestAgentRunAction_RuntimeDispatch_StatusAfterProcessExit_WithinGrace proves the
+// reverse ordering inside the grace window: the substrate process exits first, then
+// the callback status lands a moment later but BEFORE the grace elapses. The outcome
+// is the status (success), NOT a crash — the in-flight callback is honoured.
+func TestAgentRunAction_RuntimeDispatch_StatusAfterProcessExit_WithinGrace(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	// Process exits immediately; the status arrives shortly after but well within
+	// the grace (delay < grace).
+	fakeRT := &mockAgentRuntime{waitExitCode: 1}
+	statusStore := &mockCallbackStatusStore{exitCode: 0, delay: testCrashGrace / 5}
+	tokenStore := &mockTokenStore{}
+
+	act := newCrashGraceRuntimeAction(f, statusStore, tokenStore, fakeRT, testCrashGrace)
+
+	runCtx := f.newRunContext()
+	runCtx.Metadata["runtime_kind"] = model.RuntimeKindClaudeCode
+
+	if err := act.Execute(context.Background(), runCtx); err != nil {
+		t.Fatalf("expected success (status arrives within grace), got %v", err)
+	}
+
+	// The status WAS the outcome source — not a crash.
+	if got := statusStore.waitCount(); got != 1 {
+		t.Errorf("expected statusStore.WaitForStatus consulted once, got %d", got)
+	}
+	if got := fakeRT.stopCount(); got != 1 {
+		t.Errorf("expected 1 Stop call (deferred teardown), got %d", got)
+	}
+	if revoked := tokenStore.revokedTokenList(); len(revoked) != 1 || revoked[0] != testMintedToken {
+		t.Errorf("expected exactly 1 revoke of %q, got %v", testMintedToken, revoked)
+	}
+}
+
+// TestAgentRunAction_RuntimeDispatch_CleanExitWaitsForStatus proves the ADR §2d
+// exit-0 rule: a substrate process that finishes CLEANLY (exit 0) without a status
+// is NOT a crash — it is a delayed/in-flight callback. Even when the status lands
+// only AFTER the crash grace would have elapsed, the run waits for the authoritative
+// status (bounded by the 2h WaitForStatus, not the grace) and SUCCEEDS. A non-zero
+// exit on the same timing would have been declared a crash; exit 0 must not be.
+func TestAgentRunAction_RuntimeDispatch_CleanExitWaitsForStatus(t *testing.T) {
+	f := newAgentRunFixture(t)
+
+	// Process exits CLEANLY (exit 0) right away; the status arrives well AFTER the
+	// grace (3× grace) and reports success.
+	fakeRT := &mockAgentRuntime{waitExitCode: 0}
+	statusStore := &mockCallbackStatusStore{exitCode: 0, delay: testCrashGrace * 3}
+	tokenStore := &mockTokenStore{}
+
+	act := newCrashGraceRuntimeAction(f, statusStore, tokenStore, fakeRT, testCrashGrace)
+
+	runCtx := f.newRunContext()
+	runCtx.Metadata["runtime_kind"] = model.RuntimeKindClaudeCode
+
+	if err := act.Execute(context.Background(), runCtx); err != nil {
+		t.Fatalf("expected success: a clean exit-0 without a status must wait for the status, not crash; got %v", err)
+	}
+
+	// The status WAS the outcome source — waited beyond the grace, no crash.
+	if got := statusStore.waitCount(); got != 1 {
+		t.Errorf("expected statusStore.WaitForStatus consulted once, got %d", got)
+	}
+	if got := fakeRT.stopCount(); got != 1 {
+		t.Errorf("expected 1 Stop call (deferred teardown), got %d", got)
+	}
+	if revoked := tokenStore.revokedTokenList(); len(revoked) != 1 || revoked[0] != testMintedToken {
+		t.Errorf("expected exactly 1 revoke of %q, got %v", testMintedToken, revoked)
+	}
+}
+
+// newCrashGraceRuntimeAction is newCallbackRuntimeAction with an explicit short
+// CrashGrace, so the Stage 3b reconciliation tests resolve in milliseconds.
+func newCrashGraceRuntimeAction(
+	f *agentRunFixture,
+	statusStore port.CallbackStatusStore,
+	tokenStore port.ContainerTokenStore,
+	rt port.AgentRuntime,
+	crashGrace time.Duration,
+) *action.AgentRunAction {
+	agentCfg := action.AgentConfig{
+		DefaultMemory: 4294967296,
+		DefaultCPUs:   2.0,
+		NetworkName:   testNetwork,
+		LogTailLines:  50,
+		CrashGrace:    crashGrace,
+	}
+	return action.NewAgentRunAction(
+		f.containerMgr,
+		f.logStreamer,
+		f.eventPub,
+		f.storyRepo,
+		f.projectRepo,
+		f.runRepo,
+		f.environmentRepo,
+		f.sidecarMgr,
+		f.stackRepo,
+		&mockTemplateRenderer{},
+		f.costSvc,
+		agentCfg,
+		testLogger(),
+		nil, // apiKeySvc — not needed: fixture runCtx has no UserID
+		tokenStore,
+		statusStore,
+		"http://callback",
+		action.WithAgentRuntime(rt),
+	)
 }
 
 // newRuntimeAction builds an AgentRunAction from the fixture's mocks plus the


### PR DESCRIPTION
## Stage 3b — Crash reconciliation (substrate ADR §2d)

Completes Stage 3. On the substrate path (`executeViaRuntime`, callback mode), the Action now watches the substrate process via `runtime.Wait` **concurrently** with the authoritative callback status, so a crash surfaces in seconds instead of blocking the 2h status timeout.

### Behaviour
- `awaitCallbackOrCrash`: races `statusStore.WaitForStatus` (authoritative outcome) against `runtime.Wait` (crash detection only). The callback is **always** the source of truth — the process exit code never decides the outcome, only triggers detection.
- **ADR §2d fidelity**: a crash is declared only for a **non-zero** process exit without a status (within a short grace). A **clean exit (0) without a status** is treated as a delayed/in-flight callback and keeps waiting on the authoritative status (bounded by the 2h `WaitForStatus`) — never a false crash on a clean exit.
- The legacy path (`runtime==nil`) keeps `waitForCallback` unchanged. Revoke + outcome handling factored into shared `revokeCallbackToken` / `finishCallbackStatus`.
- `AgentConfig.CrashGrace` (0 → 5s default) makes the grace tunable/testable.

### Concurrency correctness
- Buffered (cap 1) channels + deferred `cancelStatus`/`cancelWait` → **no goroutine leak** on any path; the `runtime.Wait` goroutine unblocks via its context cancel or the deferred `runtime.Stop`.
- Grace uses a `context.WithTimeout` (cleaned by `defer`, no leaked timer) + a **final non-blocking `statusCh` check** before declaring a crash — closes the select race where a buffered status could be lost to the timeout.
- `go test -race -count=3` green.

### Tests
- `StatusWinsOverProcessExit`: process exits 1, callback says 0 → run succeeds (anti-drift under concurrency).
- `CrashWhenProcessExitsWithoutStatus`: process exits 1, status never arrives → crash error in ~grace (not 2h).
- `StatusAfterProcessExit_WithinGrace`: status lands within the grace → honoured, no crash.
- `CleanExitWaitsForStatus`: process exits 0, status arrives *after* the grace → success, **no false crash**.
- Golden + all Stage 2/3a tests stay green.

### Adversarial review applied
Targeted concurrency review (3 dims × verify) caught the select-grace race and the exit-0-vs-§2d deviation — both fixed here. Plus timer-leak, Wait+Stop-safety doc, and mock lock-hygiene.

### Definition of Done
Back + tests (+ `-race`) + lint ✅. openapi/front/Playwright/docs — **N/A**: internal outcome logic; a crash surfaces as a step error exactly as before, just faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)