### PR TITLE
docs(substrate): ADR accepted + migration status; microsandbox as prod policy (substrate ADR Stage 5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,11 +120,16 @@ Devcontainer = code-only. Deux Docker stacks sur le même daemon :
 
 ### Substrat microsandbox (microVM) — Mac → VM Lima
 
-Le substrat agent par défaut est **Docker** (`SUBSTRATE=docker`, tourne partout). Le substrat
-durci **microsandbox** (microVM libkrun) est **Linux/KVM-only** : il a besoin de `/dev/kvm` et
-**Docker Desktop sur macOS ne l'expose pas aux conteneurs** (pas de nested-virt passthrough).
-Sur Mac, on le fait donc tourner dans une **VM Linux Lima** avec virtu imbriquée (Apple **M3+ /
-macOS 15+**) :
+Le **défaut code/CI est Docker** (`SUBSTRATE=docker`, tourne partout). Depuis la migration
+substrate-abstraction (ADR `docs/agent-substrate-abstraction-adr.md`), `agent_run` exécute **via
+`port.AgentRuntime`** : Docker est un adapter derrière le port, égal à microsandbox/exec. **En prod
+le substrat-policy est microsandbox** (`deploy/docker-compose.microsandbox.yml`, `SUBSTRATE=microsandbox`)
+— l'agent tourne dans un microVM durci ; `SUBSTRATE` est désormais **live-wired** (sélectionner
+microsandbox injecte vraiment l'adapter microVM ; sans `-tags microsandbox`, `Launch` renvoie
+`ErrNotBuilt` et le run échoue clairement). Le substrat durci **microsandbox** (microVM libkrun) est
+**Linux/KVM-only** : il a besoin de `/dev/kvm` et **Docker Desktop sur macOS ne l'expose pas aux
+conteneurs** (pas de nested-virt passthrough). Sur Mac, on le fait donc tourner dans une **VM Linux
+Lima** avec virtu imbriquée (Apple **M3+ / macOS 15+**) :
 
 ```bash
 brew install lima

--- a/deploy/docker-compose.microsandbox.yml
+++ b/deploy/docker-compose.microsandbox.yml
@@ -1,5 +1,7 @@
 # docker-compose.microsandbox.yml — overlay that switches the api service to the
-# microVM (microsandbox) substrate. Compose it ON TOP of the base stack:
+# microVM (microsandbox) substrate. This overlay IS the production-policy substrate
+# (ADR "agent substrate abstraction", Decision §7#3): in prod the agent runs in a
+# hardened microVM. Compose it ON TOP of the base stack:
 #
 #   docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.microsandbox.yml up api
 #
@@ -11,15 +13,22 @@
 # REQUIREMENTS: the Docker HOST must expose /dev/kvm (bare-metal Linux with KVM,
 # or a nested-virt VM — see deploy/lima/microsandbox-vm.yaml). Docker Desktop on
 # macOS does NOT pass /dev/kvm through; run this from inside the Lima VM instead.
+#
+# The plain Docker substrate (base stack, SUBSTRATE=docker) stays the dev/CI
+# default — it runs anywhere without KVM. microsandbox is the prod policy, NOT a
+# hard-coded special case: every substrate is equal behind port.AgentRuntime and
+# the live one is chosen by SUBSTRATE.
 services:
   api:
     build:
       context: ../backend
       dockerfile: Dockerfile.microsandbox
     environment:
-      # Select the microVM substrate. The adapter is constructed; live agent_run
-      # still uses Docker until the P3c migration (this overlay does not change
-      # that), but SUBSTRATE drives selectSubstrate + the future wiring.
+      # Select the microVM substrate. As of the substrate-abstraction migration
+      # this is LIVE: SUBSTRATE=microsandbox injects the microsandbox adapter into
+      # agent_run via port.AgentRuntime, so the agent actually runs in a microVM.
+      # (A binary built without `-tags microsandbox` returns ErrNotBuilt at Launch
+      # and fails the run clearly instead of silently falling back to Docker.)
       SUBSTRATE: microsandbox
     # /dev/kvm is the load-bearing line: libkrun needs the KVM device node.
     devices:

--- a/docs/agent-substrate-abstraction-adr.md
+++ b/docs/agent-substrate-abstraction-adr.md
@@ -1,12 +1,30 @@
 # ADR — Agent substrate abstraction: `port.AgentRuntime` as the one execution path, Docker as an adapter
 
-- **Status:** Proposed
-- **Date:** 2026-06-23
+- **Status:** Accepted — implemented. Stages 0–4 merged to `develop`; Stage 5 landed as policy + audit only (the legacy Docker log-stream retirement stays deferred, telemetry-gated — see Migration status).
+- **Date:** 2026-06-23 (accepted 2026-06-24)
 - **Deciders:** runtime/platform
 - **Supersedes for the runtime layer:** the incremental "branch-beside-Docker" approach prototyped in the `p3c` worktree (`.claude/worktrees/p3c/backend/internal/adapter/action/agent_run_substrate.go`).
 - **Builds on:** `docs/agent-runtime-capabilities-plan.md` (port generalisation §1.2, substrate-per-context §12–14, image-substring kill §1.3).
 
 > Convention note: `docs/` has no formal ADR directory or numbering scheme (flat `*.md`, plan/research files). This ADR follows that flat convention rather than inventing an `adr/NNNN-` tree.
+
+---
+
+## Migration status (as built)
+
+The staged migration of §4 is implemented on `develop`. Where the as-built result deviates from the original plan it is because of an explicit decision (recorded in §7) or an environment gate (no live non-Docker substrate / no KVM in CI / no telemetry feed here):
+
+| Stage | What landed | Notes |
+|---|---|---|
+| **0** | `buildAgentEnv` / `buildAgentLabels` extracted from `createContainer` | pure refactor; golden byte-identical |
+| **1** | `docker.Runtime` implements `port.AgentRuntime` (off the live path) + additive `RunSpec` fields (`Memory`/`CPUs`/`Network`/`Entrypoint`/`Cmd`/`Workdir`) | own docker-package golden |
+| **2** | `Execute` dispatches via the port; `main.go` injects `docker.Runtime` by default (`WithAgentRuntime`); legacy direct path kept as the nil-fallback | anti-drift test proves the callback (not `runtime.Wait`) is the outcome source — **not** the rejected P3c fork |
+| **3a** | token mint hoisted into the Action (minted once, all substrates); **dead revoke fixed** (revokes the real token on every exit path); provider-real `cost_usd` over the callback with the pricing table as fallback; **prompt audit** on the agnostic Postgres event bus | `CallbackSpec` added to `RunSpec` |
+| **3b** | crash reconciliation: `runtime.Wait` watched concurrently for crash detection; a **non-zero** process exit without a callback status (within a short grace) becomes a crash error instead of blocking the 2h timeout (§2d) | leak-free (buffered channels + deferred cancels), `-race` clean |
+| **4** | `CancelRun` stops via `port.AgentRuntime` (handle = persisted `container_id`), falling back to `ContainerManager`; Docker reaping contract proven end-to-end | **non-Docker reaping (listing managed microVMs/pods) is DEFERRED** until a non-Docker substrate ships live — it needs a runtime-level "list managed executions" capability the port does not yet have (Decision §7#4) |
+| **5** | microsandbox declared the **production-policy** substrate (`deploy/docker-compose.microsandbox.yml`, `SUBSTRATE=microsandbox`); docker stays the **dev/CI code default** | the Docker-specific log-stream retirement (drop `streamAndWait` / NDJSON cost / image-substring fallback) is **DEFERRED, telemetry-gated**: it must not land until telemetry confirms no `runtime_kind==""` runs remain. The prompt + logs are already audit-safe via the callback path (3a), so audit will survive that retirement when it happens. The microsandbox **default cannot be exercised in CI** (no KVM) — it is a deploy policy, validated in the Lima VM (`deploy/lima/`), not the code/CI default. |
+
+**Net:** `port.AgentRuntime` is the one execution path; Docker is an adapter behind it, equal to `exec`/microsandbox and a future K8s/OpenShift adapter (P4). microsandbox is the prod policy, selected by `SUBSTRATE` — never hard-coded in `agent_run`.
 
 ---
 


### PR DESCRIPTION
## Stage 5 — microsandbox prod policy + ADR acceptance (conservative)

Final stage of `docs/agent-substrate-abstraction-adr.md`, scoped per decision to **policy + docs only** — no Go code change.

### What lands
- **microsandbox is the production-policy substrate.** `deploy/docker-compose.microsandbox.yml` is documented as *the* prod substrate overlay (`SUBSTRATE=microsandbox`, hardened microVM); plain Docker stays the **dev/CI code default** (runs anywhere, no KVM). The substrate is chosen by `SUBSTRATE`, never hard-coded in `agent_run`.
- **Refreshed now-stale comments**: the microsandbox overlay said *"live agent_run still uses Docker until the P3c migration"* — false since Stage 2. It now states `SUBSTRATE=microsandbox` is **live-wired** (injects the microVM adapter; `ErrNotBuilt` without `-tags microsandbox`). `CLAUDE.md` updated likewise.
- **ADR → Accepted** with a **Migration status** table: Stages 0–4 merged; Stage 5 = policy + audit only.

### Explicitly deferred (telemetry / environment-gated)
- The Docker-specific **log-stream retirement** (`streamAndWait` / NDJSON cost / image-substring fallback) stays until telemetry confirms no `runtime_kind==""` runs remain. Prompt + logs are already audit-safe via the callback path (Stage 3a), so audit survives that retirement when it lands.
- The microsandbox default **cannot be exercised in CI** (no KVM) — it's a deploy policy, validated in the Lima VM (`deploy/lima/`).
- Full **non-Docker reaping** (listing managed microVMs) awaits a live non-Docker substrate (Stage 4 note).

### Definition of Done
Docs/config only — **no backend/front/API/test change**, nothing to lint or regenerate. The substrate migration's code (Stages 0–4) shipped under their own PRs with golden + tests + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)