### PR TITLE
fix(dashboard): hydrater l'elapsed des Live Runs depuis started_at REST (#294)

### DIFF
--- a/frontend/src/stores/__tests__/runtimeStream.spec.ts
+++ b/frontend/src/stores/__tests__/runtimeStream.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { reduceRuntimeEvent, useRuntimeStream } from '../runtimeStream'
 
@@ -225,5 +225,92 @@ describe('useRuntimeStream store getters', () => {
     s.reset()
     expect(s.runSignal('r1')).toBeNull()
     expect([...s.activeStepIds]).toEqual([])
+  })
+})
+
+// ── #294 — Dashboard elapsed hydration (running runs without a `run.started`
+// SSE event must still show a real elapsed, not 00:00). Fake timers anchor the
+// clock so derived elapsed is deterministic. ──────────────────────────────────
+describe('hydrateRunStartedAt — REST seeding for elapsed (#294)', () => {
+  // A fixed "now" 3 minutes after the seeded start.
+  const NOW = new Date('2026-06-17T10:03:00Z')
+  const START = '2026-06-17T10:00:00Z'
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // RG1: a run whose `run.started` SSE arrives while the dashboard is open keeps
+  // ticking live; hydration of the SAME run must not disturb the live start.
+  it('RG1: SSE-started run keeps a live ticking elapsed', () => {
+    const s = useRuntimeStream()
+    s.ingest('run.started', { run_id: 'r1', started_at: '2026-06-17T10:02:30Z' })
+    // REST list later carries a (slightly different) started_at — must be ignored.
+    s.hydrateRunStartedAt('r1', '2026-06-17T09:00:00Z', undefined, 'running')
+    s.tick(NOW.getTime())
+    expect(s.runSignal('r1')?.startedAt).toBe('2026-06-17T10:02:30Z')
+    expect(s.runElapsedSeconds('r1')).toBe(30)
+  })
+
+  // RG2 (the bug): a run already running for 3min, known only via REST
+  // started_at, with no SSE — elapsed must be ~180s, never 0.
+  it('RG2: running run hydrated from REST shows real elapsed, not 0', () => {
+    const s = useRuntimeStream()
+    expect(s.runElapsedSeconds('r1')).toBe(0) // nothing known yet
+    s.hydrateRunStartedAt('r1', START, undefined, 'running')
+    s.tick(NOW.getTime())
+    expect(s.runSignal('r1')?.status).toBe('running')
+    expect(s.runElapsedSeconds('r1')).toBe(180)
+  })
+
+  // RG3: a pending run with no started_at must not be seeded — the getter keeps
+  // signalling "no duration" (0 here; the view renders the placeholder).
+  it('RG3: run without started_at is not seeded (no phantom 00:00)', () => {
+    const s = useRuntimeStream()
+    s.hydrateRunStartedAt('r1', null, undefined, 'pending')
+    s.hydrateRunStartedAt('r1', undefined, undefined, 'pending')
+    expect(s.runSignal('r1')).toBeNull()
+    expect(s.runElapsedSeconds('r1')).toBe(0)
+  })
+
+  // RG4: dashboard elapsed (store, hydrated) == list duration (raw started_at
+  // diff) within ±1s, because both derive from the same started_at.
+  it('RG4: hydrated elapsed matches the list duration computed from started_at', () => {
+    const s = useRuntimeStream()
+    s.hydrateRunStartedAt('r1', START, undefined, 'running')
+    s.tick(NOW.getTime())
+    const listSecs = Math.floor((NOW.getTime() - new Date(START).getTime()) / 1000)
+    expect(Math.abs(s.runElapsedSeconds('r1') - listSecs)).toBeLessThanOrEqual(1)
+  })
+
+  // RG5: a terminal run hydrated from REST freezes at completed_at - started_at
+  // and does not keep running as the clock advances.
+  it('RG5: terminal run hydrated from REST freezes at completed_at - started_at', () => {
+    const s = useRuntimeStream()
+    s.hydrateRunStartedAt('r1', START, '2026-06-17T10:00:45Z', 'completed')
+    s.tick(new Date('2026-06-17T11:00:00Z').getTime()) // long after
+    expect(s.runSignal('r1')?.status).toBe('completed')
+    expect(s.runElapsedSeconds('r1')).toBe(45)
+  })
+
+  it('is idempotent: re-hydrating the same run does not change timing', () => {
+    const s = useRuntimeStream()
+    s.hydrateRunStartedAt('r1', START, undefined, 'running')
+    s.hydrateRunStartedAt('r1', '2026-06-17T08:00:00Z', undefined, 'running')
+    s.tick(NOW.getTime())
+    expect(s.runSignal('r1')?.startedAt).toBe(START)
+    expect(s.runElapsedSeconds('r1')).toBe(180)
+  })
+
+  it('ignores empty runId', () => {
+    const s = useRuntimeStream()
+    s.hydrateRunStartedAt('', START, undefined, 'running')
+    expect(Object.keys(s.runs)).toHaveLength(0)
   })
 })

--- a/frontend/src/stores/runtimeStream.ts
+++ b/frontend/src/stores/runtimeStream.ts
@@ -261,6 +261,33 @@ export const useRuntimeStream = defineStore('runtimeStream', () => {
     clock.value = nowMs
   }
 
+  /**
+   * Seed a run's timing from a REST source (e.g. list endpoints carry
+   * `started_at`/`completed_at`) so elapsed derivation works for runs that were
+   * already running before this client opened — i.e. before any `run.started`
+   * SSE event could be captured.
+   *
+   * Idempotent and SSE-deferential: it only fills `startedAt`/`finishedAt`/`status`
+   * that are not already known from the live stream. A non-null SSE `startedAt`
+   * stays authoritative and is never overwritten. Pass a null/empty `startedAt`
+   * (e.g. a pending run) and nothing is seeded — the run keeps signalling "no
+   * duration" so callers can render a placeholder instead of 00:00.
+   */
+  function hydrateRunStartedAt(
+    runId: string,
+    startedAt: string | null | undefined,
+    completedAt?: string | null,
+    status?: string | null,
+  ): void {
+    if (!runId || !startedAt) return
+    const r = ensureRun(state, runId)
+    if (!r.startedAt) r.startedAt = startedAt
+    if (!r.finishedAt && completedAt) r.finishedAt = completedAt
+    // Only adopt a REST status while the run has no live signal yet (still the
+    // default 'pending'); never clobber a status the stream has already moved on.
+    if (status && r.status === 'pending') r.status = status
+  }
+
   /** Reset all tracked signals (e.g. on project switch). */
   function reset(): void {
     state.runs = {}
@@ -332,6 +359,7 @@ export const useRuntimeStream = defineStore('runtimeStream', () => {
     ingest,
     tick,
     reset,
+    hydrateRunStartedAt,
     // getters
     runSignal,
     stepSignal,

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onBeforeUnmount } from 'vue'
+import { computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import Skeleton from 'primevue/skeleton'
 import Message from 'primevue/message'
@@ -20,6 +20,19 @@ const stream = useRuntimeStream()
 
 // Recent runs (cross-project, limit 20 so dedup still gives enough)
 const { runs, isLoading: runsLoading, error: runsError, refresh: refreshRuns } = useRecentRuns({ limit: 20 })
+
+// Seed the runtime stream with REST timing so elapsed renders for runs that were
+// already running before this view opened (no `run.started` SSE captured). The
+// stream stays authoritative: hydration never overwrites a live `startedAt`.
+watch(
+  runs,
+  (list) => {
+    for (const run of list) {
+      stream.hydrateRunStartedAt(run.id, run.started_at, run.completed_at, run.status)
+    }
+  },
+  { immediate: true },
+)
 
 // Projects (prefetch to prime the store; projects ref not used directly in this view)
 const { fetchProjects } = useProjects()
@@ -61,6 +74,16 @@ function formatElapsed(s: number): string {
   const m = Math.floor(s / 60)
   const sec = s % 60
   return `${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`
+}
+
+/**
+ * Live elapsed string for a running run. Returns the placeholder when the run
+ * has no known start (pending / not yet hydrated) so we never show "00:00" for
+ * a run whose duration is simply unknown.
+ */
+function displayElapsed(run: RunSummary): string {
+  if (!run.started_at) return '—'
+  return formatElapsed(stream.runElapsedSeconds(run.id))
 }
 
 function navigateToRun(run: RunSummary) {
@@ -197,7 +220,7 @@ function navigateToApproval(item: typeof hitlStore.pendingItems[0]) {
 
             <span class="text-xs shrink-0 font-mono" style="color: var(--p-text-muted-color)">
               <template v-if="run.status === 'running'">
-                {{ formatElapsed(stream.runElapsedSeconds(run.id)) }}
+                {{ displayElapsed(run) }}
               </template>
               <template v-else>
                 {{ formatRelativeDate(run.started_at || run.created_at) }}

--- a/frontend/src/views/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/__tests__/DashboardView.spec.ts
@@ -8,7 +8,9 @@
  * the full component (which requires SSE, Pinia stores, etc.) to keep tests fast
  * and deterministic.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useRuntimeStream } from '@/stores/runtimeStream'
 import type { RunSummary } from '@/features/runs/composables/useRecentRuns'
 
 // ── Replicated dedup logic (mirrors DashboardView.vue `dedupedRuns` computed) ──
@@ -133,5 +135,87 @@ describe('DashboardView — dedupedRuns (fix #5)', () => {
     expect(ids).toContain('c1')   // newer of S-C
     expect(ids).not.toContain('a1')
     expect(ids).not.toContain('c2')
+  })
+})
+
+// ── #294 — Live Runs elapsed rendering ────────────────────────────────────────
+// Mirrors DashboardView.vue: the view hydrates the runtime stream from REST
+// (`hydrateRunStartedAt`) on load, then renders elapsed via `displayElapsed`,
+// which yields the "—" placeholder for runs with no known start. We exercise the
+// exact same wiring against the real store so the rendered string is covered.
+
+function formatElapsed(s: number): string {
+  const m = Math.floor(s / 60)
+  const sec = s % 60
+  return `${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`
+}
+
+describe('DashboardView — Live Runs elapsed rendering (#294)', () => {
+  const NOW = new Date('2026-06-17T10:03:00Z')
+  const START = '2026-06-17T10:00:00Z'
+
+  let stream: ReturnType<typeof useRuntimeStream>
+
+  // displayElapsed mirrors DashboardView.vue exactly (placeholder when no start).
+  function displayElapsed(run: RunSummary): string {
+    if (!run.started_at) return '—'
+    return formatElapsed(stream.runElapsedSeconds(run.id))
+  }
+
+  // hydrateOnLoad mirrors the view's `watch(runs, ...)` REST-seeding step.
+  function hydrateOnLoad(runs: RunSummary[]): void {
+    for (const run of runs) {
+      stream.hydrateRunStartedAt(run.id, run.started_at, run.completed_at, run.status)
+    }
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    stream = useRuntimeStream()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // RG2: a run running for 3min, known only via REST, renders ~03:00 on load.
+  it('RG2: running run from REST renders real elapsed, not 00:00', () => {
+    const run = makeRun({ id: 'r1', status: 'running', started_at: START })
+    hydrateOnLoad([run])
+    stream.tick(NOW.getTime())
+    expect(displayElapsed(run)).toBe('03:00')
+    expect(displayElapsed(run)).not.toBe('00:00')
+  })
+
+  // RG3: a pending run with no started_at renders the placeholder, never 00:00.
+  it('RG3: run without started_at renders the placeholder', () => {
+    const run = makeRun({ id: 'r1', status: 'pending', started_at: undefined })
+    hydrateOnLoad([run])
+    stream.tick(NOW.getTime())
+    expect(displayElapsed(run)).toBe('—')
+  })
+
+  // RG4: dashboard elapsed matches the list duration (same started_at source).
+  it('RG4: dashboard elapsed matches the list duration within ±1s', () => {
+    const run = makeRun({ id: 'r1', status: 'running', started_at: START })
+    hydrateOnLoad([run])
+    stream.tick(NOW.getTime())
+    const listSecs = Math.floor((NOW.getTime() - new Date(START).getTime()) / 1000)
+    expect(displayElapsed(run)).toBe(formatElapsed(listSecs))
+  })
+
+  // RG5: a terminal run hydrated from REST shows a frozen elapsed.
+  it('RG5: terminal run renders frozen completed_at - started_at', () => {
+    const run = makeRun({
+      id: 'r1',
+      status: 'running', // running branch is what renders displayElapsed
+      started_at: START,
+      completed_at: '2026-06-17T10:00:45Z',
+    })
+    hydrateOnLoad([run])
+    stream.tick(new Date('2026-06-17T11:00:00Z').getTime())
+    expect(displayElapsed(run)).toBe('00:45')
   })
 })


### PR DESCRIPTION
## Contexte
Le Dashboard Live Runs affichait « 00:00 » pour un run déjà `running` : `runElapsedSeconds` (`runtimeStream.ts`) lit `startedAt` uniquement depuis l'état SSE (null si l'event `run.started` n'a pas été capté avant l'ouverture). La liste Runs, elle, calcule depuis `started_at` REST. Closes #294.

## Changements (front-only)
- `runtimeStream.ts` : action idempotente `hydrateRunStartedAt(runId, started_at, completed_at?, status?)` qui amorce le timing depuis le REST **sans écraser un `startedAt` SSE** (SSE autoritatif → compteur live intact, RG1).
- `DashboardView.vue` : `watch(runs)` qui hydrate au chargement REST ; `displayElapsed` rend un placeholder neutre si `started_at` absent (RG3), jamais « 00:00 ».
- Run terminal figé à `completed_at - started_at` (RG5). Dashboard et liste dérivent du même `started_at` (RG4).

## Tests (QA exercée — 5/5 RG pass, fake timers déterministes)
`runtimeStream.spec.ts` + `DashboardView.spec.ts` : RG1 (SSE +30s, non écrasé), RG2 (running REST 3min → ~03:00, **≠ 00:00**), RG3 (placeholder), RG4 (== liste ±1s), RG5 (figé après +1h). type-check/lint/vitest (1041) vert.

## Périmètre
Front-only (back/openapi N/A), `docs/product.md` N/A (correctif d'affichage).

## Follow-up mineur (hors scope, non bloquant)
Le `status` du stream pour un run hydraté REST n'adopte le status terminal d'un refresh REST ultérieur que si l'état précédent était `pending` (advisory pour de futurs consommateurs du store ; sans impact sur le Dashboard, dont le template branche sur le status REST et dont l'elapsed se fige via `finishedAt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — via /forge:autopilot (autonome, pr-only)
