### PR TITLE
fix(board): classer les stories running sans stage dans une colonne cohérente (#300)

### DIFF
--- a/frontend/src/features/board/KanbanBoard.vue
+++ b/frontend/src/features/board/KanbanBoard.vue
@@ -12,6 +12,7 @@ import {
   STAGE_BACKLOG_COLUMN,
   STAGE_DONE_COLUMN,
   STAGE_FAILED_COLUMN,
+  STAGE_RUNNING_ENTRY,
 } from '@/stores/stories'
 import { statusTokenSeverity } from '@/utils/statusToken'
 import { useRuntimeStream } from '@/stores/runtimeStream'
@@ -197,12 +198,26 @@ const grouped = computed<Record<string, Story[]>>(() => {
     ? stageColumn
     : (boardColumn as (s: Story) => string)
   const fallback = viewMode.value === 'detail' ? STAGE_BACKLOG_COLUMN : 'backlog'
+  // The pipeline entry (first) stage lane, used to host running stories the
+  // executor has not yet stamped with a current_stage. Empty pipeline → no lane.
+  const entryStageKey = stages.value[0]?.name
 
   for (const story of props.stories) {
     let key = place(story)
+    // Running-without-stage resolves to the pipeline entry lane (cohérent with
+    // "running"). Degenerate fallback: an empty pipeline has no stage lane, so the
+    // card goes to the Done lane — never Backlog while running (the AC invariant).
+    if (key === STAGE_RUNNING_ENTRY) {
+      key = entryStageKey ?? STAGE_DONE_COLUMN
+    }
     // In détail mode a card whose stage name is not a known column (e.g. the
-    // pipeline changed) falls back to the entry lane so it never vanishes.
-    if (!(key in result)) key = fallback
+    // pipeline was edited/renamed, leaving a stale current_stage). A *running*
+    // story routes to the entry lane (like the running+NULL sentinel) so it never
+    // lands in Backlog while running (the RG3 invariant). Any other unknown key
+    // (non-running) falls back to Backlog so the card never vanishes.
+    if (!(key in result)) {
+      key = story.status === 'running' ? (entryStageKey ?? STAGE_DONE_COLUMN) : fallback
+    }
     result[key]!.push(story)
   }
   return result

--- a/frontend/src/features/board/__tests__/KanbanBoardPlacement.spec.ts
+++ b/frontend/src/features/board/__tests__/KanbanBoardPlacement.spec.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import PrimeVue from 'primevue/config'
+import KanbanBoard, { type BoardStage } from '../KanbanBoard.vue'
+import type { Story } from '@/stores/stories'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/api/client', () => ({
+  apiClient: { GET: vi.fn(), PUT: vi.fn(), POST: vi.fn() },
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: VueWrapper<any>
+
+function makeStory(overrides: Partial<Story> = {}): Story {
+  return {
+    id: 's1',
+    epic_id: 'e1',
+    project_id: 'p1',
+    key: 'S-01',
+    title: 'Test Story',
+    status: 'backlog',
+    created_at: '2026-01-15T10:00:00Z',
+    updated_at: '2026-01-15T10:00:00Z',
+    ...overrides,
+  }
+}
+
+const STAGES: BoardStage[] = [
+  { id: 'dev', name: 'Dev', transition: 'auto' },
+  { id: 'review', name: 'Review', transition: 'manual' },
+  { id: 'qa', name: 'QA', transition: 'gate' },
+]
+
+function mountBoard(stories: Story[], stages: BoardStage[] = STAGES) {
+  // Détail view exercises the stage-column placement; default localStorage is macro.
+  // useLocalStorage stores plain strings verbatim (no JSON quoting).
+  localStorage.setItem('board.viewMode', 'detail')
+  wrapper = mount(KanbanBoard, {
+    props: { stories, selectedId: null, projectId: 'p1', stages },
+    global: { plugins: [PrimeVue, createPinia()] },
+  })
+  return wrapper
+}
+
+afterEach(() => {
+  wrapper?.unmount()
+  localStorage.clear()
+})
+
+/**
+ * Returns the story keys placed in the détail column whose header label matches.
+ * Columns are header (label) + a card list of role="button" cards (aria-label
+ * "Story: <key> - <title>").
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function keysInColumn(w: VueWrapper<any>, label: string): string[] {
+  const column = w
+    .findAll('.flex.flex-col.gap-2.min-w-\\[240px\\]')
+    .find((col) => col.find('span').text() === label)
+  if (!column) return []
+  return column
+    .findAll('[role="button"]')
+    .map((card) => card.attributes('aria-label') ?? '')
+    .map((aria) => aria.replace(/^Story:\s*/, '').split(' - ')[0] ?? '')
+}
+
+describe('KanbanBoard détail placement (#300)', () => {
+  it('RG2/RG3: a running story with no current_stage lands in the entry stage, never Backlog', () => {
+    const story = makeStory({
+      key: 'S-05',
+      status: 'running',
+      current_stage: null,
+      latest_run: { id: 'r1', status: 'running', current_step: null },
+    })
+    const w = mountBoard([story])
+
+    expect(keysInColumn(w, 'Backlog')).not.toContain('S-05')
+    expect(keysInColumn(w, 'Dev')).toContain('S-05') // Dev = first/entry stage
+  })
+
+  it('RG1: a running story with a current_stage stays in that stage lane', () => {
+    const story = makeStory({
+      key: 'S-02',
+      status: 'running',
+      current_stage: 'Review',
+      latest_run: { id: 'r1', status: 'running', current_step: null },
+    })
+    const w = mountBoard([story])
+
+    expect(keysInColumn(w, 'Review')).toContain('S-02')
+    expect(keysInColumn(w, 'Backlog')).not.toContain('S-02')
+  })
+
+  it('RG4: a backlog story with no stage stays in Backlog', () => {
+    const story = makeStory({ key: 'S-03', status: 'backlog', current_stage: null })
+    const w = mountBoard([story])
+
+    expect(keysInColumn(w, 'Backlog')).toContain('S-03')
+    expect(keysInColumn(w, 'Dev')).not.toContain('S-03')
+  })
+
+  it('RG3: a running story with a stale current_stage (out of pipeline) lands in the entry stage, never Backlog', () => {
+    const story = makeStory({
+      key: 'S-06',
+      status: 'running',
+      current_stage: 'Ghost', // a stage name no longer in the pipeline (renamed/removed)
+      latest_run: { id: 'r1', status: 'running', current_step: null },
+    })
+    const w = mountBoard([story])
+
+    expect(keysInColumn(w, 'Backlog')).not.toContain('S-06')
+    expect(keysInColumn(w, 'Dev')).toContain('S-06') // Dev = first/entry stage
+  })
+
+  it('RG4: a non-running story with a stale/unknown current_stage falls back to Backlog', () => {
+    const story = makeStory({
+      key: 'S-07',
+      status: 'backlog',
+      current_stage: 'Ghost', // unknown column key, but not running
+    })
+    const w = mountBoard([story])
+
+    expect(keysInColumn(w, 'Backlog')).toContain('S-07')
+    expect(keysInColumn(w, 'Dev')).not.toContain('S-07')
+  })
+
+  it('degenerate: an empty pipeline routes a running+NULL story to Done, never Backlog', () => {
+    const story = makeStory({
+      key: 'S-05',
+      status: 'running',
+      current_stage: null,
+      latest_run: { id: 'r1', status: 'running', current_step: null },
+    })
+    const w = mountBoard([story], [])
+
+    expect(keysInColumn(w, 'Backlog')).not.toContain('S-05')
+    expect(keysInColumn(w, 'Done')).toContain('S-05')
+  })
+})

--- a/frontend/src/stores/__tests__/stories.spec.ts
+++ b/frontend/src/stores/__tests__/stories.spec.ts
@@ -2,10 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import {
   useStoriesStore,
+  boardColumn,
   stageColumn,
   STAGE_BACKLOG_COLUMN,
   STAGE_DONE_COLUMN,
   STAGE_FAILED_COLUMN,
+  STAGE_RUNNING_ENTRY,
   type Story,
 } from '../stories'
 
@@ -444,8 +446,21 @@ describe('stageColumn', () => {
     expect(stageColumn(makeStory({ status: 'running', current_stage: 'In Dev' }))).toBe('In Dev')
   })
 
-  it('falls back to the backlog lane when no stage is set', () => {
+  it('falls back to the backlog lane when no stage is set (backlog story)', () => {
     expect(stageColumn(makeStory({ status: 'backlog' }))).toBe(STAGE_BACKLOG_COLUMN)
+  })
+
+  it('RG2 (#300): a running story without a stage routes to the running-entry sentinel, not Backlog', () => {
+    const story = makeStory({ status: 'running', current_stage: null })
+    const col = stageColumn(story)
+    expect(col).toBe(STAGE_RUNNING_ENTRY)
+    expect(col).not.toBe(STAGE_BACKLOG_COLUMN)
+  })
+
+  it('RG3 (#300): a running+NULL story is in_progress (macro) AND off the backlog lane (détail)', () => {
+    const story = makeStory({ status: 'running', current_stage: null })
+    expect(boardColumn(story)).toBe('in_progress')
+    expect(stageColumn(story)).not.toBe(STAGE_BACKLOG_COLUMN)
   })
 
   it('sends done stories to the done lane regardless of stage', () => {

--- a/frontend/src/stores/stories.ts
+++ b/frontend/src/stores/stories.ts
@@ -57,6 +57,13 @@ export type KanbanColumn = 'backlog' | 'in_progress' | 'blocked' | 'done' | 'fai
 export const STAGE_DONE_COLUMN = '__done__'
 export const STAGE_FAILED_COLUMN = '__failed__'
 export const STAGE_BACKLOG_COLUMN = '__backlog__'
+/**
+ * Sentinel for a running story with no live `current_stage` (the executor has not
+ * stamped a stage yet). The détail board has no generic "running" lane, so the
+ * board resolves this sentinel to the pipeline's entry (first) stage. A running
+ * story must never land in the Backlog lane.
+ */
+export const STAGE_RUNNING_ENTRY = '__running_entry__'
 
 /**
  * Pure function — derives the macro (lifecycle) kanban column for a story.
@@ -81,9 +88,10 @@ export function boardColumn(story: Story): KanbanColumn {
  *
  * Terminal lifecycle states win over the live stage: a done/failed story sits in
  * its terminal lane regardless of any stale `current_stage`. Otherwise the story
- * is placed in its `current_stage` (a PipelineGroup name). A story with no live
- * stage (no run yet, or stage cleared at completion) falls back to the backlog
- * entry lane.
+ * is placed in its `current_stage` (a PipelineGroup name). A running story with no
+ * live stage yet (executor has not stamped one) returns STAGE_RUNNING_ENTRY,
+ * which the board resolves to the pipeline entry stage — never the Backlog lane.
+ * Any other stageless story (backlog before its first run) falls back to Backlog.
  *
  * The returned key is either a stage name (matched against the pipeline's stage
  * names by the board) or one of the STAGE_* sentinels.
@@ -92,6 +100,7 @@ export function stageColumn(story: Story): string {
   if (story.status === 'done') return STAGE_DONE_COLUMN
   if (story.status === 'failed') return STAGE_FAILED_COLUMN
   if (story.current_stage) return story.current_stage
+  if (story.status === 'running') return STAGE_RUNNING_ENTRY
   return STAGE_BACKLOG_COLUMN
 }
 


### PR DESCRIPTION
## Contexte
`stageColumn` (vue Détail) renvoyait la colonne **Backlog** dès que `current_stage` était NULL, sans considérer `status='running'` → une story running sans stage (seed S-05) affichait un badge « running » (issu de `boardColumn`) dans la lane Backlog. Closes #300.

## Changements (front-only)
- Nouveau sentinel `STAGE_RUNNING_ENTRY` retourné par `stageColumn` pour running+NULL ; `KanbanBoard` le résout vers la **première étape** du pipeline (point d'entrée) **avant** le fallback Backlog.
- Le garde de fallback route aussi une story running à **clé inconnue** (`current_stage` stale après renommage du pipeline) vers l'étape d'entrée → **invariant RG3** « jamais running en Backlog » pleinement tenu. Pipeline vide → Done (jamais Backlog).
- `stageColumn` reste **pure** ; backlog/done/failed et non-running inconnues **inchangés** (RG4).

## Tests (QA exercée — 4/4 RG pass)
`stories.spec.ts` (fonction pure) + `KanbanBoardPlacement.spec.ts` (placement via `mount()` réel) : RG1 (running+stage → sa colonne), RG2 (running+NULL → entrée, pas Backlog), RG3 (running+stage stale « Ghost » → entrée, pas Backlog ; cohérence macro/détail), RG4 (non-régression backlog/done/failed + non-running inconnu → Backlog). type-check/lint/vitest vert.

## Périmètre & follow-up
Front-only (back/openapi N/A, seed S-05 inchangé), `docs/product.md` N/A, e2e N/A (logique pure couverte unit + mount).
Follow-up (hors scope) : cause racine backend — l'exécuteur devrait toujours renseigner `current_stage` au lancement (« running + stage NULL » = état invalide à la source).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — via /forge:autopilot (autonome, pr-only)
