### PR TITLE
fix(router): résoudre les deep-links overview et notifications projet (#293)

### DIFF
--- a/frontend/e2e/tests/project-detail.spec.ts
+++ b/frontend/e2e/tests/project-detail.spec.ts
@@ -74,6 +74,14 @@ test.describe('Project Detail — Tabbed Navigation', () => {
         body: JSON.stringify({ data: [], pagination: { total: 0, page: 1, per_page: 20 } }),
       })
     })
+
+    await page.route('**/api/v1/projects/p1/notifications', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      })
+    })
   })
 
   test('shows project name and tabs on project detail page', async ({ page }) => {
@@ -129,6 +137,46 @@ test.describe('Project Detail — Tabbed Navigation', () => {
 
     await expect(page).toHaveURL('/projects/p1/agents')
     await expect(page.getByRole('heading', { name: 'Agents', exact: true })).toBeVisible()
+  })
+
+  // #293 — deep-link routing (direct access + refresh, legacy bookmarks, no 404)
+
+  test('RG1/RG2 direct access + refresh to /projects/:id stays Overview', async ({ page }) => {
+    await page.goto('/projects/p1')
+    await expect(page.getByTestId('project-overview-card')).toBeVisible()
+
+    await page.reload()
+    await expect(page).toHaveURL('/projects/p1')
+    await expect(page.getByTestId('project-overview-card')).toBeVisible()
+  })
+
+  test('RG3/RG4 direct access + refresh to /projects/:id/settings/notifications stays Notifications', async ({
+    page,
+  }) => {
+    await page.goto('/projects/p1/settings/notifications')
+    await expect(page.getByRole('heading', { name: 'Notification Channels' })).toBeVisible()
+
+    await page.reload()
+    await expect(page).toHaveURL('/projects/p1/settings/notifications')
+    await expect(page.getByRole('heading', { name: 'Notification Channels' })).toBeVisible()
+  })
+
+  test('RG5 legacy /projects/:id/overview lands on canonical Overview (no 404)', async ({
+    page,
+  }) => {
+    await page.goto('/projects/p1/overview')
+
+    await expect(page).toHaveURL('/projects/p1')
+    await expect(page.getByTestId('project-overview-card')).toBeVisible()
+  })
+
+  test('RG6 legacy /projects/:id/notifications lands on Notifications (no 404)', async ({
+    page,
+  }) => {
+    await page.goto('/projects/p1/notifications')
+
+    await expect(page).toHaveURL('/projects/p1/settings/notifications')
+    await expect(page.getByRole('heading', { name: 'Notification Channels' })).toBeVisible()
   })
 
   test('back button navigates to projects list', async ({ page }) => {

--- a/frontend/src/router/__tests__/projectDeepLinks.spec.ts
+++ b/frontend/src/router/__tests__/projectDeepLinks.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createRouter, createMemoryHistory, type Router } from 'vue-router'
+
+// The api client imports the configured router singleton and calls router.afterEach() at
+// module load, creating an import cycle with the route table's guards. Stubbing it lets us
+// import the REAL `routes` table without that side-effect firing on an undefined router.
+vi.mock('@/api/client', () => ({ apiClient: {} }))
+
+const { routes } = await import('../index')
+
+/**
+ * #293 — deep-links /projects/:id/overview and /projects/:id/notifications fell into
+ * the catch-all 404 because no child route declared them. Overview's canonical URL is
+ * /projects/:id ('' child) and Notifications' is /projects/:id/settings/notifications.
+ *
+ * These tests navigate the REAL route table (the exported `routes`, single source of
+ * truth). router.push follows the redirects (router.resolve does not), so currentRoute
+ * after push proves the legacy deep-links land on the canonical named routes, the URL is
+ * canonical, and the existing tabs keep matching (no regression into the catch-all).
+ */
+function createTestRouter(): Router {
+  return createRouter({ history: createMemoryHistory(), routes })
+}
+
+async function navigate(router: Router, path: string) {
+  await router.push(path)
+  await router.isReady()
+  return router.currentRoute.value
+}
+
+describe('#293 project deep-link routes', () => {
+  let router: Router
+
+  beforeEach(() => {
+    router = createTestRouter()
+  })
+
+  // RG5: legacy /projects/:id/overview redirects to the canonical Overview (/projects/:id)
+  it('redirects /projects/p1/overview to the canonical project-overview (/projects/p1)', async () => {
+    const route = await navigate(router, '/projects/p1/overview')
+    expect(route.name).toBe('project-overview')
+    expect(route.path).toBe('/projects/p1')
+    expect(route.params.id).toBe('p1')
+  })
+
+  // RG6: legacy /projects/:id/notifications redirects to settings/notifications
+  it('redirects /projects/p1/notifications to project-notifications (settings/notifications)', async () => {
+    const route = await navigate(router, '/projects/p1/notifications')
+    expect(route.name).toBe('project-notifications')
+    expect(route.path).toBe('/projects/p1/settings/notifications')
+    expect(route.params.id).toBe('p1')
+  })
+
+  // RG1/RG2: direct access to the canonical Overview URL stays Overview
+  it('keeps the canonical /projects/p1 on project-overview', async () => {
+    const route = await navigate(router, '/projects/p1')
+    expect(route.name).toBe('project-overview')
+    expect(route.params.id).toBe('p1')
+  })
+
+  // RG3/RG4: direct access to the canonical Notifications URL stays Notifications
+  it('keeps the canonical /projects/p1/settings/notifications on project-notifications', async () => {
+    const route = await navigate(router, '/projects/p1/settings/notifications')
+    expect(route.name).toBe('project-notifications')
+    expect(route.params.id).toBe('p1')
+  })
+
+  it('preserves a different :id through both redirects', async () => {
+    expect((await navigate(router, '/projects/abc-123/overview')).path).toBe('/projects/abc-123')
+    expect((await navigate(router, '/projects/abc-123/notifications')).path).toBe(
+      '/projects/abc-123/settings/notifications',
+    )
+  })
+
+  // RG8: non-regression — every other project tab still resolves to its own route,
+  // never the catch-all.
+  it.each([
+    ['/projects/p1', 'project-overview'],
+    ['/projects/p1/board', 'project-board'],
+    ['/projects/p1/runs', 'project-runs'],
+    ['/projects/p1/pipeline', 'project-pipeline'],
+    ['/projects/p1/agents', 'project-agents'],
+    ['/projects/p1/environment', 'project-environment'],
+    ['/projects/p1/costs', 'project-costs'],
+    ['/projects/p1/settings', 'project-settings'],
+    ['/projects/p1/settings/notifications', 'project-notifications'],
+  ])('keeps %s on %s (not the catch-all)', async (path, name) => {
+    const route = await navigate(router, path)
+    expect(route.name).toBe(name)
+    expect(route.name).not.toBe('not-found')
+  })
+
+  it('still routes a genuinely unknown project sub-path to the catch-all', async () => {
+    const route = await navigate(router, '/projects/p1/does-not-exist')
+    expect(route.name).toBe('not-found')
+  })
+})

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router'
 import LoginView from '@/views/LoginView.vue'
 import ForgotPasswordView from '@/views/ForgotPasswordView.vue'
 import ResetPasswordView from '@/views/ResetPasswordView.vue'
@@ -17,9 +17,9 @@ import NotFoundView from '@/views/NotFoundView.vue'
 import ProjectOverview from '@/features/projects/ProjectOverview.vue'
 import { setupAuthGuard, setupAdminGuard } from './guards'
 
-const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
-  routes: [
+/** Route table — exported so tests can resolve against the real routes without
+ *  importing the configured singleton (which pulls in the api client → router cycle). */
+export const routes: RouteRecordRaw[] = [
     {
       path: '/login',
       name: 'login',
@@ -59,6 +59,11 @@ const router = createRouter({
           path: '',
           name: 'project-overview',
           component: ProjectOverview,
+        },
+        {
+          // Legacy/bookmarked deep-link: redirect to the canonical overview (/projects/:id).
+          path: 'overview',
+          redirect: (to) => ({ name: 'project-overview', params: { id: to.params.id } }),
         },
         {
           path: 'board',
@@ -135,6 +140,11 @@ const router = createRouter({
           name: 'project-notifications',
           component: () => import('@/views/NotificationSettingsView.vue'),
         },
+        {
+          // Legacy/bookmarked deep-link: redirect to the canonical settings/notifications.
+          path: 'notifications',
+          redirect: (to) => ({ name: 'project-notifications', params: { id: to.params.id } }),
+        },
       ],
     },
     {
@@ -189,7 +199,11 @@ const router = createRouter({
       component: NotFoundView,
       meta: { requiresAuth: false },
     },
-  ],
+]
+
+const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes,
 })
 
 setupAuthGuard(router)


### PR DESCRIPTION
## Contexte
Les deep-links / refresh / bookmarks vers `/projects/:id/overview` et `/projects/:id/notifications` tombaient en 404 : aucune route ne les déclarait (Overview = path enfant `''` → URL canonique `/projects/:id` ; Notifications = `settings/notifications`). La navigation interne (`router.push({ name })`) marchait, mais pas l'accès direct. Closes #293.

## Changements (front-only)
- `router/index.ts` : 2 routes enfants de `/projects/:id` qui **redirigent** vers la canonique en préservant `:id` (`overview` → `project-overview`, `notifications` → `settings/notifications`). Fonction `redirect: to => ({ name, params: { id: to.params.id } })`, pas d'URL en dur, pas de boucle.
- Onglet actif correct par construction (basé sur le `name` de route canonique). Table `routes` exportée pour la tester.

## Tests (QA exercée — 8/8 RG pass)
- Router unit `projectDeepLinks.spec.ts` (15 tests) : RG1/RG3 canoniques, RG5/RG6 redirects (pas 404), RG8 table des 9 onglets + sous-path inconnu → catch-all intact. Exerce réellement les redirects (`push` + `currentRoute`).
- E2E `project-detail.spec.ts` (5 tests, rejoués) : RG2/RG4 (refresh stable), RG5/RG6 (bookmarks hérités), RG7 (projet inexistant → `project-error` cohérent).
- type-check / lint / vitest (1045) vert.

## Périmètre
Front-only confirmé (back/openapi N/A). `docs/product.md` N/A (correctif technique de routing, pas de comportement produit nouveau).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — via /forge:autopilot (autonome, pr-only)
