### PR TITLE
fix(frontend): sous-texte 404 générique au lieu de la copy /settings hardcodée (#298)

### DIFF
--- a/frontend/src/views/NotFoundView.vue
+++ b/frontend/src/views/NotFoundView.vue
@@ -1,8 +1,14 @@
 <script setup lang="ts">
-import { useRouter } from 'vue-router'
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import Button from 'primevue/button'
 
 const router = useRouter()
+const route = useRoute()
+
+// Path the user tried to reach. Rendered via {{ }} interpolation only
+// (never v-html), so a raw URL is auto-escaped and cannot inject markup.
+const requestedPath = computed(() => route.fullPath)
 </script>
 
 <template>
@@ -40,7 +46,7 @@ const router = useRouter()
           class="text-sm"
           :style="{ color: 'var(--p-text-muted-color)', fontFamily: 'var(--font-mono, monospace)' }"
         >
-          /settings now lives under your profile.
+          We couldn't find <code>{{ requestedPath }}</code>.
         </p>
       </div>
 
@@ -49,13 +55,7 @@ const router = useRouter()
         <Button
           label="Go to dashboard"
           icon="pi pi-home"
-          severity="secondary"
           @click="router.push('/')"
-        />
-        <Button
-          label="Profile & settings"
-          icon="pi pi-user"
-          @click="router.push({ name: 'profile' })"
         />
       </div>
     </div>

--- a/frontend/src/views/__tests__/NotFoundView.spec.ts
+++ b/frontend/src/views/__tests__/NotFoundView.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * NotFoundView — unit tests (#298).
+ *
+ * The 404 subtext used to be hardcoded to "/settings now lives under your
+ * profile." for ANY unresolved URL, which was misleading. These tests pin the
+ * fixed behaviour: a generic subtext plus the requested path, with no "/settings"
+ * mention, and the path rendered via {{ }} interpolation (auto-escaped, no XSS).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { ref } from 'vue'
+import PrimeVue from 'primevue/config'
+import NotFoundView from '../NotFoundView.vue'
+
+// Configurable mock route: each test sets fullPath before mounting.
+const mockFullPath = ref('/')
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ fullPath: mockFullPath.value }),
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function mountAt(path: string) {
+  mockFullPath.value = path
+  wrapper = mount(NotFoundView, {
+    global: { plugins: [PrimeVue] },
+  })
+  return wrapper
+}
+
+afterEach(() => {
+  wrapper?.unmount()
+})
+
+describe('NotFoundView (#298)', () => {
+  it('RG1: shows a generic subtext for any unknown URL, never mentioning /settings', () => {
+    mountAt('/xyz-bidon')
+    const text = wrapper.text()
+    expect(text).toContain("We couldn't find")
+    expect(text).not.toContain('/settings')
+    expect(text).not.toContain('now lives under your profile')
+  })
+
+  it('RG2: a directly-typed /overview shows no out-of-context settings migration copy', () => {
+    mountAt('/overview')
+    const text = wrapper.text()
+    expect(text).not.toContain('/settings')
+    expect(text).not.toContain('now lives under your profile')
+  })
+
+  it('RG4: includes the requested path in the subtext', () => {
+    mountAt('/xyz-bidon')
+    expect(wrapper.text()).toContain('/xyz-bidon')
+  })
+
+  it('RG4: renders the path via interpolation, escaping a malicious URL (no XSS)', () => {
+    mountAt('/<img src=x onerror=alert(1)>')
+    // The raw markup must appear as escaped text inside <code>, never as a real node.
+    const code = wrapper.find('code')
+    expect(code.exists()).toBe(true)
+    expect(code.text()).toContain('<img src=x onerror=alert(1)>')
+    // No injected <img> element should exist in the rendered DOM.
+    expect(wrapper.find('img').exists()).toBe(false)
+  })
+
+  it('no longer renders the legacy "Profile & settings" action', () => {
+    mountAt('/xyz-bidon')
+    expect(wrapper.text()).not.toContain('Profile & settings')
+    expect(wrapper.text()).toContain('Go to dashboard')
+  })
+})


### PR DESCRIPTION
## Contexte
Le sous-texte 404 « /settings now lives under your profile. » était hardcodé dans `NotFoundView.vue` → affiché pour **toute** URL non résolue (URL bidon, /overview, /notifications), induisant en erreur. Closes #298.

## Changements (front-only)
- Sous-texte **générique** reprenant le chemin demandé : `We couldn't find <code>{{ requestedPath }}</code>.` (`requestedPath = useRoute().fullPath`), rendu **uniquement via interpolation `{{ }}` échappée** (jamais `v-html` → pas d'XSS sur URL brute).
- Plus aucune mention « /settings ». Bouton « Profile & settings » retiré (la 404 n'est plus orientée migration). Router **intouché** : `/settings → /profile` préservé (RG3).

## Tests (QA exercée — 4/4 RG pass)
`NotFoundView.spec.ts` (RG1 générique sans /settings, RG2 /overview, RG4 anti-XSS : payload `<img onerror>` rendu en texte, pas de nœud `<img>`) + `settingsRedirect.spec.ts` (RG3 non-régression). type-check/lint/vitest vert.

## Périmètre & follow-up
Front-only (back/openapi N/A), `docs/product.md` N/A (micro-copie).
Follow-up mineur (hors scope) : `router/__tests__/settingsRedirect.spec.ts:6` a un commentaire désormais périmé citant l'ancienne copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — via /forge:autopilot (autonome, pr-only)
