### PR TITLE
feat(git): GitHub API adapter via go-github — drop gh CLI dependency for git ops

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/go-chi/cors v1.2.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
+	github.com/google/go-github/v66 v66.0.0
 	github.com/google/uuid v1.6.0
 	github.com/google/wire v0.7.0
 	github.com/jackc/pgx/v5 v5.8.0
@@ -60,6 +61,7 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/google/cel-go v0.26.1 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.8 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -114,10 +114,15 @@ github.com/google/cel-go v0.26.1/go.mod h1:A9O8OU9rdvrK5MQyrqfIxo1a0u4g3sF8KB6PU
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-github/v66 v66.0.0 h1:ADJsaXj9UotwdgK8/iFZtv7MLc8E8WBl62WLd/D/9+M=
+github.com/google/go-github/v66 v66.0.0/go.mod h1:+4SO9Zkuyf8ytMj0csN1NR/5OTR+MfqPp8P8dVlcvY4=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=

--- a/backend/internal/adapter/git/github_api_adapter.go
+++ b/backend/internal/adapter/git/github_api_adapter.go
@@ -1,0 +1,543 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-github/v66/github"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// checkStatusQueued and checkStatusInProgress are the GitHub check-run statuses
+// that map to a pending CI state. conclusionTimedOut and conclusionActionRequired
+// are the non-failure conclusions that we still treat as a CI failure, matching
+// the gh-CLI adapter behaviour exactly.
+const (
+	checkStatusQueued        = "queued"
+	checkStatusInProgress    = "in_progress"
+	conclusionTimedOut       = "timed_out"
+	conclusionActionRequired = "action_required"
+
+	mergeMethodSquash = "squash"
+)
+
+// Compile-time check that GitHubAPIAdapter implements GitProvider.
+var _ port.GitProvider = (*GitHubAPIAdapter)(nil)
+
+// GitHubAPIAdapter implements GitProvider using the GitHub REST API via
+// google/go-github and a personal access token. It removes the dependency on
+// the `gh` CLI for all API operations (branch/PR/CI/diff). Local git operations
+// (clone/branch/commit/push) still shell out to plain `git` via the
+// CommandRunner — `git` is available everywhere, unlike `gh`.
+//
+//nolint:revive // "GitHub" prefix is the provider name (mirrors GhCliAdapter/GiteaAPIAdapter), not package stutter.
+type GitHubAPIAdapter struct {
+	client *github.Client
+	token  string
+	runner port.CommandRunner
+	logger *slog.Logger
+}
+
+// NewGitHubAPIAdapter creates a GitHubAPIAdapter.
+//
+// baseURL is optional: when non-empty it overrides the GitHub API base URL
+// (used by tests pointing at an httptest.Server). When empty, the default
+// public GitHub API endpoint is used.
+// token is the GitHub personal access token used for both API auth and
+// authenticated git clone (injected into the clone URL).
+func NewGitHubAPIAdapter(baseURL, token string, runner port.CommandRunner, logger *slog.Logger) *GitHubAPIAdapter {
+	client := github.NewClient(nil).WithAuthToken(token)
+	if baseURL != "" {
+		normalized := baseURL
+		if !strings.HasSuffix(normalized, "/") {
+			normalized += "/"
+		}
+		if parsed, err := url.Parse(normalized); err == nil {
+			client.BaseURL = parsed
+		}
+	}
+	return &GitHubAPIAdapter{
+		client: client,
+		token:  token,
+		runner: runner,
+		logger: logger,
+	}
+}
+
+// CloneRepo clones a repository using plain `git` with the token injected into
+// the URL (https://{token}@host/...). It does NOT use `gh repo clone`.
+func (a *GitHubAPIAdapter) CloneRepo(ctx context.Context, repoURL string, targetDir string) error {
+	a.logger.DebugContext(ctx, "cloning repository via git",
+		"repo_url", repoURL,
+		"target_dir", targetDir,
+	)
+
+	cloneURL := repoURL
+	if a.token != "" {
+		injected, err := injectTokenInURL(repoURL, a.token)
+		if err != nil {
+			return errors.NewDomainError(
+				errors.ErrCodeGitOperationFailed,
+				fmt.Sprintf("failed to build clone URL: %v", err),
+				map[string]any{"repo_url": repoURL},
+			)
+		}
+		cloneURL = injected
+	}
+
+	if _, err := a.runner.Run(ctx, "", "git", "clone", cloneURL, targetDir); err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to clone repository %s: %v", repoURL, err),
+			map[string]any{"repo_url": repoURL, "target_dir": targetDir},
+		)
+	}
+	return nil
+}
+
+// CreateBranch creates and checks out a new branch in the given working
+// directory using plain `git`.
+func (a *GitHubAPIAdapter) CreateBranch(ctx context.Context, workDir string, branchName string) error {
+	if !branchNamePattern.MatchString(branchName) {
+		return errors.NewDomainError(
+			errors.ErrCodeInvalidInput,
+			fmt.Sprintf("invalid branch name format: %s (expected feat/{story-key}-{slug} or fix/{story-key}-{slug})", branchName),
+			map[string]any{"branch_name": branchName},
+		)
+	}
+
+	a.logger.DebugContext(ctx, "creating branch",
+		"work_dir", workDir,
+		"branch_name", branchName,
+	)
+
+	if _, err := a.runner.Run(ctx, workDir, "git", "checkout", "-b", branchName); err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to create branch %s: %v", branchName, err),
+			map[string]any{"branch_name": branchName, "work_dir": workDir},
+		)
+	}
+	return nil
+}
+
+// Push stages all changes, commits with the given message, and pushes to origin
+// using plain `git`.
+func (a *GitHubAPIAdapter) Push(ctx context.Context, workDir string, commitMsg string) error {
+	a.logger.DebugContext(ctx, "pushing changes",
+		"work_dir", workDir,
+	)
+
+	if _, err := a.runner.Run(ctx, workDir, "git", "add", "."); err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to stage changes: %v", err),
+			map[string]any{"work_dir": workDir},
+		)
+	}
+
+	if _, err := a.runner.Run(ctx, workDir, "git", "commit", "-m", commitMsg); err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to commit changes: %v", err),
+			map[string]any{"work_dir": workDir, "commit_msg": commitMsg},
+		)
+	}
+
+	if _, err := a.runner.Run(ctx, workDir, "git", "push", "-u", "origin", "HEAD"); err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to push changes: %v", err),
+			map[string]any{"work_dir": workDir},
+		)
+	}
+
+	return nil
+}
+
+// CreatePR creates a pull request via the GitHub API and returns the PR URL.
+// owner/repo and the head branch are derived from the workDir git remote.
+func (a *GitHubAPIAdapter) CreatePR(ctx context.Context, workDir string, title string, body string, baseBranch string) (string, error) {
+	remoteURL, err := a.remoteURL(ctx, workDir)
+	if err != nil {
+		return "", err
+	}
+
+	headBranch, err := a.currentBranch(ctx, workDir)
+	if err != nil {
+		return "", err
+	}
+
+	return a.CreateRemotePR(ctx, remoteURL, title, body, headBranch, baseBranch)
+}
+
+// MergePR squash-merges a pull request and deletes the source branch via the
+// GitHub API. prIdentifier is a PR number or a full PR URL; owner/repo are
+// derived from the workDir git remote when only a number is supplied.
+func (a *GitHubAPIAdapter) MergePR(ctx context.Context, workDir string, prIdentifier string) error {
+	owner, repo, number, err := a.resolvePR(ctx, workDir, prIdentifier)
+	if err != nil {
+		return err
+	}
+
+	a.logger.DebugContext(ctx, "merging pull request via API",
+		"owner", owner, "repo", repo, "pr_number", number,
+	)
+
+	_, _, err = a.client.PullRequests.Merge(ctx, owner, repo, number, "", &github.PullRequestOptions{
+		MergeMethod: mergeMethodSquash,
+	})
+	if err != nil {
+		return classifyMergeError(prIdentifier, owner, repo, number, err)
+	}
+
+	// Delete the source branch after a successful squash merge.
+	pr, _, getErr := a.client.PullRequests.Get(ctx, owner, repo, number)
+	if getErr != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("merged PR %d but failed to resolve head branch for deletion: %v", number, getErr),
+			map[string]any{"owner": owner, "repo": repo, "pr_number": number},
+		)
+	}
+	if pr.GetHead() != nil && pr.GetHead().GetRef() != "" {
+		ref := fmt.Sprintf("heads/%s", pr.GetHead().GetRef())
+		if _, delErr := a.client.Git.DeleteRef(ctx, owner, repo, ref); delErr != nil {
+			return errors.NewDomainError(
+				errors.ErrCodeGitOperationFailed,
+				fmt.Sprintf("merged PR %d but failed to delete branch %q: %v", number, pr.GetHead().GetRef(), delErr),
+				map[string]any{"owner": owner, "repo": repo, "branch": pr.GetHead().GetRef()},
+			)
+		}
+	}
+
+	return nil
+}
+
+// GetCIStatus returns the CI check status for the current branch's PR via the
+// GitHub API. owner/repo come from the workDir remote; the open PR for the
+// current branch is located, then its head SHA's check runs are evaluated.
+func (a *GitHubAPIAdapter) GetCIStatus(ctx context.Context, workDir string) (string, error) {
+	remoteURL, err := a.remoteURL(ctx, workDir)
+	if err != nil {
+		return "", err
+	}
+	owner, repo, err := parseGitHubOwnerRepo(remoteURL)
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeInvalidInput,
+			fmt.Sprintf("failed to parse repo URL: %v", err),
+			map[string]any{"repo_url": remoteURL},
+		)
+	}
+
+	headBranch, err := a.currentBranch(ctx, workDir)
+	if err != nil {
+		return "", err
+	}
+
+	prs, _, err := a.client.PullRequests.List(ctx, owner, repo, &github.PullRequestListOptions{
+		Head:  fmt.Sprintf("%s:%s", owner, headBranch),
+		State: "open",
+	})
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to list PRs for branch %q: %v", headBranch, err),
+			map[string]any{"owner": owner, "repo": repo, "head": headBranch},
+		)
+	}
+	if len(prs) == 0 {
+		return "", errors.NewDomainError(
+			errors.ErrCodePRNotFound,
+			"no pull request found for current branch",
+			map[string]any{"owner": owner, "repo": repo, "head": headBranch},
+		)
+	}
+
+	sha := prs[0].GetHead().GetSHA()
+	return a.ciStatusForSHA(ctx, owner, repo, sha)
+}
+
+// GetPRDiff returns the unified diff content for the given pull request URL via
+// the GitHub API (application/vnd.github.v3.diff media type).
+func (a *GitHubAPIAdapter) GetPRDiff(ctx context.Context, prURL string) (string, error) {
+	owner, repo, number, err := parseGitHubPR(prURL)
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeInvalidInput,
+			fmt.Sprintf("failed to parse PR URL: %v", err),
+			map[string]any{"pr_url": prURL},
+		)
+	}
+
+	a.logger.DebugContext(ctx, "fetching PR diff via API",
+		"owner", owner, "repo", repo, "pr_number", number,
+	)
+
+	diff, _, err := a.client.PullRequests.GetRaw(ctx, owner, repo, number, github.RawOptions{Type: github.Diff})
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to get PR diff for %s: %v", prURL, err),
+			map[string]any{"pr_url": prURL},
+		)
+	}
+	return diff, nil
+}
+
+// CreateRemoteBranch creates a new branch on the remote repository via the
+// GitHub API. It resolves the base branch SHA then creates refs/heads/<branch>.
+func (a *GitHubAPIAdapter) CreateRemoteBranch(ctx context.Context, repoURL string, branchName string, baseBranch string) error {
+	owner, repo, err := parseGitHubOwnerRepo(repoURL)
+	if err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeInvalidInput,
+			fmt.Sprintf("failed to parse repo URL: %v", err),
+			map[string]any{"repo_url": repoURL},
+		)
+	}
+
+	a.logger.DebugContext(ctx, "creating remote branch via API",
+		"owner", owner, "repo", repo,
+		"branch_name", branchName, "base_branch", baseBranch,
+	)
+
+	baseRef, _, err := a.client.Git.GetRef(ctx, owner, repo, fmt.Sprintf("heads/%s", baseBranch))
+	if err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to get base branch %q SHA: %v", baseBranch, err),
+			map[string]any{"owner": owner, "repo": repo, "base_branch": baseBranch},
+		)
+	}
+	sha := baseRef.GetObject().GetSHA()
+
+	newRef := &github.Reference{
+		Ref:    github.String(fmt.Sprintf("refs/heads/%s", branchName)),
+		Object: &github.GitObject{SHA: github.String(sha)},
+	}
+	if _, _, err := a.client.Git.CreateRef(ctx, owner, repo, newRef); err != nil {
+		return errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to create remote branch %q: %v", branchName, err),
+			map[string]any{"owner": owner, "repo": repo, "branch_name": branchName, "sha": sha},
+		)
+	}
+
+	return nil
+}
+
+// CreateRemotePR creates a pull request via the GitHub API and returns its URL.
+func (a *GitHubAPIAdapter) CreateRemotePR(ctx context.Context, repoURL string, title string, body string, headBranch string, baseBranch string) (string, error) {
+	owner, repo, err := parseGitHubOwnerRepo(repoURL)
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeInvalidInput,
+			fmt.Sprintf("failed to parse repo URL: %v", err),
+			map[string]any{"repo_url": repoURL},
+		)
+	}
+
+	a.logger.DebugContext(ctx, "creating remote PR via API",
+		"owner", owner, "repo", repo,
+		"head", headBranch, "base", baseBranch,
+	)
+
+	pr, _, err := a.client.PullRequests.Create(ctx, owner, repo, &github.NewPullRequest{
+		Title: github.String(title),
+		Body:  github.String(body),
+		Head:  github.String(headBranch),
+		Base:  github.String(baseBranch),
+	})
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to create remote PR: %v", err),
+			map[string]any{"owner": owner, "repo": repo, "head": headBranch, "base": baseBranch},
+		)
+	}
+
+	prURL := pr.GetHTMLURL()
+	if !strings.HasPrefix(prURL, "http") {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			"failed to parse PR URL from GitHub API response",
+			map[string]any{"owner": owner, "repo": repo},
+		)
+	}
+
+	return prURL, nil
+}
+
+// GetRemoteCIStatus returns CI status for a PR identified by its URL via the
+// GitHub API. Mapping matches GhCliAdapter.GetRemoteCIStatus exactly.
+func (a *GitHubAPIAdapter) GetRemoteCIStatus(ctx context.Context, prURL string) (string, error) {
+	owner, repo, prNumber, err := parseGitHubPR(prURL)
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeInvalidInput,
+			fmt.Sprintf("failed to parse PR URL: %v", err),
+			map[string]any{"pr_url": prURL},
+		)
+	}
+
+	a.logger.DebugContext(ctx, "getting remote CI status via API",
+		"owner", owner, "repo", repo, "pr_number", prNumber,
+	)
+
+	pr, _, err := a.client.PullRequests.Get(ctx, owner, repo, prNumber)
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to get PR head SHA: %v", err),
+			map[string]any{"pr_url": prURL},
+		)
+	}
+
+	return a.ciStatusForSHA(ctx, owner, repo, pr.GetHead().GetSHA())
+}
+
+// ciStatusForSHA lists the check runs for a commit SHA and maps them to one of
+// "pass"|"fail"|"pending"|"no_checks", replicating the gh-CLI adapter logic.
+func (a *GitHubAPIAdapter) ciStatusForSHA(ctx context.Context, owner, repo, sha string) (string, error) {
+	results, _, err := a.client.Checks.ListCheckRunsForRef(ctx, owner, repo, sha, nil)
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to get check runs: %v", err),
+			map[string]any{"owner": owner, "repo": repo, "sha": sha},
+		)
+	}
+
+	if results.GetTotal() == 0 {
+		return CIStatusNoChecks, nil
+	}
+
+	hasPending := false
+	for _, check := range results.CheckRuns {
+		status := check.GetStatus()
+		if status == checkStatusQueued || status == checkStatusInProgress {
+			hasPending = true
+			continue
+		}
+		conclusion := check.GetConclusion()
+		if conclusion == conclusionFailure || conclusion == conclusionTimedOut || conclusion == conclusionActionRequired {
+			return CIStatusFail, nil
+		}
+	}
+
+	if hasPending {
+		return CIStatusPending, nil
+	}
+
+	return CIStatusPass, nil
+}
+
+// remoteURL returns the origin remote URL of the given working directory,
+// stripping any embedded credentials so owner/repo parsing is stable.
+func (a *GitHubAPIAdapter) remoteURL(ctx context.Context, workDir string) (string, error) {
+	out, err := a.runner.Run(ctx, workDir, "git", "remote", "get-url", "origin")
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to resolve origin remote: %v", err),
+			map[string]any{"work_dir": workDir},
+		)
+	}
+	return stripCredentials(strings.TrimSpace(out)), nil
+}
+
+// currentBranch returns the current branch name of the given working directory.
+func (a *GitHubAPIAdapter) currentBranch(ctx context.Context, workDir string) (string, error) {
+	out, err := a.runner.Run(ctx, workDir, "git", "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", errors.NewDomainError(
+			errors.ErrCodeGitOperationFailed,
+			fmt.Sprintf("failed to resolve current branch: %v", err),
+			map[string]any{"work_dir": workDir},
+		)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// resolvePR resolves owner/repo/number from a PR identifier (URL or number).
+// When only a number is given, owner/repo come from the workDir git remote.
+func (a *GitHubAPIAdapter) resolvePR(ctx context.Context, workDir, prIdentifier string) (owner, repo string, number int, err error) {
+	if strings.HasPrefix(prIdentifier, "http") {
+		o, r, n, perr := parseGitHubPR(prIdentifier)
+		if perr != nil {
+			return "", "", 0, errors.NewDomainError(
+				errors.ErrCodeInvalidInput,
+				fmt.Sprintf("failed to parse PR URL: %v", perr),
+				map[string]any{"pr_identifier": prIdentifier},
+			)
+		}
+		return o, r, n, nil
+	}
+
+	n, perr := parsePRNumber(prIdentifier)
+	if perr != nil {
+		return "", "", 0, errors.NewDomainError(
+			errors.ErrCodeInvalidInput,
+			fmt.Sprintf("invalid PR identifier %q: %v", prIdentifier, perr),
+			map[string]any{"pr_identifier": prIdentifier},
+		)
+	}
+
+	remoteURL, rerr := a.remoteURL(ctx, workDir)
+	if rerr != nil {
+		return "", "", 0, rerr
+	}
+	o, r, oerr := parseGitHubOwnerRepo(remoteURL)
+	if oerr != nil {
+		return "", "", 0, errors.NewDomainError(
+			errors.ErrCodeInvalidInput,
+			fmt.Sprintf("failed to parse repo URL: %v", oerr),
+			map[string]any{"repo_url": remoteURL},
+		)
+	}
+	return o, r, n, nil
+}
+
+// parsePRNumber parses a bare PR number (optionally prefixed with '#').
+func parsePRNumber(s string) (int, error) {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(s), "#")
+	n, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("not a PR number: %q", s)
+	}
+	return n, nil
+}
+
+// classifyMergeError maps a merge API error to the closest domain error,
+// mirroring the gh-CLI adapter's conflict / not-found classification.
+func classifyMergeError(prIdentifier, owner, repo string, number int, err error) error {
+	msg := strings.ToLower(err.Error())
+	details := map[string]any{"pr_identifier": prIdentifier, "owner": owner, "repo": repo, "pr_number": number}
+
+	if strings.Contains(msg, "merge conflict") || strings.Contains(msg, "conflict") {
+		return errors.NewDomainError(
+			errors.ErrCodeMergeConflict,
+			fmt.Sprintf("merge conflict detected for PR %s: %v", prIdentifier, err),
+			details,
+		)
+	}
+	if strings.Contains(msg, "not found") || strings.Contains(msg, "no pull request") {
+		return errors.NewDomainError(
+			errors.ErrCodePRNotFound,
+			fmt.Sprintf("pull request not found: %s", prIdentifier),
+			details,
+		)
+	}
+	return errors.NewDomainError(
+		errors.ErrCodeGitOperationFailed,
+		fmt.Sprintf("failed to merge PR %s: %v", prIdentifier, err),
+		details,
+	)
+}

--- a/backend/internal/adapter/git/github_api_adapter_test.go
+++ b/backend/internal/adapter/git/github_api_adapter_test.go
@@ -1,0 +1,312 @@
+package git
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+const (
+	testRepoURL  = "https://github.com/octocat/hello"
+	testPRURL    = "https://github.com/octocat/hello/pull/42"
+	testBaseSHA  = "abc123def456"
+	testToken    = "ghp_testtoken"
+	testHTMLURL  = "https://github.com/octocat/hello/pull/42"
+	headRunsPath = "/repos/octocat/hello/commits/" + testBaseSHA + "/check-runs"
+	prPath       = "/repos/octocat/hello/pulls/42"
+	baseMain     = "main"
+)
+
+// newTestAdapter builds a GitHubAPIAdapter pointing at the given test server.
+func newTestAdapter(t *testing.T, serverURL string) *GitHubAPIAdapter {
+	t.Helper()
+	return NewGitHubAPIAdapter(serverURL, testToken, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+// writeJSON is a small helper to marshal a value to the response writer.
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}
+
+func TestGitHubAPIAdapter_CreateRemoteBranch(t *testing.T) {
+	var gotRefBody map[string]string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/octocat/hello/git/ref/heads/main":
+			writeJSON(t, w, map[string]any{
+				"ref":    "refs/heads/main",
+				"object": map[string]any{"sha": testBaseSHA, "type": "commit"},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/octocat/hello/git/refs":
+			_ = json.NewDecoder(r.Body).Decode(&gotRefBody)
+			w.WriteHeader(http.StatusCreated)
+			writeJSON(t, w, map[string]any{
+				"ref":    "refs/heads/feat/s-01-thing",
+				"object": map[string]any{"sha": testBaseSHA},
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	err := a.CreateRemoteBranch(context.Background(), testRepoURL, "feat/s-01-thing", baseMain)
+	if err != nil {
+		t.Fatalf("CreateRemoteBranch: unexpected error: %v", err)
+	}
+	if gotRefBody["ref"] != "refs/heads/feat/s-01-thing" {
+		t.Errorf("ref = %q, want refs/heads/feat/s-01-thing", gotRefBody["ref"])
+	}
+	if gotRefBody["sha"] != testBaseSHA {
+		t.Errorf("sha = %q, want %q", gotRefBody["sha"], testBaseSHA)
+	}
+}
+
+func TestGitHubAPIAdapter_CreateRemotePR(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/repos/octocat/hello/pulls" {
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body["head"] != "feat/s-01-thing" || body["base"] != baseMain {
+				t.Errorf("unexpected PR body: %+v", body)
+			}
+			w.WriteHeader(http.StatusCreated)
+			writeJSON(t, w, map[string]any{"number": 42, "html_url": testHTMLURL})
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	url, err := a.CreateRemotePR(context.Background(), testRepoURL, "title", "body", "feat/s-01-thing", baseMain)
+	if err != nil {
+		t.Fatalf("CreateRemotePR: unexpected error: %v", err)
+	}
+	if url != testHTMLURL {
+		t.Errorf("prURL = %q, want %q", url, testHTMLURL)
+	}
+}
+
+// ciCheckRunsHandler returns an httptest server that serves PR head SHA and
+// the supplied check-runs payload for GetRemoteCIStatus tests.
+func ciCheckRunsHandler(t *testing.T, checkRuns []map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case prPath:
+			writeJSON(t, w, map[string]any{
+				"number": 42,
+				"head":   map[string]any{"sha": testBaseSHA, "ref": "feat/s-01-thing"},
+			})
+		case headRunsPath:
+			writeJSON(t, w, map[string]any{
+				"total_count": len(checkRuns),
+				"check_runs":  checkRuns,
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestGitHubAPIAdapter_GetRemoteCIStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		checkRuns []map[string]any
+		want      string
+	}{
+		{
+			name: "all completed success -> pass",
+			checkRuns: []map[string]any{
+				{"name": "build", "status": "completed", "conclusion": "success"},
+				{"name": "test", "status": "completed", "conclusion": "success"},
+			},
+			want: CIStatusPass,
+		},
+		{
+			name: "one failure -> fail",
+			checkRuns: []map[string]any{
+				{"name": "build", "status": "completed", "conclusion": "success"},
+				{"name": "test", "status": "completed", "conclusion": "failure"},
+			},
+			want: CIStatusFail,
+		},
+		{
+			name: "timed_out conclusion -> fail",
+			checkRuns: []map[string]any{
+				{"name": "build", "status": "completed", "conclusion": "timed_out"},
+			},
+			want: CIStatusFail,
+		},
+		{
+			name: "action_required conclusion -> fail",
+			checkRuns: []map[string]any{
+				{"name": "build", "status": "completed", "conclusion": "action_required"},
+			},
+			want: CIStatusFail,
+		},
+		{
+			name: "in_progress with success -> pending",
+			checkRuns: []map[string]any{
+				{"name": "build", "status": "completed", "conclusion": "success"},
+				{"name": "test", "status": "in_progress", "conclusion": ""},
+			},
+			want: CIStatusPending,
+		},
+		{
+			name: "queued -> pending",
+			checkRuns: []map[string]any{
+				{"name": "build", "status": "queued", "conclusion": ""},
+			},
+			want: CIStatusPending,
+		},
+		{
+			name:      "no checks -> no_checks",
+			checkRuns: []map[string]any{},
+			want:      CIStatusNoChecks,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := ciCheckRunsHandler(t, tt.checkRuns)
+			defer srv.Close()
+
+			a := newTestAdapter(t, srv.URL)
+			got, err := a.GetRemoteCIStatus(context.Background(), testPRURL)
+			if err != nil {
+				t.Fatalf("GetRemoteCIStatus: unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("status = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGitHubAPIAdapter_MergePR(t *testing.T) {
+	var merged, deleted bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/repos/octocat/hello/pulls/42/merge":
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body["merge_method"] != mergeMethodSquash {
+				t.Errorf("merge_method = %v, want squash", body["merge_method"])
+			}
+			merged = true
+			writeJSON(t, w, map[string]any{"merged": true, "sha": testBaseSHA})
+		case r.Method == http.MethodGet && r.URL.Path == prPath:
+			writeJSON(t, w, map[string]any{
+				"number": 42,
+				"head":   map[string]any{"sha": testBaseSHA, "ref": "feat/s-01-thing"},
+			})
+		case r.Method == http.MethodDelete && r.URL.Path == "/repos/octocat/hello/git/refs/heads/feat/s-01-thing":
+			deleted = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	if err := a.MergePR(context.Background(), "", testPRURL); err != nil {
+		t.Fatalf("MergePR: unexpected error: %v", err)
+	}
+	if !merged {
+		t.Error("expected squash merge to be called")
+	}
+	if !deleted {
+		t.Error("expected source branch deletion to be called")
+	}
+}
+
+func TestGitHubAPIAdapter_MergePR_Conflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && r.URL.Path == "/repos/octocat/hello/pulls/42/merge" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			writeJSON(t, w, map[string]any{"message": "Merge conflict"})
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	err := a.MergePR(context.Background(), "", testPRURL)
+	if err == nil {
+		t.Fatal("expected error for merge conflict")
+	}
+	var de *errors.DomainError
+	if !stderrors.As(err, &de) || de.Code != errors.ErrCodeMergeConflict {
+		t.Errorf("expected MERGE_CONFLICT domain error, got %v", err)
+	}
+}
+
+func TestGitHubAPIAdapter_GetPRDiff(t *testing.T) {
+	const diffBody = "diff --git a/foo.go b/foo.go\n+added line\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == prPath {
+			if !strings.Contains(r.Header.Get("Accept"), "diff") {
+				t.Errorf("Accept header = %q, want diff media type", r.Header.Get("Accept"))
+			}
+			w.Header().Set("Content-Type", "application/vnd.github.v3.diff")
+			_, _ = io.WriteString(w, diffBody)
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	diff, err := a.GetPRDiff(context.Background(), testPRURL)
+	if err != nil {
+		t.Fatalf("GetPRDiff: unexpected error: %v", err)
+	}
+	if diff != diffBody {
+		t.Errorf("diff = %q, want %q", diff, diffBody)
+	}
+}
+
+func TestGitHubAPIAdapter_TokenAuthHeader(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		writeJSON(t, w, map[string]any{
+			"ref":    "refs/heads/main",
+			"object": map[string]any{"sha": testBaseSHA},
+		})
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	// Any API call exercises the auth header; ignore the (expected) failure
+	// from the second request having no handler.
+	_ = a.CreateRemoteBranch(context.Background(), testRepoURL, "feat/s-01-thing", baseMain)
+	if gotAuth != "Bearer "+testToken {
+		t.Errorf("Authorization = %q, want Bearer %s", gotAuth, testToken)
+	}
+}

--- a/backend/internal/adapter/git/provider_factory.go
+++ b/backend/internal/adapter/git/provider_factory.go
@@ -38,7 +38,10 @@ func (f *DefaultGitProviderFactory) ForProjectID(ctx context.Context, projectID 
 
 	switch project.GitProvider {
 	case "github", "":
-		return NewGhCliAdapter(f.runner, f.logger), nil
+		// API-based adapter (google/go-github) — no `gh` CLI dependency.
+		// GhCliAdapter is kept in the package as a fallback/reference.
+		token := resolveGitToken(project.GitTokenEnv)
+		return NewGitHubAPIAdapter("", token, f.runner, f.logger), nil
 	case "gitea":
 		token := resolveGitToken(project.GitTokenEnv)
 		baseURL := extractBaseURL(safeDeref(project.RepoURL))

--- a/backend/internal/adapter/git/provider_factory_test.go
+++ b/backend/internal/adapter/git/provider_factory_test.go
@@ -56,9 +56,9 @@ func TestDefaultGitProviderFactory_ForProjectID_GitHub(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Verify it returns a GhCliAdapter
-	if _, ok := provider.(*GhCliAdapter); !ok {
-		t.Fatalf("expected *GhCliAdapter, got %T", provider)
+	// Verify it returns the API-based GitHub adapter (no gh CLI dependency).
+	if _, ok := provider.(*GitHubAPIAdapter); !ok {
+		t.Fatalf("expected *GitHubAPIAdapter, got %T", provider)
 	}
 }
 
@@ -80,8 +80,8 @@ func TestDefaultGitProviderFactory_ForProjectID_EmptyDefaultsToGitHub(t *testing
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if _, ok := provider.(*GhCliAdapter); !ok {
-		t.Fatalf("expected *GhCliAdapter for empty git_provider, got %T", provider)
+	if _, ok := provider.(*GitHubAPIAdapter); !ok {
+		t.Fatalf("expected *GitHubAPIAdapter for empty git_provider, got %T", provider)
 	}
 }
 


### PR DESCRIPTION
## GitHub API GitProvider adapter (go-github) — no more `gh` CLI

Replaces the `gh` CLI shell-outs in the backend's git orchestration (`git_branch` / `git_pr` / `ci_poll`) with **direct GitHub REST API** calls via `google/go-github` + the project token. Behind the **existing `port.GitProvider`** — no contract change.

### Why
The backend's git steps (`CreateRemoteBranch`, `CreateRemotePR`, `GetRemoteCIStatus`) shelled out to `gh api …`, which requires the `gh` binary in the **API image**. The microsandbox API image (`Dockerfile.microsandbox`, ubuntu) lacks `gh`, so those steps failed (`gh: not found`). The **agent** never needed `gh` (it commits/pushes with `git`+token); only the backend did. Using the API directly removes the `gh` dependency from **every** image and substrate.

### What lands
- **`GitHubAPIAdapter`** (`github_api_adapter.go`) implements `port.GitProvider` via `go-github/v66`: `Git.GetRef/CreateRef/DeleteRef` (branch), `PullRequests.Create/Merge(squash)/Get/GetRaw` (PR + diff), `Checks.ListCheckRunsForRef` (CI). Local git ops (clone/branch/commit/push) use plain **`git`** with a token-injected URL — never `gh`.
- **Factory** routes `github` (and default `""`) to the new adapter; token resolved from the project's `GitTokenEnv` (default `GITHUB_TOKEN`). `GhCliAdapter` kept as fallback/reference; gitea adapter unchanged.
- CI-status mapping is **byte-for-byte** the old semantics (`queued/in_progress`→pending, `failure/timed_out/action_required`→fail, no checks→no_checks, else pass).

### Tests
`github_api_adapter_test.go` drives go-github against an `httptest` GitHub mock: create-branch (base SHA + ref), create-PR, the 4 CI cases, squash-merge+delete-branch, diff. Factory test asserts github→API adapter.

### Verification
`golangci-lint` exit 0; `go build`/`vet`/`go test ./... -short` green (21 pkgs). go.mod adds only `go-github/v66` (+`go-querystring`).

### DoD
Back + tests + lint ✅. openapi/front/Playwright/docs — **N/A**: internal adapter swap behind an existing port; git actions' contract unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)