### PR TITLE
feat(run): cancel stops via port.AgentRuntime; document Docker-bound reaping (substrate ADR Stage 4)

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -360,6 +360,7 @@ func run() error {
 	runService := service.NewRunService(runRepo, projectRepo, storyRepo, pipelineConfigRepo, jobQueue, eventRepo)
 	if containerMgr != nil {
 		runService.SetContainerManager(containerMgr)
+		runService.SetAgentRuntime(agentRuntime)
 	}
 	runService.SetAgentRepo(agentRepo)
 	runService.SetStackRepo(stackRepo)

--- a/backend/internal/domain/service/orphan_cleaner.go
+++ b/backend/internal/domain/service/orphan_cleaner.go
@@ -31,6 +31,16 @@ func NewOrphanCleaner(
 	}
 }
 
+// Substrate scope (ADR Stage 4): this reaper is Docker-shaped — it lists managed
+// executions via ContainerManager.ListContainers(managed_by=hopeitworks) and reads
+// the run_id label. DockerRuntime.Launch preserves those labels and persists the
+// real container id, so the Docker reaping contract holds through the substrate
+// dispatch with zero change. Reaping a NON-Docker substrate (listing managed
+// microVMs/pods) needs a runtime-level "list managed executions" capability and is
+// DEFERRED until a non-Docker substrate ships live (ADR Stage 4 / Decision §7#4).
+// CancelRun already stops via port.AgentRuntime (substrate-correct); orphan/timeout
+// listing remains Docker-bound for now.
+//
 // CleanupOrphans removes containers not associated with active runs.
 // A container is considered an orphan if:
 //   - It has no run_id label

--- a/backend/internal/domain/service/orphan_cleaner_test.go
+++ b/backend/internal/domain/service/orphan_cleaner_test.go
@@ -2,9 +2,11 @@ package service
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
+	dockeradapter "github.com/zakari/hopeitworks/backend/internal/adapter/docker"
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
 	"github.com/zakari/hopeitworks/backend/internal/domain/port"
 	"github.com/zakari/hopeitworks/backend/pkg/errors"
@@ -259,5 +261,157 @@ func TestCleanupOrphans_ListContainersError(t *testing.T) {
 	err := cleaner.CleanupOrphans(context.Background())
 	if err == nil {
 		t.Fatal("expected error when ListContainers fails, got nil")
+	}
+}
+
+// reapableCM is a stateful fake port.ContainerManager that records containers on
+// Create (with the labels stamped by the caller) and filters them on
+// ListContainers / Remove. It is the shared substrate the contract test uses to
+// prove that a container launched through docker.Runtime is later reapable by
+// OrphanCleaner — the labels round-trip end-to-end, no special-casing.
+type reapableCM struct {
+	mu         sync.Mutex
+	seq        int
+	containers map[string]map[string]string // id -> labels
+	removed    []string
+}
+
+func newReapableCM() *reapableCM {
+	return &reapableCM{containers: map[string]map[string]string{}}
+}
+
+func (c *reapableCM) Create(_ context.Context, opts model.ContainerOpts) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.seq++
+	id := uuid.NewString()
+	labels := make(map[string]string, len(opts.Labels))
+	for k, v := range opts.Labels {
+		labels[k] = v
+	}
+	c.containers[id] = labels
+	return id, nil
+}
+
+func (c *reapableCM) Start(_ context.Context, _ string) error { return nil }
+
+func (c *reapableCM) Stop(_ context.Context, _ string) error { return nil }
+
+func (c *reapableCM) Remove(_ context.Context, containerID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.removed = append(c.removed, containerID)
+	delete(c.containers, containerID)
+	return nil
+}
+
+func (c *reapableCM) Wait(_ context.Context, _ string) (int, error) { return 0, nil }
+
+func (c *reapableCM) ListContainers(_ context.Context, filter map[string]string) ([]port.ContainerInfo, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []port.ContainerInfo
+	for id, labels := range c.containers {
+		if labelsMatch(labels, filter) {
+			out = append(out, port.ContainerInfo{ID: id, Labels: labels})
+		}
+	}
+	return out, nil
+}
+
+func (c *reapableCM) ListRunningContainers(_ context.Context, _ map[string]string) ([]port.ContainerInfo, error) {
+	return nil, nil
+}
+
+func (c *reapableCM) CreateNetwork(_ context.Context, _ string, _ map[string]string) (string, error) {
+	return "", nil
+}
+func (c *reapableCM) RemoveNetwork(_ context.Context, _ string) error { return nil }
+func (c *reapableCM) ConnectContainer(_ context.Context, _, _ string, _ []string) error {
+	return nil
+}
+func (c *reapableCM) ListNetworks(_ context.Context, _ map[string]string) ([]model.NetworkInfo, error) {
+	return nil, nil
+}
+func (c *reapableCM) InspectHealth(_ context.Context, _ string) (string, error) {
+	return model.HealthRunning, nil
+}
+
+func (c *reapableCM) getRemoved() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.removed))
+	copy(out, c.removed)
+	return out
+}
+
+// labelsMatch reports whether every key/value in filter is present in labels.
+func labelsMatch(labels, filter map[string]string) bool {
+	for k, v := range filter {
+		if labels[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// TestOrphanCleaner_FindsContainerLaunchedViaDockerRuntime proves the reaper
+// contract end-to-end: a container launched through docker.Runtime.Launch carries
+// the managed_by/run_id labels (stamped via RunSpec.Labels), so OrphanCleaner finds
+// and removes it when its run_id is unknown (orphan) — and leaves it alone when the
+// run is active. This is the substrate-dispatch proof: the Docker reaping contract
+// holds through the port with zero special-casing.
+func TestOrphanCleaner_FindsContainerLaunchedViaDockerRuntime(t *testing.T) {
+	orphanRunID := uuid.New()
+	activeRunID := uuid.New()
+	stepID := uuid.New()
+
+	cm := newReapableCM()
+	rt := dockeradapter.NewRuntime(cm, "agent-net", discardLogger())
+
+	// Labels mirror buildAgentLabels: managed_by + run/step/story identity.
+	launch := func(runID uuid.UUID) port.RunHandle {
+		h, err := rt.Launch(context.Background(), port.RunSpec{
+			Image: "img",
+			Labels: map[string]string{
+				"managed_by": "hopeitworks",
+				"run_id":     runID.String(),
+				"step_id":    stepID.String(),
+				"story_key":  "S-1",
+			},
+		})
+		if err != nil {
+			t.Fatalf("launch via docker.Runtime failed: %v", err)
+		}
+		return h
+	}
+
+	orphanHandle := launch(orphanRunID)
+	activeHandle := launch(activeRunID)
+
+	runRepo := &mockRunRepo{
+		getRunFn: func(_ context.Context, id uuid.UUID) (*model.Run, error) {
+			if id == activeRunID {
+				return &model.Run{ID: activeRunID, Status: model.RunStatusRunning}, nil
+			}
+			// orphanRunID (and anything else) is unknown → orphan.
+			return nil, errors.NewNotFound("run", id)
+		},
+	}
+
+	cleaner := NewOrphanCleaner(cm, runRepo, discardLogger())
+	if err := cleaner.CleanupOrphans(context.Background()); err != nil {
+		t.Fatalf("CleanupOrphans returned error: %v", err)
+	}
+
+	removed := cm.getRemoved()
+	if len(removed) != 1 {
+		t.Fatalf("expected exactly 1 reaped container (the orphan), got %d: %v", len(removed), removed)
+	}
+	if removed[0] != orphanHandle.ID {
+		t.Errorf("expected orphan container %q reaped, got %q", orphanHandle.ID, removed[0])
+	}
+	if removed[0] == activeHandle.ID {
+		t.Errorf("active-run container %q must NOT be reaped", activeHandle.ID)
 	}
 }

--- a/backend/internal/domain/service/run_service.go
+++ b/backend/internal/domain/service/run_service.go
@@ -22,6 +22,7 @@ type RunService struct {
 	jobQueue           port.JobQueue
 	eventPub           port.EventPublisher
 	containerMgr       port.ContainerManager
+	agentRuntime       port.AgentRuntime
 	agentRepo          port.AgentRepository
 	stackRepo          port.StackRepository
 }
@@ -52,6 +53,13 @@ func NewRunService(
 func (s *RunService) SetContainerManager(cm port.ContainerManager) {
 	s.containerMgr = cm
 }
+
+// SetAgentRuntime configures the execution substrate used to stop a step's
+// execution on cancel. When set, CancelRun stops via port.AgentRuntime (handle =
+// the persisted run_steps.container_id), making cancellation substrate-correct
+// for any adapter (Docker today, microsandbox later). nil falls back to the raw
+// ContainerManager (Docker), preserving back-compat.
+func (s *RunService) SetAgentRuntime(rt port.AgentRuntime) { s.agentRuntime = rt }
 
 // SetAgentRepo configures the agent repository for agent resolution at run launch.
 func (s *RunService) SetAgentRepo(repo port.AgentRepository) {
@@ -659,10 +667,9 @@ func (s *RunService) CancelRun(ctx context.Context, projectID, runID uuid.UUID) 
 	for _, step := range steps {
 		switch step.Status {
 		case model.StepStatusRunning, model.StepStatusWaitingApproval:
-			// Stop the container if one is running
-			if s.containerMgr != nil && step.ContainerID != nil && *step.ContainerID != "" {
-				_ = s.containerMgr.Stop(ctx, *step.ContainerID)
-			}
+			// Stop the live execution if one is running (substrate-correct: prefers
+			// the runtime adapter, falls back to the raw ContainerManager).
+			s.stopStepExecution(ctx, step.ContainerID)
 			if _, err := s.runRepo.UpdateRunStepStatus(ctx, step.ID, model.StepStatusCancelled, nil, &now, &cancelMsg); err != nil {
 				return nil, err
 			}
@@ -691,6 +698,24 @@ func (s *RunService) CancelRun(ctx context.Context, projectID, runID uuid.UUID) 
 	s.transitionStoryToBacklog(ctx, updated)
 
 	return updated, nil
+}
+
+// stopStepExecution stops a step's live execution by its persisted handle. It
+// prefers the substrate runtime (substrate-correct: a microVM handle is torn down
+// via its adapter, not the Docker daemon), falling back to the raw ContainerManager
+// when no runtime is configured. Best-effort: errors are swallowed (cancel must not
+// fail because teardown raced the natural exit).
+func (s *RunService) stopStepExecution(ctx context.Context, containerID *string) {
+	if containerID == nil || *containerID == "" {
+		return
+	}
+	if s.agentRuntime != nil {
+		_ = s.agentRuntime.Stop(ctx, port.RunHandle{ID: *containerID})
+		return
+	}
+	if s.containerMgr != nil {
+		_ = s.containerMgr.Stop(ctx, *containerID)
+	}
 }
 
 // transitionStoryToBacklog resets the run's story to backlog and publishes a

--- a/backend/internal/domain/service/run_service_test.go
+++ b/backend/internal/domain/service/run_service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
 	"github.com/zakari/hopeitworks/backend/pkg/errors"
 )
 
@@ -2201,6 +2202,129 @@ func TestCancelRun_ResetsStoryToBacklog(t *testing.T) {
 	}
 	if !foundStoryBacklog {
 		t.Error("expected story.status_updated event with status backlog")
+	}
+}
+
+// mockAgentRuntime is a minimal port.AgentRuntime recording Stop handles. Only Stop
+// is exercised by CancelRun; the other methods satisfy the interface and are no-ops.
+type mockAgentRuntime struct {
+	stopHandles []port.RunHandle
+}
+
+func (m *mockAgentRuntime) Provision(_ context.Context, _ model.CapabilitySpec) (model.ProvisionResult, error) {
+	return model.ProvisionResult{}, nil
+}
+
+func (m *mockAgentRuntime) Launch(_ context.Context, _ port.RunSpec) (port.RunHandle, error) {
+	return port.RunHandle{}, nil
+}
+
+func (m *mockAgentRuntime) Wait(_ context.Context, _ port.RunHandle) (port.RunResult, error) {
+	return port.RunResult{}, nil
+}
+
+func (m *mockAgentRuntime) Stop(_ context.Context, h port.RunHandle) error {
+	m.stopHandles = append(m.stopHandles, h)
+	return nil
+}
+
+func (m *mockAgentRuntime) SupportedCapabilities() model.CapabilitySet {
+	return model.CapabilitySet{}
+}
+
+// TestCancelRun_StopsViaAgentRuntime asserts that, when an AgentRuntime is wired,
+// CancelRun stops the running step's execution through the runtime port (handle =
+// the persisted container_id) and does NOT touch the raw ContainerManager.
+func TestCancelRun_StopsViaAgentRuntime(t *testing.T) {
+	projectID := uuid.New()
+	runID := uuid.New()
+
+	containerID := "cid-1"
+	runRepo := &mockRunRepo{
+		getRunFn: func(_ context.Context, id uuid.UUID) (*model.Run, error) {
+			return &model.Run{ID: id, ProjectID: projectID, Status: model.RunStatusRunning}, nil
+		},
+		listRunStepsByRunFn: func(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+			return []*model.RunStep{
+				{ID: uuid.New(), Status: model.StepStatusRunning, ContainerID: &containerID},
+			}, nil
+		},
+		updateRunStepStatusFn: func(_ context.Context, id uuid.UUID, status model.StepStatus, _, _ *time.Time, _ *string) (*model.RunStep, error) {
+			return &model.RunStep{ID: id, Status: status}, nil
+		},
+		updateRunStatusFn: func(_ context.Context, id uuid.UUID, status model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
+			return &model.Run{ID: id, ProjectID: projectID, Status: status}, nil
+		},
+	}
+
+	mockRT := &mockAgentRuntime{}
+	containerMgr := &mockContainerManager{}
+
+	svc := newRunServiceForTest(runRepo, newMockProjectRepoForService())
+	// Wire BOTH: the runtime must win over the raw ContainerManager.
+	svc.SetContainerManager(containerMgr)
+	svc.SetAgentRuntime(mockRT)
+
+	result, err := svc.CancelRun(context.Background(), projectID, runID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Status != model.RunStatusCancelled {
+		t.Errorf("expected status cancelled, got %s", result.Status)
+	}
+
+	if len(mockRT.stopHandles) != 1 {
+		t.Fatalf("expected 1 runtime Stop call, got %d", len(mockRT.stopHandles))
+	}
+	if got := mockRT.stopHandles[0]; got != (port.RunHandle{ID: containerID}) {
+		t.Errorf("expected runtime Stop with handle %q, got %+v", containerID, got)
+	}
+	if calls := containerMgr.getStopCalls(); len(calls) != 0 {
+		t.Errorf("expected ContainerManager.Stop NOT called when runtime is present, got %d calls", len(calls))
+	}
+}
+
+// TestCancelRun_FallsBackToContainerManager asserts that, with no AgentRuntime
+// configured, CancelRun stops the running step through the raw ContainerManager
+// (Docker back-compat).
+func TestCancelRun_FallsBackToContainerManager(t *testing.T) {
+	projectID := uuid.New()
+	runID := uuid.New()
+
+	containerID := "cid-1"
+	runRepo := &mockRunRepo{
+		getRunFn: func(_ context.Context, id uuid.UUID) (*model.Run, error) {
+			return &model.Run{ID: id, ProjectID: projectID, Status: model.RunStatusRunning}, nil
+		},
+		listRunStepsByRunFn: func(_ context.Context, _ uuid.UUID) ([]*model.RunStep, error) {
+			return []*model.RunStep{
+				{ID: uuid.New(), Status: model.StepStatusRunning, ContainerID: &containerID},
+			}, nil
+		},
+		updateRunStepStatusFn: func(_ context.Context, id uuid.UUID, status model.StepStatus, _, _ *time.Time, _ *string) (*model.RunStep, error) {
+			return &model.RunStep{ID: id, Status: status}, nil
+		},
+		updateRunStatusFn: func(_ context.Context, id uuid.UUID, status model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
+			return &model.Run{ID: id, ProjectID: projectID, Status: status}, nil
+		},
+	}
+
+	containerMgr := &mockContainerManager{}
+
+	svc := newRunServiceForTest(runRepo, newMockProjectRepoForService())
+	svc.SetContainerManager(containerMgr) // no runtime → fallback
+
+	result, err := svc.CancelRun(context.Background(), projectID, runID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Status != model.RunStatusCancelled {
+		t.Errorf("expected status cancelled, got %s", result.Status)
+	}
+
+	calls := containerMgr.getStopCalls()
+	if len(calls) != 1 || calls[0] != containerID {
+		t.Errorf("expected ContainerManager.Stop(%q) once, got %v", containerID, calls)
 	}
 }
 

--- a/backend/internal/domain/service/timeout_enforcer.go
+++ b/backend/internal/domain/service/timeout_enforcer.go
@@ -71,6 +71,16 @@ func (t *TimeoutEnforcer) Start(ctx context.Context) error {
 	}
 }
 
+// Substrate scope (ADR Stage 4): this reaper is Docker-shaped — it lists managed
+// executions via ContainerManager.ListContainers(managed_by=hopeitworks) and reads
+// the run_id label. DockerRuntime.Launch preserves those labels and persists the
+// real container id, so the Docker reaping contract holds through the substrate
+// dispatch with zero change. Reaping a NON-Docker substrate (listing managed
+// microVMs/pods) needs a runtime-level "list managed executions" capability and is
+// DEFERRED until a non-Docker substrate ships live (ADR Stage 4 / Decision §7#4).
+// CancelRun already stops via port.AgentRuntime (substrate-correct); orphan/timeout
+// listing remains Docker-bound for now.
+//
 // CheckTimeouts iterates active containers and enforces timeouts.
 // Containers that have run longer than their allowed timeout are stopped,
 // and their associated run steps and runs are marked as failed.


### PR DESCRIPTION
## Stage 4 — Reapers substrate-aware (conservative) (substrate ADR)

Per the ADR, Docker-only reaping needs **zero change** (the contract already holds); non-Docker reaping is deferred until a non-Docker substrate ships live. This stage makes the user-facing cancel path substrate-correct and proves + documents the contract.

### What lands
- **`CancelRun` stops via `port.AgentRuntime`.** New `RunService.agentRuntime` + `SetAgentRuntime`; `CancelRun` calls `stopStepExecution(step.ContainerID)` which prefers `runtime.Stop(RunHandle{ID})` (substrate-correct — a microVM handle is torn down via its adapter), **falling back** to the raw `ContainerManager.Stop` when no runtime is wired (back-compat). `main.go` wires the same `agentRuntime` (DockerRuntime by default) into the run service.
- **Reaping stays Docker-bound, documented.** `CleanupOrphans` / `CheckTimeouts` keep listing via `ContainerManager.ListContainers(managed_by)` + the `run_id` label — which `DockerRuntime.Launch` preserves, so the Docker reaping contract holds through the substrate dispatch unchanged. A comment on each documents that non-Docker listing (a runtime-level "list managed executions") is **deferred** until a non-Docker substrate ships (ADR Stage 4 / Decision §7#4).

### The reaper contract, proven end-to-end
`TestOrphanCleaner_FindsContainerLaunchedViaDockerRuntime`: launches a container *through* `docker.Runtime.Launch` against a shared fake `ContainerManager`, then runs `OrphanCleaner` over the same fake — the orphan (run-not-found) is found by its `managed_by` label and reaped, while an active-run container is spared. This proves the labels stamped by `DockerRuntime.Launch` keep executions reapable.
- `TestCancelRun_StopsViaAgentRuntime` / `TestCancelRun_FallsBackToContainerManager` cover the routing + fallback.

### Verification
`golangci-lint` exit 0; `go build`/`vet`/`go test ./... -short` green; golden untouched & green.

### Definition of Done
Back + tests + lint ✅. openapi/front/Playwright/docs — **N/A**: internal teardown/reaping; `CancelRun` is the same endpoint with the same observable behaviour (run→cancelled, step→cancelled, story→backlog), only the teardown mechanism becomes substrate-correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)