### PR TITLE
fix(api-keys): route api-key endpoints through generated server (fix 501) (#288)

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -449,7 +449,7 @@ func run() error {
 	epicRunService := service.NewEpicRunService(epicRunRepo, storyRepo, epicRepo, schedulerService, parallelGroupExecutor, eventRepo, logger)
 	epicRunHandler := handler.NewEpicRunHandler(epicRunService)
 
-	server := handler.NewServer(authHandler, projectHandler, userHandler, profileHandler, epicHandler, storyHandler, agentHandler, stackHandler, runHandler, pipelineConfigHandler, hitlHandler, costHandler, notificationHandler, epicRunHandler, environmentHandler)
+	server := handler.NewServer(authHandler, projectHandler, userHandler, profileHandler, epicHandler, storyHandler, agentHandler, stackHandler, runHandler, pipelineConfigHandler, hitlHandler, costHandler, notificationHandler, epicRunHandler, environmentHandler, apiKeyHandler)
 
 	// Project user handler
 	projectUserHandler := handler.NewProjectUserHandler(projectUserService)
@@ -480,13 +480,6 @@ func run() error {
 		r.Get("/", projectUserHandler.ListMembers)
 		r.Post("/", projectUserHandler.AddUser)
 		r.Delete("/{user_id}", projectUserHandler.RemoveUser)
-	})
-
-	// Mount user API keys routes (manually registered)
-	r.Route("/api/v1/users/me/api-keys", func(r chi.Router) {
-		r.Get("/", apiKeyHandler.ListMyAPIKeys)
-		r.Post("/", apiKeyHandler.CreateMyAPIKey)
-		r.Delete("/{keyId}", apiKeyHandler.DeleteMyAPIKey)
 	})
 
 	// Mount internal callback routes for agent containers (container token auth, NOT JWT).

--- a/backend/internal/api/handler/api_key_handler.go
+++ b/backend/internal/api/handler/api_key_handler.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/zakari/hopeitworks/backend/internal/api/middleware"
 	"github.com/zakari/hopeitworks/backend/internal/domain/model"
@@ -83,21 +82,18 @@ func (h *APIKeyHandler) CreateMyAPIKey(w http.ResponseWriter, r *http.Request) {
 }
 
 // DeleteMyAPIKey handles DELETE /api/v1/users/me/api-keys/{keyId}.
-func (h *APIKeyHandler) DeleteMyAPIKey(w http.ResponseWriter, r *http.Request) {
-	_, ok := middleware.UserIDFromContext(r.Context())
+// keyID is parsed and validated as a UUID by the generated router wrapper, so an
+// invalid id is rejected with 400 upstream and never reaches this handler. The
+// deletion is scoped to the authenticated user: a key that does not exist or
+// belongs to another user is a no-op (idempotent 204), never a 5xx.
+func (h *APIKeyHandler) DeleteMyAPIKey(w http.ResponseWriter, r *http.Request, keyID KeyIdPath) {
+	userID, ok := middleware.UserIDFromContext(r.Context())
 	if !ok {
 		writeErrorResponse(w, errors.NewUnauthorized("authentication required"))
 		return
 	}
 
-	keyIDStr := chi.URLParam(r, "keyId")
-	keyID, err := uuid.Parse(keyIDStr)
-	if err != nil {
-		writeErrorResponse(w, errors.NewValidation("keyId", "must be a valid UUID"))
-		return
-	}
-
-	if err := h.service.DeleteKey(r.Context(), keyID); err != nil {
+	if err := h.service.DeleteKey(r.Context(), userID, keyID); err != nil {
 		writeErrorResponse(w, err)
 		return
 	}

--- a/backend/internal/api/handler/api_key_handler_test.go
+++ b/backend/internal/api/handler/api_key_handler_test.go
@@ -1,0 +1,152 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/api/middleware"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/service"
+	apperrors "github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// mockAPIKeyHandlerRepo is an in-memory port.APIKeyRepository for router-level tests.
+type mockAPIKeyHandlerRepo struct {
+	mu   sync.Mutex
+	keys map[uuid.UUID]*model.UserAPIKey
+}
+
+func newMockAPIKeyHandlerRepo() *mockAPIKeyHandlerRepo {
+	return &mockAPIKeyHandlerRepo{keys: make(map[uuid.UUID]*model.UserAPIKey)}
+}
+
+func (m *mockAPIKeyHandlerRepo) put(k *model.UserAPIKey) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.keys[k.ID] = k
+}
+
+func (m *mockAPIKeyHandlerRepo) Create(_ context.Context, k *model.UserAPIKey) error {
+	m.put(k)
+	return nil
+}
+
+func (m *mockAPIKeyHandlerRepo) GetByID(_ context.Context, id uuid.UUID) (*model.UserAPIKey, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k, ok := m.keys[id]
+	if !ok {
+		return nil, apperrors.NewNotFound("api_key", id)
+	}
+	return k, nil
+}
+
+func (m *mockAPIKeyHandlerRepo) ListByUser(_ context.Context, userID uuid.UUID) ([]*model.UserAPIKey, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []*model.UserAPIKey
+	for _, k := range m.keys {
+		if k.UserID == userID {
+			out = append(out, k)
+		}
+	}
+	return out, nil
+}
+
+func (m *mockAPIKeyHandlerRepo) GetByUserAndProvider(_ context.Context, _ uuid.UUID, provider string) (*model.UserAPIKey, error) {
+	return nil, apperrors.NewNotFound("api_key", provider)
+}
+
+func (m *mockAPIKeyHandlerRepo) Delete(_ context.Context, id uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.keys, id)
+	return nil
+}
+
+// newAPIKeyRouter mounts the generated mux for a Server wired only with the API
+// key handler. When userID is non-nil, a middleware injects it into the request
+// context, simulating the JWT auth middleware. This exercises the real routing
+// path (generated wrapper -> *Server.DeleteMyAPIKey -> handler), which is what
+// regressed in bug #288 (the route fell through to Unimplemented -> 501).
+func newAPIKeyRouter(repo *mockAPIKeyHandlerRepo, userID *uuid.UUID) http.Handler {
+	svc := service.NewAPIKeyService(repo, "test-master-key")
+	srv := &Server{apiKeys: NewAPIKeyHandler(svc)}
+	r := chi.NewRouter()
+	if userID != nil {
+		uid := *userID
+		r.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				ctx := middleware.SetUserContext(req.Context(), uid, model.RoleUser)
+				next.ServeHTTP(w, req.WithContext(ctx))
+			})
+		})
+	}
+	HandlerFromMuxWithBaseURL(srv, r, "/api/v1")
+	return r
+}
+
+// TestDeleteMyAPIKey_InvalidUUID_400 covers RG5: a non-UUID id is rejected with
+// 400 by the generated wrapper, never 501.
+func TestDeleteMyAPIKey_InvalidUUID_400(t *testing.T) {
+	uid := uuid.New()
+	router := newAPIKeyRouter(newMockAPIKeyHandlerRepo(), &uid)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/users/me/api-keys/not-a-uuid", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("RG5: invalid uuid should be 400, got %d (body %s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestDeleteMyAPIKey_Owned_NoContent covers RG6 (route served by the real
+// handler, never 501), RG1 (owned delete -> 204, key removed) and RG3 (a second
+// delete of the same id is an idempotent 204).
+func TestDeleteMyAPIKey_Owned_NoContent(t *testing.T) {
+	repo := newMockAPIKeyHandlerRepo()
+	uid := uuid.New()
+	keyID := uuid.New()
+	repo.put(&model.UserAPIKey{ID: keyID, UserID: uid, Provider: "claude", KeyName: "default", KeyHint: "...1234"})
+	router := newAPIKeyRouter(repo, &uid)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/users/me/api-keys/"+keyID.String(), nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusNotImplemented {
+		t.Fatal("RG6: DELETE still served by Unimplemented (501) — the fix regressed")
+	}
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("RG1: owned delete should be 204, got %d (body %s)", rec.Code, rec.Body.String())
+	}
+	if _, ok := repo.keys[keyID]; ok {
+		t.Fatal("RG1: key should be removed from the store after delete")
+	}
+
+	rec2 := httptest.NewRecorder()
+	router.ServeHTTP(rec2, httptest.NewRequest(http.MethodDelete, "/api/v1/users/me/api-keys/"+keyID.String(), nil))
+	if rec2.Code != http.StatusNoContent {
+		t.Fatalf("RG3: second delete of the same id should be idempotent 204, got %d", rec2.Code)
+	}
+}
+
+// TestDeleteMyAPIKey_Unauthenticated_401 verifies the handler still requires
+// authentication once routing is fixed.
+func TestDeleteMyAPIKey_Unauthenticated_401(t *testing.T) {
+	router := newAPIKeyRouter(newMockAPIKeyHandlerRepo(), nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/users/me/api-keys/"+uuid.New().String(), nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated delete should be 401, got %d (body %s)", rec.Code, rec.Body.String())
+	}
+}

--- a/backend/internal/api/handler/server.go
+++ b/backend/internal/api/handler/server.go
@@ -21,11 +21,12 @@ type Server struct {
 	notifications  *NotificationHandler
 	epicRuns       *EpicRunHandler
 	environment    *EnvironmentHandler
+	apiKeys        *APIKeyHandler
 }
 
 // NewServer creates a new Server with the given handlers.
-func NewServer(auth *AuthHandler, projects *ProjectHandler, users *UserHandler, profile *ProfileHandler, epics *EpicHandler, stories *StoryHandler, agents *AgentHandler, stacks *StackHandler, runs *RunHandler, pipelineConfig *PipelineConfigHandler, hitl *HITLHandler, costs *CostHandler, notifications *NotificationHandler, epicRuns *EpicRunHandler, environment *EnvironmentHandler) *Server {
-	return &Server{auth: auth, projects: projects, users: users, profile: profile, epics: epics, stories: stories, agents: agents, stacks: stacks, runs: runs, pipelineConfig: pipelineConfig, hitl: hitl, costs: costs, notifications: notifications, epicRuns: epicRuns, environment: environment}
+func NewServer(auth *AuthHandler, projects *ProjectHandler, users *UserHandler, profile *ProfileHandler, epics *EpicHandler, stories *StoryHandler, agents *AgentHandler, stacks *StackHandler, runs *RunHandler, pipelineConfig *PipelineConfigHandler, hitl *HITLHandler, costs *CostHandler, notifications *NotificationHandler, epicRuns *EpicRunHandler, environment *EnvironmentHandler, apiKeys *APIKeyHandler) *Server {
+	return &Server{auth: auth, projects: projects, users: users, profile: profile, epics: epics, stories: stories, agents: agents, stacks: stacks, runs: runs, pipelineConfig: pipelineConfig, hitl: hitl, costs: costs, notifications: notifications, epicRuns: epicRuns, environment: environment, apiKeys: apiKeys}
 }
 
 // RegisterUser delegates to AuthHandler.
@@ -451,4 +452,19 @@ func (s *Server) PutProjectEnvironment(w http.ResponseWriter, r *http.Request, p
 // DeleteProjectEnvironment delegates to EnvironmentHandler.
 func (s *Server) DeleteProjectEnvironment(w http.ResponseWriter, r *http.Request, projectID ProjectIdPath) {
 	s.environment.DeleteProjectEnvironment(w, r, projectID)
+}
+
+// ListMyAPIKeys delegates to APIKeyHandler.
+func (s *Server) ListMyAPIKeys(w http.ResponseWriter, r *http.Request) {
+	s.apiKeys.ListMyAPIKeys(w, r)
+}
+
+// CreateMyAPIKey delegates to APIKeyHandler.
+func (s *Server) CreateMyAPIKey(w http.ResponseWriter, r *http.Request) {
+	s.apiKeys.CreateMyAPIKey(w, r)
+}
+
+// DeleteMyAPIKey delegates to APIKeyHandler.
+func (s *Server) DeleteMyAPIKey(w http.ResponseWriter, r *http.Request, keyID KeyIdPath) {
+	s.apiKeys.DeleteMyAPIKey(w, r, keyID)
 }

--- a/backend/internal/domain/service/api_key_service.go
+++ b/backend/internal/domain/service/api_key_service.go
@@ -97,8 +97,22 @@ func (s *APIKeyService) ListKeys(ctx context.Context, userID uuid.UUID) ([]*mode
 	return s.repo.ListByUser(ctx, userID)
 }
 
-// DeleteKey removes an API key by ID.
-func (s *APIKeyService) DeleteKey(ctx context.Context, id uuid.UUID) error {
+// DeleteKey removes an API key owned by the given user. The deletion is scoped
+// to userID, so a user can never delete another user's key by guessing its UUID.
+// A key that is absent or owned by someone else is a no-op: the call is
+// idempotent (a second delete of the same id never errors), and it leaks no
+// information about keys the caller does not own.
+func (s *APIKeyService) DeleteKey(ctx context.Context, userID, id uuid.UUID) error {
+	key, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		if domErr, ok := err.(*errors.DomainError); ok && domErr.Category == errors.CategoryNotFound {
+			return nil
+		}
+		return err
+	}
+	if key.UserID != userID {
+		return nil
+	}
 	return s.repo.Delete(ctx, id)
 }
 

--- a/backend/internal/domain/service/api_key_service_test.go
+++ b/backend/internal/domain/service/api_key_service_test.go
@@ -167,8 +167,8 @@ func TestAPIKeyService_DeleteKey(t *testing.T) {
 		t.Fatalf("CreateKey failed: %v", err)
 	}
 
-	// Delete the key
-	if err := svc.DeleteKey(ctx, key.ID); err != nil {
+	// Delete the key (owner)
+	if err := svc.DeleteKey(ctx, userID, key.ID); err != nil {
 		t.Fatalf("DeleteKey failed: %v", err)
 	}
 
@@ -179,6 +179,61 @@ func TestAPIKeyService_DeleteKey(t *testing.T) {
 	}
 	if len(keys) != 0 {
 		t.Fatalf("expected 0 keys after delete, got %d", len(keys))
+	}
+}
+
+// TestAPIKeyService_DeleteKey_Idempotent verifies that deleting an already-absent
+// key (e.g. a second DELETE of the same id, RG3) is a no-op, not an error.
+func TestAPIKeyService_DeleteKey_Idempotent(t *testing.T) {
+	repo := newMockAPIKeyRepo()
+	svc := NewAPIKeyService(repo, "test-master-key")
+	ctx := context.Background()
+	userID := uuid.New()
+
+	key, err := svc.CreateKey(ctx, userID, "claude", "default", "sk-ant-12345678")
+	if err != nil {
+		t.Fatalf("CreateKey failed: %v", err)
+	}
+
+	if err := svc.DeleteKey(ctx, userID, key.ID); err != nil {
+		t.Fatalf("first DeleteKey failed: %v", err)
+	}
+	// Second delete of the same id must also succeed (idempotent), never error.
+	if err := svc.DeleteKey(ctx, userID, key.ID); err != nil {
+		t.Fatalf("second DeleteKey (idempotent) failed: %v", err)
+	}
+	// Deleting an id that never existed is also a no-op.
+	if err := svc.DeleteKey(ctx, userID, uuid.New()); err != nil {
+		t.Fatalf("DeleteKey of unknown id failed: %v", err)
+	}
+}
+
+// TestAPIKeyService_DeleteKey_ScopedToOwner verifies that a user cannot delete
+// another user's key by guessing its id: the call is a no-op and the key is kept.
+func TestAPIKeyService_DeleteKey_ScopedToOwner(t *testing.T) {
+	repo := newMockAPIKeyRepo()
+	svc := NewAPIKeyService(repo, "test-master-key")
+	ctx := context.Background()
+	owner := uuid.New()
+	attacker := uuid.New()
+
+	key, err := svc.CreateKey(ctx, owner, "claude", "default", "sk-ant-12345678")
+	if err != nil {
+		t.Fatalf("CreateKey failed: %v", err)
+	}
+
+	// Attacker tries to delete the owner's key: no error (no information leak),
+	// but the key must remain.
+	if err := svc.DeleteKey(ctx, attacker, key.ID); err != nil {
+		t.Fatalf("DeleteKey by non-owner should be a no-op, got error: %v", err)
+	}
+
+	keys, err := svc.ListKeys(ctx, owner)
+	if err != nil {
+		t.Fatalf("ListKeys failed: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("owner's key must survive a non-owner delete, got %d keys", len(keys))
 	}
 }
 

--- a/frontend/e2e/tests/profile.spec.ts
+++ b/frontend/e2e/tests/profile.spec.ts
@@ -195,3 +195,137 @@ test.describe('Profile Page', () => {
     await expect(page.getByRole('button', { name: 'Update Password' })).toBeDisabled()
   })
 })
+
+// Bug #288: deleting an API key returned 501 and double-fired the request, with
+// no user feedback. These specs cover the acceptance criteria RG1-RG6.
+// RG5 (non-UUID id -> 400) and RG6 (route no longer 501) are server concerns
+// proven by the backend tests; the UI only ever sends valid ids and consumes a
+// 204, so they are not re-asserted at the e2e layer.
+test.describe('Profile — API Keys (#288)', () => {
+  const apiKeyFixture = {
+    id: '11111111-1111-1111-1111-111111111111',
+    provider: 'claude',
+    key_name: 'default',
+    key_hint: '...1234',
+    created_at: '2026-01-01T00:00:00Z',
+  }
+  // Stateful list so the GET mock stays faithful to the server across a delete:
+  // a successful DELETE mutates it, so any refetch reflects the real state.
+  let apiKeys: Array<typeof apiKeyFixture>
+
+  test.beforeEach(async ({ page }) => {
+    apiKeys = [{ ...apiKeyFixture }]
+
+    await page.route('**/api/v1/auth/me', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(userFixture) })
+    })
+    await page.route('**/api/v1/users/me', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(userFixture) })
+      } else {
+        await route.fallback()
+      }
+    })
+    await page.route('**/api/v1/users/me/api-keys', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(apiKeys) })
+      } else {
+        await route.fallback()
+      }
+    })
+  })
+
+  /** Mocks DELETE: 204 (and mutates the stateful list) or a failure status. */
+  async function mockDelete(page: import('@playwright/test').Page, status: number) {
+    await page.route('**/api/v1/users/me/api-keys/*', async (route) => {
+      if (route.request().method() !== 'DELETE') {
+        await route.fallback()
+        return
+      }
+      if (status === 204) {
+        const id = route.request().url().split('/').pop()
+        apiKeys = apiKeys.filter((k) => k.id !== id)
+        await route.fulfill({ status: 204, body: '' })
+      } else {
+        await route.fulfill({
+          status,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: { code: 'INTERNAL_ERROR', message: 'boom' } }),
+        })
+      }
+    })
+  }
+
+  /** Tracks every DELETE issued against the api-keys collection. */
+  function trackDeletes(page: import('@playwright/test').Page): string[] {
+    const calls: string[] = []
+    page.on('request', (req) => {
+      if (req.method() === 'DELETE' && req.url().includes('/users/me/api-keys/')) {
+        calls.push(req.url())
+      }
+    })
+    return calls
+  }
+
+  // PrimeVue ConfirmDialog uses role="alertdialog" and default labels Yes/No.
+  // Anchor on the button labels (^...$) so they never match the trash button
+  // (aria-label "Delete API key"); the accept button being visible is the
+  // "dialog open" signal.
+  const acceptBtn = (page: import('@playwright/test').Page) =>
+    page.getByRole('button', { name: /^(yes|accept|confirm|ok)$/i })
+  const rejectBtn = (page: import('@playwright/test').Page) =>
+    page.getByRole('button', { name: /^(no|cancel|reject)$/i })
+
+  async function openDeleteConfirm(page: import('@playwright/test').Page) {
+    await expect(page.getByRole('cell', { name: 'default' })).toBeVisible()
+    await page.getByRole('button', { name: 'Delete API key' }).click()
+    await expect(acceptBtn(page)).toBeVisible()
+  }
+
+  test('RG1: confirming a delete returns 204, removes the row and shows a success toast', async ({ page }) => {
+    await mockDelete(page, 204)
+
+    await page.goto('/profile')
+    await openDeleteConfirm(page)
+    await acceptBtn(page).click()
+
+    await expect(page.getByText('API key deleted')).toBeVisible()
+    await expect(page.getByText('No API keys configured yet.')).toBeVisible()
+    await expect(page.getByRole('cell', { name: 'default' })).toHaveCount(0)
+  })
+
+  test('RG2: cancelling the dialog emits no DELETE and keeps the key', async ({ page }) => {
+    const deletes = trackDeletes(page)
+
+    await page.goto('/profile')
+    await openDeleteConfirm(page)
+    await rejectBtn(page).click()
+
+    await expect(acceptBtn(page)).toBeHidden()
+    await expect(page.getByRole('cell', { name: 'default' })).toBeVisible()
+    expect(deletes).toHaveLength(0)
+  })
+
+  test('RG3: confirming once emits exactly one DELETE (no double-fire)', async ({ page }) => {
+    const deletes = trackDeletes(page)
+    await mockDelete(page, 204)
+
+    await page.goto('/profile')
+    await openDeleteConfirm(page)
+    await acceptBtn(page).click()
+
+    await expect(page.getByText('API key deleted')).toBeVisible()
+    expect(deletes).toHaveLength(1)
+  })
+
+  test('RG4: an API failure shows a visible error and keeps the key (no optimistic removal)', async ({ page }) => {
+    await mockDelete(page, 500)
+
+    await page.goto('/profile')
+    await openDeleteConfirm(page)
+    await acceptBtn(page).click()
+
+    await expect(page.getByText('Delete failed')).toBeVisible()
+    await expect(page.getByRole('cell', { name: 'default' })).toBeVisible()
+  })
+})

--- a/frontend/src/composables/__tests__/useAPIKeys.spec.ts
+++ b/frontend/src/composables/__tests__/useAPIKeys.spec.ts
@@ -122,31 +122,65 @@ describe('useAPIKeys', () => {
 
       const result = await deleteKey('key-1')
 
-      expect(result).toBe(true)
+      expect(result).toBe('deleted')
       expect(mockDelete).toHaveBeenCalledWith('/users/me/api-keys/{keyId}', {
         params: { path: { keyId: 'key-1' } },
       })
       expect(keys.value).toHaveLength(0)
     })
 
-    it('returns false when API returns error', async () => {
+    it("returns 'error' when API returns error", async () => {
       mockDelete.mockResolvedValue({ error: { message: 'not found' } })
 
       const { error, deleteKey } = useAPIKeys()
       const result = await deleteKey('key-missing')
 
-      expect(result).toBe(false)
+      expect(result).toBe('error')
       expect(error.value).toBe('Failed to delete API key')
     })
 
-    it('returns false on network failure', async () => {
+    it("returns 'error' on network failure", async () => {
       mockDelete.mockRejectedValue(new Error('Network error'))
 
       const { error, deleteKey } = useAPIKeys()
       const result = await deleteKey('key-1')
 
-      expect(result).toBe(false)
+      expect(result).toBe('error')
       expect(error.value).toBe('Network error')
+    })
+
+    it('keeps the key on error — no optimistic removal (RG4)', async () => {
+      mockGet.mockResolvedValue({ data: [sampleKey], error: undefined })
+      mockDelete.mockResolvedValue({ error: { message: 'boom' } })
+
+      const { keys, fetchKeys, deleteKey } = useAPIKeys()
+      await fetchKeys()
+      expect(keys.value).toHaveLength(1)
+
+      const result = await deleteKey('key-1')
+
+      expect(result).toBe('error')
+      expect(keys.value).toHaveLength(1)
+    })
+
+    it('coalesces concurrent deletes of the same key into one DELETE (RG3, anti double-fire)', async () => {
+      let resolveDelete!: (value: { error: undefined }) => void
+      mockDelete.mockReturnValue(
+        new Promise((resolve) => {
+          resolveDelete = resolve
+        }),
+      )
+
+      const { deleteKey } = useAPIKeys()
+      const first = deleteKey('key-1')
+      // Second call while the first DELETE is still in flight must be coalesced.
+      const second = deleteKey('key-1')
+
+      expect(await second).toBe('busy')
+
+      resolveDelete({ error: undefined })
+      expect(await first).toBe('deleted')
+      expect(mockDelete).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/frontend/src/composables/useAPIKeys.ts
+++ b/frontend/src/composables/useAPIKeys.ts
@@ -14,10 +14,15 @@ export interface APIKey {
  * Composable for managing the current user's API keys.
  * Provides fetch, create, and delete operations.
  */
+/** Outcome of a delete: a 204, a failure, or coalesced because already in flight. */
+export type DeleteKeyResult = 'deleted' | 'error' | 'busy'
+
 export function useAPIKeys() {
   const keys = ref<APIKey[]>([])
   const isLoading = ref(false)
   const error = ref<string | null>(null)
+  // Ids whose DELETE is in flight, to coalesce concurrent calls (anti double-fire).
+  const deleting = new Set<string>()
 
   /** Fetch the current user's API keys */
   async function fetchKeys() {
@@ -56,8 +61,18 @@ export function useAPIKeys() {
     }
   }
 
-  /** Delete an API key by ID */
-  async function deleteKey(keyId: string): Promise<boolean> {
+  /**
+   * Delete an API key by ID. Concurrent calls for the same key are coalesced: a
+   * call issued while a delete of that key is still in flight returns 'busy'
+   * without firing a second DELETE (bug #288 RG3, anti double-fire). Returns
+   * 'deleted' on a 204 (the key is removed from the list, no reload), or 'error'
+   * on any failure (the key is kept — no optimistic removal).
+   */
+  async function deleteKey(keyId: string): Promise<DeleteKeyResult> {
+    if (deleting.has(keyId)) {
+      return 'busy'
+    }
+    deleting.add(keyId)
     error.value = null
     try {
       const { error: apiError } = await apiClient.DELETE('/users/me/api-keys/{keyId}', {
@@ -65,13 +80,15 @@ export function useAPIKeys() {
       })
       if (apiError) {
         error.value = 'Failed to delete API key'
-        return false
+        return 'error'
       }
       keys.value = keys.value.filter((k) => k.id !== keyId)
-      return true
+      return 'deleted'
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to delete API key'
-      return false
+      return 'error'
+    } finally {
+      deleting.delete(keyId)
     }
   }
 

--- a/frontend/src/features/profile/APIKeyList.vue
+++ b/frontend/src/features/profile/APIKeyList.vue
@@ -7,10 +7,12 @@ import Tag from 'primevue/tag'
 import Message from 'primevue/message'
 import ConfirmDialog from 'primevue/confirmdialog'
 import { useConfirm } from 'primevue/useconfirm'
+import { useToast } from 'primevue/usetoast'
 import { useAPIKeys } from '@/composables/useAPIKeys'
 import APIKeyDialog from './APIKeyDialog.vue'
 
 const confirm = useConfirm()
+const toast = useToast()
 const { keys, isLoading, error, fetchKeys, deleteKey } = useAPIKeys()
 
 const dialogVisible = ref(false)
@@ -30,7 +32,24 @@ function handleDelete(keyId: string, keyName: string) {
     icon: 'pi pi-exclamation-triangle',
     acceptClass: 'p-button-danger',
     accept: async () => {
-      await deleteKey(keyId)
+      // deleteKey coalesces a concurrent duplicate into 'busy' (anti double-fire),
+      // so a re-entrant accept never fires a second DELETE nor a duplicate toast.
+      const result = await deleteKey(keyId)
+      if (result === 'deleted') {
+        toast.add({
+          severity: 'success',
+          summary: 'API key deleted',
+          detail: `"${keyName}" was revoked.`,
+          life: 3000,
+        })
+      } else if (result === 'error') {
+        toast.add({
+          severity: 'error',
+          summary: 'Delete failed',
+          detail: error.value ?? 'Could not delete the API key.',
+          life: 5000,
+        })
+      }
     },
   })
 }


### PR DESCRIPTION
Closes #288.

## Problème

`DELETE /api/v1/users/me/api-keys/{id}` renvoyait **501 Not Implemented** : le serveur généré (`*Server`) embarque `Unimplemented` et n'overridait pas `ListMyAPIKeys`/`CreateMyAPIKey`/`DeleteMyAPIKey` → les 3 routes du mux généré tombaient sur `Unimplemented.*`. Les routes manuelles chi censées les shadow (`main.go`) étaient un override non fiable → le DELETE restait en 501, la clé jamais supprimée, aucune erreur remontée à l'utilisateur.

## Fix

**Backend**
- Implémente `ListMyAPIKeys`/`CreateMyAPIKey`/`DeleteMyAPIKey` sur `*Server` (délégation à `APIKeyHandler`, comme les 83 autres endpoints) + **suppression du bloc de routes manuelles mortes**. Le mux généré sert désormais les vrais handlers (plus de 501 — RG6).
- `DeleteMyAPIKey` prend le `keyId` typé du wrapper généré → un id non-UUID est un **400** géré en amont (RG5), plus de parse manuel.
- **Scoping ownership** dans `DeleteKey(ctx, userID, id)` : le fix *active* l'endpoint, ce qui exposerait sinon un **IDOR** (supprimer la clé d'autrui via son UUID). Une clé absente ou appartenant à un autre user est un no-op → suppression **idempotente** (un 2e DELETE = 204, jamais 5xx — RG3).

**Frontend** (`Profile → API Keys`)
- `useAPIKeys.deleteKey` **coalesce les suppressions concurrentes** de la même clé (`'deleted' | 'error' | 'busy'`) → fin du double-fire (RG3).
- Toast succès/erreur (`APIKeyList.vue`) ; la clé n'est retirée **qu'après un 204 confirmé** (pas de retrait optimiste — RG4).

## Test plan (RG1–RG6)

| RG | Couverture |
|----|-----------|
| RG1 — 204 + retrait sans reload + retour succès | backend router-test (204) ; e2e `RG1` ; unit `removes the key on success` |
| RG2 — annulation → aucun DELETE | e2e `RG2` |
| RG3 — exactement 1 DELETE / idempotence | backend router-test (2e DELETE = 204) ; service test idempotence ; unit `coalesces concurrent deletes` ; e2e `RG3` |
| RG4 — erreur visible, clé conservée (pas d'optimiste) | unit `keeps the key on error` ; e2e `RG4` |
| RG5 — id non-UUID → 400 | backend router-test `InvalidUUID_400` |
| RG6 — plus de 501 | backend router-test (assert explicite ≠ 501) |

**Suites** : backend `go test ./... -short` vert · frontend `vitest` 1030 ✓ · e2e Playwright `profile.spec.ts` 10/10 ✓ (exécutés contre le front du worktree). `golangci-lint` non installé localement → délégué à la CI.

## Notes

- **Pas de changement de contrat** : `openapi.yaml` déclarait déjà `deleteMyAPIKey` (204/401/404), aucun type régénéré nécessaire. Le `404` déclaré n'est volontairement plus émis (delete idempotent → 204) ; choix assumé anti-IDOR, non bloquant.
- IDOR fermé au niveau service (vérif via `GetByID` existant) → **zéro régénération sqlc**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)