### PR TITLE
fix(ui): garde anti-double-clic sur les suppressions (#295)

### DIFF
--- a/frontend/src/composables/__tests__/useInFlightGuard.spec.ts
+++ b/frontend/src/composables/__tests__/useInFlightGuard.spec.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useInFlightGuard } from '../useInFlightGuard'
+
+/** A promise whose resolution/rejection is controlled by the test. */
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('useInFlightGuard', () => {
+  it('runs the action once and returns its value', async () => {
+    const { run, isBusy } = useInFlightGuard()
+    const fn = vi.fn().mockResolvedValue('ok')
+
+    expect(isBusy()).toBe(false)
+    const result = await run(fn)
+
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(isBusy()).toBe(false)
+  })
+
+  it('marks the default key busy while the action is in flight (RG3)', async () => {
+    const { run, isBusy } = useInFlightGuard()
+    const d = deferred<string>()
+
+    const first = run(() => d.promise)
+    expect(isBusy()).toBe(true)
+
+    d.resolve('done')
+    await first
+    expect(isBusy()).toBe(false)
+  })
+
+  it('ignores a second call while the first is in flight (RG2)', async () => {
+    const { run } = useInFlightGuard()
+    const d = deferred<string>()
+    const fn = vi.fn(() => d.promise)
+
+    const first = run(fn)
+    const second = run(fn)
+
+    // The re-entrant call is ignored without invoking fn again.
+    expect(await second).toBeUndefined()
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    d.resolve('done')
+    expect(await first).toBe('done')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases the key after success so the action is re-triggerable', async () => {
+    const { run, isBusy } = useInFlightGuard()
+    const fn = vi.fn().mockResolvedValue('ok')
+
+    await run(fn)
+    expect(isBusy()).toBe(false)
+
+    await run(fn)
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('releases the key after a rejection and re-throws (RG4)', async () => {
+    const { run, isBusy } = useInFlightGuard()
+    const d = deferred<string>()
+    const fn = vi.fn(() => d.promise)
+
+    const first = run(fn)
+    expect(isBusy()).toBe(true)
+
+    d.reject(new Error('boom'))
+    await expect(first).rejects.toThrow('boom')
+    expect(isBusy()).toBe(false)
+
+    // Re-triggerable after the error.
+    const ok = vi.fn().mockResolvedValue('retry')
+    expect(await run(ok)).toBe('retry')
+  })
+
+  it('tracks busy state per key so distinct items do not block each other', async () => {
+    const { run, isBusy } = useInFlightGuard()
+    const dA = deferred<string>()
+    const dB = deferred<string>()
+    const fnA = vi.fn(() => dA.promise)
+    const fnB = vi.fn(() => dB.promise)
+
+    const a = run(fnA, 'a')
+    const b = run(fnB, 'b')
+
+    expect(isBusy('a')).toBe(true)
+    expect(isBusy('b')).toBe(true)
+
+    dA.resolve('a-done')
+    await a
+    expect(isBusy('a')).toBe(false)
+    // 'b' is still in flight and unaffected by 'a' settling.
+    expect(isBusy('b')).toBe(true)
+
+    dB.resolve('b-done')
+    await b
+    expect(isBusy('b')).toBe(false)
+    expect(fnA).toHaveBeenCalledTimes(1)
+    expect(fnB).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a second click on the same key but allows other keys (RG2 per item)', async () => {
+    const { run } = useInFlightGuard()
+    const dA = deferred<string>()
+    const fnA = vi.fn(() => dA.promise)
+    const fnB = vi.fn().mockResolvedValue('b-done')
+
+    const a1 = run(fnA, 'a')
+    const a2 = run(fnA, 'a')
+    expect(await a2).toBeUndefined()
+    expect(fnA).toHaveBeenCalledTimes(1)
+
+    // A different item deletes fine while 'a' is in flight.
+    expect(await run(fnB, 'b')).toBe('b-done')
+    expect(fnB).toHaveBeenCalledTimes(1)
+
+    dA.resolve('a-done')
+    expect(await a1).toBe('a-done')
+  })
+})

--- a/frontend/src/composables/useInFlightGuard.ts
+++ b/frontend/src/composables/useInFlightGuard.ts
@@ -1,0 +1,50 @@
+import { ref } from 'vue'
+
+/** Default key used when a guard tracks a single control (no per-item id). */
+const DEFAULT_KEY = '__default__'
+
+/**
+ * Re-entrancy guard for async actions, keyed by an optional item id.
+ *
+ * Prevents a control from firing the same async action twice while a previous
+ * invocation is still in flight (anti double-click, bug #295). The first call
+ * for a given key runs `fn`; any call for the same key issued before it settles
+ * is ignored (returns `undefined`) without invoking `fn`. The key is released
+ * in a `finally`, so the action is re-triggerable after both success AND error
+ * (RG4).
+ *
+ * For a single control (e.g. one Delete button), call `run(fn)` with no key.
+ * For a list where each row deletes its own item, pass the item id so a second
+ * click on the SAME row is ignored while other rows stay clickable.
+ */
+export function useInFlightGuard() {
+  const inFlight = ref<Set<string>>(new Set())
+
+  /** Whether an action for `key` (or the default control) is currently running. */
+  function isBusy(key: string = DEFAULT_KEY): boolean {
+    return inFlight.value.has(key)
+  }
+
+  /**
+   * Run `fn` guarded by `key`. Returns the resolved value of `fn`, or
+   * `undefined` if the call was ignored because `key` is already in flight.
+   * Rejections from `fn` propagate to the caller after the key is released.
+   */
+  async function run<T>(fn: () => Promise<T>, key: string = DEFAULT_KEY): Promise<T | undefined> {
+    if (inFlight.value.has(key)) {
+      return undefined
+    }
+    const next = new Set(inFlight.value)
+    next.add(key)
+    inFlight.value = next
+    try {
+      return await fn()
+    } finally {
+      const after = new Set(inFlight.value)
+      after.delete(key)
+      inFlight.value = after
+    }
+  }
+
+  return { isBusy, run }
+}

--- a/frontend/src/features/agents/AgentTable.vue
+++ b/frontend/src/features/agents/AgentTable.vue
@@ -8,10 +8,17 @@ import Button from 'primevue/button'
 import type { Agent, AgentScope } from '@/stores/agents'
 import AgentChip from '@/ui/primitives/AgentChip.vue'
 
-const props = defineProps<{
-  agents: Agent[]
-  isAdmin: boolean
-}>()
+const props = withDefaults(
+  defineProps<{
+    agents: Agent[]
+    isAdmin: boolean
+    /** Returns true while the DELETE for an agent id is in flight (#295). */
+    isDeleting?: (agentId: string) => boolean
+  }>(),
+  {
+    isDeleting: () => false,
+  },
+)
 
 const emit = defineEmits<{
   rowClick: [agentId: string]
@@ -112,6 +119,8 @@ function handleRowClick(event: { data: Agent }) {
               severity="danger"
               title="Delete agent"
               data-testid="delete-agent-button"
+              :loading="props.isDeleting((data as Agent).id)"
+              :disabled="props.isDeleting((data as Agent).id)"
               @click.stop="emit('delete', (data as Agent).id)"
             />
           </div>

--- a/frontend/src/features/environments/EnvironmentEditor.vue
+++ b/frontend/src/features/environments/EnvironmentEditor.vue
@@ -7,12 +7,15 @@ import Select from 'primevue/select'
 import Message from 'primevue/message'
 import ProgressSpinner from 'primevue/progressspinner'
 import { useEnvironmentEditor } from '@/composables/useEnvironmentEditor'
+import { useInFlightGuard } from '@/composables/useInFlightGuard'
 
 const props = defineProps<{
   projectId: string
 }>()
 
 const toast = useToast()
+// Guard the Delete button against double-click while the DELETE is in flight (#295).
+const deleteGuard = useInFlightGuard()
 
 const {
   stacks,
@@ -52,13 +55,16 @@ async function handleSave() {
 }
 
 async function handleDelete() {
+  if (deleteGuard.isBusy()) return
   if (!window.confirm('Delete the environment configuration for this project?')) return
-  const ok = await remove()
-  if (ok) {
-    toast.add({ severity: 'success', summary: 'Environment deleted', life: 3000 })
-  } else {
-    toast.add({ severity: 'error', summary: 'Failed to delete environment', life: 4000 })
-  }
+  await deleteGuard.run(async () => {
+    const ok = await remove()
+    if (ok) {
+      toast.add({ severity: 'success', summary: 'Environment deleted', life: 3000 })
+    } else {
+      toast.add({ severity: 'error', summary: 'Failed to delete environment', life: 4000 })
+    }
+  })
 }
 </script>
 
@@ -197,7 +203,8 @@ async function handleDelete() {
           label="Delete"
           icon="pi pi-trash"
           severity="danger"
-          :disabled="!exists"
+          :disabled="!exists || deleteGuard.isBusy()"
+          :loading="deleteGuard.isBusy()"
           @click="handleDelete"
         />
       </div>

--- a/frontend/src/features/environments/__tests__/EnvironmentEditor.spec.ts
+++ b/frontend/src/features/environments/__tests__/EnvironmentEditor.spec.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, type VueWrapper, flushPromises } from '@vue/test-utils'
+import { ref, computed } from 'vue'
+import PrimeVue from 'primevue/config'
+import ToastService from 'primevue/toastservice'
+import EnvironmentEditor from '../EnvironmentEditor.vue'
+
+/** A promise whose resolution is controlled by the test (in-flight window). */
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+const mockRemove = vi.fn()
+const mockSave = vi.fn()
+
+// useEnvironmentEditor is mocked so the test drives `remove`'s timing directly.
+vi.mock('@/composables/useEnvironmentEditor', () => ({
+  useEnvironmentEditor: () => ({
+    stacks: ref<string[]>([]),
+    source: ref('declared'),
+    services: ref([]),
+    commandsPairs: ref([]),
+    isLoading: computed(() => false),
+    isSaving: computed(() => false),
+    error: computed(() => null),
+    exists: computed(() => true),
+    canSave: computed(() => true),
+    addService: vi.fn(),
+    removeService: vi.fn(),
+    addEnvPair: vi.fn(),
+    removeEnvPair: vi.fn(),
+    addCommand: vi.fn(),
+    removeCommand: vi.fn(),
+    save: mockSave,
+    remove: mockRemove,
+  }),
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function mountComponent() {
+  wrapper = mount(EnvironmentEditor, {
+    props: { projectId: 'proj-1' },
+    global: {
+      plugins: [PrimeVue, ToastService],
+      stubs: { Toast: true, ProgressSpinner: true },
+    },
+  })
+  return wrapper
+}
+
+function deleteButton() {
+  return wrapper.findAll('button').find((b) => b.text().includes('Delete'))!
+}
+
+describe('EnvironmentEditor — delete double-click guard (#295)', () => {
+  beforeEach(() => {
+    mockRemove.mockReset()
+    mockSave.mockReset()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    // PrimeVue Select/MultiSelect call matchMedia, absent in jsdom.
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    vi.restoreAllMocks()
+  })
+
+  it('fires exactly one delete on a double-click while the call is in flight (RG1, RG2)', async () => {
+    const d = deferred<boolean>()
+    mockRemove.mockReturnValue(d.promise)
+
+    mountComponent()
+    const btn = deleteButton()
+
+    await btn.trigger('click')
+    // Second click before the first DELETE settles must be ignored.
+    await btn.trigger('click')
+
+    expect(mockRemove).toHaveBeenCalledTimes(1)
+
+    d.resolve(true)
+    await flushPromises()
+  })
+
+  it('disables the Delete button while the call is in flight (RG3)', async () => {
+    const d = deferred<boolean>()
+    mockRemove.mockReturnValue(d.promise)
+
+    mountComponent()
+    await deleteButton().trigger('click')
+    await flushPromises()
+
+    expect(deleteButton().attributes('disabled')).toBeDefined()
+
+    d.resolve(true)
+    await flushPromises()
+    expect(deleteButton().attributes('disabled')).toBeUndefined()
+  })
+
+  it('releases the guard after an error so delete is re-triggerable (RG4)', async () => {
+    mockRemove.mockResolvedValueOnce(false)
+
+    mountComponent()
+    await deleteButton().trigger('click')
+    await flushPromises()
+
+    expect(mockRemove).toHaveBeenCalledTimes(1)
+    expect(deleteButton().attributes('disabled')).toBeUndefined()
+
+    // Re-triggerable after the failure.
+    mockRemove.mockResolvedValueOnce(true)
+    await deleteButton().trigger('click')
+    await flushPromises()
+    expect(mockRemove).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not fire delete when the confirm is dismissed', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    mockRemove.mockResolvedValue(true)
+
+    mountComponent()
+    await deleteButton().trigger('click')
+    await flushPromises()
+
+    expect(mockRemove).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/features/profile/APIKeyList.vue
+++ b/frontend/src/features/profile/APIKeyList.vue
@@ -9,6 +9,7 @@ import ConfirmDialog from 'primevue/confirmdialog'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { useAPIKeys } from '@/composables/useAPIKeys'
+import { useInFlightGuard } from '@/composables/useInFlightGuard'
 import APIKeyDialog from './APIKeyDialog.vue'
 
 const confirm = useConfirm()
@@ -16,6 +17,9 @@ const toast = useToast()
 const { keys, isLoading, error, fetchKeys, deleteKey } = useAPIKeys()
 
 const dialogVisible = ref(false)
+// Per-key guard for the trash button feedback + re-entrancy at the UI layer
+// (#295). The store's deleteKey also coalesces concurrent DELETEs as a backstop.
+const deleteGuard = useInFlightGuard()
 
 onMounted(() => {
   fetchKeys()
@@ -26,30 +30,34 @@ function providerSeverity(provider: string): 'info' | 'secondary' {
 }
 
 function handleDelete(keyId: string, keyName: string) {
+  if (deleteGuard.isBusy(keyId)) return
   confirm.require({
     message: `Delete API key "${keyName}"? This cannot be undone.`,
     header: 'Delete API Key',
     icon: 'pi pi-exclamation-triangle',
     acceptClass: 'p-button-danger',
     accept: async () => {
-      // deleteKey coalesces a concurrent duplicate into 'busy' (anti double-fire),
-      // so a re-entrant accept never fires a second DELETE nor a duplicate toast.
-      const result = await deleteKey(keyId)
-      if (result === 'deleted') {
-        toast.add({
-          severity: 'success',
-          summary: 'API key deleted',
-          detail: `"${keyName}" was revoked.`,
-          life: 3000,
-        })
-      } else if (result === 'error') {
-        toast.add({
-          severity: 'error',
-          summary: 'Delete failed',
-          detail: error.value ?? 'Could not delete the API key.',
-          life: 5000,
-        })
-      }
+      // Guard at the UI layer so the trash button shows a spinner and a
+      // re-entrant accept is ignored; deleteKey also coalesces concurrent
+      // DELETEs into 'busy' as a backstop (anti double-fire).
+      await deleteGuard.run(async () => {
+        const result = await deleteKey(keyId)
+        if (result === 'deleted') {
+          toast.add({
+            severity: 'success',
+            summary: 'API key deleted',
+            detail: `"${keyName}" was revoked.`,
+            life: 3000,
+          })
+        } else if (result === 'error') {
+          toast.add({
+            severity: 'error',
+            summary: 'Delete failed',
+            detail: error.value ?? 'Could not delete the API key.',
+            life: 5000,
+          })
+        }
+      }, keyId)
     },
   })
 }
@@ -111,6 +119,8 @@ function handleDelete(keyId: string, keyName: string) {
             text
             size="small"
             aria-label="Delete API key"
+            :loading="deleteGuard.isBusy(data.id)"
+            :disabled="deleteGuard.isBusy(data.id)"
             @click="handleDelete(data.id, data.key_name)"
           />
         </template>

--- a/frontend/src/features/profile/__tests__/APIKeyList.spec.ts
+++ b/frontend/src/features/profile/__tests__/APIKeyList.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, type VueWrapper, flushPromises } from '@vue/test-utils'
+import { ref, computed } from 'vue'
+import PrimeVue from 'primevue/config'
+import ToastService from 'primevue/toastservice'
+import APIKeyList from '../APIKeyList.vue'
+
+/** A promise whose resolution is controlled by the test (in-flight window). */
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+const sampleKey = {
+  id: 'key-1',
+  provider: 'claude',
+  key_name: 'default',
+  key_hint: 'abcd',
+  created_at: '2026-01-15T10:00:00Z',
+}
+
+const mockFetchKeys = vi.fn()
+const mockDeleteKey = vi.fn()
+
+vi.mock('@/composables/useAPIKeys', () => ({
+  useAPIKeys: () => ({
+    keys: computed(() => [sampleKey]),
+    isLoading: computed(() => false),
+    error: ref<string | null>(null),
+    fetchKeys: mockFetchKeys,
+    deleteKey: mockDeleteKey,
+  }),
+}))
+
+// Capture the accept callback so the test can invoke it twice (double accept).
+let capturedAccept: (() => void) | null = null
+vi.mock('primevue/useconfirm', () => ({
+  useConfirm: () => ({
+    require: (options: { accept: () => void }) => {
+      capturedAccept = options.accept
+    },
+  }),
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function mountComponent() {
+  wrapper = mount(APIKeyList, {
+    global: {
+      plugins: [PrimeVue, ToastService],
+      stubs: {
+        ConfirmDialog: true,
+        Toast: true,
+        APIKeyDialog: true,
+      },
+    },
+  })
+  return wrapper
+}
+
+function trashButton() {
+  return wrapper.find('[aria-label="Delete API key"]')
+}
+
+describe('APIKeyList — delete double-click guard (#295)', () => {
+  beforeEach(() => {
+    capturedAccept = null
+    mockFetchKeys.mockReset()
+    mockDeleteKey.mockReset()
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('fires exactly one DELETE when the dialog accept is double-clicked (RG1, RG2)', async () => {
+    const d = deferred<'deleted'>()
+    mockDeleteKey.mockReturnValue(d.promise)
+
+    mountComponent()
+    await trashButton().trigger('click')
+    expect(capturedAccept).toBeTypeOf('function')
+
+    capturedAccept!()
+    capturedAccept!()
+    await flushPromises()
+
+    expect(mockDeleteKey).toHaveBeenCalledTimes(1)
+    expect(mockDeleteKey).toHaveBeenCalledWith('key-1')
+
+    d.resolve('deleted')
+    await flushPromises()
+  })
+
+  it('disables the key trash button while its DELETE is in flight (RG3)', async () => {
+    const d = deferred<'deleted'>()
+    mockDeleteKey.mockReturnValue(d.promise)
+
+    mountComponent()
+    await trashButton().trigger('click')
+    capturedAccept!()
+    await flushPromises()
+
+    expect(trashButton().attributes('disabled')).toBeDefined()
+
+    d.resolve('deleted')
+    await flushPromises()
+    expect(trashButton().attributes('disabled')).toBeUndefined()
+  })
+
+  it('releases the guard after an error so the key is re-deletable (RG4)', async () => {
+    mockDeleteKey.mockResolvedValueOnce('error')
+
+    mountComponent()
+    await trashButton().trigger('click')
+    capturedAccept!()
+    await flushPromises()
+
+    expect(mockDeleteKey).toHaveBeenCalledTimes(1)
+    expect(trashButton().attributes('disabled')).toBeUndefined()
+
+    mockDeleteKey.mockResolvedValueOnce('deleted')
+    await trashButton().trigger('click')
+    capturedAccept!()
+    await flushPromises()
+    expect(mockDeleteKey).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/views/AgentListView.vue
+++ b/frontend/src/views/AgentListView.vue
@@ -9,6 +9,7 @@ import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { useAgents } from '@/composables/useAgents'
 import { useAuth } from '@/composables/useAuth'
+import { useInFlightGuard } from '@/composables/useInFlightGuard'
 import { useAgentsStore } from '@/stores/agents'
 import AgentTable from '@/features/agents/AgentTable.vue'
 import AgentEmptyState from '@/features/agents/AgentEmptyState.vue'
@@ -25,6 +26,10 @@ const agentsStore = useAgentsStore()
 
 const { agents, isLoading, error, fetchAgents, retry } = useAgents(projectId)
 
+// Per-agent guard so a double-click on a row's trash icon (or the confirm
+// dialog's accept) only fires one DELETE (#295). Other rows stay clickable.
+const deleteGuard = useInFlightGuard()
+
 onMounted(() => {
   fetchAgents()
 })
@@ -38,30 +43,38 @@ function handleCreateClick() {
 }
 
 function handleDelete(agentId: string) {
+  if (deleteGuard.isBusy(agentId)) return
   confirm.require({
     message: 'Are you sure you want to delete this agent?',
     header: 'Confirm Delete',
     icon: 'pi pi-exclamation-triangle',
     acceptClass: 'p-button-danger',
     accept: async () => {
-      const success = await agentsStore.deleteAgent(projectId, agentId)
-      if (success) {
-        toast.add({
-          severity: 'success',
-          summary: 'Deleted',
-          detail: 'Agent deleted successfully',
-          life: 3000,
-        })
-      } else {
-        toast.add({
-          severity: 'error',
-          summary: 'Error',
-          detail: 'Failed to delete agent',
-          life: 5000,
-        })
-      }
+      await deleteGuard.run(async () => {
+        const success = await agentsStore.deleteAgent(projectId, agentId)
+        if (success) {
+          toast.add({
+            severity: 'success',
+            summary: 'Deleted',
+            detail: 'Agent deleted successfully',
+            life: 3000,
+          })
+        } else {
+          toast.add({
+            severity: 'error',
+            summary: 'Error',
+            detail: 'Failed to delete agent',
+            life: 5000,
+          })
+        }
+      }, agentId)
     },
   })
+}
+
+/** True while the DELETE for `agentId` is in flight (drives the row's spinner). */
+function isDeleting(agentId: string): boolean {
+  return deleteGuard.isBusy(agentId)
 }
 </script>
 
@@ -113,6 +126,7 @@ function handleDelete(agentId: string) {
       v-else
       :agents="agents"
       :is-admin="isAdmin"
+      :is-deleting="isDeleting"
       @row-click="handleRowClick"
       @delete="handleDelete"
     />

--- a/frontend/src/views/__tests__/AgentListView.spec.ts
+++ b/frontend/src/views/__tests__/AgentListView.spec.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, type VueWrapper, flushPromises } from '@vue/test-utils'
+import { ref, computed, h, defineComponent } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import PrimeVue from 'primevue/config'
+import ToastService from 'primevue/toastservice'
+import AgentListView from '../AgentListView.vue'
+
+/** A promise whose resolution is controlled by the test (in-flight window). */
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { id: 'proj-1' } }),
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+const mockFetchAgents = vi.fn()
+const mockAgents = ref<unknown[]>([
+  {
+    id: 'a1',
+    name: 'Implement Agent',
+    model: 'claude-opus-4-6',
+    image: 'img:1',
+    template_content: '',
+    scope: 'project',
+    project_id: 'proj-1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+])
+
+vi.mock('@/composables/useAgents', () => ({
+  useAgents: () => ({
+    agents: computed(() => mockAgents.value),
+    isLoading: computed(() => false),
+    error: computed(() => null),
+    fetchAgents: mockFetchAgents,
+    retry: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useAuth', () => ({
+  useAuth: () => ({ user: ref({ role: 'admin' }) }),
+}))
+
+// Capture the accept callback handed to PrimeVue's confirm.require so the test
+// can invoke it twice (simulating a double-click on the dialog's accept).
+let capturedAccept: (() => void) | null = null
+vi.mock('primevue/useconfirm', () => ({
+  useConfirm: () => ({
+    require: (options: { accept: () => void }) => {
+      capturedAccept = options.accept
+    },
+  }),
+}))
+
+const mockDeleteAgent = vi.fn()
+vi.mock('@/stores/agents', () => ({
+  useAgentsStore: () => ({ deleteAgent: mockDeleteAgent }),
+}))
+
+// Stub AgentTable: exposes a delete button + reflects the isDeleting predicate.
+const AgentTableStub = defineComponent({
+  name: 'AgentTable',
+  props: ['agents', 'isAdmin', 'isDeleting'],
+  emits: ['rowClick', 'delete'],
+  setup(props, { emit }) {
+    return () =>
+      h('div', { 'data-testid': 'agent-table' }, [
+        h('button', {
+          'data-testid': 'delete-a1',
+          disabled: props.isDeleting?.('a1') ?? false,
+          onClick: () => emit('delete', 'a1'),
+        }),
+      ])
+  },
+})
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function mountComponent() {
+  wrapper = mount(AgentListView, {
+    global: {
+      plugins: [PrimeVue, ToastService, createPinia()],
+      stubs: {
+        AgentTable: AgentTableStub,
+        AgentEmptyState: true,
+        ConfirmDialog: true,
+        Toast: true,
+        Skeleton: true,
+      },
+    },
+  })
+  return wrapper
+}
+
+function deleteTrigger() {
+  return wrapper.find('[data-testid="delete-a1"]')
+}
+
+describe('AgentListView — delete double-click guard (#295)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    capturedAccept = null
+    mockFetchAgents.mockReset()
+    mockDeleteAgent.mockReset()
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('fires exactly one DELETE when the dialog accept is double-clicked (RG1, RG2)', async () => {
+    const d = deferred<boolean>()
+    mockDeleteAgent.mockReturnValue(d.promise)
+
+    mountComponent()
+    await deleteTrigger().trigger('click')
+    expect(capturedAccept).toBeTypeOf('function')
+
+    // Two rapid accepts before the DELETE settles → only one store call.
+    capturedAccept!()
+    capturedAccept!()
+    await flushPromises()
+
+    expect(mockDeleteAgent).toHaveBeenCalledTimes(1)
+    expect(mockDeleteAgent).toHaveBeenCalledWith('proj-1', 'a1')
+
+    d.resolve(true)
+    await flushPromises()
+  })
+
+  it('marks the row delete button disabled while its DELETE is in flight (RG3)', async () => {
+    const d = deferred<boolean>()
+    mockDeleteAgent.mockReturnValue(d.promise)
+
+    mountComponent()
+    await deleteTrigger().trigger('click')
+    capturedAccept!()
+    await flushPromises()
+
+    expect(deleteTrigger().attributes('disabled')).toBeDefined()
+
+    d.resolve(true)
+    await flushPromises()
+    expect(deleteTrigger().attributes('disabled')).toBeUndefined()
+  })
+
+  it('releases the guard after a failure so the agent is re-deletable (RG4)', async () => {
+    mockDeleteAgent.mockResolvedValueOnce(false)
+
+    mountComponent()
+    await deleteTrigger().trigger('click')
+    capturedAccept!()
+    await flushPromises()
+
+    expect(mockDeleteAgent).toHaveBeenCalledTimes(1)
+    expect(deleteTrigger().attributes('disabled')).toBeUndefined()
+
+    // Re-triggerable after the error.
+    mockDeleteAgent.mockResolvedValueOnce(true)
+    await deleteTrigger().trigger('click')
+    capturedAccept!()
+    await flushPromises()
+    expect(mockDeleteAgent).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Contexte
Aucune garde anti-ré-entrance au déclencheur : le bouton/accept de confirmation restait actif pendant l'appel DELETE async → un double-clic ré-invoquait le handler et émettait **2 DELETE** (risque réel sur endpoint non-idempotent). La duplication venait de l'UI (store/client n'émettent qu'un DELETE sans retry). Closes #295.

## Changements (front-only)
- Composable partagé `useInFlightGuard()` : `{ isBusy(key?), run(fn, key?) }` — pose le flag **synchronement avant le 1er `await`** (RG2), release dans un `finally` (RG4), `Set` réactif **par id**.
- Câblé sur les 3 écrans : `EnvironmentEditor` (window.confirm), `AgentListView`+`AgentTable` (ConfirmDialog, garde par agentId, trash `:loading`), `APIKeyList` (par keyId). Contrôle désactivé/loading pendant l'appel (RG3), par-élément pour les listes.
- Mécanismes de confirmation **non touchés** (homogénéisation = #299 séparé). Extension à d'autres actions destructrices hors scope.

## Tests (QA exercée — 4/4 RG pass, 17 tests)
Composable + 3 écrans, avec **promesse contrôlable** (fenêtre in-flight déterministe) : RG1 (1 DELETE, bon item), RG2 (double-clic → `toHaveBeenCalledTimes(1)`), RG3 (disabled pendant le vol, par-clé), RG4 (erreur → flag relâché → re-déclenchable sans doublon). type-check/lint/vitest vert.

## Périmètre
Front-only (back/openapi N/A), `docs/product.md` N/A (robustesse UI, pas de comportement nouveau).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — via /forge:autopilot (autonome, pr-only)
