### PR TITLE
fix(agents): lever l'ambiguïté du double bouton New Agent en empty state (#304)

### DIFF
--- a/frontend/e2e/tests/templates.spec.ts
+++ b/frontend/e2e/tests/templates.spec.ts
@@ -298,7 +298,13 @@ test.describe('Agent List Page', () => {
       await expect(
         page.getByText('No agents found for this project.'),
       ).toBeVisible()
-      await expect(page.getByRole('button', { name: 'New Agent' })).toBeVisible()
+      // In empty state the header button is hidden, so the EmptyState CTA is the
+      // single "New Agent" button — getByRole no longer hits strict-mode (#304).
+      const cta = page.getByTestId('empty-create-agent-button')
+      await expect(cta).toBeVisible()
+      await expect(page.getByRole('button', { name: 'New Agent' })).toHaveCount(1)
+      await cta.click()
+      await expect(page).toHaveURL(`/projects/${PROJECT_ID}/agents/new`)
     })
   })
 })

--- a/frontend/src/features/agents/AgentEmptyState.vue
+++ b/frontend/src/features/agents/AgentEmptyState.vue
@@ -22,6 +22,7 @@ const emit = defineEmits<{
       label="New Agent"
       icon="pi pi-plus"
       severity="success"
+      data-testid="empty-create-agent-button"
       @click="emit('createClick')"
     />
   </div>

--- a/frontend/src/features/agents/__tests__/AgentEmptyState.spec.ts
+++ b/frontend/src/features/agents/__tests__/AgentEmptyState.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import AgentEmptyState from '../AgentEmptyState.vue'
+
+function mountComponent(isAdmin: boolean) {
+  return mount(AgentEmptyState, {
+    props: { isAdmin },
+    global: { plugins: [PrimeVue] },
+  })
+}
+
+describe('AgentEmptyState', () => {
+  it('renders the empty message regardless of role', () => {
+    const wrapper = mountComponent(false)
+    expect(wrapper.text()).toContain('No agents found for this project.')
+  })
+
+  it('shows the New Agent CTA with a unique testid for admins (RG1)', () => {
+    const wrapper = mountComponent(true)
+    const cta = wrapper.find('[data-testid="empty-create-agent-button"]')
+    expect(cta.exists()).toBe(true)
+    expect(cta.text()).toContain('New Agent')
+  })
+
+  it('hides the New Agent CTA for non-admins (RG2)', () => {
+    const wrapper = mountComponent(false)
+    expect(wrapper.find('[data-testid="empty-create-agent-button"]').exists()).toBe(false)
+  })
+
+  it('emits createClick when the CTA is clicked', async () => {
+    const wrapper = mountComponent(true)
+    await wrapper.find('[data-testid="empty-create-agent-button"]').trigger('click')
+    expect(wrapper.emitted('createClick')).toHaveLength(1)
+  })
+})

--- a/frontend/src/views/AgentListView.vue
+++ b/frontend/src/views/AgentListView.vue
@@ -30,6 +30,13 @@ const { agents, isLoading, error, fetchAgents, retry } = useAgents(projectId)
 // dialog's accept) only fires one DELETE (#295). Other rows stay clickable.
 const deleteGuard = useInFlightGuard()
 
+// True once loaded with no agents and no error: the EmptyState (with its own
+// create CTA) is shown, so the header button is hidden to avoid a duplicate
+// "New Agent" button (#304).
+const showEmptyState = computed(
+  () => !isLoading.value && !error.value && agents.value.length === 0,
+)
+
 onMounted(() => {
   fetchAgents()
 })
@@ -89,7 +96,7 @@ function isDeleting(agentId: string): boolean {
         </p>
       </div>
       <Button
-        v-if="isAdmin"
+        v-if="isAdmin && !showEmptyState"
         label="New Agent"
         icon="pi pi-plus"
         severity="success"
@@ -116,7 +123,7 @@ function isDeleting(agentId: string): boolean {
 
     <!-- Empty state -->
     <AgentEmptyState
-      v-else-if="!isLoading && !error && agents.length === 0"
+      v-else-if="showEmptyState"
       :is-admin="isAdmin"
       @create-click="handleCreateClick"
     />

--- a/frontend/src/views/__tests__/AgentListView.spec.ts
+++ b/frontend/src/views/__tests__/AgentListView.spec.ts
@@ -4,6 +4,7 @@ import { ref, computed, h, defineComponent } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import ToastService from 'primevue/toastservice'
+import type { Agent } from '@/stores/agents'
 import AgentListView from '../AgentListView.vue'
 
 /** A promise whose resolution is controlled by the test (in-flight window). */
@@ -15,38 +16,36 @@ function deferred<T>() {
   return { promise, resolve }
 }
 
+const mockPush = vi.fn()
+
 vi.mock('vue-router', () => ({
   useRoute: () => ({ params: { id: 'proj-1' } }),
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: mockPush }),
 }))
 
 const mockFetchAgents = vi.fn()
-const mockAgents = ref<unknown[]>([
-  {
-    id: 'a1',
-    name: 'Implement Agent',
-    model: 'claude-opus-4-6',
-    image: 'img:1',
-    template_content: '',
-    scope: 'project',
-    project_id: 'proj-1',
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
-  },
-])
+const mockRetry = vi.fn()
+const mockAgents = ref<Agent[]>([])
+const mockIsLoading = ref(false)
+const mockError = ref<string | null>(null)
 
 vi.mock('@/composables/useAgents', () => ({
   useAgents: () => ({
     agents: computed(() => mockAgents.value),
-    isLoading: computed(() => false),
-    error: computed(() => null),
+    pagination: computed(() => null),
+    isLoading: computed(() => mockIsLoading.value),
+    error: computed(() => mockError.value),
     fetchAgents: mockFetchAgents,
-    retry: vi.fn(),
+    retry: mockRetry,
   }),
 }))
 
+const mockUser = ref<{ role: string } | null>(null)
+
 vi.mock('@/composables/useAuth', () => ({
-  useAuth: () => ({ user: ref({ role: 'admin' }) }),
+  useAuth: () => ({
+    user: computed(() => mockUser.value),
+  }),
 }))
 
 // Capture the accept callback handed to PrimeVue's confirm.require so the test
@@ -82,6 +81,46 @@ const AgentTableStub = defineComponent({
   },
 })
 
+/** Stub the EmptyState so we can assert the single CTA testid through it. */
+const AgentEmptyStateStub = defineComponent({
+  name: 'AgentEmptyState',
+  props: ['isAdmin'],
+  emits: ['createClick'],
+  setup(props, { emit }) {
+    return () =>
+      h(
+        'div',
+        { 'data-testid': 'empty-state' },
+        props.isAdmin
+          ? [
+              h(
+                'button',
+                {
+                  'data-testid': 'empty-create-agent-button',
+                  onClick: () => emit('createClick'),
+                },
+                'New Agent',
+              ),
+            ]
+          : ['No agents'],
+      )
+  },
+})
+
+const sampleAgents: Agent[] = [
+  {
+    id: 'a1',
+    name: 'Implement Agent',
+    model: 'claude-opus-4-6',
+    image: 'ghcr.io/org/agent:latest',
+    template_content: 'You are a developer...',
+    scope: 'project',
+    project_id: 'proj-1',
+    created_at: '2026-01-15T10:00:00Z',
+    updated_at: '2026-01-15T10:00:00Z',
+  },
+]
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let wrapper: VueWrapper<any>
 
@@ -91,10 +130,11 @@ function mountComponent() {
       plugins: [PrimeVue, ToastService, createPinia()],
       stubs: {
         AgentTable: AgentTableStub,
-        AgentEmptyState: true,
+        AgentEmptyState: AgentEmptyStateStub,
         ConfirmDialog: true,
         Toast: true,
         Skeleton: true,
+        Message: true,
       },
     },
   })
@@ -105,12 +145,30 @@ function deleteTrigger() {
   return wrapper.find('[data-testid="delete-a1"]')
 }
 
+/** Count visible "New Agent" buttons across the whole view (header + CTA). */
+function newAgentButtons() {
+  return wrapper.findAll('button').filter((b) => b.text().includes('New Agent'))
+}
+
+function resetState() {
+  setActivePinia(createPinia())
+  capturedAccept = null
+  mockPush.mockReset()
+  mockFetchAgents.mockReset()
+  mockRetry.mockReset()
+  mockDeleteAgent.mockReset()
+  mockAgents.value = []
+  mockIsLoading.value = false
+  mockError.value = null
+  mockUser.value = null
+}
+
 describe('AgentListView — delete double-click guard (#295)', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
-    capturedAccept = null
-    mockFetchAgents.mockReset()
-    mockDeleteAgent.mockReset()
+    resetState()
+    // The guard suite operates on a populated table as an admin.
+    mockUser.value = { role: 'admin' }
+    mockAgents.value = sampleAgents
   })
 
   afterEach(() => {
@@ -170,5 +228,94 @@ describe('AgentListView — delete double-click guard (#295)', () => {
     capturedAccept!()
     await flushPromises()
     expect(mockDeleteAgent).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('AgentListView — empty-state CTA disambiguation (#304)', () => {
+  beforeEach(() => {
+    resetState()
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('fetches agents on mount', () => {
+    mountComponent()
+    expect(mockFetchAgents).toHaveBeenCalled()
+  })
+
+  it('RG1: admin + 0 agent shows the empty state with exactly one New Agent button (the CTA), header hidden', async () => {
+    mockUser.value = { role: 'admin' }
+    mockAgents.value = []
+    mountComponent()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="empty-state"]').exists()).toBe(true)
+    // Header button must be gone in empty state.
+    expect(wrapper.find('[data-testid="create-agent-button"]').exists()).toBe(false)
+    // Exactly one "New Agent" button in the DOM, and it is the CTA.
+    expect(newAgentButtons()).toHaveLength(1)
+    expect(wrapper.find('[data-testid="empty-create-agent-button"]').exists()).toBe(true)
+  })
+
+  it('RG1: clicking the empty-state CTA navigates to the create page', async () => {
+    mockUser.value = { role: 'admin' }
+    mockAgents.value = []
+    mountComponent()
+    await wrapper.vm.$nextTick()
+
+    await wrapper.find('[data-testid="empty-create-agent-button"]').trigger('click')
+
+    expect(mockPush).toHaveBeenCalledWith({
+      name: 'agent-create',
+      params: { id: 'proj-1' },
+    })
+  })
+
+  it('RG2: non-admin + 0 agent shows no New Agent button at all', async () => {
+    mockUser.value = { role: 'member' }
+    mockAgents.value = []
+    mountComponent()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="empty-state"]').exists()).toBe(true)
+    expect(newAgentButtons()).toHaveLength(0)
+    expect(wrapper.find('[data-testid="create-agent-button"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="empty-create-agent-button"]').exists()).toBe(false)
+  })
+
+  it('non-regression: admin with agents shows the header button (no empty state)', async () => {
+    mockUser.value = { role: 'admin' }
+    mockAgents.value = sampleAgents
+    mountComponent()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="empty-state"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="agent-table"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="create-agent-button"]').exists()).toBe(true)
+    expect(newAgentButtons()).toHaveLength(1)
+  })
+
+  it('non-regression: admin while loading shows the header button (no empty state)', async () => {
+    mockUser.value = { role: 'admin' }
+    mockAgents.value = []
+    mockIsLoading.value = true
+    mountComponent()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="empty-state"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="create-agent-button"]').exists()).toBe(true)
+  })
+
+  it('non-regression: admin on error shows the header button (no empty state)', async () => {
+    mockUser.value = { role: 'admin' }
+    mockAgents.value = []
+    mockError.value = 'boom'
+    mountComponent()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="empty-state"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="create-agent-button"]').exists()).toBe(true)
   })
 })


### PR DESCRIPTION
## Contexte
En empty state admin (page Agents), le bouton header (`create-agent-button`) ET le CTA de l'`AgentEmptyState` rendaient tous deux « New Agent » → `getByRole('button',{name:'New Agent'})` résolvait 2 éléments → **strict-mode violation** (e2e T1). Closes #304.

## Changements (front-only)
- Computed `showEmptyState = !isLoading && !error && agents.length===0` (partagé avec le `v-else-if` de l'EmptyState, **DRY** → pas de divergence header/empty state).
- Bouton header `v-if="isAdmin && !showEmptyState"` → masqué en empty state ; le CTA central de l'`AgentEmptyState` devient le bouton **unique** de création (`data-testid="empty-create-agent-button"`).
- Header reste visible en loading/erreur/agents présents (pas de doublon). Non-admin → aucun bouton (`v-if isAdmin`). Flux de création réel inchangé.
- **e2e T1** (`templates.spec.ts`) corrigé : cible unique, `getByRole New Agent` = 1 match.

## Tests (QA exercée — 4/4 pass)
`AgentListView.spec.ts` + `AgentEmptyState.spec.ts` (11 tests) : RG1 (admin+0 → 1 bouton CTA, header masqué, cliquable→agent-create), RG2 (non-admin+0 → 0 bouton), RG3 (1 match, testid unique), non-régression (agents/loading/erreur → header visible). type-check/lint/vitest vert.

Front-only (back/openapi N/A), `docs/product.md` N/A (ajustement empty state).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — via /forge:autopilot (autonome, pr-only)
