### PR TITLE
docs: substrate execution model + image-vs-sidecars + go-github (README & product)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## What it is
 
-**hopeitworks** turns a backlog into merged pull requests. You launch an *epic*; the platform schedules its stories on a dependency graph and runs each one through a fully configurable pipeline — a Docker-isolated AI agent writes the code, opens a branch, a reviewer agent checks it, a human approves at a gate, a PR is opened and CI is polled. You watch the whole thing build in real time.
+**hopeitworks** turns a backlog into merged pull requests. You launch an *epic*; the platform schedules its stories on a dependency graph and runs each one through a fully configurable pipeline — an isolated AI agent writes the code, opens a branch, a reviewer agent checks it, a human approves at a gate, a PR is opened and CI is polled. You watch the whole thing build in real time. Agents run on a **pluggable execution substrate** — Docker by default for dev/CI, a hardened microVM (microsandbox) as the production isolation policy.
 
 > **Positioning** — hopeitworks is an **execution layer that is agnostic to both your planning tool and your process.** Plan in markdown, Jira, GitHub Issues, BMAD, GSD — whatever. The team composes its *own* agents (image / model / provider / prompt) and its *own* pipeline (no workflow is imposed). The platform is opinionated only about the **runtime**: containers, parallelism, isolation, and human-in-the-loop.
 
@@ -35,12 +35,12 @@ Project (Git repo)
         └─ Story ─────── one user story with testable acceptance criteria
              └─ Run ──── one full pipeline execution for that story
                   └─ Step ── git_branch → agent_run → review → HITL gate → git_pr → ci_poll
-                       └─ Agent ── runs the step in an isolated Docker container
+                       └─ Agent ── execs a harness on a pluggable substrate (Docker / microVM / …)
 ```
 
 1. **Plan** anywhere and import stories (markdown, in-app editor, …).
 2. **Launch** a story or an entire epic. The scheduler builds a DAG and runs independent stories concurrently.
-3. **Execute** — each story flows through its project's pipeline; agents run in throwaway containers and talk back to the API over HTTP callbacks.
+3. **Execute** — each story flows through its project's pipeline; agents run on the configured execution substrate (Docker container, microVM, …) and talk back to the API over HTTP callbacks.
 4. **Supervise** — follow agent logs over SSE, approve changes at human gates, retry failed steps.
 5. **Ship** — branches and PRs land on your Git provider, ready to merge.
 
@@ -51,7 +51,7 @@ Project (Git repo)
 | Area | Capabilities |
 |------|--------------|
 | **Orchestration & execution** | Launch a story or a whole epic; DAG-based parallel scheduling; per-project configurable pipeline (step groups, agents, models, prompts); pause / resume / cancel a run; retry a failed step from the UI |
-| **Agents & runtime** | Configurable `Agent` entity (Docker image · model · provider · prompt); multi-provider (Claude, opencode); Go agent runtime with HTTP callbacks; multi-stack agent images (go-node, node, go, python) |
+| **Agents & runtime** | Configurable `Agent` entity (image · model · provider · prompt); multi-provider (Claude, opencode); Go agent runtime with HTTP callbacks; **pluggable execution substrate** behind one port (Docker default, microsandbox microVM for hardened isolation); stack catalogue of digest-pinned agent images (go-node, node, go, python); **Environment** feature for sidecar services (db, redis, …) with injected connection strings |
 | **Resilience** | Incremental retry (the agent receives the diff + CI error and fixes the existing code); fallback to a full retry after repeated failures; project-scoped circuit breaker; native CI polling via the Git provider (no agent wasted on waiting) |
 | **Human-in-the-loop** | Automatic pause at configured checkpoints; diff viewer; approve / reject with a reason |
 | **Real-time monitoring** | SSE streaming of agent logs in the browser; step-by-step progress; live execution tree; Discord & webhook notifications |
@@ -80,18 +80,19 @@ flowchart LR
         EV["LISTEN/NOTIFY → SSE"]
     end
 
-    subgraph RT["Agent runtime"]
-        C1["Docker container<br/>(agent + LLM)"]
+    subgraph RT["Agent runtime — port.AgentRuntime"]
+        C1["Substrate adapter<br/>(Docker / microVM / exec)<br/>agent harness + LLM"]
     end
 
     PG[("PostgreSQL")]
-    GIT["Git provider<br/>(GitHub …)"]
+    GIT["Git provider<br/>(GitHub API · go-github)"]
 
     UI -->|"openapi-fetch (typed)"| H
     UI <-->|"SSE live updates"| EV
     H --> S --> Q --> C1
     C1 -->|"HTTP callbacks"| H
-    C1 -->|"branch · PR · CI"| GIT
+    S -->|"branch · PR · CI (GitHub API)"| GIT
+    C1 -->|"git commit / push"| GIT
     S --- PG
     EV --- PG
 ```
@@ -109,7 +110,9 @@ Detailed design docs live under [`_bmad-output/docs/`](_bmad-output/docs/) (arch
 | **Backend** | Go · [chi](https://github.com/go-chi/chi) router · [pgx](https://github.com/jackc/pgx) + [sqlc](https://sqlc.dev) (type-safe SQL) · [google/wire](https://github.com/google/wire) (compile-time DI) · [River](https://riverqueue.com) (Postgres-backed durable job queue) · golang-migrate · pgxlisten (LISTEN/NOTIFY) · JWT · slog |
 | **Frontend** | Vue 3 (Composition API) · [PrimeVue 4](https://primevue.org) (unstyled + design tokens) · Tailwind CSS v4 · Pinia · Vue Router · [openapi-fetch](https://openapi-ts.dev) (typed client) · [Vue Flow](https://vueflow.dev) (DAG) · Monaco (editors) · Vitest · Playwright |
 | **Contract** | A single [`api/openapi.yaml`](api/openapi.yaml) is the source of truth — the Go server interfaces (oapi-codegen) **and** the TypeScript client are generated from it |
-| **Runtime / infra** | Docker (agents spawned through a filtered docker-socket-proxy) · PostgreSQL · nginx (serves the SPA + reverse-proxies the API) · MailHog (dev mail) · SSE |
+| **Agent substrate** | Pluggable behind `port.AgentRuntime` — **Docker** (default, via a filtered docker-socket-proxy) or **microsandbox** (libkrun microVM, KVM); `exec` and K8s/OpenShift slot behind the same port |
+| **Git** | Backend git actions (branch · PR · CI) talk to the **GitHub API** directly via [go-github](https://github.com/google/go-github) (token auth) — no `gh` CLI dependency on the backend path; the agent commits/pushes with `git` |
+| **Runtime / infra** | PostgreSQL · nginx (serves the SPA + reverse-proxies the API) · sidecar services via the **Environment** feature (isolated run-network + injected conn-strings) · MailHog (dev mail) · SSE |
 
 ---
 
@@ -120,7 +123,8 @@ Detailed design docs live under [`_bmad-output/docs/`](_bmad-output/docs/) (arch
 - **DAG topological scheduling** — stories are ordered with a Kahn topological sort; implicit *file-conflict edges* are added so two agents never edit the same file concurrently.
 - **Durable, recoverable execution** — a Postgres-backed job queue, a guarded run/step state machine, and HITL **suspend/resume** that replays a paused run to exactly the right step.
 - **Live execution tree** — Postgres `LISTEN/NOTIFY` fan-out to **SSE** with `Last-Event-ID` replay on reconnect, so the UI rebuilds live without polling.
-- **Isolation & security by design** — agents run in throwaway Docker containers reached through a **scoped socket-proxy** (no raw Docker daemon access), per-user API keys encrypted with **AES-256**, JWT auth with role-based access.
+- **Pluggable execution substrate** — an agent is just *"exec a harness"*; *where* it execs lives behind a single `port.AgentRuntime`. Docker (default, scoped socket-proxy — no raw daemon access) and a hardened **microVM** (microsandbox / libkrun, KVM-class kernel isolation for untrusted agent code) are equal adapters selected by `SUBSTRATE`; `exec` and a future K8s/OpenShift adapter slot in without touching the domain.
+- **Isolation & security by design** — per-user API keys encrypted with **AES-256**, JWT auth with role-based access, and substrate-chosen isolation (container or microVM) for the untrusted code the agent generates.
 - **Resilience built in** — a project-scoped **circuit breaker** and **incremental retry** that feeds the agent the previous diff + the CI error instead of starting from scratch.
 
 ---
@@ -143,7 +147,7 @@ Detailed design docs live under [`_bmad-output/docs/`](_bmad-output/docs/) (arch
 
 ## 🚀 Run it locally
 
-The whole stack runs in Docker (frontend, API, Postgres, mail, and a filtered Docker socket proxy).
+The whole stack runs in Docker (frontend, API, Postgres, mail, and a filtered Docker socket proxy). Agents use the **Docker substrate by default** (`SUBSTRATE=docker`) — no KVM required.
 
 ```bash
 # Build images, start the stack, and seed dev data
@@ -161,17 +165,42 @@ The whole stack runs in Docker (frontend, API, Postgres, mail, and a filtered Do
 
 > Pipeline execution needs a Git provider with push access (`GITHUB_TOKEN`) and an LLM token for the agents. See [`docs/local-setup.md`](docs/local-setup.md) for the full setup.
 
-### Execution substrates & platform support
+### Runtime — the execution substrate
 
-The runtime is pluggable. The **default substrate is Docker** (`SUBSTRATE=docker`) and
-runs anywhere Docker runs — Linux, macOS, Windows.
+An agent is fundamentally **"exec a harness"**: clone the repo, run the Go `agent-runtime`,
+which drives the chosen CLI (`claude` / `opencode`) and reports its outcome back over plain
+HTTP. *Where* that exec happens is a separate, **pluggable** concern behind a single
+`port.AgentRuntime`. Every substrate is an equal adapter — **Docker is not special** — selected
+by the `SUBSTRATE` config:
 
-A **hardened microVM substrate (microsandbox / libkrun)** is also supported for stronger
-isolation and native nested-container fidelity (testcontainers / DinD inside the agent).
-It is **Linux-only: it requires KVM** (`/dev/kvm`). It cannot run inside Docker Desktop on
-macOS (no nested-virt passthrough). On macOS, run the stack inside a Linux VM with nested
-virtualization (Apple **M3+ / macOS 15+**) — see [`deploy/lima/README.md`](deploy/lima/README.md)
-for a one-command, reproducible setup.
+| Substrate | Role | Needs |
+|-----------|------|-------|
+| **Docker** (`SUBSTRATE=docker`) | **Default for dev / CI** — runs anywhere a Docker daemon exists (Linux, macOS, Windows) | a Docker daemon |
+| **microsandbox** (`SUBSTRATE=microsandbox`) | **Production isolation policy** — libkrun **microVM**, KVM-class kernel isolation for the untrusted code the agent generates; native nested-container fidelity (testcontainers / DinD inside the agent) | Linux + **KVM** (`/dev/kvm`) |
+| **exec** (`SUBSTRATE=exec`) | Local inner-loop — runs the harness as a child process, no container, fastest/in-process debuggable; dev-only | — |
+| **K8s / OpenShift** | Future (P4) — addable behind the same port (RuntimeClass gVisor / Kata), no domain change | — |
+
+microsandbox is **Linux/KVM-only** and cannot run inside Docker Desktop on macOS (no nested-virt
+passthrough). On macOS, run the agent stack inside a Linux VM with nested virtualization (Apple
+**M3+ / macOS 15+**) — see [`deploy/lima/README.md`](deploy/lima/README.md) for a one-command,
+reproducible setup. (Selecting microsandbox requires the `microsandbox` build tag; otherwise the
+adapter is built as a clear no-op stub.)
+
+### Image vs services — the agent image is *where it runs*, sidecars are *what it talks to*
+
+These are two distinct concerns:
+
+- **Agent image (the microVM/container rootfs)** = the environment the agent *runs in*: the
+  `agent-runtime` harness + CLI (`claude` / `opencode`) **and the toolchain** (go / node / python)
+  it needs to build and test. These come from a **catalogue of stacks** — digest-pinned ghcr
+  images (go-node, node, go, python). A microVM, like a container, **always needs an image** (its
+  rootfs).
+- **Services** (db, redis, keycloak, …) = network **dependencies**, not the agent's runtime. They
+  are run as **sidecars** via the **Environment** feature: an isolated per-run network plus
+  connection strings injected into the agent's env. They are reachable services, never part of the
+  image.
+- **Caveat:** sidecars-under-microVM aren't supported by microsandbox yet — it degrades to
+  injected connection strings only. The **Docker substrate** gives full sidecars.
 
 ### Repository layout
 
@@ -189,5 +218,5 @@ docs/           Product vision, setup, design notes
 ---
 
 <div align="center">
-<sub>Built with Go, Vue 3, Docker, and PostgreSQL · hexagonal architecture · OpenAPI-first · agent runtime in containers</sub>
+<sub>Built with Go, Vue 3, Docker, and PostgreSQL · hexagonal architecture · OpenAPI-first · pluggable agent execution substrate (Docker / microVM)</sub>
 </div>

--- a/docs/product.md
+++ b/docs/product.md
@@ -1,6 +1,6 @@
 # hopeitworks — Vision Produit
 
-*Maintenu par François. Dernière mise à jour : 2026-06-23.*
+*Maintenu par François. Dernière mise à jour : 2026-06-24.*
 
 ## Vision
 
@@ -36,7 +36,7 @@ Configure l'instance : providers Git, modèles IA, pipelines, notifications, bud
 ```
 Project → Epic → Story → Run → Step
                            ↓
-                         Agent (container Docker isolé)
+                         Agent (exec d'un harness sur un substrat isolé)
 ```
 
 - **Project** : un repo Git avec sa configuration (pipeline, provider, budget)
@@ -44,7 +44,7 @@ Project → Epic → Story → Run → Step
 - **Story** : une user story avec des critères d'acceptation testables
 - **Run** : une exécution complète de la pipeline pour une story
 - **Step** : une étape de la pipeline (code, CI, review, merge...)
-- **Agent** : un agent IA qui exécute une étape dans un container isolé
+- **Agent** : un agent IA qui exécute une étape — fondamentalement « exec d'un harness » (clone repo → `agent-runtime` → CLI claude/opencode → callback HTTP) sur un **substrat d'exécution isolé et pluggable** (Docker, microVM, …)
 
 ## Capacités livrées
 
@@ -69,7 +69,7 @@ Project → Epic → Story → Run → Step
 - Lancement d'un epic entier avec exécution parallèle
 
 ### Exécution de pipeline
-- Lancement d'une story : container Docker → agent code → branche → PR
+- Lancement d'une story : substrat isolé → agent code → branche → PR
 - Pipeline configurable par projet (groupes d'étapes = stages, agents, modèles, prompts)
 - **Politique de transition par stage** (configurée dans l'éditeur de pipeline) :
   - **auto** : la carte avance seule au stage suivant
@@ -106,15 +106,25 @@ Project → Epic → Story → Run → Step
 - Limites de budget configurables par projet
 
 ### Agents et runtime
-- Entité Agent configurable (image Docker, modèle, provider, prompt)
+- Entité Agent configurable (image, modèle, provider, prompt)
 - Support multi-provider (Claude, opencode)
 - Agent runtime Go avec callbacks HTTP
-- Images Docker multi-stack (go-node, node, go, python)
+
+#### Substrat d'exécution pluggable
+- L'exécution d'un agent est une couche **pluggable derrière `port.AgentRuntime`** : tous les substrats sont **égaux derrière le même port**, le substrat live est choisi par config (`SUBSTRATE`). **Docker n'est pas un cas spécial** — c'est un adapter comme les autres.
+- **Docker** (`SUBSTRATE=docker`) — **défaut dev/CI**, tourne partout (pas besoin de KVM).
+- **microsandbox** (`SUBSTRATE=microsandbox`) — **policy de prod** : microVM libkrun, isolation noyau (KVM) pour le code non-fiable généré par l'agent ; fidélité nested-container native (testcontainers/DinD dans l'agent). Linux/KVM-only.
+- **exec** (local, sans container) et **K8s/OpenShift gVisor/Kata** (futur P4) sont ajoutables derrière le même port, **sans toucher le domaine**.
+
+#### Image agent vs services (deux concerns distincts)
+- **Image agent** = l'environnement *où* l'agent s'exécute (rootfs du microVM/container) : harness `agent-runtime` + CLI (claude/opencode) **et la toolchain** (go/node/python) pour build/test. Fournie par un **catalogue de stacks** — images ghcr digest-pinnées (go-node, node, go, python). Un microVM, comme un container, a **toujours** besoin d'une image (son rootfs).
+- **Services** (db, redis, keycloak…) = **dépendances réseau**, pas le runtime de l'agent. Lancés en **sidecars** via la feature **Environment** : réseau de run isolé + conn-strings injectées dans l'env de l'agent.
+- **Caveat** : sidecars-sous-microVM pas encore supportés par microsandbox (dégrade en conn-strings seules) ; le substrat **Docker** fournit les sidecars complets.
 
 ### Actions pipeline intégrées
-- `agent_run` : exécution d'agent en container (mode callback ou legacy)
-- `ci_poll` : polling CI (GitHub Actions, GitLab)
-- `git_branch` / `git_pr` : création de branche et PR
+- `agent_run` : exécution d'agent sur le substrat configuré, dispatchée via `port.AgentRuntime` (mode callback ou legacy)
+- `ci_poll` : polling CI via l'API GitHub (go-github)
+- `git_branch` / `git_pr` : création de branche et PR via l'**API GitHub** (go-github, token) — plus de dépendance au binaire `gh` côté backend ; l'agent commit/push avec `git`
 - `hitl_gate` : gate d'approbation humaine
 - `notification` : envoi de notifications
 - `incremental_retry` : retry intelligent avec contexte d'erreur


### PR DESCRIPTION
Docs-only. Reflects the as-built substrate execution model:
- pluggable runtime behind `port.AgentRuntime` (Docker dev/CI, microsandbox prod-policy, exec, K8s/OpenShift P4)
- image (microVM/container rootfs = harness + toolchain, ghcr stacks) **vs** services (db/redis as Docker sidecars via Environment)
- backend git via GitHub API (go-github), no `gh` CLI dependency; agent commits/pushes with `git`

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)