### PR TITLE
fix(runtime): réconcilier les runs running orphelins au boot + watchdog (#291)

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -373,10 +373,21 @@ func run() error {
 			logger.Error("orphan cleanup failed on startup", "error", err)
 		}
 
+		// Reconcile DB run statuses against live containers: runs left `running`
+		// by a previous crash (container gone) are marked failed so they leave
+		// "Active runs". Runs once at boot, then on every watchdog tick below.
+		orphanReconciler := service.NewOrphanReconciler(
+			containerMgr, runRepo, logger, service.DefaultOrphanGraceWindow,
+		)
+		if err := orphanReconciler.ReconcileOrphanedRuns(appCtx); err != nil {
+			logger.Error("orphan run reconciliation failed on startup", "error", err)
+		}
+
 		timeoutEnforcer := service.NewTimeoutEnforcer(
 			containerMgr, runRepo, projectRepo, logger,
 			30*time.Minute, // default container timeout
 			30*time.Second, // check interval
+			orphanReconciler,
 		)
 		go func() {
 			if err := timeoutEnforcer.Start(appCtx); err != nil && err != context.Canceled {

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -298,6 +298,12 @@ func (m *mockRunRepo) ListRunsByStory(ctx context.Context, storyID uuid.UUID, li
 	}
 	return nil, nil
 }
+func (m *mockRunRepo) ListRunsByStatus(_ context.Context, _ model.RunStatus) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *mockRunRepo) MarkRunOrphanedIfRunning(_ context.Context, _ uuid.UUID, _ time.Time, _ string) (bool, error) {
+	return false, nil
+}
 func (m *mockRunRepo) UpdateRunStatus(ctx context.Context, id uuid.UUID, status model.RunStatus, startedAt, completedAt, pausedAt *time.Time, errorMsg *string) (*model.Run, error) {
 	if m.updateRunStatusFn != nil {
 		return m.updateRunStatusFn(ctx, id, status, startedAt, completedAt, pausedAt, errorMsg)

--- a/backend/internal/adapter/action/hitl_gate_test.go
+++ b/backend/internal/adapter/action/hitl_gate_test.go
@@ -103,6 +103,12 @@ func (m *hitlMockRunRepo) ListRunsByProject(_ context.Context, _ uuid.UUID, _, _
 func (m *hitlMockRunRepo) ListRunsByStory(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
 	return nil, nil
 }
+func (m *hitlMockRunRepo) ListRunsByStatus(_ context.Context, _ model.RunStatus) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *hitlMockRunRepo) MarkRunOrphanedIfRunning(_ context.Context, _ uuid.UUID, _ time.Time, _ string) (bool, error) {
+	return false, nil
+}
 func (m *hitlMockRunRepo) UpdateRunStatus(_ context.Context, id uuid.UUID, _ model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
 	return &model.Run{ID: id}, nil
 }

--- a/backend/internal/adapter/action/human_test.go
+++ b/backend/internal/adapter/action/human_test.go
@@ -90,6 +90,12 @@ func (m *humanMockRunRepo) ListRunsByProject(_ context.Context, _ uuid.UUID, _, 
 func (m *humanMockRunRepo) ListRunsByStory(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
 	return nil, nil
 }
+func (m *humanMockRunRepo) ListRunsByStatus(_ context.Context, _ model.RunStatus) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *humanMockRunRepo) MarkRunOrphanedIfRunning(_ context.Context, _ uuid.UUID, _ time.Time, _ string) (bool, error) {
+	return false, nil
+}
 func (m *humanMockRunRepo) UpdateRunStatus(_ context.Context, id uuid.UUID, _ model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
 	return &model.Run{ID: id}, nil
 }

--- a/backend/internal/adapter/action/incremental_retry_test.go
+++ b/backend/internal/adapter/action/incremental_retry_test.go
@@ -53,6 +53,12 @@ func (m *retryMockRunRepo) ListRunsByProject(_ context.Context, _ uuid.UUID, _, 
 func (m *retryMockRunRepo) ListRunsByStory(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
 	return nil, nil
 }
+func (m *retryMockRunRepo) ListRunsByStatus(_ context.Context, _ model.RunStatus) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *retryMockRunRepo) MarkRunOrphanedIfRunning(_ context.Context, _ uuid.UUID, _ time.Time, _ string) (bool, error) {
+	return false, nil
+}
 func (m *retryMockRunRepo) UpdateRunStatus(_ context.Context, id uuid.UUID, status model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
 	return &model.Run{ID: id, Status: status}, nil
 }

--- a/backend/internal/adapter/postgres/run_repo.go
+++ b/backend/internal/adapter/postgres/run_repo.go
@@ -203,6 +203,30 @@ func (r *RunRepo) ListRunsByStory(ctx context.Context, storyID uuid.UUID, limit,
 	return runs, nil
 }
 
+func (r *RunRepo) ListRunsByStatus(ctx context.Context, status model.RunStatus) ([]*model.Run, error) {
+	rows, err := r.queries.ListRunsByStatus(ctx, string(status))
+	if err != nil {
+		return nil, apperrors.NewInternal("failed to list runs by status", err)
+	}
+	runs := make([]*model.Run, len(rows))
+	for i, row := range rows {
+		runs[i] = toDomainRun(row)
+	}
+	return runs, nil
+}
+
+func (r *RunRepo) MarkRunOrphanedIfRunning(ctx context.Context, id uuid.UUID, completedAt time.Time, errorMsg string) (bool, error) {
+	affected, err := r.queries.MarkRunOrphanedIfRunning(ctx, MarkRunOrphanedIfRunningParams{
+		ID:           id,
+		CompletedAt:  pgtype.Timestamptz{Time: completedAt, Valid: true},
+		ErrorMessage: pgtype.Text{String: errorMsg, Valid: true},
+	})
+	if err != nil {
+		return false, apperrors.NewInternal("failed to mark run orphaned", err)
+	}
+	return affected > 0, nil
+}
+
 func (r *RunRepo) UpdateRunStatus(ctx context.Context, id uuid.UUID, status model.RunStatus, startedAt, completedAt, pausedAt *time.Time, errorMsg *string) (*model.Run, error) {
 	params := UpdateRunStatusParams{
 		ID:     id,

--- a/backend/internal/adapter/postgres/runs.sql.go
+++ b/backend/internal/adapter/postgres/runs.sql.go
@@ -493,6 +493,45 @@ func (q *Queries) ListRunsByProjectWithStoryKey(ctx context.Context, arg ListRun
 	return items, nil
 }
 
+const listRunsByStatus = `-- name: ListRunsByStatus :many
+SELECT id, project_id, story_id, status, pipeline_config_snapshot, started_at, completed_at, error_message, created_at, updated_at, paused_at, metadata FROM runs
+WHERE status = $1
+ORDER BY created_at ASC
+`
+
+func (q *Queries) ListRunsByStatus(ctx context.Context, status string) ([]Run, error) {
+	rows, err := q.db.Query(ctx, listRunsByStatus, status)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Run{}
+	for rows.Next() {
+		var i Run
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.StoryID,
+			&i.Status,
+			&i.PipelineConfigSnapshot,
+			&i.StartedAt,
+			&i.CompletedAt,
+			&i.ErrorMessage,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.PausedAt,
+			&i.Metadata,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRunsByStory = `-- name: ListRunsByStory :many
 SELECT id, project_id, story_id, status, pipeline_config_snapshot, started_at, completed_at, error_message, created_at, updated_at, paused_at, metadata FROM runs
 WHERE story_id = $1
@@ -537,6 +576,33 @@ func (q *Queries) ListRunsByStory(ctx context.Context, arg ListRunsByStoryParams
 		return nil, err
 	}
 	return items, nil
+}
+
+const markRunOrphanedIfRunning = `-- name: MarkRunOrphanedIfRunning :execrows
+UPDATE runs
+SET status = 'failed',
+    completed_at = $2,
+    error_message = $3,
+    updated_at = now()
+WHERE id = $1 AND status = 'running'
+`
+
+type MarkRunOrphanedIfRunningParams struct {
+	ID           uuid.UUID          `json:"id"`
+	CompletedAt  pgtype.Timestamptz `json:"completed_at"`
+	ErrorMessage pgtype.Text        `json:"error_message"`
+}
+
+// Conditionally fail a run only while it is still running. The status='running'
+// guard makes orphan reconciliation TOCTOU-safe: a run that transitioned to a
+// terminal state between the reconciler's snapshot and this write is left intact
+// (0 rows affected).
+func (q *Queries) MarkRunOrphanedIfRunning(ctx context.Context, arg MarkRunOrphanedIfRunningParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markRunOrphanedIfRunning, arg.ID, arg.CompletedAt, arg.ErrorMessage)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const updateRunMetadata = `-- name: UpdateRunMetadata :exec

--- a/backend/internal/api/handler/agent_callback_handler_test.go
+++ b/backend/internal/api/handler/agent_callback_handler_test.go
@@ -115,6 +115,12 @@ func (m *runRepoForCallback) ListRunsByProject(_ context.Context, _ uuid.UUID, _
 func (m *runRepoForCallback) ListRunsByStory(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
 	return nil, nil
 }
+func (m *runRepoForCallback) ListRunsByStatus(_ context.Context, _ model.RunStatus) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *runRepoForCallback) MarkRunOrphanedIfRunning(_ context.Context, _ uuid.UUID, _ time.Time, _ string) (bool, error) {
+	return false, nil
+}
 func (m *runRepoForCallback) UpdateRunStatus(_ context.Context, id uuid.UUID, status model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
 	return &model.Run{ID: id, Status: status}, nil
 }

--- a/backend/internal/api/handler/epic_handler_test.go
+++ b/backend/internal/api/handler/epic_handler_test.go
@@ -166,6 +166,12 @@ func (m *epicRunRepo) ListRunsByProject(_ context.Context, _ uuid.UUID, _, _ int
 func (m *epicRunRepo) ListRunsByStory(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
 	return nil, nil
 }
+func (m *epicRunRepo) ListRunsByStatus(_ context.Context, _ model.RunStatus) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *epicRunRepo) MarkRunOrphanedIfRunning(_ context.Context, _ uuid.UUID, _ time.Time, _ string) (bool, error) {
+	return false, nil
+}
 func (m *epicRunRepo) UpdateRunStatus(_ context.Context, _ uuid.UUID, _ model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
 	return nil, nil
 }

--- a/backend/internal/api/handler/hitl_handler_test.go
+++ b/backend/internal/api/handler/hitl_handler_test.go
@@ -129,6 +129,12 @@ func (m *mockRunRepoForHITLHandler) ListRunsByProject(_ context.Context, _ uuid.
 func (m *mockRunRepoForHITLHandler) ListRunsByStory(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
 	return nil, nil
 }
+func (m *mockRunRepoForHITLHandler) ListRunsByStatus(_ context.Context, _ model.RunStatus) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *mockRunRepoForHITLHandler) MarkRunOrphanedIfRunning(_ context.Context, _ uuid.UUID, _ time.Time, _ string) (bool, error) {
+	return false, nil
+}
 func (m *mockRunRepoForHITLHandler) UpdateRunStatus(_ context.Context, _ uuid.UUID, _ model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
 	return nil, nil
 }

--- a/backend/internal/api/handler/run_handler_test.go
+++ b/backend/internal/api/handler/run_handler_test.go
@@ -55,6 +55,12 @@ func (m *runHandlerRunRepo) ListRunsByProject(_ context.Context, _ uuid.UUID, _,
 func (m *runHandlerRunRepo) ListRunsByStory(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
 	return nil, nil
 }
+func (m *runHandlerRunRepo) ListRunsByStatus(_ context.Context, _ model.RunStatus) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *runHandlerRunRepo) MarkRunOrphanedIfRunning(_ context.Context, _ uuid.UUID, _ time.Time, _ string) (bool, error) {
+	return false, nil
+}
 func (m *runHandlerRunRepo) UpdateRunStatus(ctx context.Context, id uuid.UUID, status model.RunStatus, startedAt, completedAt, pausedAt *time.Time, errMsg *string) (*model.Run, error) {
 	if m.updateRunStatusFn != nil {
 		return m.updateRunStatusFn(ctx, id, status, startedAt, completedAt, pausedAt, errMsg)

--- a/backend/internal/api/handler/story_handler_test.go
+++ b/backend/internal/api/handler/story_handler_test.go
@@ -694,6 +694,12 @@ func (m *storyHandlerRunRepo) ListRunsByProject(_ context.Context, _ uuid.UUID, 
 func (m *storyHandlerRunRepo) ListRunsByStory(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
 	return nil, nil
 }
+func (m *storyHandlerRunRepo) ListRunsByStatus(_ context.Context, _ model.RunStatus) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *storyHandlerRunRepo) MarkRunOrphanedIfRunning(_ context.Context, _ uuid.UUID, _ time.Time, _ string) (bool, error) {
+	return false, nil
+}
 func (m *storyHandlerRunRepo) UpdateRunStatus(_ context.Context, _ uuid.UUID, _ model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
 	return nil, nil
 }

--- a/backend/internal/domain/port/run_repository.go
+++ b/backend/internal/domain/port/run_repository.go
@@ -27,6 +27,14 @@ type RunRepository interface {
 	GetDAGNodeRunInfoByStories(ctx context.Context, storyIDs []uuid.UUID) (map[uuid.UUID]model.DAGNodeRunInfo, error)
 	ListRunsByProject(ctx context.Context, projectID uuid.UUID, limit, offset int32) ([]*model.Run, error)
 	ListRunsByStory(ctx context.Context, storyID uuid.UUID, limit, offset int32) ([]*model.Run, error)
+	// ListRunsByStatus returns all runs in the given status, oldest first.
+	// Used by orphan reconciliation to enumerate running runs from the DB.
+	ListRunsByStatus(ctx context.Context, status model.RunStatus) ([]*model.Run, error)
+	// MarkRunOrphanedIfRunning fails a run (status=failed, completed_at, error_message)
+	// ONLY while it is still running. Returns true if a row was updated, false if the
+	// run had already transitioned to a terminal state (TOCTOU-safe; used by orphan
+	// reconciliation so a concurrently-completed run is never overwritten).
+	MarkRunOrphanedIfRunning(ctx context.Context, id uuid.UUID, completedAt time.Time, errorMsg string) (bool, error)
 	UpdateRunStatus(ctx context.Context, id uuid.UUID, status model.RunStatus, startedAt, completedAt, pausedAt *time.Time, errorMsg *string) (*model.Run, error)
 	// UpdateRunMetadata persists the run's metadata map to the DB.
 	// Used to survive HITL suspend/resume by flushing in-memory mutations after each step.

--- a/backend/internal/domain/service/cost_service_test.go
+++ b/backend/internal/domain/service/cost_service_test.go
@@ -244,6 +244,12 @@ func (m *mockRunRepoForCost) ListRunsByProject(_ context.Context, _ uuid.UUID, _
 func (m *mockRunRepoForCost) ListRunsByStory(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
 	return nil, nil
 }
+func (m *mockRunRepoForCost) ListRunsByStatus(_ context.Context, _ model.RunStatus) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *mockRunRepoForCost) MarkRunOrphanedIfRunning(_ context.Context, _ uuid.UUID, _ time.Time, _ string) (bool, error) {
+	return false, nil
+}
 func (m *mockRunRepoForCost) UpdateRunStatus(_ context.Context, _ uuid.UUID, _ model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
 	return nil, nil
 }

--- a/backend/internal/domain/service/hitl_service_test.go
+++ b/backend/internal/domain/service/hitl_service_test.go
@@ -156,6 +156,12 @@ func (m *mockRunRepoForHITL) ListRunsByProject(_ context.Context, _ uuid.UUID, _
 func (m *mockRunRepoForHITL) ListRunsByStory(_ context.Context, _ uuid.UUID, _, _ int32) ([]*model.Run, error) {
 	return nil, nil
 }
+func (m *mockRunRepoForHITL) ListRunsByStatus(_ context.Context, _ model.RunStatus) ([]*model.Run, error) {
+	return nil, nil
+}
+func (m *mockRunRepoForHITL) MarkRunOrphanedIfRunning(_ context.Context, _ uuid.UUID, _ time.Time, _ string) (bool, error) {
+	return false, nil
+}
 func (m *mockRunRepoForHITL) UpdateRunStatus(_ context.Context, id uuid.UUID, status model.RunStatus, _, _, _ *time.Time, _ *string) (*model.Run, error) {
 	run, ok := m.runs[id]
 	if !ok {

--- a/backend/internal/domain/service/orphan_reconciler.go
+++ b/backend/internal/domain/service/orphan_reconciler.go
@@ -1,0 +1,200 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+)
+
+// orphanedNoContainerReason is the error message set on a run that is marked
+// failed because its active (running) step launched a container that is no
+// longer running.
+const orphanedNoContainerReason = "orphaned_no_container"
+
+// DefaultOrphanGraceWindow is the minimum age (since the active step's
+// started_at) a running step must have before its run can be reconciled as
+// orphaned. It gives the launch→persist(container_id) window time to complete so
+// a freshly launched container is never mistaken for a missing one.
+const DefaultOrphanGraceWindow = 60 * time.Second
+
+// OrphanReconciler reconciles DB run statuses against live container state.
+//
+// Whereas OrphanCleaner removes leftover *containers* (and never touches run
+// statuses), this reconciler does the inverse: it finds runs whose active step
+// launched a container that has since died (crashed/killed) yet left the run
+// stuck `running` in the DB forever (it shows in "Active runs" with an
+// ever-growing duration). The timeout enforcer can't help because it iterates
+// EXISTING containers, so a run whose container is already gone is never
+// visited.
+//
+// Correct orphan invariant (the crux of this service):
+//
+// A `running` run is orphaned IFF it has a run_step with status=running that
+// carries a non-nil container_id, whose started_at is older than the grace
+// window, AND that container_id is absent from the set of currently RUNNING
+// managed containers. Concretely:
+//
+//   - Only steps that actually launched a container (agent_run) carry a
+//     container_id. ci_poll / hitl_gate / git_pr / git_branch run NO container,
+//     so their running step has a nil container_id → never orphaned (a run can
+//     legitimately sit `running` for the ci_poll 15-min timeout or a human gate).
+//   - Between two agent_run steps there is a gap with no running step / no
+//     container — no running step with a container_id → never orphaned.
+//   - A just-launched container is covered by the per-step grace window.
+//   - A crashed agent_run container leaves its step `running` with a posted
+//     container_id absent from ListRunningContainers → orphaned after grace.
+//
+// We list via ContainerManager.ListRunningContainers (RUNNING only, not
+// ListContainers): an exited-but-not-yet-removed container must count as gone,
+// otherwise a crashed run would never be detected.
+//
+// Substrate scope (ADR Stage 4): like OrphanCleaner/TimeoutEnforcer this reaper
+// is Docker-shaped — it enumerates live executions via ListRunningContainers
+// (managed_by=hopeitworks) keyed by container id. Reconciling a NON-Docker
+// substrate needs a runtime-level "list managed executions" capability and is
+// DEFERRED until one ships live.
+type OrphanReconciler struct {
+	containerMgr port.ContainerManager
+	runRepo      port.RunRepository
+	logger       *slog.Logger
+	graceWindow  time.Duration
+}
+
+// NewOrphanReconciler creates a new OrphanReconciler. graceWindow is the minimum
+// age the active running step must have before its run can be reconciled (use
+// DefaultOrphanGraceWindow).
+func NewOrphanReconciler(
+	containerMgr port.ContainerManager,
+	runRepo port.RunRepository,
+	logger *slog.Logger,
+	graceWindow time.Duration,
+) *OrphanReconciler {
+	return &OrphanReconciler{
+		containerMgr: containerMgr,
+		runRepo:      runRepo,
+		logger:       logger,
+		graceWindow:  graceWindow,
+	}
+}
+
+// ReconcileOrphanedRuns marks `running` runs whose active container-backed step
+// has no live container as `failed` with reason orphaned_no_container.
+//
+// Safety contract (the whole point of this method):
+//   - It reconciles ONLY on PROOF OF ABSENCE: the running-container listing must
+//     SUCCEED, and the step's container_id must be absent from it. If
+//     ListRunningContainers errors (Docker/runtime unreachable) it logs and
+//     aborts WITHOUT touching any run — a transient listing failure must never
+//     mass-fail healthy runs.
+//   - A run whose active step launched no container (ci_poll/hitl_gate/git_*) is
+//     left untouched: that is a normal long-lived `running` state.
+//   - A run whose active step is still within the grace window is left untouched,
+//     giving a just-launched container time to appear.
+//   - The DB write is conditional on status='running' (TOCTOU-safe): a run that
+//     transitioned to completed/cancelled between the snapshot and the write is
+//     never overwritten (0 rows affected → no-op).
+//   - Only `status=running` runs are considered (ListRunsByStatus), so terminal
+//     runs (failed/completed/cancelled) are idempotently left alone.
+func (o *OrphanReconciler) ReconcileOrphanedRuns(ctx context.Context) error {
+	containers, err := o.containerMgr.ListRunningContainers(ctx, map[string]string{
+		"managed_by": "hopeitworks",
+	})
+	if err != nil {
+		// Proof of absence requires a successful listing of RUNNING containers. On
+		// error we cannot tell a dead run from an unreachable runtime, so we touch
+		// nothing — abort before querying DB runs.
+		o.logger.Error("orphan reconcile aborted: failed to list running containers", "error", err)
+		return err
+	}
+
+	liveContainerIDs := make(map[string]struct{}, len(containers))
+	for _, container := range containers {
+		if container.ID != "" {
+			liveContainerIDs[container.ID] = struct{}{}
+		}
+	}
+
+	runningRuns, err := o.runRepo.ListRunsByStatus(ctx, model.RunStatusRunning)
+	if err != nil {
+		o.logger.Error("orphan reconcile aborted: failed to list running runs", "error", err)
+		return err
+	}
+
+	now := time.Now()
+	reconciled := 0
+	for _, run := range runningRuns {
+		orphaned, err := o.isOrphaned(ctx, run, liveContainerIDs, now)
+		if err != nil {
+			o.logger.Error("failed to evaluate run for reconciliation", "run_id", run.ID, "error", err)
+			continue
+		}
+		if !orphaned {
+			continue
+		}
+
+		// TOCTOU-safe: only flip the run if it is STILL running. A run that
+		// completed/cancelled between the snapshot above and this write is not
+		// overwritten (affected == false).
+		affected, err := o.runRepo.MarkRunOrphanedIfRunning(ctx, run.ID, now, orphanedNoContainerReason)
+		if err != nil {
+			o.logger.Error("failed to reconcile orphaned run", "run_id", run.ID, "error", err)
+			continue
+		}
+		if !affected {
+			// Run already transitioned to a terminal state concurrently — no-op.
+			continue
+		}
+		o.logger.Warn("reconciled orphaned run (no live container for active step)",
+			"run_id", run.ID,
+			"reason", orphanedNoContainerReason,
+		)
+		reconciled++
+	}
+
+	o.logger.Info("orphan run reconciliation completed", "runs_reconciled", reconciled)
+	return nil
+}
+
+// isOrphaned reports whether a `running` run has an active (running) step that
+// launched a container which is no longer running, past the grace window. It is
+// the sole place the orphan invariant is decided.
+//
+// Returns false (NOT orphaned) when the run has no running step, when the
+// running step launched no container (nil container_id), when the step is still
+// within the grace window, or when the step's container is still running.
+func (o *OrphanReconciler) isOrphaned(
+	ctx context.Context,
+	run *model.Run,
+	liveContainerIDs map[string]struct{},
+	now time.Time,
+) (bool, error) {
+	steps, err := o.runRepo.ListRunStepsByRun(ctx, run.ID)
+	if err != nil {
+		return false, err
+	}
+
+	for _, step := range steps {
+		if step.Status != model.StepStatusRunning {
+			continue
+		}
+		// Steps without a launched container (ci_poll/hitl_gate/git_*, or a step
+		// not yet started) are legitimately long-lived running states.
+		if step.ContainerID == nil || *step.ContainerID == "" {
+			continue
+		}
+		// Grace is relative to the STEP's start: covers the launch→persist window.
+		if step.StartedAt == nil || now.Sub(*step.StartedAt) < o.graceWindow {
+			continue
+		}
+		if _, alive := liveContainerIDs[*step.ContainerID]; alive {
+			continue
+		}
+		// Running step, container was launched, past grace, container not running.
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/backend/internal/domain/service/orphan_reconciler_test.go
+++ b/backend/internal/domain/service/orphan_reconciler_test.go
@@ -1,0 +1,428 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zakari/hopeitworks/backend/internal/domain/model"
+	"github.com/zakari/hopeitworks/backend/internal/domain/port"
+	"github.com/zakari/hopeitworks/backend/pkg/errors"
+)
+
+// stepPlan describes the active step of a run for the reconciler harness: its
+// status, optional container_id, and how long ago it started. A run is orphaned
+// IFF its active running step launched a container (containerID != "") that is
+// not in the live-running set, past the grace window.
+type stepPlan struct {
+	status      model.StepStatus
+	containerID string // "" means no container was launched (ci_poll/hitl/git_*)
+	startedAgo  time.Duration
+	noStartedAt bool // active step with a nil started_at (launch in flight)
+}
+
+// runPlan binds a run id to the steps the repo should return for it.
+type runPlan struct {
+	id    uuid.UUID
+	steps []stepPlan
+}
+
+// runningStep builds a `running` step with a launched container started ago.
+func runningStep(containerID string, startedAgo time.Duration) stepPlan {
+	return stepPlan{status: model.StepStatusRunning, containerID: containerID, startedAgo: startedAgo}
+}
+
+// reconcileResult captures one MarkRunOrphanedIfRunning call for assertions.
+type reconcileResult struct {
+	id          uuid.UUID
+	completedAt time.Time
+	errMsg      string
+}
+
+// reconcilerHarness wires a mockContainerManager (driving ListRunningContainers)
+// and a mockRunRepo (driving ListRunsByStatus / ListRunStepsByRun /
+// MarkRunOrphanedIfRunning) for the reconciler RG tests.
+//
+// liveContainerIDs is the set of currently RUNNING managed container ids.
+// markAffected controls whether MarkRunOrphanedIfRunning reports a row updated
+// (false models the TOCTOU case: the run already transitioned terminal).
+func reconcilerHarness(
+	t *testing.T,
+	liveContainerIDs []string,
+	listErr error,
+	runs []runPlan,
+	markAffected bool,
+) (*OrphanReconciler, *[]reconcileResult) {
+	t.Helper()
+
+	containers := make([]port.ContainerInfo, 0, len(liveContainerIDs))
+	for _, id := range liveContainerIDs {
+		containers = append(containers, port.ContainerInfo{
+			ID:     id,
+			Labels: map[string]string{"managed_by": "hopeitworks"},
+		})
+	}
+
+	containerMgr := &mockContainerManager{
+		listRunningFn: func(_ context.Context, _ map[string]string) ([]port.ContainerInfo, error) {
+			if listErr != nil {
+				return nil, listErr
+			}
+			return containers, nil
+		},
+		// ListContainers must NOT be consulted by the reconciler; make it loud.
+		listFn: func(_ context.Context, _ map[string]string) ([]port.ContainerInfo, error) {
+			t.Error("reconciler must use ListRunningContainers, not ListContainers")
+			return nil, nil
+		},
+	}
+
+	now := time.Now()
+	stepsByRun := make(map[uuid.UUID][]*model.RunStep, len(runs))
+	running := make([]*model.Run, 0, len(runs))
+	for _, rp := range runs {
+		running = append(running, &model.Run{ID: rp.id, Status: model.RunStatusRunning})
+		steps := make([]*model.RunStep, 0, len(rp.steps))
+		for _, sp := range rp.steps {
+			step := &model.RunStep{ID: uuid.New(), RunID: rp.id, Status: sp.status}
+			if sp.containerID != "" {
+				cid := sp.containerID
+				step.ContainerID = &cid
+			}
+			if !sp.noStartedAt {
+				started := now.Add(-sp.startedAgo)
+				step.StartedAt = &started
+			}
+			steps = append(steps, step)
+		}
+		stepsByRun[rp.id] = steps
+	}
+
+	results := &[]reconcileResult{}
+	runRepo := &mockRunRepo{
+		listRunsByStatusFn: func(_ context.Context, status model.RunStatus) ([]*model.Run, error) {
+			if status != model.RunStatusRunning {
+				t.Errorf("reconciler must query only running runs, got %s", status)
+			}
+			return running, nil
+		},
+		listRunStepsByRunFn: func(_ context.Context, runID uuid.UUID) ([]*model.RunStep, error) {
+			return stepsByRun[runID], nil
+		},
+		markRunOrphanedFn: func(_ context.Context, id uuid.UUID, completedAt time.Time, errMsg string) (bool, error) {
+			*results = append(*results, reconcileResult{id: id, completedAt: completedAt, errMsg: errMsg})
+			return markAffected, nil
+		},
+	}
+
+	r := NewOrphanReconciler(containerMgr, runRepo, discardLogger(), DefaultOrphanGraceWindow)
+	return r, results
+}
+
+// RG1 + RG4: a run whose running step launched a container that is no longer in
+// ListRunningContainers (crashed/exited/removed), past the grace window, is
+// marked failed with reason orphaned_no_container and a completed_at timestamp
+// (RG4: bounded duration).
+func TestReconcileOrphanedRuns_CrashedContainer_MarkedFailed(t *testing.T) {
+	orphanID := uuid.New()
+	// Step launched container "c-dead"; live-running set is EMPTY (container
+	// exited — present in ListContainers but absent from ListRunningContainers).
+	r, results := reconcilerHarness(t,
+		nil, // no live running containers
+		nil,
+		[]runPlan{{id: orphanID, steps: []stepPlan{runningStep("c-dead", 10*time.Minute)}}},
+		true,
+	)
+
+	if err := r.ReconcileOrphanedRuns(context.Background()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(*results) != 1 {
+		t.Fatalf("expected exactly 1 run reconciled, got %d", len(*results))
+	}
+	got := (*results)[0]
+	if got.id != orphanID {
+		t.Errorf("expected orphan run %s reconciled, got %s", orphanID, got.id)
+	}
+	if got.errMsg != orphanedNoContainerReason {
+		t.Errorf("expected reason %q, got %q", orphanedNoContainerReason, got.errMsg)
+	}
+	// RG4: completed_at is set → duration is bounded.
+	if got.completedAt.IsZero() {
+		t.Error("expected completed_at to be set (RG4: bounded duration)")
+	}
+}
+
+// RG3 (a): a running step with NO container_id (ci_poll/hitl_gate/git_*) is a
+// legit long-lived running state and is never reconciled, even past grace.
+func TestReconcileOrphanedRuns_RunningStepNoContainer_Untouched(t *testing.T) {
+	id := uuid.New()
+	noContainer := stepPlan{status: model.StepStatusRunning, containerID: "", startedAgo: 30 * time.Minute}
+
+	r, results := reconcilerHarness(t, nil, nil,
+		[]runPlan{{id: id, steps: []stepPlan{noContainer}}}, true)
+
+	if err := r.ReconcileOrphanedRuns(context.Background()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(*results) != 0 {
+		t.Fatalf("expected no run reconciled (no-container step is legit), got %d", len(*results))
+	}
+}
+
+// RG3 (b): a running step whose container IS in ListRunningContainers is healthy
+// and never reconciled.
+func TestReconcileOrphanedRuns_ContainerAlive_Untouched(t *testing.T) {
+	id := uuid.New()
+
+	r, results := reconcilerHarness(t,
+		[]string{"c-alive"}, nil,
+		[]runPlan{{id: id, steps: []stepPlan{runningStep("c-alive", 10*time.Minute)}}}, true)
+
+	if err := r.ReconcileOrphanedRuns(context.Background()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(*results) != 0 {
+		t.Fatalf("expected no run reconciled (container alive), got %d", len(*results))
+	}
+}
+
+// RG3 (c): a running step with a container but started < grace ago is left
+// untouched — the container may still be starting / its id not yet persisted.
+func TestReconcileOrphanedRuns_WithinGraceWindow_Untouched(t *testing.T) {
+	id := uuid.New()
+
+	r, results := reconcilerHarness(t, nil, nil,
+		[]runPlan{{id: id, steps: []stepPlan{runningStep("c-fresh", 5*time.Second)}}}, true)
+
+	if err := r.ReconcileOrphanedRuns(context.Background()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(*results) != 0 {
+		t.Fatalf("expected no run reconciled (within grace window), got %d", len(*results))
+	}
+}
+
+// RG3 (c, nil started_at): a running container-backed step with nil started_at
+// (launch in flight) is left untouched — no lower bound for the grace check.
+func TestReconcileOrphanedRuns_StepNilStartedAt_Untouched(t *testing.T) {
+	id := uuid.New()
+	inFlight := stepPlan{status: model.StepStatusRunning, containerID: "c-inflight", noStartedAt: true}
+
+	r, results := reconcilerHarness(t, nil, nil,
+		[]runPlan{{id: id, steps: []stepPlan{inFlight}}}, true)
+
+	if err := r.ReconcileOrphanedRuns(context.Background()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(*results) != 0 {
+		t.Fatalf("expected no run reconciled (step nil started_at), got %d", len(*results))
+	}
+}
+
+// RG3 (d): a run in an inter-step gap (no step is `running`; previous completed,
+// next not yet started) is left untouched — there is no active container to miss.
+func TestReconcileOrphanedRuns_InterStepGap_Untouched(t *testing.T) {
+	id := uuid.New()
+	completed := stepPlan{status: model.StepStatusCompleted, containerID: "c-old", startedAgo: 20 * time.Minute}
+	pending := stepPlan{status: model.StepStatusPending}
+
+	r, results := reconcilerHarness(t, nil, nil,
+		[]runPlan{{id: id, steps: []stepPlan{completed, pending}}}, true)
+
+	if err := r.ReconcileOrphanedRuns(context.Background()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(*results) != 0 {
+		t.Fatalf("expected no run reconciled (inter-step gap), got %d", len(*results))
+	}
+}
+
+// RG5 (CRITICAL): when ListRunningContainers errors (runtime/Docker unreachable)
+// the reconciler returns the error and touches NO run AND never queries DB runs —
+// reconcile only on proof of absence, never on a listing failure.
+func TestReconcileOrphanedRuns_ListError_TouchesNothing(t *testing.T) {
+	listErr := errors.NewInternal("docker unreachable", nil)
+
+	results := &[]reconcileResult{}
+	containerMgr := &mockContainerManager{
+		listRunningFn: func(_ context.Context, _ map[string]string) ([]port.ContainerInfo, error) {
+			return nil, listErr
+		},
+	}
+	listRunsCalled := false
+	runRepo := &mockRunRepo{
+		listRunsByStatusFn: func(_ context.Context, _ model.RunStatus) ([]*model.Run, error) {
+			listRunsCalled = true
+			return []*model.Run{{ID: uuid.New(), Status: model.RunStatusRunning}}, nil
+		},
+		markRunOrphanedFn: func(_ context.Context, id uuid.UUID, completedAt time.Time, errMsg string) (bool, error) {
+			*results = append(*results, reconcileResult{id: id, completedAt: completedAt, errMsg: errMsg})
+			return true, nil
+		},
+	}
+
+	r := NewOrphanReconciler(containerMgr, runRepo, discardLogger(), DefaultOrphanGraceWindow)
+
+	if err := r.ReconcileOrphanedRuns(context.Background()); err == nil {
+		t.Fatal("expected error to propagate when ListRunningContainers fails, got nil")
+	}
+	if len(*results) != 0 {
+		t.Fatalf("RG5 violated: %d run(s) marked failed on a listing error; must be 0", len(*results))
+	}
+	if listRunsCalled {
+		t.Error("RG5: must abort before querying DB runs when listing fails (proof-of-absence only)")
+	}
+}
+
+// RG6 / TOCTOU: a run that transitioned to a terminal state between the snapshot
+// and the conditional write is NOT overwritten. MarkRunOrphanedIfRunning reports
+// 0 rows affected (markAffected=false); the reconciler treats it as a no-op.
+func TestReconcileOrphanedRuns_ConcurrentlyCompleted_NotOverwritten(t *testing.T) {
+	id := uuid.New()
+
+	// Looks orphaned (crashed container, past grace) but the conditional update
+	// affects 0 rows because the run already completed concurrently.
+	r, results := reconcilerHarness(t, nil, nil,
+		[]runPlan{{id: id, steps: []stepPlan{runningStep("c-dead", 10*time.Minute)}}},
+		false, // MarkRunOrphanedIfRunning → 0 rows affected
+	)
+
+	if err := r.ReconcileOrphanedRuns(context.Background()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	// The conditional write was attempted exactly once...
+	if len(*results) != 1 {
+		t.Fatalf("expected exactly 1 conditional write attempt, got %d", len(*results))
+	}
+	// ...but reported 0 rows affected → the run keeps its terminal state (the
+	// reconciler did not log it as reconciled; correctness lives in the WHERE
+	// clause asserted by MarkRunOrphanedIfRunning returning false).
+}
+
+// RG6 (idempotence): with no running runs the reconciler is a no-op and stays a
+// no-op on a second pass.
+func TestReconcileOrphanedRuns_NoRunningRuns_Idempotent(t *testing.T) {
+	r, results := reconcilerHarness(t, nil, nil, nil, true)
+
+	if err := r.ReconcileOrphanedRuns(context.Background()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := r.ReconcileOrphanedRuns(context.Background()); err != nil {
+		t.Fatalf("expected no error on second pass, got %v", err)
+	}
+	if len(*results) != 0 {
+		t.Fatalf("expected reconciliation to remain idempotent, got %d", len(*results))
+	}
+}
+
+// Mixed batch: among a crashed orphan, a healthy run (container alive), a fresh
+// run (within grace), and a ci_poll run (no-container step), only the orphan is
+// reconciled — zero false positives at scale.
+func TestReconcileOrphanedRuns_MixedBatch_OnlyOrphanReconciled(t *testing.T) {
+	orphanID := uuid.New()
+	healthyID := uuid.New()
+	freshID := uuid.New()
+	ciPollID := uuid.New()
+
+	r, results := reconcilerHarness(t,
+		[]string{"c-healthy"}, // only healthy's container is running
+		nil,
+		[]runPlan{
+			{id: orphanID, steps: []stepPlan{runningStep("c-dead", 10*time.Minute)}},
+			{id: healthyID, steps: []stepPlan{runningStep("c-healthy", 10*time.Minute)}},
+			{id: freshID, steps: []stepPlan{runningStep("c-fresh", 2*time.Second)}},
+			{id: ciPollID, steps: []stepPlan{{status: model.StepStatusRunning, startedAgo: 12 * time.Minute}}},
+		},
+		true,
+	)
+
+	if err := r.ReconcileOrphanedRuns(context.Background()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(*results) != 1 {
+		t.Fatalf("expected exactly 1 run reconciled (the orphan), got %d", len(*results))
+	}
+	if (*results)[0].id != orphanID {
+		t.Errorf("expected orphan %s reconciled, got %s", orphanID, (*results)[0].id)
+	}
+}
+
+// RG2 (boot entrypoint): the boot path is the same ReconcileOrphanedRuns method
+// main() calls at startup; this exercises that entrypoint and proves a boot-time
+// orphan is reconciled.
+func TestReconcileOrphanedRuns_BootEntrypoint_ReconcilesOrphan(t *testing.T) {
+	orphanID := uuid.New()
+
+	r, results := reconcilerHarness(t, nil, nil,
+		[]runPlan{{id: orphanID, steps: []stepPlan{runningStep("c-dead", 30*time.Minute)}}}, true)
+
+	if err := r.ReconcileOrphanedRuns(context.Background()); err != nil {
+		t.Fatalf("boot reconciliation returned error: %v", err)
+	}
+	if len(*results) != 1 || (*results)[0].id != orphanID {
+		t.Fatalf("expected boot reconciliation to fail the orphan, got %+v", *results)
+	}
+}
+
+// RG2 (watchdog wiring): a TimeoutEnforcer constructed WITH a reconciler invokes
+// it on each tick. Drives the real Start loop and asserts the orphan is
+// reconciled with no live container present.
+func TestTimeoutEnforcer_TickReconcilesOrphans(t *testing.T) {
+	orphanID := uuid.New()
+	cid := "c-dead"
+	started := time.Now().Add(-10 * time.Minute)
+
+	containerMgr := &mockContainerManager{
+		// No running containers for the orphan's step.
+		listRunningFn: func(_ context.Context, _ map[string]string) ([]port.ContainerInfo, error) {
+			return []port.ContainerInfo{}, nil
+		},
+		// CheckTimeouts iterates ListContainers; keep it empty.
+		listFn: func(_ context.Context, _ map[string]string) ([]port.ContainerInfo, error) {
+			return []port.ContainerInfo{}, nil
+		},
+	}
+
+	reconciled := make(chan uuid.UUID, 1)
+	runRepo := &mockRunRepo{
+		listRunsByStatusFn: func(_ context.Context, _ model.RunStatus) ([]*model.Run, error) {
+			return []*model.Run{{ID: orphanID, Status: model.RunStatusRunning}}, nil
+		},
+		listRunStepsByRunFn: func(_ context.Context, runID uuid.UUID) ([]*model.RunStep, error) {
+			return []*model.RunStep{{
+				ID: uuid.New(), RunID: runID, Status: model.StepStatusRunning,
+				ContainerID: &cid, StartedAt: &started,
+			}}, nil
+		},
+		markRunOrphanedFn: func(_ context.Context, id uuid.UUID, _ time.Time, _ string) (bool, error) {
+			select {
+			case reconciled <- id:
+			default:
+			}
+			return true, nil
+		},
+	}
+	projectRepo := newMockProjectRepoForService()
+
+	enforcer := NewTimeoutEnforcer(
+		containerMgr, runRepo, projectRepo, discardLogger(),
+		30*time.Minute, 20*time.Millisecond,
+		NewOrphanReconciler(containerMgr, runRepo, discardLogger(), DefaultOrphanGraceWindow),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = enforcer.Start(ctx) }()
+
+	select {
+	case id := <-reconciled:
+		if id != orphanID {
+			t.Errorf("expected watchdog to reconcile orphan %s, got %s", orphanID, id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog tick did not reconcile the orphaned run")
+	}
+}

--- a/backend/internal/domain/service/run_service_test.go
+++ b/backend/internal/domain/service/run_service_test.go
@@ -20,6 +20,8 @@ type mockRunRepo struct {
 	getActiveRunByStoryFn    func(ctx context.Context, storyID uuid.UUID) (*model.Run, error)
 	listRunsByProjectFn      func(ctx context.Context, projectID uuid.UUID, limit, offset int32) ([]*model.Run, error)
 	listRunsByStoryFn        func(ctx context.Context, storyID uuid.UUID, limit, offset int32) ([]*model.Run, error)
+	listRunsByStatusFn       func(ctx context.Context, status model.RunStatus) ([]*model.Run, error)
+	markRunOrphanedFn        func(ctx context.Context, id uuid.UUID, completedAt time.Time, errorMsg string) (bool, error)
 	updateRunStatusFn        func(ctx context.Context, id uuid.UUID, status model.RunStatus, startedAt, completedAt, pausedAt *time.Time, errorMsg *string) (*model.Run, error)
 	countRunsByProjectFn     func(ctx context.Context, projectID uuid.UUID) (int64, error)
 	countRunsByStoryFn       func(ctx context.Context, storyID uuid.UUID) (int64, error)
@@ -61,6 +63,18 @@ func (m *mockRunRepo) ListRunsByStory(ctx context.Context, storyID uuid.UUID, li
 		return m.listRunsByStoryFn(ctx, storyID, limit, offset)
 	}
 	return nil, nil
+}
+func (m *mockRunRepo) ListRunsByStatus(ctx context.Context, status model.RunStatus) ([]*model.Run, error) {
+	if m.listRunsByStatusFn != nil {
+		return m.listRunsByStatusFn(ctx, status)
+	}
+	return nil, nil
+}
+func (m *mockRunRepo) MarkRunOrphanedIfRunning(ctx context.Context, id uuid.UUID, completedAt time.Time, errorMsg string) (bool, error) {
+	if m.markRunOrphanedFn != nil {
+		return m.markRunOrphanedFn(ctx, id, completedAt, errorMsg)
+	}
+	return true, nil
 }
 func (m *mockRunRepo) UpdateRunStatus(ctx context.Context, id uuid.UUID, status model.RunStatus, startedAt, completedAt, pausedAt *time.Time, errorMsg *string) (*model.Run, error) {
 	if m.updateRunStatusFn != nil {

--- a/backend/internal/domain/service/timeout_enforcer.go
+++ b/backend/internal/domain/service/timeout_enforcer.go
@@ -23,11 +23,16 @@ type TimeoutEnforcer struct {
 	logger         *slog.Logger
 	defaultTimeout time.Duration
 	checkInterval  time.Duration
+	// reconciler reconciles DB run statuses against live containers on each tick.
+	// Optional: nil disables periodic reconciliation.
+	reconciler *OrphanReconciler
 }
 
 // NewTimeoutEnforcer creates a new TimeoutEnforcer.
 // defaultTimeout is the maximum time a container may run before being stopped (default 30 minutes).
 // checkInterval is how often the enforcer checks for timed-out containers (default 30 seconds).
+// reconciler is invoked on each watchdog tick to reconcile orphaned DB run
+// statuses (runs stuck `running` with no live container); pass nil to disable.
 func NewTimeoutEnforcer(
 	containerMgr port.ContainerManager,
 	runRepo port.RunRepository,
@@ -35,6 +40,7 @@ func NewTimeoutEnforcer(
 	logger *slog.Logger,
 	defaultTimeout time.Duration,
 	checkInterval time.Duration,
+	reconciler *OrphanReconciler,
 ) *TimeoutEnforcer {
 	return &TimeoutEnforcer{
 		containerMgr:   containerMgr,
@@ -43,6 +49,7 @@ func NewTimeoutEnforcer(
 		logger:         logger,
 		defaultTimeout: defaultTimeout,
 		checkInterval:  checkInterval,
+		reconciler:     reconciler,
 	}
 }
 
@@ -66,6 +73,11 @@ func (t *TimeoutEnforcer) Start(ctx context.Context) error {
 		case <-ticker.C:
 			if err := t.CheckTimeouts(ctx); err != nil {
 				t.logger.Error("timeout check failed", "error", err)
+			}
+			if t.reconciler != nil {
+				if err := t.reconciler.ReconcileOrphanedRuns(ctx); err != nil {
+					t.logger.Error("orphan run reconciliation failed", "error", err)
+				}
 			}
 		}
 	}

--- a/backend/internal/domain/service/timeout_enforcer_test.go
+++ b/backend/internal/domain/service/timeout_enforcer_test.go
@@ -16,15 +16,16 @@ import (
 
 // mockContainerManager implements port.ContainerManager for testing.
 type mockContainerManager struct {
-	mu          sync.Mutex
-	listFn      func(ctx context.Context, labels map[string]string) ([]port.ContainerInfo, error)
-	stopCalls   []string
-	stopFn      func(ctx context.Context, containerID string) error
-	removeCalls []string
-	removeFn    func(ctx context.Context, containerID string) error
-	createFn    func(ctx context.Context, opts model.ContainerOpts) (string, error)
-	startFn     func(ctx context.Context, containerID string) error
-	waitFn      func(ctx context.Context, containerID string) (int, error)
+	mu            sync.Mutex
+	listFn        func(ctx context.Context, labels map[string]string) ([]port.ContainerInfo, error)
+	listRunningFn func(ctx context.Context, labels map[string]string) ([]port.ContainerInfo, error)
+	stopCalls     []string
+	stopFn        func(ctx context.Context, containerID string) error
+	removeCalls   []string
+	removeFn      func(ctx context.Context, containerID string) error
+	createFn      func(ctx context.Context, opts model.ContainerOpts) (string, error)
+	startFn       func(ctx context.Context, containerID string) error
+	waitFn        func(ctx context.Context, containerID string) (int, error)
 }
 
 func (m *mockContainerManager) ListContainers(ctx context.Context, labels map[string]string) ([]port.ContainerInfo, error) {
@@ -75,7 +76,10 @@ func (m *mockContainerManager) Wait(ctx context.Context, containerID string) (in
 	return 0, nil
 }
 
-func (m *mockContainerManager) ListRunningContainers(_ context.Context, _ map[string]string) ([]port.ContainerInfo, error) {
+func (m *mockContainerManager) ListRunningContainers(ctx context.Context, labels map[string]string) ([]port.ContainerInfo, error) {
+	if m.listRunningFn != nil {
+		return m.listRunningFn(ctx, labels)
+	}
 	return nil, nil
 }
 
@@ -181,7 +185,7 @@ func TestCheckTimeouts_ContainerExceedsTimeout(t *testing.T) {
 		Name: "test-project",
 	})
 
-	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second)
+	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second, nil)
 
 	err := enforcer.CheckTimeouts(context.Background())
 	if err != nil {
@@ -258,7 +262,7 @@ func TestCheckTimeouts_ContainerWithinTimeout(t *testing.T) {
 		Name: "test-project",
 	})
 
-	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second)
+	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second, nil)
 
 	err := enforcer.CheckTimeouts(context.Background())
 	if err != nil {
@@ -328,7 +332,7 @@ func TestCheckTimeouts_ProjectTimeoutOverridesDefault(t *testing.T) {
 		MaxContainerTimeout: &projectTimeout,
 	})
 
-	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second)
+	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second, nil)
 
 	err := enforcer.CheckTimeouts(context.Background())
 	if err != nil {
@@ -392,7 +396,7 @@ func TestCheckTimeouts_ProjectTimeoutNotExceeded(t *testing.T) {
 		MaxContainerTimeout: &projectTimeout,
 	})
 
-	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second)
+	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second, nil)
 
 	err := enforcer.CheckTimeouts(context.Background())
 	if err != nil {
@@ -464,7 +468,7 @@ func TestCheckTimeouts_MultipleContainers(t *testing.T) {
 		Name: "test-project",
 	})
 
-	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second)
+	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second, nil)
 
 	err := enforcer.CheckTimeouts(context.Background())
 	if err != nil {
@@ -521,7 +525,7 @@ func TestCheckTimeouts_StopFailureContinues(t *testing.T) {
 		Name: "test-project",
 	})
 
-	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second)
+	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second, nil)
 
 	// Should not panic or return error even though Stop fails
 	err := enforcer.CheckTimeouts(context.Background())
@@ -549,7 +553,7 @@ func TestCheckTimeouts_SkipsMissingLabels(t *testing.T) {
 	runRepo := &mockRunRepo{}
 	projectRepo := newMockProjectRepoForService()
 
-	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second)
+	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second, nil)
 
 	err := enforcer.CheckTimeouts(context.Background())
 	if err != nil {
@@ -603,7 +607,7 @@ func TestCheckTimeouts_NilStartedAt(t *testing.T) {
 		Name: "test-project",
 	})
 
-	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second)
+	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 30*time.Second, nil)
 
 	err := enforcer.CheckTimeouts(context.Background())
 	if err != nil {
@@ -625,7 +629,7 @@ func TestStart_StopsOnContextCancellation(t *testing.T) {
 	runRepo := &mockRunRepo{}
 	projectRepo := newMockProjectRepoForService()
 
-	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 50*time.Millisecond)
+	enforcer := NewTimeoutEnforcer(containerMgr, runRepo, projectRepo, discardLogger(), 30*time.Minute, 50*time.Millisecond, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/backend/queries/runs.sql
+++ b/backend/queries/runs.sql
@@ -48,6 +48,23 @@ WHERE story_id = $1 AND status IN ('pending', 'running', 'paused')
 ORDER BY created_at DESC
 LIMIT 1;
 
+-- name: ListRunsByStatus :many
+SELECT * FROM runs
+WHERE status = $1
+ORDER BY created_at ASC;
+
+-- name: MarkRunOrphanedIfRunning :execrows
+-- Conditionally fail a run only while it is still running. The status='running'
+-- guard makes orphan reconciliation TOCTOU-safe: a run that transitioned to a
+-- terminal state between the reconciler's snapshot and this write is left intact
+-- (0 rows affected).
+UPDATE runs
+SET status = 'failed',
+    completed_at = $2,
+    error_message = $3,
+    updated_at = now()
+WHERE id = $1 AND status = 'running';
+
 -- name: UpdateRunMetadata :exec
 UPDATE runs SET metadata = $2, updated_at = now() WHERE id = $1;
 


### PR DESCRIPTION
## Contexte
Au boot, seul `OrphanCleaner` tournait (supprime des containers, ne flippe jamais le statut DB) et `TimeoutEnforcer` itère les containers existants : un run figé `running` dont le container a disparu restait fantôme dans « Active runs » avec une durée aberrante (7359:xx). Aucune réconciliation ne partait de la DB. Closes #291.

## Changements (back-only)
Nouveau `OrphanReconciler.ReconcileOrphanedRuns`, appelé **au boot** (`cmd/api/main.go`) et à **chaque tick du watchdog** (boucle 30s de `TimeoutEnforcer`, reconciler injecté au constructeur).

**Invariant** : un run `running` est orphelin **ssi** il a un `run_step` `running` portant un `container_id` **absent de `ListRunningContainers`** (les containers `exited` comptent comme morts), avec une **grâce de 60s relative au step**.
- Zéro faux positif : les steps sans container (`ci_poll`, `hitl_gate`, `git_*`), les gaps inter-step, la fenêtre de grâce et les containers vivants sont épargnés.
- **RG5** : erreur de listing → rien touché (réconciliation sur *preuve d'absence*, jamais sur erreur).
- **TOCTOU** : écriture conditionnelle `MarkRunOrphanedIfRunning` (`UPDATE ... WHERE id=$1 AND status='running'`) → n'écrase jamais un `completed`/`cancelled` concurrent. La query partagée `UpdateRunStatus` est inchangée.
- Statut cible `failed` + raison `orphaned_no_container`, `completed_at` posé (borne la durée, RG4). Scope v1 Docker.

## Tests (QA exercée — 6/6 RG pass)
Tests Go service avec mock `ContainerManager` mappés à chaque RG (RG1 crash réel, RG2 boot+watchdog, RG3 les 4 faux-positifs épargnés, RG4 completed_at, RG5 erreur-listing → 0 write, RG6/TOCTOU). Regression postgres (testcontainers) verte. `go build`/`vet`/`golangci-lint` vert.

## Volet front
**Back-only justifié** : le Dashboard « Active runs » et les durées lisent déjà `status`/`completed_at` ; corriger la transition DB suffit, aucun changement front.

## Limitation connue (follow-up, hors scope #291)
Cas résiduel signalé en revue : un run dont le step passe `running` mais dont le `container_id` n'a jamais été persisté (crash de l'orchestrateur dans la fenêtre sub-seconde mark-running→persist) n'est couvert par aucun reaper. Hors de l'invariant « container crashé » du ticket, non régressif. Candidat follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — via /forge:autopilot (autonome, pr-only)
