### PR TITLE
fix(run-detail): distinguer step sélectionné sans logs de no-step (STREAM) (#297)

### DIFF
--- a/frontend/src/ui/composed/LogStreamPanel.vue
+++ b/frontend/src/ui/composed/LogStreamPanel.vue
@@ -13,16 +13,27 @@ import type { LogLine } from '@/ui/composed/LogViewer.vue'
  * from BOTH the connection status AND whether a stream is even expected
  * (`active`) and whether any lines have arrived. Clear states:
  *
- *   idle      — no active stream (no step selected) → neutral message
+ *   idle      — nothing selected at all → "No step selected" (RG3)
  *   connecting— stream active, opening, nothing yet
  *   streaming — open + receiving (blinking caret)
  *   waiting   — open but no lines yet (agent quiet) — NOT "no output"
- *   closed    — stream ended (shows whatever was captured)
- *   error     — connection error
+ *   empty     — a non-terminal step IS selected but has no lines → "No logs
+ *               available" (RG1, #297) — distinct from idle/no-selection
+ *   closed    — terminal step ended with no captured output → "No output was
+ *               captured", OR a finished SSE stream (shows captured lines)
+ *   error     — connection error (RG4)
+ *
+ * `active` means "a step is targeted" (selection), NOT "the stream is live".
+ * When the optional `stepStatus` is provided, the empty/closed distinction is
+ * driven by the STEP status (terminal vs non-terminal) rather than the SSE
+ * status, so a non-running selected step never shows a perpetual "Connecting…".
  *
  * Fully prop-driven (lines + status in) so Run Detail and the DAG inspector can
  * both mount it. ANSI rendered via the shared formatLogLine (ansi-to-html).
  */
+/** Step status the panel may be targeting (subset relevant to the stream). */
+type StepStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
+
 const props = withDefaults(
   defineProps<{
     /** Captured log lines (ANSI allowed). */
@@ -30,12 +41,21 @@ const props = withDefaults(
     /** SSE connection status from the host composable. */
     status: SSEStatus
     /**
-     * Whether a stream is expected at all. False when nothing is selected — so
-     * we show "idle" instead of a misleading "no output". Default true.
+     * Whether a step is targeted at all. False when nothing is selected — so
+     * we show "idle" ("No step selected") instead of a misleading "no output".
+     * Default true.
      */
     active?: boolean
+    /**
+     * Status of the targeted step, when known. Drives the empty/closed split:
+     * a terminal step (completed/failed/cancelled) with no lines shows "No
+     * output was captured" (closed); a non-terminal selected step with no lines
+     * shows "No logs available" (empty, RG1). When omitted, the panel falls
+     * back to deriving everything from the SSE status (legacy callers).
+     */
+    stepStatus?: StepStatus | null
   }>(),
-  { active: true },
+  { active: true, stepStatus: null },
 )
 
 const emit = defineEmits<{
@@ -47,16 +67,45 @@ const autoScroll = ref(true)
 
 const hasLines = computed(() => props.lines.length > 0)
 
+const isTerminalStep = computed(
+  () =>
+    props.stepStatus === 'completed' ||
+    props.stepStatus === 'failed' ||
+    props.stepStatus === 'cancelled',
+)
+const isRunningStep = computed(() => props.stepStatus === 'running')
+
 /** Derived lifecycle — the single source of truth for what the panel shows. */
 const lifecycle = computed(() => {
+  // RG3: nothing is targeted → neutral "No step selected".
   if (!props.active) return 'idle'
+
+  // RG2: lines have arrived → live stream (or terminal recap when SSE closed).
+  if (hasLines.value) {
+    if (props.status === 'error') return 'error'
+    if (props.status === 'closed') return 'closed'
+    return 'streaming'
+  }
+
+  // No lines yet. A connection error always wins (RG4).
+  if (props.status === 'error') return 'error'
+
+  // When the step status is known, it (not the SSE phase) decides the empty
+  // distinction — a non-running step must not show a perpetual "Connecting…".
+  if (props.stepStatus !== null) {
+    if (isTerminalStep.value) return 'closed' // Q1: terminal, no output captured
+    if (isRunningStep.value) {
+      return props.status === 'connecting' ? 'connecting' : 'waiting'
+    }
+    return 'empty' // RG1: selected (pending/seed) non-terminal step, no logs
+  }
+
+  // Legacy callers (no stepStatus): derive purely from the SSE status.
   switch (props.status) {
     case 'connecting':
-      return hasLines.value ? 'streaming' : 'connecting'
+      return 'connecting'
     case 'open':
-      return hasLines.value ? 'streaming' : 'waiting'
-    case 'error':
-      return 'error'
+      return 'waiting'
     case 'closed':
       return 'closed'
     default:
@@ -72,6 +121,7 @@ const STATE_META: Record<
   connecting: { label: 'Connecting…', tone: 'queued' },
   waiting: { label: 'Connected — waiting for output…', tone: 'running' },
   streaming: { label: 'Live', tone: 'running' },
+  empty: { label: 'No logs', tone: 'queued' },
   closed: { label: 'Stream ended', tone: 'done' },
   error: { label: 'Connection error', tone: 'failed' },
 }
@@ -90,6 +140,8 @@ const emptyMessage = computed(() => {
       return 'Connecting to the log stream…'
     case 'waiting':
       return 'Connected. Waiting for the agent to emit output…'
+    case 'empty':
+      return 'No logs available'
     case 'error':
       return 'Could not connect to the log stream'
     case 'closed':

--- a/frontend/src/ui/composed/__tests__/LogStreamPanel.spec.ts
+++ b/frontend/src/ui/composed/__tests__/LogStreamPanel.spec.ts
@@ -9,7 +9,14 @@ const LINES: LogLine[] = [
   { text: 'building…', timestamp: new Date('2026-06-17T10:00:00Z') },
 ]
 
-function mountPanel(props: { lines: LogLine[]; status: SSEStatus; active?: boolean }) {
+type StepStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
+
+function mountPanel(props: {
+  lines: LogLine[]
+  status: SSEStatus
+  active?: boolean
+  stepStatus?: StepStatus | null
+}) {
   return mount(LogStreamPanel, { props, global: { plugins: [PrimeVue] } })
 }
 
@@ -80,5 +87,72 @@ describe('LogStreamPanel lifecycle', () => {
   it('hides the Clear button when there are no lines', () => {
     const w = mountPanel({ lines: [], status: 'open' })
     expect(w.find('button').exists()).toBe(false)
+  })
+})
+
+describe('LogStreamPanel selected-step empty states (#297)', () => {
+  it('RG1: selected non-terminal step with no lines shows "No logs available" (NOT "No step selected")', () => {
+    // A seed/pending step is selected (active) but not running and has no logs.
+    const w = mountPanel({ lines: [], status: 'closed', active: true, stepStatus: 'pending' })
+    expect(w.attributes('data-lifecycle')).toBe('empty')
+    expect(w.find('[data-testid="log-stream-empty"]').text()).toContain('No logs available')
+    expect(w.find('[data-testid="log-stream-status"]').text()).not.toContain('No step selected')
+  })
+
+  it('RG1: empty state holds even while the SSE socket is "open" (non-running selected step)', () => {
+    const w = mountPanel({ lines: [], status: 'open', active: true, stepStatus: 'pending' })
+    expect(w.attributes('data-lifecycle')).toBe('empty')
+    expect(w.find('[data-testid="log-stream-empty"]').text()).toContain('No logs available')
+  })
+
+  it('RG2: running selected step with lines streams + shows the live caret', () => {
+    const w = mountPanel({ lines: LINES, status: 'open', active: true, stepStatus: 'running' })
+    expect(w.attributes('data-lifecycle')).toBe('streaming')
+    expect(w.find('[data-testid="log-stream-caret"]').exists()).toBe(true)
+  })
+
+  it('RG2: running selected step without lines yet shows the live "waiting" state', () => {
+    const w = mountPanel({ lines: [], status: 'open', active: true, stepStatus: 'running' })
+    expect(w.attributes('data-lifecycle')).toBe('waiting')
+    expect(w.find('[data-testid="log-stream-empty"]').text()).toContain('Waiting')
+  })
+
+  it('RG2: running selected step while still connecting shows "Connecting…"', () => {
+    const w = mountPanel({ lines: [], status: 'connecting', active: true, stepStatus: 'running' })
+    expect(w.attributes('data-lifecycle')).toBe('connecting')
+    expect(w.find('[data-testid="log-stream-status"]').text()).toContain('Connecting')
+  })
+
+  it('RG3: no step selected (not active) shows "No step selected"', () => {
+    const w = mountPanel({ lines: [], status: 'closed', active: false, stepStatus: null })
+    expect(w.attributes('data-lifecycle')).toBe('idle')
+    expect(w.find('[data-testid="log-stream-status"]').text()).toContain('No step selected')
+    expect(w.find('[data-testid="log-stream-empty"]').text()).toContain('Select a step')
+  })
+
+  it('RG4: SSE error on a selected step shows "Connection error" (NOT "No step selected")', () => {
+    const w = mountPanel({ lines: [], status: 'error', active: true, stepStatus: 'running' })
+    expect(w.attributes('data-lifecycle')).toBe('error')
+    expect(w.find('[data-testid="log-stream-status"]').text()).toContain('Connection error')
+    expect(w.find('[data-testid="log-stream-status"]').text()).not.toContain('No step selected')
+  })
+
+  it('RG4: SSE error wins even for a terminal selected step with no lines', () => {
+    const w = mountPanel({ lines: [], status: 'error', active: true, stepStatus: 'failed' })
+    expect(w.attributes('data-lifecycle')).toBe('error')
+    expect(w.find('[data-testid="log-stream-empty"]').text()).toContain('Could not connect')
+  })
+
+  it('Q1: terminal step (completed) with no captured output shows "No output was captured"', () => {
+    const w = mountPanel({ lines: [], status: 'closed', active: true, stepStatus: 'completed' })
+    expect(w.attributes('data-lifecycle')).toBe('closed')
+    expect(w.find('[data-testid="log-stream-empty"]').text()).toContain('No output was captured')
+  })
+
+  it('Q1: terminal step (failed) with captured lines recaps them (closed, no caret)', () => {
+    const w = mountPanel({ lines: LINES, status: 'closed', active: true, stepStatus: 'failed' })
+    expect(w.attributes('data-lifecycle')).toBe('closed')
+    expect(w.find('[data-testid="log-stream-caret"]').exists()).toBe(false)
+    expect(w.findAll('.log-line')).toHaveLength(1)
   })
 })

--- a/frontend/src/views/RunDetailView.vue
+++ b/frontend/src/views/RunDetailView.vue
@@ -146,9 +146,13 @@ const { lines: streamLines, sseStatus: streamStatus } = useStepLogs(
   runId.value,
   streamStepId,
 )
-const streamActive = computed(
-  () => activeStep.value?.status === 'running' || streamLines.value.length > 0,
-)
+// `active` for the panel means "a step is targeted" (selection), not "the
+// stream is live". A seed step selected with no logs must still be treated as
+// selected so the panel shows "No logs available" rather than "No step
+// selected" (#297). The empty/closed/live distinction is derived inside the
+// panel from `streamStepStatus` + lines + SSE status.
+const streamActive = computed(() => activeStep.value !== null)
+const streamStepStatus = computed(() => activeStep.value?.status ?? null)
 const streamContainerLabel = computed(() => {
   const id = activeStep.value?.container_id
   if (!id) return null
@@ -418,6 +422,7 @@ watch(runId, () => {
               :lines="streamLines"
               :status="streamStatus"
               :active="streamActive"
+              :step-status="streamStepStatus"
             />
           </div>
         </div>

--- a/frontend/src/views/__tests__/RunDetailView.spec.ts
+++ b/frontend/src/views/__tests__/RunDetailView.spec.ts
@@ -86,20 +86,37 @@ const RunPipelineViewStub = defineComponent({
   name: 'RunPipelineView',
   props: ['run', 'steps'],
   emits: ['step-selected'],
-  setup(_, { emit }) {
+  setup(props, { emit }) {
+    // Root click selects the first step (running) — keeps existing tests stable.
+    // A per-step button lets tests select any step (e.g. the seed/pending one).
+    return () =>
+      h(
+        'div',
+        {
+          'data-testid': 'run-pipeline-view',
+          onClick: () => emit('step-selected', props.steps?.[0]),
+        },
+        (props.steps ?? []).map((s: { id: string }) =>
+          h('button', {
+            'data-testid': `select-${s.id}`,
+            onClick: (e: Event) => {
+              e.stopPropagation()
+              emit('step-selected', s)
+            },
+          }),
+        ),
+      )
+  },
+})
+const LogStreamPanelStub = defineComponent({
+  name: 'LogStreamPanel',
+  props: ['lines', 'status', 'active', 'stepStatus'],
+  setup(props) {
     return () =>
       h('div', {
-        'data-testid': 'run-pipeline-view',
-        onClick: () =>
-          emit('step-selected', {
-            id: 'step-1',
-            run_id: 'run-1',
-            step_name: 'dev-story',
-            step_order: 0,
-            action: 'agent_run',
-            status: 'running',
-            created_at: '2026-02-17T10:00:00Z',
-          }),
+        'data-testid': 'log-stream-panel',
+        'data-active': String(props.active),
+        'data-step-status': props.stepStatus ?? '',
       })
   },
 })
@@ -184,7 +201,7 @@ function mountView() {
         HitlGateCard: HitlGateCardStub,
         RunCostByRole: true,
         StepTimeline: true,
-        LogStreamPanel: true,
+        LogStreamPanel: LogStreamPanelStub,
         LiveProgress: true,
         Toast: true,
         Skeleton: true,
@@ -386,5 +403,61 @@ describe('RunDetailView', () => {
     const pipelineView = wrapper.findComponent(RunPipelineViewStub)
     expect(pipelineView.props('run')).toEqual(run)
     expect(pipelineView.props('steps')).toEqual(run.steps)
+  })
+
+  // ── STREAM panel selection wiring (#297) ────────────────────────────────────────
+  it('marks the STREAM panel inactive when no step runs and none is selected (RG3)', () => {
+    // All steps pending → no running step + nothing selected yet → no target.
+    mockRun.value = makeRun({
+      status: 'pending',
+      steps: [
+        {
+          id: 'step-1',
+          run_id: 'run-1',
+          step_name: 'dev-story',
+          step_order: 0,
+          action: 'agent_run',
+          status: 'pending',
+          created_at: '2026-02-17T10:00:00Z',
+        },
+      ],
+    })
+    mountView()
+    const panel = wrapper.find('[data-testid="log-stream-panel"]')
+    expect(panel.attributes('data-active')).toBe('false')
+    expect(panel.attributes('data-step-status')).toBe('')
+  })
+
+  it('marks the STREAM panel active + forwards step status when a seed step is selected (RG1)', async () => {
+    // No running step; user selects a pending (seed) step → panel must be active
+    // with its status so the panel can render "No logs available", not idle.
+    mockRun.value = makeRun({
+      status: 'pending',
+      steps: [
+        {
+          id: 'step-seed',
+          run_id: 'run-1',
+          step_name: 'setup',
+          step_order: 0,
+          action: 'git_branch',
+          status: 'pending',
+          created_at: '2026-02-17T10:00:00Z',
+        },
+      ],
+    })
+    mountView()
+    await wrapper.find('[data-testid="select-step-seed"]').trigger('click')
+    await flushPromises()
+    const panel = wrapper.find('[data-testid="log-stream-panel"]')
+    expect(panel.attributes('data-active')).toBe('true')
+    expect(panel.attributes('data-step-status')).toBe('pending')
+  })
+
+  it('targets the running step (active) for the STREAM panel by default (RG2)', () => {
+    mockRun.value = makeRun() // step-1 is running
+    mountView()
+    const panel = wrapper.find('[data-testid="log-stream-panel"]')
+    expect(panel.attributes('data-active')).toBe('true')
+    expect(panel.attributes('data-step-status')).toBe('running')
   })
 })


### PR DESCRIPTION
## Contexte
Le panneau STREAM (Run detail) affichait « No step selected » pour un step **sélectionné** mais sans logs : `streamActive` ne passait `active=true` que si le step était `running` ou avait déjà des lignes → un step seed sélectionné non-running gardait `active=false` → lifecycle `idle`. Closes #297.

## Changements (front-only)
- `RunDetailView.streamActive` = signal de **sélection** (`activeStep !== null`), plus « running||lines » ; nouvelle prop optionnelle `stepStatus` passée à `LogStreamPanel`.
- `LogStreamPanel` dérive un état `empty` distinct (source unique du lifecycle) :
  - sélectionné non-terminal sans ligne → `empty` « **No logs available** » (RG1) ;
  - lignes/running → `streaming`/`waiting`/`connecting` (RG2) ;
  - aucune sélection → `idle` « No step selected » (RG3) ;
  - erreur SSE (prioritaire, terminal inclus) → `error` « Connection error » (RG4) ;
  - terminal sans output → `closed` « No output was captured » (Q1).
- **Rétrocompat** : `stepStatus` optionnel (défaut `null`) → `DagInspector`/`RunStepLogPanel` gardent leur comportement (fallback SSE).

## Tests (QA exercée — 5/5 pass)
`LogStreamPanel.spec.ts` + `RunDetailView.spec.ts` (45 tests) : RG1-RG4 + Q1 sur libellé/`data-lifecycle`/`data-testid` + wiring (active/step-status forwardés). type-check/lint/vitest vert.

## Périmètre
Front-only (back/openapi N/A), `docs/product.md` N/A (correctif d'affichage d'état vide).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — via /forge:autopilot (autonome, pr-only)
