### PR TITLE
feat(frontend): supprimer un projet depuis l'UI (#296)

### DIFF
--- a/frontend/e2e/tests/project-delete.spec.ts
+++ b/frontend/e2e/tests/project-delete.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from './fixtures'
+
+const mockProject = {
+  id: 'p1',
+  name: 'Test Project',
+  description: 'A test project for e2e testing',
+  repo_url: 'https://github.com/org/repo',
+  git_provider: 'github',
+  agent_runtime: 'docker',
+  owner_id: 'u1',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const otherProject = {
+  id: 'p2',
+  name: 'Surviving Project',
+  owner_id: 'u1',
+  created_at: '2026-01-02T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+}
+
+/** Register the admin + project + list mocks shared by every test. */
+async function setupCommonRoutes(page: import('@playwright/test').Page) {
+  await page.route('**/api/v1/auth/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '1',
+        email: 'admin@test.com',
+        name: 'Admin User',
+        role: 'admin',
+      }),
+    })
+  })
+
+  await page.route('**/api/v1/projects/p1', async (route) => {
+    if (route.request().url().includes('/epics')) return route.fallback()
+    if (route.request().url().includes('/pipeline')) return route.fallback()
+    if (route.request().url().includes('/agents')) return route.fallback()
+    if (route.request().method() === 'DELETE') return route.fallback()
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockProject),
+    })
+  })
+}
+
+test.describe('Project delete from Settings danger zone', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupCommonRoutes(page)
+  })
+
+  test('admin deletes a project: retype name → confirm → redirect to list without it', async ({
+    page,
+  }) => {
+    let deleteCalled = false
+
+    await page.route('**/api/v1/projects/p1', async (route) => {
+      if (route.request().method() === 'DELETE') {
+        deleteCalled = true
+        await route.fulfill({ status: 204, body: '' })
+        return
+      }
+      await route.fallback()
+    })
+
+    // List shown after redirect — the deleted project is gone.
+    await page.route('**/api/v1/projects?*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [otherProject],
+          pagination: { total: 1, page: 1, per_page: 20 },
+        }),
+      })
+    })
+
+    await page.goto('/projects/p1/settings')
+
+    // Danger zone is visible for admins (RG1/RG6).
+    await expect(page.getByTestId('project-danger-zone')).toBeVisible()
+    await page.getByTestId('open-delete-dialog-btn').click()
+
+    // Cascade warning is explicit (RG3).
+    const warning = page.getByTestId('delete-cascade-warning')
+    await expect(warning).toBeVisible()
+    await expect(warning).toContainText('runs')
+    await expect(warning).toContainText('stories')
+
+    // Confirm stays disabled until the typed name matches exactly (RG2).
+    const confirmBtn = page.getByTestId('delete-confirm-btn')
+    await expect(confirmBtn).toBeDisabled()
+    await page.getByTestId('delete-confirm-input').fill('Wrong Name')
+    await expect(confirmBtn).toBeDisabled()
+    await page.getByTestId('delete-confirm-input').fill('Test Project')
+    await expect(confirmBtn).toBeEnabled()
+
+    await confirmBtn.click()
+
+    // Success → redirect to /projects, deleted project absent (RG4).
+    await expect(page).toHaveURL('/projects')
+    expect(deleteCalled).toBe(true)
+    await expect(page.getByText('Surviving Project')).toBeVisible()
+    await expect(page.getByText('Test Project')).toHaveCount(0)
+  })
+
+  test('cancelling the confirmation never deletes and stays on Settings (RG7)', async ({
+    page,
+  }) => {
+    let deleteCalled = false
+    await page.route('**/api/v1/projects/p1', async (route) => {
+      if (route.request().method() === 'DELETE') {
+        deleteCalled = true
+        await route.fulfill({ status: 204, body: '' })
+        return
+      }
+      await route.fallback()
+    })
+
+    await page.goto('/projects/p1/settings')
+
+    await page.getByTestId('open-delete-dialog-btn').click()
+    await expect(page.getByTestId('delete-confirm-btn')).toBeVisible()
+    await page.getByTestId('delete-cancel-btn').click()
+
+    await expect(page).toHaveURL('/projects/p1/settings')
+    expect(deleteCalled).toBe(false)
+  })
+})

--- a/frontend/src/composables/useProjects.ts
+++ b/frontend/src/composables/useProjects.ts
@@ -33,5 +33,8 @@ export function useProjects() {
     retry,
     createProject,
     updateProject,
+    // Exposed raw (not wrapped in useAsyncAction) so callers can await the
+    // throw and branch redirect-on-success vs toast-on-error (RG4/RG5).
+    deleteProject: store.deleteProject,
   }
 }

--- a/frontend/src/features/projects/ProjectDeleteDialog.vue
+++ b/frontend/src/features/projects/ProjectDeleteDialog.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import Dialog from 'primevue/dialog'
+import Button from 'primevue/button'
+import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
+
+const props = defineProps<{
+  visible: boolean
+  projectName: string
+  loading: boolean
+}>()
+
+const emit = defineEmits<{
+  confirm: []
+  cancel: []
+  'update:visible': [value: boolean]
+}>()
+
+const confirmationName = ref('')
+
+// Reset the typed name whenever the dialog (re)opens, so a previous attempt
+// never leaves a stale match that would pre-enable the destructive button.
+watch(
+  () => props.visible,
+  (isOpen) => {
+    if (isOpen) confirmationName.value = ''
+  },
+)
+
+const nameMatches = computed(() => confirmationName.value === props.projectName)
+
+function handleCancel() {
+  emit('cancel')
+  emit('update:visible', false)
+}
+
+function handleConfirm() {
+  if (!nameMatches.value || props.loading) return
+  emit('confirm')
+}
+</script>
+
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    header="Delete project"
+    class="w-full max-w-lg"
+    data-testid="project-delete-dialog"
+    @update:visible="handleCancel"
+  >
+    <div class="flex flex-col gap-4">
+      <div id="delete-cascade-warning">
+        <Message severity="error" :closable="false" data-testid="delete-cascade-warning">
+          This permanently deletes <strong>{{ projectName }}</strong> and everything linked to it,
+          runs, stories, epics, and pipeline configs. This action cannot be undone.
+        </Message>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <label for="delete-confirm-name" class="text-sm">
+          Type <strong>{{ projectName }}</strong> to confirm.
+        </label>
+        <InputText
+          id="delete-confirm-name"
+          v-model="confirmationName"
+          class="w-full"
+          autocomplete="off"
+          aria-describedby="delete-cascade-warning"
+          data-testid="delete-confirm-input"
+        />
+      </div>
+    </div>
+
+    <template #footer>
+      <div class="flex justify-end gap-2">
+        <Button
+          label="Cancel"
+          severity="secondary"
+          text
+          :disabled="loading"
+          data-testid="delete-cancel-btn"
+          @click="handleCancel"
+        />
+        <Button
+          label="Delete permanently"
+          severity="danger"
+          icon="pi pi-trash"
+          :loading="loading"
+          :disabled="!nameMatches || loading"
+          data-testid="delete-confirm-btn"
+          @click="handleConfirm"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>

--- a/frontend/src/features/projects/ProjectSettingsForm.vue
+++ b/frontend/src/features/projects/ProjectSettingsForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useForm } from 'vee-validate'
 import { toTypedSchema } from '@vee-validate/zod'
 import { z } from 'zod'
@@ -8,16 +8,27 @@ import Textarea from 'primevue/textarea'
 import Select from 'primevue/select'
 import FloatLabel from 'primevue/floatlabel'
 import Button from 'primevue/button'
+import { useAuthStore } from '@/stores/auth'
+import ProjectDeleteDialog from './ProjectDeleteDialog.vue'
 import type { Project, UpdateProjectPayload } from '@/stores/projects'
 
 const props = defineProps<{
   project: Project
   isSaving: boolean
+  isDeleting: boolean
 }>()
 
 const emit = defineEmits<{
   save: [payload: UpdateProjectPayload]
+  delete: []
 }>()
+
+const authStore = useAuthStore()
+const deleteDialogVisible = ref(false)
+
+// Admin-only danger zone — mirrors the gating used elsewhere (AppSidebar).
+// The backend enforces admin via requireAdmin (403); the UI never exposes it.
+const isAdmin = computed(() => authStore.user?.role === 'admin')
 
 const projectSettingsSchema = toTypedSchema(
   z.object({
@@ -25,14 +36,8 @@ const projectSettingsSchema = toTypedSchema(
       .string()
       .min(1, 'Project name is required')
       .max(255, 'Name must be 255 characters or less'),
-    description: z
-      .string()
-      .max(1000, 'Description must be 1000 characters or less')
-      .default(''),
-    repo_url: z
-      .string()
-      .min(1, 'Repository URL is required')
-      .url('Must be a valid URL'),
+    description: z.string().max(1000, 'Description must be 1000 characters or less').default(''),
+    repo_url: z.string().min(1, 'Repository URL is required').url('Must be a valid URL'),
     git_provider: z.enum(['github', 'gitea']).default('github'),
     git_token_env: z.string().optional().or(z.literal('')),
     agent_runtime: z.enum(['docker']).default('docker'),
@@ -92,121 +97,176 @@ const onSubmit = handleSubmit((values) => {
 </script>
 
 <template>
-  <form class="flex flex-col gap-6" data-testid="project-settings-form" @submit.prevent="onSubmit">
-    <div class="flex flex-col gap-2">
-      <FloatLabel>
-        <InputText
-          id="settings-name"
-          v-model="name"
-          v-bind="nameAttrs"
-          class="w-full"
-          :invalid="!!errors.name"
+  <div class="flex flex-col gap-8">
+    <form
+      class="flex flex-col gap-6"
+      data-testid="project-settings-form"
+      @submit.prevent="onSubmit"
+    >
+      <div class="flex flex-col gap-2">
+        <FloatLabel>
+          <InputText
+            id="settings-name"
+            v-model="name"
+            v-bind="nameAttrs"
+            class="w-full"
+            :invalid="!!errors.name"
+          />
+          <label for="settings-name">Name *</label>
+        </FloatLabel>
+        <small v-if="errors.name" :style="{ color: 'var(--status-failed-color)' }">{{
+          errors.name
+        }}</small>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <FloatLabel>
+          <Textarea
+            id="settings-description"
+            v-model="description"
+            v-bind="descriptionAttrs"
+            class="w-full"
+            rows="3"
+            :invalid="!!errors.description"
+          />
+          <label for="settings-description">Description</label>
+        </FloatLabel>
+        <small v-if="errors.description" :style="{ color: 'var(--status-failed-color)' }">{{
+          errors.description
+        }}</small>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <p class="text-sm font-semibold" :style="{ color: 'var(--p-text-muted-color)' }">
+          Pipeline Configuration
+        </p>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <FloatLabel>
+          <InputText
+            id="settings-repo-url"
+            v-model="repoUrl"
+            v-bind="repoUrlAttrs"
+            class="w-full"
+            :invalid="!!errors.repo_url"
+          />
+          <label for="settings-repo-url">Repository URL *</label>
+        </FloatLabel>
+        <small v-if="errors.repo_url" :style="{ color: 'var(--status-failed-color)' }">{{
+          errors.repo_url
+        }}</small>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <FloatLabel>
+          <Select
+            id="settings-git-provider"
+            v-model="gitProvider"
+            v-bind="gitProviderAttrs"
+            :options="['github', 'gitea']"
+            class="w-full"
+            :invalid="!!errors.git_provider"
+          />
+          <label for="settings-git-provider">Git Provider *</label>
+        </FloatLabel>
+        <small v-if="errors.git_provider" :style="{ color: 'var(--status-failed-color)' }">{{
+          errors.git_provider
+        }}</small>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <FloatLabel>
+          <InputText
+            id="settings-git-token-env"
+            v-model="gitTokenEnv"
+            v-bind="gitTokenEnvAttrs"
+            class="w-full"
+            placeholder="GITEA_TOKEN"
+          />
+          <label for="settings-git-token-env">Git Token Env Var</label>
+        </FloatLabel>
+        <small :style="{ color: 'var(--p-text-muted-color)' }"
+          >Name of the environment variable holding the git token (defaults to GITHUB_TOKEN)</small
+        >
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <FloatLabel>
+          <Select
+            id="settings-agent-runtime"
+            v-model="agentRuntime"
+            v-bind="agentRuntimeAttrs"
+            :options="['docker']"
+            class="w-full"
+            :invalid="!!errors.agent_runtime"
+          />
+          <label for="settings-agent-runtime">Agent Runtime *</label>
+        </FloatLabel>
+        <small v-if="errors.agent_runtime" :style="{ color: 'var(--status-failed-color)' }">{{
+          errors.agent_runtime
+        }}</small>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <FloatLabel>
+          <InputText
+            id="settings-default-model"
+            v-model="defaultModel"
+            v-bind="defaultModelAttrs"
+            class="w-full"
+            placeholder="claude-opus-4-5"
+          />
+          <label for="settings-default-model">Default Model</label>
+        </FloatLabel>
+        <small v-if="errors.default_model" :style="{ color: 'var(--status-failed-color)' }">{{
+          errors.default_model
+        }}</small>
+      </div>
+
+      <div class="flex justify-end">
+        <Button
+          label="Save"
+          severity="success"
+          icon="pi pi-save"
+          type="submit"
+          :loading="isSaving"
+          data-testid="save-settings-btn"
         />
-        <label for="settings-name">Name *</label>
-      </FloatLabel>
-      <small v-if="errors.name" :style="{ color: 'var(--status-failed-color)' }">{{ errors.name }}</small>
-    </div>
+      </div>
+    </form>
 
-    <div class="flex flex-col gap-2">
-      <FloatLabel>
-        <Textarea
-          id="settings-description"
-          v-model="description"
-          v-bind="descriptionAttrs"
-          class="w-full"
-          rows="3"
-          :invalid="!!errors.description"
+    <section
+      v-if="isAdmin"
+      class="flex flex-col gap-3"
+      data-testid="project-danger-zone"
+      aria-label="Danger zone"
+    >
+      <h3 class="text-sm font-semibold" :style="{ color: 'var(--status-failed-color)' }">
+        Danger zone
+      </h3>
+      <div class="flex items-center justify-between gap-4">
+        <p class="text-sm" :style="{ color: 'var(--p-text-muted-color)' }">
+          Permanently delete this project and all of its runs, stories, epics, and configs. This
+          cannot be undone.
+        </p>
+        <Button
+          label="Delete project"
+          severity="danger"
+          icon="pi pi-trash"
+          type="button"
+          data-testid="open-delete-dialog-btn"
+          @click="deleteDialogVisible = true"
         />
-        <label for="settings-description">Description</label>
-      </FloatLabel>
-      <small v-if="errors.description" :style="{ color: 'var(--status-failed-color)' }">{{ errors.description }}</small>
-    </div>
+      </div>
+    </section>
 
-    <div class="flex flex-col gap-1">
-      <p class="text-sm font-semibold" :style="{ color: 'var(--p-text-muted-color)' }">Pipeline Configuration</p>
-    </div>
-
-    <div class="flex flex-col gap-2">
-      <FloatLabel>
-        <InputText
-          id="settings-repo-url"
-          v-model="repoUrl"
-          v-bind="repoUrlAttrs"
-          class="w-full"
-          :invalid="!!errors.repo_url"
-        />
-        <label for="settings-repo-url">Repository URL *</label>
-      </FloatLabel>
-      <small v-if="errors.repo_url" :style="{ color: 'var(--status-failed-color)' }">{{ errors.repo_url }}</small>
-    </div>
-
-    <div class="flex flex-col gap-2">
-      <FloatLabel>
-        <Select
-          id="settings-git-provider"
-          v-model="gitProvider"
-          v-bind="gitProviderAttrs"
-          :options="['github', 'gitea']"
-          class="w-full"
-          :invalid="!!errors.git_provider"
-        />
-        <label for="settings-git-provider">Git Provider *</label>
-      </FloatLabel>
-      <small v-if="errors.git_provider" :style="{ color: 'var(--status-failed-color)' }">{{ errors.git_provider }}</small>
-    </div>
-
-    <div class="flex flex-col gap-2">
-      <FloatLabel>
-        <InputText
-          id="settings-git-token-env"
-          v-model="gitTokenEnv"
-          v-bind="gitTokenEnvAttrs"
-          class="w-full"
-          placeholder="GITEA_TOKEN"
-        />
-        <label for="settings-git-token-env">Git Token Env Var</label>
-      </FloatLabel>
-      <small :style="{ color: 'var(--p-text-muted-color)' }">Name of the environment variable holding the git token (defaults to GITHUB_TOKEN)</small>
-    </div>
-
-    <div class="flex flex-col gap-2">
-      <FloatLabel>
-        <Select
-          id="settings-agent-runtime"
-          v-model="agentRuntime"
-          v-bind="agentRuntimeAttrs"
-          :options="['docker']"
-          class="w-full"
-          :invalid="!!errors.agent_runtime"
-        />
-        <label for="settings-agent-runtime">Agent Runtime *</label>
-      </FloatLabel>
-      <small v-if="errors.agent_runtime" :style="{ color: 'var(--status-failed-color)' }">{{ errors.agent_runtime }}</small>
-    </div>
-
-    <div class="flex flex-col gap-2">
-      <FloatLabel>
-        <InputText
-          id="settings-default-model"
-          v-model="defaultModel"
-          v-bind="defaultModelAttrs"
-          class="w-full"
-          placeholder="claude-opus-4-5"
-        />
-        <label for="settings-default-model">Default Model</label>
-      </FloatLabel>
-      <small v-if="errors.default_model" :style="{ color: 'var(--status-failed-color)' }">{{ errors.default_model }}</small>
-    </div>
-
-    <div class="flex justify-end">
-      <Button
-        label="Save"
-        severity="success"
-        icon="pi pi-save"
-        type="submit"
-        :loading="isSaving"
-        data-testid="save-settings-btn"
-      />
-    </div>
-  </form>
+    <ProjectDeleteDialog
+      v-if="isAdmin"
+      v-model:visible="deleteDialogVisible"
+      :project-name="project.name"
+      :loading="isDeleting"
+      @confirm="emit('delete')"
+    />
+  </div>
 </template>

--- a/frontend/src/features/projects/__tests__/ProjectDeleteDialog.spec.ts
+++ b/frontend/src/features/projects/__tests__/ProjectDeleteDialog.spec.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mount, type VueWrapper, flushPromises } from '@vue/test-utils'
+import { h, defineComponent } from 'vue'
+import PrimeVue from 'primevue/config'
+import ProjectDeleteDialog from '../ProjectDeleteDialog.vue'
+
+/** Stub Dialog to render inline (header + content + footer) instead of teleporting. */
+const DialogStub = defineComponent({
+  name: 'DialogStub',
+  props: ['visible', 'modal', 'header'],
+  emits: ['update:visible'],
+  setup(props, { slots }) {
+    return () => {
+      if (!props.visible) return null
+      return h('div', { class: 'p-dialog', 'data-testid': 'project-delete-dialog' }, [
+        h('div', { class: 'p-dialog-content' }, slots.default?.()),
+        h('div', { class: 'p-dialog-footer' }, slots.footer?.()),
+      ])
+    }
+  },
+})
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function mountDialog(
+  props: Partial<{ visible: boolean; projectName: string; loading: boolean }> = {},
+) {
+  wrapper = mount(ProjectDeleteDialog, {
+    props: {
+      visible: true,
+      projectName: 'Test Project',
+      loading: false,
+      ...props,
+    },
+    global: {
+      plugins: [PrimeVue],
+      stubs: { Dialog: DialogStub },
+    },
+  })
+  return wrapper
+}
+
+function confirmBtn() {
+  return wrapper.find('[data-testid="delete-confirm-btn"]')
+}
+
+async function typeName(value: string) {
+  const input = wrapper.find('[data-testid="delete-confirm-input"]')
+  await input.setValue(value)
+  await flushPromises()
+}
+
+describe('ProjectDeleteDialog', () => {
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  // RG3: cascade warning is explicit about permanent deletion of linked data
+  it('shows an explicit cascade warning (RG3)', () => {
+    mountDialog()
+    const warning = wrapper.find('[data-testid="delete-cascade-warning"]')
+    expect(warning.exists()).toBe(true)
+    const text = warning.text()
+    expect(text).toContain('runs')
+    expect(text).toContain('stories')
+    expect(text).toContain('epics')
+    expect(text).toContain('configs')
+    expect(text.toLowerCase()).toContain('cannot be undone')
+  })
+
+  // RG2: confirm button disabled until the typed name matches exactly
+  it('keeps the confirm button disabled while the typed name is empty (RG2)', () => {
+    mountDialog()
+    expect(confirmBtn().attributes('disabled')).toBeDefined()
+  })
+
+  it('keeps the confirm button disabled on a partial / wrong name (RG2)', async () => {
+    mountDialog()
+    await typeName('Test Projec')
+    expect(confirmBtn().attributes('disabled')).toBeDefined()
+  })
+
+  it('enables the confirm button when the typed name matches exactly (RG2)', async () => {
+    mountDialog()
+    await typeName('Test Project')
+    expect(confirmBtn().attributes('disabled')).toBeUndefined()
+  })
+
+  // RG1 happy path: confirm emits when name matches
+  it('emits confirm when the name matches and confirm is clicked (RG1)', async () => {
+    mountDialog()
+    await typeName('Test Project')
+    await confirmBtn().trigger('click')
+    expect(wrapper.emitted('confirm')).toBeDefined()
+  })
+
+  it('does not emit confirm when the name does not match', async () => {
+    mountDialog()
+    await typeName('wrong')
+    await confirmBtn().trigger('click')
+    expect(wrapper.emitted('confirm')).toBeUndefined()
+  })
+
+  // RG7: cancel emits cancel + closes, never confirm
+  it('emits cancel and closes on Cancel without emitting confirm (RG7)', async () => {
+    mountDialog()
+    await wrapper.find('[data-testid="delete-cancel-btn"]').trigger('click')
+    expect(wrapper.emitted('cancel')).toBeDefined()
+    expect(wrapper.emitted('update:visible')?.[0]).toEqual([false])
+    expect(wrapper.emitted('confirm')).toBeUndefined()
+  })
+
+  it('disables the confirm button while loading even when the name matches (anti double-click)', async () => {
+    mountDialog({ loading: true })
+    await typeName('Test Project')
+    expect(confirmBtn().attributes('disabled')).toBeDefined()
+  })
+
+  it('resets the typed name when the dialog reopens', async () => {
+    mountDialog({ visible: false })
+    await wrapper.setProps({ visible: true })
+    await typeName('Test Project')
+    // close then reopen — the field must be cleared, re-disabling confirm
+    await wrapper.setProps({ visible: false })
+    await wrapper.setProps({ visible: true })
+    const input = wrapper.find('[data-testid="delete-confirm-input"]')
+    expect((input.element as HTMLInputElement).value).toBe('')
+    expect(confirmBtn().attributes('disabled')).toBeDefined()
+  })
+})

--- a/frontend/src/features/projects/__tests__/ProjectSettingsForm.spec.ts
+++ b/frontend/src/features/projects/__tests__/ProjectSettingsForm.spec.ts
@@ -4,6 +4,7 @@ import { h, defineComponent } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import ProjectSettingsForm from '../ProjectSettingsForm.vue'
+import { useAuthStore } from '@/stores/auth'
 import type { Project } from '@/stores/projects'
 
 const baseProject: Project = {
@@ -36,16 +37,33 @@ const SelectStub = defineComponent({
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let wrapper: VueWrapper<any>
 
-function mountComponent(project: Project = baseProject, isSaving = false) {
+function mountComponent(
+  project: Project = baseProject,
+  isSaving = false,
+  opts: { role?: 'admin' | 'user'; isDeleting?: boolean } = {},
+) {
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  if (opts.role) {
+    const auth = useAuthStore()
+    auth.user = {
+      id: 'u1',
+      email: 'u@test.dev',
+      name: 'U',
+      role: opts.role,
+    }
+  }
   wrapper = mount(ProjectSettingsForm, {
     props: {
       project,
       isSaving,
+      isDeleting: opts.isDeleting ?? false,
     },
     global: {
-      plugins: [PrimeVue, createPinia()],
+      plugins: [PrimeVue, pinia],
       stubs: {
         Select: SelectStub,
+        teleport: true,
       },
     },
   })
@@ -140,5 +158,40 @@ describe('ProjectSettingsForm', () => {
     mountComponent(baseProject, true)
     const saveBtn = wrapper.find('[data-testid="save-settings-btn"]')
     expect(saveBtn.exists()).toBe(true)
+  })
+
+  // RG6: admin gating of the danger zone
+  it('hides the danger zone for non-admin users', () => {
+    mountComponent(baseProject, false, { role: 'user' })
+    expect(wrapper.find('[data-testid="project-danger-zone"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="open-delete-dialog-btn"]').exists()).toBe(false)
+  })
+
+  it('hides the danger zone when no user is authenticated', () => {
+    mountComponent()
+    expect(wrapper.find('[data-testid="project-danger-zone"]').exists()).toBe(false)
+  })
+
+  it('shows the danger zone with a delete button for admins (RG1)', () => {
+    mountComponent(baseProject, false, { role: 'admin' })
+    expect(wrapper.find('[data-testid="project-danger-zone"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="open-delete-dialog-btn"]').exists()).toBe(true)
+  })
+
+  it('opens the delete dialog when the danger-zone button is clicked', async () => {
+    mountComponent(baseProject, false, { role: 'admin' })
+    const dialog = wrapper.findComponent({ name: 'ProjectDeleteDialog' })
+    expect(dialog.props('visible')).toBe(false)
+    await wrapper.find('[data-testid="open-delete-dialog-btn"]').trigger('click')
+    await flushPromises()
+    expect(dialog.props('visible')).toBe(true)
+  })
+
+  it('re-emits delete when the dialog confirms', async () => {
+    mountComponent(baseProject, false, { role: 'admin' })
+    const dialog = wrapper.findComponent({ name: 'ProjectDeleteDialog' })
+    dialog.vm.$emit('confirm')
+    await flushPromises()
+    expect(wrapper.emitted('delete')).toBeDefined()
   })
 })

--- a/frontend/src/stores/__tests__/projects.spec.ts
+++ b/frontend/src/stores/__tests__/projects.spec.ts
@@ -5,12 +5,14 @@ import { useProjectsStore } from '../projects'
 const mockGet = vi.fn()
 const mockPost = vi.fn()
 const mockPut = vi.fn()
+const mockDelete = vi.fn()
 
 vi.mock('@/api/client', () => ({
   apiClient: {
     GET: (...args: unknown[]) => mockGet(...args),
     POST: (...args: unknown[]) => mockPost(...args),
     PUT: (...args: unknown[]) => mockPut(...args),
+    DELETE: (...args: unknown[]) => mockDelete(...args),
   },
 }))
 
@@ -20,6 +22,7 @@ describe('useProjectsStore', () => {
     mockGet.mockReset()
     mockPost.mockReset()
     mockPut.mockReset()
+    mockDelete.mockReset()
   })
 
   it('starts with default state', () => {
@@ -301,5 +304,51 @@ describe('useProjectsStore', () => {
     await expect(store.updateProject('p1', { name: 'X' })).rejects.toThrow(
       'Failed to update project',
     )
+  })
+
+  // RG1: deleteProject calls DELETE /projects/{id} and resolves on 204
+  it('deleteProject calls DELETE with the project id and resolves on success', async () => {
+    mockDelete.mockResolvedValue({ data: undefined, error: undefined })
+
+    const store = useProjectsStore()
+    await expect(store.deleteProject('p1')).resolves.toBeUndefined()
+    expect(mockDelete).toHaveBeenCalledWith('/projects/{id}', {
+      params: { path: { id: 'p1' } },
+    })
+  })
+
+  it('deleteProject removes the project from local state when present', async () => {
+    mockDelete.mockResolvedValue({ data: undefined, error: undefined })
+
+    const store = useProjectsStore()
+    store.items = [
+      { id: 'p1', name: 'A', owner_id: 'u1', created_at: 'x', updated_at: 'x' },
+      { id: 'p2', name: 'B', owner_id: 'u1', created_at: 'x', updated_at: 'x' },
+    ]
+    await store.deleteProject('p1')
+    expect(store.items.map((p) => p.id)).toEqual(['p2'])
+  })
+
+  // RG5: error path — throws and leaves state untouched (project preserved)
+  it('deleteProject throws with API error message and keeps state on failure', async () => {
+    mockDelete.mockResolvedValue({
+      data: undefined,
+      error: { error: { code: 'NOT_FOUND', message: 'Project not found' } },
+    })
+
+    const store = useProjectsStore()
+    store.items = [{ id: 'p1', name: 'A', owner_id: 'u1', created_at: 'x', updated_at: 'x' }]
+    await expect(store.deleteProject('p1')).rejects.toThrow('Project not found')
+    expect(store.items.map((p) => p.id)).toEqual(['p1'])
+  })
+
+  it('deleteProject throws fallback message when API error has no message', async () => {
+    mockDelete.mockResolvedValue({
+      data: undefined,
+      error: { error: { code: 'INTERNAL' } },
+    })
+
+    const store = useProjectsStore()
+    await expect(store.deleteProject('p1')).rejects.toThrow('Failed to delete project')
   })
 })

--- a/frontend/src/stores/projects.ts
+++ b/frontend/src/stores/projects.ts
@@ -113,6 +113,17 @@ export const useProjectsStore = defineStore('projects', () => {
     return data as Project
   }
 
+  /** Delete a project via the API and drop it from local state if present */
+  async function deleteProject(id: string): Promise<void> {
+    const { error: apiError } = await apiClient.DELETE('/projects/{id}', {
+      params: { path: { id } },
+    })
+    if (apiError) {
+      throw new Error(getApiErrorMessage(apiError, 'Failed to delete project'))
+    }
+    items.value = items.value.filter((p) => p.id !== id)
+  }
+
   /** Reset store state to initial values */
   function reset() {
     items.value = []
@@ -120,5 +131,15 @@ export const useProjectsStore = defineStore('projects', () => {
     error.value = null
   }
 
-  return { items, pagination, isLoading, error, fetchProjects, createProject, updateProject, reset }
+  return {
+    items,
+    pagination,
+    isLoading,
+    error,
+    fetchProjects,
+    createProject,
+    updateProject,
+    deleteProject,
+    reset,
+  }
 })

--- a/frontend/src/views/ProjectSettingsView.vue
+++ b/frontend/src/views/ProjectSettingsView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { inject } from 'vue'
+import { inject, ref } from 'vue'
 import type { Ref } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useToast } from 'primevue/usetoast'
 import Toast from 'primevue/toast'
 import ProjectSettingsForm from '@/features/projects/ProjectSettingsForm.vue'
@@ -9,11 +9,14 @@ import { useProjects } from '@/composables/useProjects'
 import type { Project, UpdateProjectPayload } from '@/stores/projects'
 
 const route = useRoute()
+const router = useRouter()
 const toast = useToast()
 const projectId = route.params.id as string
 
 const project = inject<Ref<Project | null>>('project')
-const { updateProject } = useProjects()
+const { updateProject, deleteProject } = useProjects()
+
+const isDeleting = ref(false)
 
 async function handleSave(payload: UpdateProjectPayload) {
   const result = await updateProject.execute(projectId, payload)
@@ -26,6 +29,30 @@ async function handleSave(payload: UpdateProjectPayload) {
     })
   }
 }
+
+async function handleDelete() {
+  if (isDeleting.value) return
+  isDeleting.value = true
+  try {
+    await deleteProject(projectId)
+    toast.add({
+      severity: 'success',
+      summary: 'Project deleted',
+      life: 3000,
+    })
+    await router.push('/projects')
+  } catch (e) {
+    // RG5: keep the user on Settings, surface the error, project is preserved.
+    toast.add({
+      severity: 'error',
+      summary: 'Delete failed',
+      detail: e instanceof Error ? e.message : 'Could not delete the project.',
+      life: 5000,
+    })
+  } finally {
+    isDeleting.value = false
+  }
+}
 </script>
 
 <template>
@@ -36,7 +63,9 @@ async function handleSave(payload: UpdateProjectPayload) {
       v-if="project"
       :project="project"
       :is-saving="updateProject.isLoading.value"
+      :is-deleting="isDeleting"
       @save="handleSave"
+      @delete="handleDelete"
     />
 
     <p v-else :style="{ color: 'var(--p-text-muted-color)' }">Loading project settings...</p>

--- a/frontend/src/views/__tests__/ProjectSettingsView.spec.ts
+++ b/frontend/src/views/__tests__/ProjectSettingsView.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, type VueWrapper, flushPromises } from '@vue/test-utils'
+import { ref, computed, h, defineComponent } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import PrimeVue from 'primevue/config'
+import ProjectSettingsView from '../ProjectSettingsView.vue'
+import type { Project } from '@/stores/projects'
+
+const mockPush = vi.fn()
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return {
+    ...actual,
+    useRoute: () => ({ params: { id: 'p1' } }),
+    useRouter: () => ({ push: mockPush }),
+  }
+})
+
+const mockToastAdd = vi.fn()
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: mockToastAdd }),
+}))
+
+const mockUpdateExecute = vi.fn()
+const mockDeleteProject = vi.fn()
+const mockUpdateIsLoading = ref(false)
+
+vi.mock('@/composables/useProjects', () => ({
+  useProjects: () => ({
+    updateProject: {
+      execute: mockUpdateExecute,
+      isLoading: mockUpdateIsLoading,
+      error: ref<Error | null>(null),
+    },
+    deleteProject: mockDeleteProject,
+  }),
+}))
+
+/** Stub the form: it just re-emits delete/save up to the view. */
+const ProjectSettingsFormStub = defineComponent({
+  name: 'ProjectSettingsForm',
+  props: ['project', 'isSaving', 'isDeleting'],
+  emits: ['save', 'delete'],
+  setup(props, { emit }) {
+    return () =>
+      h('button', {
+        'data-testid': 'stub-delete',
+        'data-deleting': String(props.isDeleting),
+        onClick: () => emit('delete'),
+      })
+  },
+})
+
+const project = ref<Project | null>({
+  id: 'p1',
+  name: 'Test Project',
+  owner_id: 'u1',
+  created_at: 'x',
+  updated_at: 'x',
+})
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function mountView() {
+  wrapper = mount(ProjectSettingsView, {
+    global: {
+      plugins: [PrimeVue, createPinia()],
+      provide: { project },
+      stubs: {
+        ProjectSettingsForm: ProjectSettingsFormStub,
+        Toast: true,
+      },
+    },
+  })
+  return wrapper
+}
+
+describe('ProjectSettingsView delete flow', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockPush.mockReset()
+    mockToastAdd.mockReset()
+    mockDeleteProject.mockReset()
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  // RG4: success → toast + redirect to /projects
+  it('on delete success shows a success toast and redirects to /projects (RG4)', async () => {
+    mockDeleteProject.mockResolvedValue(undefined)
+    mountView()
+
+    await wrapper.find('[data-testid="stub-delete"]').trigger('click')
+    await flushPromises()
+
+    expect(mockDeleteProject).toHaveBeenCalledWith('p1')
+    expect(mockToastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'success' }),
+    )
+    expect(mockPush).toHaveBeenCalledWith('/projects')
+  })
+
+  // RG5: error → error toast, NO redirect
+  it('on delete error shows an error toast and does not redirect (RG5)', async () => {
+    mockDeleteProject.mockRejectedValue(new Error('Project not found'))
+    mountView()
+
+    await wrapper.find('[data-testid="stub-delete"]').trigger('click')
+    await flushPromises()
+
+    expect(mockToastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error', detail: 'Project not found' }),
+    )
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('does not fire a second delete while one is in flight (anti double-click)', async () => {
+    let resolveDelete: () => void = () => {}
+    mockDeleteProject.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDelete = resolve
+      }),
+    )
+    mountView()
+
+    const btn = wrapper.find('[data-testid="stub-delete"]')
+    await btn.trigger('click')
+    await flushPromises()
+    // second click while in flight
+    await btn.trigger('click')
+    await flushPromises()
+
+    resolveDelete()
+    await flushPromises()
+
+    expect(mockDeleteProject).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Contexte
Le backend `DELETE /api/v1/projects/{id}` (admin-only, 204, FK `ON DELETE CASCADE`) était opérationnel mais **aucune action front** ne l'exposait (Settings = Save only). Impossible de supprimer un projet depuis l'UI. Closes #296.

## Changements (front-only, le DELETE back existait déjà)
- Danger zone **admin-only** dans `ProjectSettingsForm` ouvrant un `ProjectDeleteDialog` dédié.
- Confirmation **forte** : ressaisie exacte du nom du projet (bouton « Delete permanently » rouge désactivé tant que `saisie !== nom`), avertissement **cascade** explicite (runs/stories/epics/configs, irréversible).
- Action store `deleteProject(id)` calquée sur create/update (throw sur erreur, retire du state). Succès → toast + `router.push('/projects')` ; erreur → toast d'erreur **sans** redirection, projet conservé. Garde anti-double-clic.

## Tests (QA exercée — 7/7 RG pass)
44 tests unitaires (store + dialog + form + view) : RG1 (delete admin), RG2 (bouton désactivé sauf nom exact), RG3 (cascade), RG4 (redirect+toast), RG5 (erreur → pas de redirect, projet conservé), RG6 (non-admin → danger zone absente), RG7 (cancel → pas de delete). E2E `project-delete.spec.ts` (parcours admin + cancel) rejoué 2/2 sur port dédié. type-check/lint/vitest (1051) vert.

## Périmètre
Front-only (back/openapi déjà en place, N/A). `docs/product.md` N/A (doc vision/personas sans section CRUD projet).
Décisions : danger zone Settings seule (pas de kebab carte, follow-up) ; confirmation par ressaisie du nom (pas de fetch de compteurs d'impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — via /forge:autopilot (autonome, pr-only)
