### PR TITLE
feat(runtime): opt-in East-West run isolation (DOCKER_ISOLATE_RUNS)

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -233,7 +233,7 @@ func run() error {
 	// container manager the agent_run/runService wiring below is disabled anyway.
 	var agentRuntime port.AgentRuntime
 	if containerMgr != nil {
-		agentRuntime = selectSubstrate(cfg.Substrate.Kind, stackRepo, containerMgr, cfg.Docker.AgentNetwork, logger)
+		agentRuntime = selectSubstrate(cfg.Substrate.Kind, stackRepo, containerMgr, cfg.Docker.AgentNetwork, cfg.Docker.IsolateRuns, logger)
 	} else {
 		logger.Warn("substrate selection skipped: no container manager available, agent runs disabled", "substrate", cfg.Substrate.Kind)
 	}
@@ -304,9 +304,15 @@ func run() error {
 				DefaultMemory: 4294967296, // 4GB
 				DefaultCPUs:   2.0,
 				NetworkName:   cfg.Docker.AgentNetwork,
+				IsolateRuns:   cfg.Docker.IsolateRuns,
 				LogTailLines:  50,
 			}
-			sidecarMgr = dockeradapter.NewDockerSidecarManager(containerMgr, logger)
+			sidecarMgr = dockeradapter.NewDockerSidecarManagerWithIsolation(
+				containerMgr, cfg.Docker.IsolateRuns, cfg.Docker.APIContainerName, logger)
+			if cfg.Docker.IsolateRuns {
+				logger.Info("East-West run isolation enabled: agents are single-homed on their per-run network; API attached per-run",
+					"api_container", cfg.Docker.APIContainerName)
+			}
 
 			agentRunAction := actionadapter.NewAgentRunAction(
 				containerMgr, logStreamer, eventRepo,
@@ -602,7 +608,7 @@ func stackCatalogueFromConfig(entries []pkgconfig.StackConfig, logger *slog.Logg
 // build returns microsandbox.ErrNotBuilt, so selecting microsandbox without that
 // build fails the run clearly rather than silently falling back to Docker.
 // enabled=true lets the tagged build launch microVMs; the fallback build ignores it.
-func selectSubstrate(kind string, stacks port.StackRepository, containerMgr port.ContainerManager, networkName string, logger *slog.Logger) port.AgentRuntime {
+func selectSubstrate(kind string, stacks port.StackRepository, containerMgr port.ContainerManager, networkName string, isolateRuns bool, logger *slog.Logger) port.AgentRuntime {
 	switch kind {
 	case pkgconfig.SubstrateMicrosandbox:
 		logger.Info("substrate selected", "substrate", pkgconfig.SubstrateMicrosandbox)
@@ -612,7 +618,9 @@ func selectSubstrate(kind string, stacks port.StackRepository, containerMgr port
 		return rt
 	default:
 		logger.Info("substrate selected", "substrate", pkgconfig.SubstrateDocker)
-		return dockeradapter.NewRuntime(containerMgr, networkName, logger)
+		// isolateRuns makes the Docker adapter single-home the agent on its per-run
+		// network (East-West isolation) instead of dual-homing on the shared network.
+		return dockeradapter.NewRuntimeWithIsolation(containerMgr, networkName, isolateRuns, logger)
 	}
 }
 

--- a/backend/cmd/api/main_test.go
+++ b/backend/cmd/api/main_test.go
@@ -22,7 +22,7 @@ func TestSelectSubstrate(t *testing.T) {
 	// special path. containerMgr is stored, not dereferenced at construction, so a
 	// nil one is safe for this routing test.
 	t.Run("docker default returns the Docker adapter (docker.Runtime)", func(t *testing.T) {
-		got := selectSubstrate(pkgconfig.SubstrateDocker, nil, nil, "agent-net", quietLogger())
+		got := selectSubstrate(pkgconfig.SubstrateDocker, nil, nil, "agent-net", false, quietLogger())
 		if got == nil {
 			t.Fatal("selectSubstrate(docker) = nil, want *docker.Runtime")
 		}
@@ -34,14 +34,14 @@ func TestSelectSubstrate(t *testing.T) {
 	t.Run("unknown kind falls through to the docker default (docker.Runtime)", func(t *testing.T) {
 		// validate() rejects unknown kinds at load time; the factory itself
 		// defaults defensively so it never panics on an unexpected value.
-		got := selectSubstrate("k8s", nil, nil, "agent-net", quietLogger())
+		got := selectSubstrate("k8s", nil, nil, "agent-net", false, quietLogger())
 		if _, ok := got.(*dockeradapter.Runtime); !ok {
 			t.Fatalf("selectSubstrate(unknown) = %T, want *docker.Runtime", got)
 		}
 	})
 
 	t.Run("microsandbox constructs the scaffold AgentRuntime", func(t *testing.T) {
-		got := selectSubstrate(pkgconfig.SubstrateMicrosandbox, nil, nil, "", quietLogger())
+		got := selectSubstrate(pkgconfig.SubstrateMicrosandbox, nil, nil, "", false, quietLogger())
 		if got == nil {
 			t.Fatal("selectSubstrate(microsandbox) = nil, want a scaffold adapter")
 		}

--- a/backend/internal/adapter/action/agent_run.go
+++ b/backend/internal/adapter/action/agent_run.go
@@ -24,6 +24,15 @@ type AgentConfig struct {
 	DefaultCPUs float64
 	// NetworkName is the Docker network for agent containers.
 	NetworkName string
+	// IsolateRuns mirrors cfg.Docker.IsolateRuns (DOCKER_ISOLATE_RUNS). When true,
+	// the agent is single-homed on its per-run network instead of the shared
+	// NetworkName, so the per-run network must ALWAYS be created — even for a
+	// project with no sidecars. The Action therefore launches the SidecarManager
+	// unconditionally under this flag; the manager creates the network and wires
+	// the API callback in. When false, behaviour is unchanged (no per-run network
+	// unless there are sidecars). The substrate (docker.Runtime) is configured with
+	// the same flag so it makes the per-run network primary.
+	IsolateRuns bool
 	// LogTailLines is the number of log lines to keep for error context.
 	LogTailLines int
 	// CrashGrace bounds how long the Action waits for a callback status AFTER the
@@ -212,8 +221,14 @@ func (a *AgentRunAction) Execute(ctx context.Context, runCtx *model.RunContext) 
 
 	// Launch sidecars on a per-run isolated network. Nil-safe: env==nil or no
 	// services yields a nil sidecarCtx and is a no-op. Fail-fast on launch error.
+	//
+	// Under East-West run isolation we launch the SidecarManager even when there
+	// are no sidecars: the manager must still create the per-run network (and wire
+	// the API callback into it) because the agent is single-homed on it. The
+	// manager's Launch is a no-op only when isolation is OFF and there are no
+	// services, so the guard here mirrors that to avoid a pointless call.
 	var sidecarCtx *port.SidecarContext
-	if env != nil && len(env.Services) > 0 {
+	if (env != nil && len(env.Services) > 0) || a.config.IsolateRuns {
 		sc, launchErr := a.sidecarMgr.Launch(ctx, runCtx.Run.ID, env)
 		if launchErr != nil {
 			return fmt.Errorf("launch sidecars: %w", launchErr)
@@ -400,11 +415,18 @@ func (a *AgentRunAction) createContainer(
 		Labels:      a.buildAgentLabels(runCtx, story),
 	}
 
-	// Dual-home the agent container: it keeps its shared NetworkName (API callback
-	// / egress) AND attaches to the run network so it can reach the sidecars by
-	// their service-name DNS alias. Only set when a run network actually exists,
-	// so a project without an Environment keeps identical ContainerOpts.
-	if sidecarCtx != nil && sidecarCtx.NetworkName != "" {
+	switch {
+	case a.config.IsolateRuns && sidecarCtx != nil && sidecarCtx.NetworkName != "":
+		// East-West isolation: the per-run network is the agent's primary and only
+		// network; the shared network is dropped so agents from different runs never
+		// share an L2 segment. The API is attached to the per-run network by the
+		// SidecarManager, keeping the callback reachable.
+		opts.NetworkName = sidecarCtx.NetworkName
+	case sidecarCtx != nil && sidecarCtx.NetworkName != "":
+		// Dual-home (default): keep the shared NetworkName (API callback / egress)
+		// AND attach to the run network so the agent can reach sidecars by their
+		// service-name DNS alias. Only set when a run network actually exists, so a
+		// project without an Environment keeps identical ContainerOpts.
 		opts.ExtraNetworks = []string{sidecarCtx.NetworkName}
 	}
 

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -123,6 +123,10 @@ func (m *mockContainerManager) ConnectContainer(_ context.Context, _, _ string, 
 	return nil
 }
 
+func (m *mockContainerManager) DisconnectContainer(_ context.Context, _, _ string) error {
+	return nil
+}
+
 func (m *mockContainerManager) ListNetworks(_ context.Context, _ map[string]string) ([]model.NetworkInfo, error) {
 	return nil, nil
 }

--- a/backend/internal/adapter/action/agent_run_test.go
+++ b/backend/internal/adapter/action/agent_run_test.go
@@ -689,6 +689,39 @@ func newAgentRunFixture(t *testing.T) *agentRunFixture {
 	return f
 }
 
+// setIsolateRuns rebuilds f.action with the given East-West isolation flag,
+// reusing the same mocks. It keeps the legacy path (no AgentRuntime injected) so
+// createContainer is exercised — the second security-critical network path.
+func (f *agentRunFixture) setIsolateRuns(t *testing.T, isolate bool) {
+	t.Helper()
+	agentCfg := action.AgentConfig{
+		DefaultMemory: 4294967296,
+		DefaultCPUs:   2.0,
+		NetworkName:   testNetwork,
+		IsolateRuns:   isolate,
+		LogTailLines:  50,
+	}
+	f.action = action.NewAgentRunAction(
+		f.containerMgr,
+		f.logStreamer,
+		f.eventPub,
+		f.storyRepo,
+		f.projectRepo,
+		f.runRepo,
+		f.environmentRepo,
+		f.sidecarMgr,
+		f.stackRepo,
+		&mockTemplateRenderer{},
+		f.costSvc,
+		agentCfg,
+		testLogger(),
+		nil, // apiKeySvc - legacy mode
+		nil, // tokenStore - legacy mode
+		nil, // statusStore - legacy mode
+		"",  // callbackURL - legacy mode
+	)
+}
+
 func (f *agentRunFixture) newRunContext() *model.RunContext {
 	return &model.RunContext{
 		Run:       f.run,
@@ -1317,6 +1350,103 @@ func TestAgentRunAction_WithEnvironment_SidecarWiring(t *testing.T) {
 	}
 	if len(opts.ExtraNetworks) != 1 || opts.ExtraNetworks[0] != runNetwork {
 		t.Errorf("expected ExtraNetworks=[%s], got %v", runNetwork, opts.ExtraNetworks)
+	}
+}
+
+// TestAgentRunAction_Legacy_RunNetworkIsolation is the action-package pendant of
+// the docker-package TestRuntime_Launch_Isolated_RunNetworkPrimary: it covers the
+// SECOND security-critical path, the legacy createContainer (a.runtime == nil),
+// for both isolation states. It closes the silent-regression hole where a future
+// re-dual-home of the isolated branch would break East-West isolation without
+// failing any test.
+//
+// Both cases run the live legacy path (the fixture injects no AgentRuntime) with a
+// project that HAS an Environment, so sidecarCtx.NetworkName is non-empty.
+func TestAgentRunAction_Legacy_RunNetworkIsolation(t *testing.T) {
+	tests := []struct {
+		name        string
+		isolateRuns bool
+		// wantPrimary is the expected opts.NetworkName.
+		wantPrimary func(runNet string) string
+		// wantExtra is the expected opts.ExtraNetworks.
+		wantExtra func(runNet string) []string
+	}{
+		{
+			name:        "default dual-homes on shared network",
+			isolateRuns: false,
+			wantPrimary: func(_ string) string { return testNetwork },
+			wantExtra:   func(runNet string) []string { return []string{runNet} },
+		},
+		{
+			name:        "isolated single-homes on per-run network",
+			isolateRuns: true,
+			wantPrimary: func(runNet string) string { return runNet },
+			wantExtra:   func(_ string) []string { return nil },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newAgentRunFixture(t)
+			f.setIsolateRuns(t, tt.isolateRuns)
+
+			runNetwork := "hopeitworks-run-" + f.runID.String()
+			env := &model.Environment{
+				ProjectID: f.projectID,
+				Services: []model.EnvironmentService{
+					{Name: "db", Image: "postgres:16", Env: map[string]string{"POSTGRES_PASSWORD": "x"}},
+				},
+			}
+			f.environmentRepo.getByProjectIDFn = func(_ context.Context, _ uuid.UUID) (*model.Environment, error) {
+				return env, nil
+			}
+			f.sidecarMgr.launchFn = func(_ context.Context, runID uuid.UUID, _ *model.Environment) (*port.SidecarContext, error) {
+				return &port.SidecarContext{
+					RunID:        runID,
+					NetworkName:  runNetwork,
+					ContainerIDs: map[string]string{"db": "sidecar-db"},
+					ServiceAddrs: map[string]string{"db": "db"},
+				}, nil
+			}
+
+			if err := f.action.Execute(context.Background(), f.newRunContext()); err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			f.containerMgr.mu.Lock()
+			createCalls := f.containerMgr.createCalls
+			f.containerMgr.mu.Unlock()
+			if len(createCalls) != 1 {
+				t.Fatalf("expected 1 create call, got %d", len(createCalls))
+			}
+			opts := createCalls[0]
+
+			if got, want := opts.NetworkName, tt.wantPrimary(runNetwork); got != want {
+				t.Errorf("primary NetworkName: got %q, want %q", got, want)
+			}
+			wantExtra := tt.wantExtra(runNetwork)
+			if len(opts.ExtraNetworks) != len(wantExtra) {
+				t.Fatalf("ExtraNetworks: got %v, want %v", opts.ExtraNetworks, wantExtra)
+			}
+			for i := range wantExtra {
+				if opts.ExtraNetworks[i] != wantExtra[i] {
+					t.Errorf("ExtraNetworks[%d]: got %q, want %q", i, opts.ExtraNetworks[i], wantExtra[i])
+				}
+			}
+
+			// Under isolation the SHARED network must appear NOWHERE (primary or extra):
+			// that is the East-West invariant the agent is single-homed on its run net.
+			if tt.isolateRuns {
+				if opts.NetworkName == testNetwork {
+					t.Errorf("isolated agent must NOT be on the shared network %q", testNetwork)
+				}
+				for _, n := range opts.ExtraNetworks {
+					if n == testNetwork {
+						t.Errorf("shared network %q leaked into ExtraNetworks: %v", testNetwork, opts.ExtraNetworks)
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/backend/internal/adapter/docker/container_manager.go
+++ b/backend/internal/adapter/docker/container_manager.go
@@ -31,6 +31,7 @@ type dockerClient interface {
 	NetworkCreate(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error)
 	NetworkRemove(ctx context.Context, networkID string) error
 	NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error
+	NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error
 	NetworkList(ctx context.Context, options network.ListOptions) ([]network.Summary, error)
 }
 
@@ -358,6 +359,32 @@ func (m *ContainerManager) ConnectContainer(ctx context.Context, networkNameOrID
 	}
 
 	m.logger.Debug("container connected to network",
+		slog.String("container_id", containerID),
+		slog.String("network", networkNameOrID),
+	)
+	return nil
+}
+
+// DisconnectContainer detaches a container from a network (force=true so a
+// stopped/already-half-detached endpoint is still cleared). It is idempotent: a
+// missing network or container is treated as success, so detaching the API from
+// a per-run network is safe to call repeatedly from rollback/Cleanup/GC.
+func (m *ContainerManager) DisconnectContainer(ctx context.Context, networkNameOrID, containerID string) error {
+	if err := m.client.NetworkDisconnect(ctx, networkNameOrID, containerID, true); err != nil {
+		if cerrdefs.IsNotFound(err) {
+			m.logger.Debug("disconnect: network or container already absent",
+				slog.String("container_id", containerID),
+				slog.String("network", networkNameOrID),
+			)
+			return nil
+		}
+		return apperrors.NewContainerError(
+			fmt.Sprintf("failed to disconnect container %s from network %s: %v", containerID, networkNameOrID, err),
+			err,
+		)
+	}
+
+	m.logger.Debug("container disconnected from network",
 		slog.String("container_id", containerID),
 		slog.String("network", networkNameOrID),
 	)

--- a/backend/internal/adapter/docker/container_manager.go
+++ b/backend/internal/adapter/docker/container_manager.go
@@ -345,13 +345,27 @@ func (m *ContainerManager) RemoveNetwork(ctx context.Context, nameOrID string) e
 }
 
 // ConnectContainer attaches a container to a network, optionally registering DNS
-// aliases for it on that network.
+// aliases for it on that network. It is idempotent: a container already attached
+// to the network is treated as success, so re-attaching the API to a per-run
+// network (e.g. a retried Launch under East-West isolation) is a no-op rather than
+// an error — symmetric with DisconnectContainer's IsNotFound handling.
 func (m *ContainerManager) ConnectContainer(ctx context.Context, networkNameOrID, containerID string, aliases []string) error {
 	var cfg *network.EndpointSettings
 	if len(aliases) > 0 {
 		cfg = &network.EndpointSettings{Aliases: aliases}
 	}
 	if err := m.client.NetworkConnect(ctx, networkNameOrID, containerID, cfg); err != nil {
+		// Docker reports an already-attached endpoint as Conflict (409) or, on
+		// older daemons, Forbidden (403 -> PermissionDenied): "endpoint with name
+		// ... already exists in network ...". Treat it as a no-op success so
+		// connectAPI is genuinely re-entrant.
+		if cerrdefs.IsConflict(err) || cerrdefs.IsPermissionDenied(err) {
+			m.logger.Debug("connect: container already attached to network",
+				slog.String("container_id", containerID),
+				slog.String("network", networkNameOrID),
+			)
+			return nil
+		}
 		return apperrors.NewContainerError(
 			fmt.Sprintf("failed to connect container %s to network %s: %v", containerID, networkNameOrID, err),
 			err,

--- a/backend/internal/adapter/docker/container_manager_test.go
+++ b/backend/internal/adapter/docker/container_manager_test.go
@@ -789,6 +789,27 @@ func TestConnectContainer_Error(t *testing.T) {
 	}
 }
 
+func TestConnectContainer_IdempotentAlreadyAttached(t *testing.T) {
+	// Docker reports an already-attached endpoint as Conflict (409) or, on older
+	// daemons, Forbidden (403). Both must be treated as a no-op success so
+	// re-connecting the API to a per-run network (a retried isolated Launch) does
+	// not fail — symmetric with RemoveNetwork/DisconnectContainer idempotency.
+	cases := map[string]error{
+		"conflict (409)":  errdefs.Conflict(errors.New("endpoint with name api already exists in network n")),
+		"forbidden (403)": errdefs.Forbidden(errors.New("endpoint already exists in network n")),
+	}
+	for name, connectErr := range cases {
+		t.Run(name, func(t *testing.T) {
+			mock := &mockDockerClient{netConnectErr: connectErr}
+			mgr := newTestManager(mock)
+
+			if err := mgr.ConnectContainer(context.Background(), "n", "ctr-1", []string{"api"}); err != nil {
+				t.Fatalf("expected nil for already-attached endpoint (idempotent), got %v", err)
+			}
+		})
+	}
+}
+
 func TestListNetworks_Success(t *testing.T) {
 	created := time.Unix(1700000000, 0)
 	mock := &mockDockerClient{

--- a/backend/internal/adapter/docker/container_manager_test.go
+++ b/backend/internal/adapter/docker/container_manager_test.go
@@ -41,12 +41,15 @@ type mockDockerClient struct {
 	listOpts dockercontainer.ListOptions
 
 	// Network captured args.
-	netCreateName string
-	netCreateOpts network.CreateOptions
-	netRemoveID   string
-	netConnectNet string
-	netConnectCtr string
-	netConnectCfg *network.EndpointSettings
+	netCreateName    string
+	netCreateOpts    network.CreateOptions
+	netRemoveID      string
+	netConnectNet    string
+	netConnectCtr    string
+	netConnectCfg    *network.EndpointSettings
+	netDisconnectNet string
+	netDisconnectCtr string
+	netDisconnectFrc bool
 
 	// Configurable return values.
 	createResp     dockercontainer.CreateResponse
@@ -59,14 +62,15 @@ type mockDockerClient struct {
 	listContainers []dockercontainer.Summary
 	listErr        error
 
-	netCreateResp network.CreateResponse
-	netCreateErr  error
-	netRemoveErr  error
-	netConnectErr error
-	netList       []network.Summary
-	netListErr    error
-	inspectResp   dockercontainer.InspectResponse
-	inspectErr    error
+	netCreateResp    network.CreateResponse
+	netCreateErr     error
+	netRemoveErr     error
+	netConnectErr    error
+	netDisconnectErr error
+	netList          []network.Summary
+	netListErr       error
+	inspectResp      dockercontainer.InspectResponse
+	inspectErr       error
 }
 
 func (m *mockDockerClient) ContainerCreate(
@@ -141,6 +145,13 @@ func (m *mockDockerClient) NetworkConnect(_ context.Context, networkID, containe
 	m.netConnectCtr = containerID
 	m.netConnectCfg = config
 	return m.netConnectErr
+}
+
+func (m *mockDockerClient) NetworkDisconnect(_ context.Context, networkID, containerID string, force bool) error {
+	m.netDisconnectNet = networkID
+	m.netDisconnectCtr = containerID
+	m.netDisconnectFrc = force
+	return m.netDisconnectErr
 }
 
 func (m *mockDockerClient) NetworkList(_ context.Context, _ network.ListOptions) ([]network.Summary, error) {

--- a/backend/internal/adapter/docker/runtime.go
+++ b/backend/internal/adapter/docker/runtime.go
@@ -35,17 +35,32 @@ type Runtime struct {
 	// attached to every execution. It is NEVER a per-run identity — the per-run
 	// isolated network arrives via RunSpec.Network and maps to ExtraNetworks.
 	networkName string
+	// isolateRuns opts into East-West run isolation (DOCKER_ISOLATE_RUNS). When
+	// true AND a per-run network is supplied on the spec, that per-run network
+	// becomes the agent's PRIMARY (and only) network: the shared agent network is
+	// NOT attached, so agents from different runs no longer share an L2 segment.
+	// When false (default) the shared network stays primary and the per-run
+	// network is an extra attachment — byte-identical to before.
+	isolateRuns bool
 	logger      *slog.Logger
 }
 
-// NewRuntime constructs the Docker substrate adapter. containerMgr is the
-// low-level container CRUD dependency; networkName is the shared agent network
-// every execution attaches to (deployment config, never per-run).
+// NewRuntime constructs the Docker substrate adapter with East-West run isolation
+// DISABLED. containerMgr is the low-level container CRUD dependency; networkName
+// is the shared agent network every execution attaches to (deployment config,
+// never per-run). Use NewRuntimeWithIsolation to opt into isolation.
 func NewRuntime(containerMgr port.ContainerManager, networkName string, logger *slog.Logger) *Runtime {
+	return NewRuntimeWithIsolation(containerMgr, networkName, false, logger)
+}
+
+// NewRuntimeWithIsolation constructs the Docker substrate adapter and configures
+// East-West run isolation. When isolateRuns is true, an execution carrying a
+// per-run network is single-homed on it (the shared networkName is not attached).
+func NewRuntimeWithIsolation(containerMgr port.ContainerManager, networkName string, isolateRuns bool, logger *slog.Logger) *Runtime {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Runtime{containerMgr: containerMgr, networkName: networkName, logger: logger}
+	return &Runtime{containerMgr: containerMgr, networkName: networkName, isolateRuns: isolateRuns, logger: logger}
 }
 
 // Launch builds ContainerOpts from the agnostic spec, creates and starts the
@@ -70,10 +85,18 @@ func (r *Runtime) Launch(ctx context.Context, spec port.RunSpec) (port.RunHandle
 		Entrypoint:  spec.Entrypoint, // nil for an agent launch
 		Cmd:         spec.Cmd,        // nil for an agent launch
 	}
-	// Per-run isolated network: dual-home the execution. Empty Name leaves the
-	// container single-homed on the shared network, keeping ContainerOpts
-	// byte-identical to the no-Environment case.
-	if spec.Network.Name != "" {
+	switch {
+	case r.isolateRuns && spec.Network.Name != "":
+		// East-West isolation: the per-run network is the PRIMARY and only network.
+		// The shared agent network is NOT attached, so two agents from different
+		// runs never share an L2 segment. The API container is attached to this
+		// per-run network out-of-band (SidecarManager) so the callback still works.
+		opts.NetworkName = spec.Network.Name
+		opts.Aliases = spec.Network.Aliases
+	case spec.Network.Name != "":
+		// Default (dual-home): keep the shared network primary and attach the
+		// per-run network as an extra. Empty Name leaves the container single-homed
+		// on the shared network — byte-identical to the no-Environment case.
 		opts.ExtraNetworks = []string{spec.Network.Name}
 		opts.Aliases = spec.Network.Aliases
 	}

--- a/backend/internal/adapter/docker/runtime_test.go
+++ b/backend/internal/adapter/docker/runtime_test.go
@@ -114,6 +114,10 @@ func (f *fakeRuntimeCM) ConnectContainer(_ context.Context, _, _ string, _ []str
 	return nil
 }
 
+func (f *fakeRuntimeCM) DisconnectContainer(_ context.Context, _, _ string) error {
+	return nil
+}
+
 func (f *fakeRuntimeCM) ListNetworks(_ context.Context, _ map[string]string) ([]model.NetworkInfo, error) {
 	return nil, nil
 }
@@ -282,6 +286,76 @@ func TestRuntime_Launch_WithRunNetwork(t *testing.T) {
 	}
 	if got := opts.Aliases[runNet]; got != "agent" {
 		t.Errorf("expected Aliases[%s]=agent, got %q (full: %v)", runNet, got, opts.Aliases)
+	}
+}
+
+// TestRuntime_Launch_Isolated_RunNetworkPrimary proves East-West isolation: with
+// the flag ON and a per-run network supplied, the agent is SINGLE-HOMED on the
+// per-run network — it becomes the primary NetworkName and the shared agent
+// network is NOT attached (no ExtraNetworks), so two agents from different runs
+// never share an L2 segment.
+func TestRuntime_Launch_Isolated_RunNetworkPrimary(t *testing.T) {
+	cm := &fakeRuntimeCM{}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	rt := NewRuntimeWithIsolation(cm, runtimeSharedNetwork, true, logger)
+
+	const runNet = "hopeitworks-run-isolated"
+	spec := legacyAgentSpec()
+	spec.Network = port.RunNetwork{Name: runNet, Aliases: map[string]string{runNet: "agent"}}
+
+	if _, err := rt.Launch(context.Background(), spec); err != nil {
+		t.Fatalf("Launch returned error: %v", err)
+	}
+
+	created, _, _, _, _ := cm.snapshot()
+	if len(created) != 1 {
+		t.Fatalf("expected 1 create call, got %d", len(created))
+	}
+	opts := created[0]
+
+	// Primary network is the per-run network, NOT the shared one.
+	if opts.NetworkName != runNet {
+		t.Errorf("expected primary NetworkName %q (per-run), got %q", runNet, opts.NetworkName)
+	}
+	// The shared agent network must not appear anywhere.
+	if opts.NetworkName == runtimeSharedNetwork {
+		t.Errorf("agent must NOT be on the shared network %q under isolation", runtimeSharedNetwork)
+	}
+	for _, n := range opts.ExtraNetworks {
+		if n == runtimeSharedNetwork {
+			t.Errorf("shared network %q leaked into ExtraNetworks: %v", runtimeSharedNetwork, opts.ExtraNetworks)
+		}
+	}
+	// Single-homed: no extra attachments at all (the per-run net is primary).
+	if len(opts.ExtraNetworks) != 0 {
+		t.Errorf("expected no ExtraNetworks under isolation, got %v", opts.ExtraNetworks)
+	}
+	if got := opts.Aliases[runNet]; got != "agent" {
+		t.Errorf("expected Aliases[%s]=agent, got %q", runNet, got)
+	}
+}
+
+// TestRuntime_Launch_Isolated_NoRunNetwork_FallsBack proves the isolation flag is
+// inert without a per-run network on the spec: the agent stays on the shared
+// network exactly like the default. (In the live flow the SidecarManager always
+// supplies a per-run network under isolation, so this only guards the edge case.)
+func TestRuntime_Launch_Isolated_NoRunNetwork_FallsBack(t *testing.T) {
+	cm := &fakeRuntimeCM{}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	rt := NewRuntimeWithIsolation(cm, runtimeSharedNetwork, true, logger)
+
+	spec := legacyAgentSpec() // zero Network
+
+	if _, err := rt.Launch(context.Background(), spec); err != nil {
+		t.Fatalf("Launch returned error: %v", err)
+	}
+	created, _, _, _, _ := cm.snapshot()
+	opts := created[0]
+	if opts.NetworkName != runtimeSharedNetwork {
+		t.Errorf("expected fallback to shared network %q, got %q", runtimeSharedNetwork, opts.NetworkName)
+	}
+	if len(opts.ExtraNetworks) != 0 {
+		t.Errorf("expected no ExtraNetworks, got %v", opts.ExtraNetworks)
 	}
 }
 

--- a/backend/internal/adapter/docker/sidecar_manager.go
+++ b/backend/internal/adapter/docker/sidecar_manager.go
@@ -72,6 +72,20 @@ type SidecarManager struct {
 	containers port.ContainerManager
 	logger     *slog.Logger
 
+	// isolateRuns opts into East-West run isolation (DOCKER_ISOLATE_RUNS). When
+	// true, Launch ALWAYS creates the per-run network (even with zero sidecars)
+	// and attaches the API container to it (alias "api") so the agent — single-
+	// homed on this per-run network instead of the shared agent network — can
+	// still reach the callback. Cleanup/rollback/GC detach the API before removing
+	// the network. When false (default), behaviour is byte-identical to before:
+	// no per-run network unless there are sidecars, and the API is never touched.
+	isolateRuns bool
+	// apiContainerName is the name (or id) of the platform API container the
+	// SidecarManager attaches to / detaches from each per-run network when
+	// isolateRuns is enabled. Empty disables the attach (no-op) so an unset
+	// identity can never break a run silently.
+	apiContainerName string
+
 	// Tunables (defaulted in the constructor) kept as fields for testability.
 	readinessTimeout  time.Duration
 	readinessInterval time.Duration
@@ -82,13 +96,28 @@ type SidecarManager struct {
 	now func() time.Time
 }
 
+// apiNetworkAlias is the DNS alias the API container is registered under on each
+// per-run network, so the agent's CALLBACK_URL (http://api:8080) resolves there.
+const apiNetworkAlias = "api"
+
 // NewDockerSidecarManager builds a SidecarManager backed by the given
-// ContainerManager. The ContainerManager is reused for both networks and
-// containers — no second Docker client is created.
+// ContainerManager, with East-West run isolation DISABLED. The ContainerManager
+// is reused for both networks and containers — no second Docker client is
+// created. Use NewDockerSidecarManagerWithIsolation to opt into isolation.
 func NewDockerSidecarManager(containers port.ContainerManager, logger *slog.Logger) *SidecarManager {
+	return NewDockerSidecarManagerWithIsolation(containers, false, "", logger)
+}
+
+// NewDockerSidecarManagerWithIsolation builds a SidecarManager and configures
+// East-West run isolation. When isolateRuns is true, every run gets its own
+// network and the API container (apiContainerName) is attached to it so the
+// callback keeps working while the agent leaves the shared agent network.
+func NewDockerSidecarManagerWithIsolation(containers port.ContainerManager, isolateRuns bool, apiContainerName string, logger *slog.Logger) *SidecarManager {
 	return &SidecarManager{
 		containers:        containers,
 		logger:            logger,
+		isolateRuns:       isolateRuns,
+		apiContainerName:  apiContainerName,
 		readinessTimeout:  defaultReadinessTimeout,
 		readinessInterval: defaultReadinessInterval,
 		runningGrace:      defaultRunningGrace,
@@ -109,6 +138,45 @@ func networkName(runID uuid.UUID) string {
 	return sidecarNetworkPrefix + runID.String()
 }
 
+// connectAPI attaches the platform API container to a per-run network (alias
+// "api") so the isolated agent's callback (http://api:8080) resolves there. It is
+// a no-op unless run isolation is enabled AND an API container name is
+// configured, so a build with the flag off — or a misconfigured identity — never
+// adds an API endpoint and never errors. Returns an error only when a configured
+// connect fails (so Launch can roll back rather than start an agent with no path
+// to the callback).
+func (s *SidecarManager) connectAPI(ctx context.Context, netName string) error {
+	if !s.isolateRuns || s.apiContainerName == "" {
+		return nil
+	}
+	if err := s.containers.ConnectContainer(ctx, netName, s.apiContainerName, []string{apiNetworkAlias}); err != nil {
+		return fmt.Errorf("connecting API container %s to run network %s: %w", s.apiContainerName, netName, err)
+	}
+	s.logger.Debug("API attached to run network",
+		slog.String("network", netName),
+		slog.String("api_container", s.apiContainerName),
+	)
+	return nil
+}
+
+// disconnectAPI detaches the platform API container from a per-run network. It
+// MUST run before RemoveNetwork or Docker rejects the removal ("network has
+// active endpoints"). Best-effort and idempotent: a no-op when isolation is off /
+// no API name is configured, and DisconnectContainer treats an already-absent
+// endpoint as success, so it is safe to call from rollback, Cleanup and GC alike.
+func (s *SidecarManager) disconnectAPI(ctx context.Context, netNameOrID string) {
+	if !s.isolateRuns || s.apiContainerName == "" {
+		return
+	}
+	if err := s.containers.DisconnectContainer(ctx, netNameOrID, s.apiContainerName); err != nil {
+		s.logger.Warn("detach API from run network failed",
+			slog.String("network", netNameOrID),
+			slog.String("api_container", s.apiContainerName),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
 // Launch brings up the Environment's services on a fresh per-run network. It is
 // nil-safe (nil/empty env -> empty context, no side effects) and rolls back
 // atomically on any error.
@@ -119,8 +187,14 @@ func (s *SidecarManager) Launch(ctx context.Context, runID uuid.UUID, env *model
 		ServiceAddrs: map[string]string{},
 	}
 
-	// Nil-safe: nothing to do.
-	if env == nil || len(env.Services) == 0 {
+	hasServices := env != nil && len(env.Services) > 0
+
+	// Nil-safe: with run isolation OFF and no services there is nothing to do —
+	// byte-identical to before. With isolation ON we ALWAYS create the per-run
+	// network (and attach the API) even when there are no sidecars, because the
+	// agent is single-homed on it and would otherwise have no path to the
+	// callback or to Internet egress.
+	if !hasServices && !s.isolateRuns {
 		return sc, nil
 	}
 
@@ -135,11 +209,21 @@ func (s *SidecarManager) Launch(ctx context.Context, runID uuid.UUID, env *model
 	}
 	sc.NetworkName = netName
 
-	for _, svc := range env.Services {
-		if err := s.launchService(ctx, sc, runID, svc); err != nil {
-			// Rollback atomically: tear down everything started so far.
-			s.rollback(ctx, sc)
-			return nil, err
+	// East-West isolation: attach the API container to this per-run network BEFORE
+	// the agent starts (otherwise its first callback would fail to resolve "api").
+	// On failure, roll back so we never leak a half-wired network.
+	if err := s.connectAPI(ctx, netName); err != nil {
+		s.rollback(ctx, sc)
+		return nil, err
+	}
+
+	if hasServices {
+		for _, svc := range env.Services {
+			if err := s.launchService(ctx, sc, runID, svc); err != nil {
+				// Rollback atomically: tear down everything started so far.
+				s.rollback(ctx, sc)
+				return nil, err
+			}
 		}
 	}
 
@@ -261,6 +345,8 @@ func (s *SidecarManager) rollback(ctx context.Context, sc *port.SidecarContext) 
 
 	s.teardownContainers(tctx, sc)
 	if sc.NetworkName != "" {
+		// Detach the API BEFORE removing the network (active endpoints block it).
+		s.disconnectAPI(tctx, sc.NetworkName)
 		if err := s.containers.RemoveNetwork(tctx, sc.NetworkName); err != nil {
 			s.logger.Warn("rollback: remove network failed",
 				slog.String("network", sc.NetworkName),
@@ -324,6 +410,8 @@ func (s *SidecarManager) Cleanup(ctx context.Context, sc *port.SidecarContext) e
 
 	s.teardownContainers(tctx, sc)
 	if sc.NetworkName != "" {
+		// Detach the API BEFORE removing the network (active endpoints block it).
+		s.disconnectAPI(tctx, sc.NetworkName)
 		if err := s.containers.RemoveNetwork(tctx, sc.NetworkName); err != nil {
 			s.logger.Warn("cleanup: remove network failed",
 				slog.String("network", sc.NetworkName),
@@ -400,6 +488,9 @@ func (s *SidecarManager) gcNetworks(ctx context.Context, cutoff time.Time) error
 			// Too recent: a run may still be starting up. Keep it.
 			continue
 		}
+		// Detach the API BEFORE removing the network (active endpoints block it).
+		// No-op when isolation is off; idempotent when the run already cleaned up.
+		s.disconnectAPI(ctx, n.ID)
 		if err := s.containers.RemoveNetwork(ctx, n.ID); err != nil {
 			s.logger.Warn("gc: remove orphan network failed",
 				slog.String("network", n.Name),

--- a/backend/internal/adapter/docker/sidecar_manager_test.go
+++ b/backend/internal/adapter/docker/sidecar_manager_test.go
@@ -26,6 +26,8 @@ type mockContainerManager struct {
 	startedIDs      []string
 	stoppedIDs      []string
 	removedIDs      []string
+	connectedAPI    []apiNetAttach // network<-container pairs passed to ConnectContainer
+	disconnectedAPI []apiNetAttach // network<-container pairs passed to DisconnectContainer
 
 	// Hooks. Defaults are "succeed".
 	createNetworkFn func(name string) (string, error)
@@ -33,9 +35,18 @@ type mockContainerManager struct {
 	startFn         func(id string) error
 	inspectHealthFn func(id string) (string, error)
 	removeNetworkFn func(nameOrID string) error
+	connectFn       func(net, ctr string, aliases []string) error
 	listNetworksFn  func() ([]model.NetworkInfo, error)
 	listContainerFn func() ([]port.ContainerInfo, error)
 	listRunningFn   func() ([]port.ContainerInfo, error)
+}
+
+// apiNetAttach records one (network, container, aliases) attach/detach call so
+// the East-West isolation tests can assert the API was wired in and torn down.
+type apiNetAttach struct {
+	network   string
+	container string
+	aliases   []string
 }
 
 func newMockCM() *mockContainerManager {
@@ -122,8 +133,45 @@ func (m *mockContainerManager) RemoveNetwork(_ context.Context, nameOrID string)
 	return nil
 }
 
-func (m *mockContainerManager) ConnectContainer(_ context.Context, _, _ string, _ []string) error {
+func (m *mockContainerManager) ConnectContainer(_ context.Context, networkNameOrID, containerID string, aliases []string) error {
+	m.mu.Lock()
+	m.connectedAPI = append(m.connectedAPI, apiNetAttach{network: networkNameOrID, container: containerID, aliases: aliases})
+	m.mu.Unlock()
+	if m.connectFn != nil {
+		return m.connectFn(networkNameOrID, containerID, aliases)
+	}
 	return nil
+}
+
+func (m *mockContainerManager) DisconnectContainer(_ context.Context, networkNameOrID, containerID string) error {
+	m.mu.Lock()
+	m.disconnectedAPI = append(m.disconnectedAPI, apiNetAttach{network: networkNameOrID, container: containerID})
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *mockContainerManager) getConnectedAPI() []apiNetAttach {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]apiNetAttach, len(m.connectedAPI))
+	copy(out, m.connectedAPI)
+	return out
+}
+
+func (m *mockContainerManager) getDisconnectedAPI() []apiNetAttach {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]apiNetAttach, len(m.disconnectedAPI))
+	copy(out, m.disconnectedAPI)
+	return out
+}
+
+func (m *mockContainerManager) getRemovedNetworks() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.removedNetworks))
+	copy(out, m.removedNetworks)
+	return out
 }
 
 func (m *mockContainerManager) ListNetworks(_ context.Context, _ map[string]string) ([]model.NetworkInfo, error) {
@@ -539,6 +587,195 @@ func TestSidecarListOrphanNetworks(t *testing.T) {
 	}
 	if len(orphans) != 1 || orphans[0].ID != "n-orphan" {
 		t.Errorf("expected only n-orphan, got %v", orphans)
+	}
+}
+
+// testAPIContainer is the API container name the East-West isolation tests
+// configure the SidecarManager with.
+const testAPIContainer = "hopeitworks-api"
+
+// newIsolatedSidecarManager builds a SidecarManager with East-West run isolation
+// enabled and fast test timings.
+func newIsolatedSidecarManager(cm *mockContainerManager) *SidecarManager {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	s := NewDockerSidecarManagerWithIsolation(cm, true, testAPIContainer, logger)
+	s.readinessTimeout = 200 * time.Millisecond
+	s.readinessInterval = 5 * time.Millisecond
+	s.runningGrace = 0
+	return s
+}
+
+// TestSidecarLaunch_Isolated_NoServices_CreatesNetworkAndConnectsAPI proves the
+// core of East-West isolation: with the flag ON and a project that has NO
+// sidecars (nil env), Launch STILL creates the per-run network and attaches the
+// API container to it (alias "api"), so the single-homed agent can reach the
+// callback. (With the flag off this is a no-op — see TestSidecarLaunch_NilEnv_NoOp.)
+func TestSidecarLaunch_Isolated_NoServices_CreatesNetworkAndConnectsAPI(t *testing.T) {
+	cm := newMockCM()
+	s := newIsolatedSidecarManager(cm)
+
+	runID := uuid.New()
+	sc, err := s.Launch(context.Background(), runID, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	wantNet := networkName(runID)
+	if sc.NetworkName != wantNet {
+		t.Errorf("expected per-run network %q created, got %q", wantNet, sc.NetworkName)
+	}
+	if len(cm.createdNetworks) != 1 || cm.createdNetworks[0] != wantNet {
+		t.Errorf("expected network %q created, got %v", wantNet, cm.createdNetworks)
+	}
+	// No sidecar containers created.
+	if len(cm.createdOpts) != 0 {
+		t.Errorf("expected no sidecar containers, got %d", len(cm.createdOpts))
+	}
+	// API connected to the per-run network with alias "api".
+	conn := cm.getConnectedAPI()
+	if len(conn) != 1 {
+		t.Fatalf("expected exactly 1 API connect, got %d (%v)", len(conn), conn)
+	}
+	if conn[0].network != wantNet || conn[0].container != testAPIContainer {
+		t.Errorf("API connect mismatch: got net=%q ctr=%q, want net=%q ctr=%q",
+			conn[0].network, conn[0].container, wantNet, testAPIContainer)
+	}
+	if len(conn[0].aliases) != 1 || conn[0].aliases[0] != apiNetworkAlias {
+		t.Errorf("expected API alias [%q], got %v", apiNetworkAlias, conn[0].aliases)
+	}
+}
+
+// TestSidecarLaunch_Isolated_WithServices_ConnectsAPIBeforeSidecars proves that
+// with services present the per-run network is created, the API is attached, AND
+// the sidecars come up on the same per-run network.
+func TestSidecarLaunch_Isolated_WithServices_ConnectsAPIBeforeSidecars(t *testing.T) {
+	cm := newMockCM() // defaults: create ok, start ok, health=healthy
+	s := newIsolatedSidecarManager(cm)
+
+	runID := uuid.New()
+	sc, err := s.Launch(context.Background(), runID, pgEnv())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	wantNet := networkName(runID)
+	if sc.NetworkName != wantNet {
+		t.Errorf("expected per-run network %q, got %q", wantNet, sc.NetworkName)
+	}
+	conn := cm.getConnectedAPI()
+	if len(conn) != 1 || conn[0].network != wantNet || conn[0].container != testAPIContainer {
+		t.Errorf("expected API connected to %q, got %v", wantNet, conn)
+	}
+	// Sidecar landed on the per-run network.
+	if len(cm.createdOpts) != 1 || cm.createdOpts[0].NetworkName != wantNet {
+		t.Errorf("expected sidecar on %q, got %v", wantNet, cm.createdOpts)
+	}
+}
+
+// TestSidecarCleanup_Isolated_DetachesAPIBeforeRemove proves Cleanup detaches the
+// API from the per-run network BEFORE removing it (otherwise Docker rejects the
+// removal with "network has active endpoints").
+func TestSidecarCleanup_Isolated_DetachesAPIBeforeRemove(t *testing.T) {
+	cm := newMockCM()
+	s := newIsolatedSidecarManager(cm)
+
+	runID := uuid.New()
+	sc, err := s.Launch(context.Background(), runID, nil)
+	if err != nil {
+		t.Fatalf("launch error: %v", err)
+	}
+
+	if err := s.Cleanup(context.Background(), sc); err != nil {
+		t.Fatalf("cleanup error: %v", err)
+	}
+
+	wantNet := networkName(runID)
+	disc := cm.getDisconnectedAPI()
+	if len(disc) != 1 || disc[0].network != wantNet || disc[0].container != testAPIContainer {
+		t.Fatalf("expected API detached from %q, got %v", wantNet, disc)
+	}
+	removed := cm.getRemovedNetworks()
+	if len(removed) != 1 || removed[0] != wantNet {
+		t.Fatalf("expected network %q removed, got %v", wantNet, removed)
+	}
+}
+
+// TestSidecarLaunch_Isolated_TwoRuns_DistinctNetworks proves two distinct runs
+// get two distinct per-run networks (no shared segment between agents).
+func TestSidecarLaunch_Isolated_TwoRuns_DistinctNetworks(t *testing.T) {
+	cm := newMockCM()
+	s := newIsolatedSidecarManager(cm)
+
+	runA := uuid.New()
+	runB := uuid.New()
+	scA, errA := s.Launch(context.Background(), runA, nil)
+	scB, errB := s.Launch(context.Background(), runB, nil)
+	if errA != nil || errB != nil {
+		t.Fatalf("launch errors: %v / %v", errA, errB)
+	}
+
+	if scA.NetworkName == scB.NetworkName {
+		t.Fatalf("expected distinct per-run networks, both were %q", scA.NetworkName)
+	}
+	if scA.NetworkName != networkName(runA) || scB.NetworkName != networkName(runB) {
+		t.Errorf("network names not run-scoped: A=%q B=%q", scA.NetworkName, scB.NetworkName)
+	}
+	if len(cm.createdNetworks) != 2 {
+		t.Errorf("expected 2 networks created, got %v", cm.createdNetworks)
+	}
+}
+
+// TestSidecarLaunch_Isolated_APIConnectFails_RollsBack proves a failed API
+// connect rolls the launch back: the half-wired network is detached + removed and
+// the error surfaces, so we never start an agent that cannot reach the callback.
+func TestSidecarLaunch_Isolated_APIConnectFails_RollsBack(t *testing.T) {
+	cm := newMockCM()
+	cm.connectFn = func(_, _ string, _ []string) error {
+		return errors.New("docker connect refused")
+	}
+	s := newIsolatedSidecarManager(cm)
+
+	runID := uuid.New()
+	sc, err := s.Launch(context.Background(), runID, nil)
+	if err == nil {
+		t.Fatal("expected Launch to fail when API connect fails")
+	}
+	if sc != nil {
+		t.Errorf("expected nil context on failure, got %v", sc)
+	}
+	// Rollback removed the network it had created.
+	wantNet := networkName(runID)
+	removed := cm.getRemovedNetworks()
+	if len(removed) != 1 || removed[0] != wantNet {
+		t.Errorf("expected rollback to remove %q, got %v", wantNet, removed)
+	}
+}
+
+// TestSidecarGC_Isolated_DetachesAPIBeforeRemove proves the periodic network GC
+// also detaches the API before removing an orphan per-run network.
+func TestSidecarGC_Isolated_DetachesAPIBeforeRemove(t *testing.T) {
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	cm := newMockCM()
+	cm.listNetworksFn = func() ([]model.NetworkInfo, error) {
+		return []model.NetworkInfo{
+			{ID: "net-old", Name: "hopeitworks-run-old", Labels: map[string]string{labelRunID: "run-old"}, CreatedAt: now.Add(-2 * time.Hour)},
+		}, nil
+	}
+	cm.listRunningFn = func() ([]port.ContainerInfo, error) { return nil, nil }
+	s := newIsolatedSidecarManager(cm)
+	s.now = func() time.Time { return now }
+
+	if err := s.GC(context.Background(), 30*time.Minute); err != nil {
+		t.Fatalf("GC error: %v", err)
+	}
+
+	disc := cm.getDisconnectedAPI()
+	if len(disc) != 1 || disc[0].network != "net-old" || disc[0].container != testAPIContainer {
+		t.Fatalf("expected API detached from net-old during GC, got %v", disc)
+	}
+	removed := cm.getRemovedNetworks()
+	if len(removed) != 1 || removed[0] != "net-old" {
+		t.Fatalf("expected net-old removed, got %v", removed)
 	}
 }
 

--- a/backend/internal/config/loader.go
+++ b/backend/internal/config/loader.go
@@ -40,6 +40,11 @@ func setDefaults(cfg *pkgconfig.Config) {
 	if cfg.Substrate.Kind == "" {
 		cfg.Substrate.Kind = pkgconfig.SubstrateDocker
 	}
+	// East-West isolation needs to know the API container to attach to each per-run
+	// network. Default to the compose service container name.
+	if cfg.Docker.APIContainerName == "" {
+		cfg.Docker.APIContainerName = "hopeitworks-api"
+	}
 }
 
 func applyEnvOverrides(cfg *pkgconfig.Config) {
@@ -83,6 +88,12 @@ func applyEnvOverrides(cfg *pkgconfig.Config) {
 	}
 	if v := os.Getenv("CALLBACK_BASE_URL"); v != "" {
 		cfg.Docker.CallbackBaseURL = v
+	}
+	if v := os.Getenv("DOCKER_ISOLATE_RUNS"); v != "" {
+		cfg.Docker.IsolateRuns = strings.EqualFold(v, "true") || v == "1"
+	}
+	if v := os.Getenv("DOCKER_API_CONTAINER"); v != "" {
+		cfg.Docker.APIContainerName = v
 	}
 	if v := os.Getenv("SUBSTRATE"); v != "" {
 		cfg.Substrate.Kind = v

--- a/backend/internal/domain/port/container_manager.go
+++ b/backend/internal/domain/port/container_manager.go
@@ -62,6 +62,13 @@ type ContainerManager interface {
 	// registering DNS aliases for it on that network. aliases may be nil/empty.
 	ConnectContainer(ctx context.Context, networkNameOrID, containerID string, aliases []string) error
 
+	// DisconnectContainer detaches a container from a network. It is idempotent: a
+	// container (or network) that is already absent / not attached is treated as
+	// success (returns nil). Used by East-West run isolation to detach the API
+	// container before removing a per-run network (otherwise Docker rejects the
+	// removal with "network has active endpoints").
+	DisconnectContainer(ctx context.Context, networkNameOrID, containerID string) error
+
 	// ListNetworks lists managed Docker networks matching the given label
 	// filter (e.g. managed_by=hopeitworks). An empty/nil filter lists all.
 	ListNetworks(ctx context.Context, labelFilter map[string]string) ([]model.NetworkInfo, error)

--- a/backend/internal/domain/service/orphan_cleaner_test.go
+++ b/backend/internal/domain/service/orphan_cleaner_test.go
@@ -330,6 +330,9 @@ func (c *reapableCM) RemoveNetwork(_ context.Context, _ string) error { return n
 func (c *reapableCM) ConnectContainer(_ context.Context, _, _ string, _ []string) error {
 	return nil
 }
+func (c *reapableCM) DisconnectContainer(_ context.Context, _, _ string) error {
+	return nil
+}
 func (c *reapableCM) ListNetworks(_ context.Context, _ map[string]string) ([]model.NetworkInfo, error) {
 	return nil, nil
 }

--- a/backend/internal/domain/service/timeout_enforcer_test.go
+++ b/backend/internal/domain/service/timeout_enforcer_test.go
@@ -95,6 +95,10 @@ func (m *mockContainerManager) ConnectContainer(_ context.Context, _, _ string, 
 	return nil
 }
 
+func (m *mockContainerManager) DisconnectContainer(_ context.Context, _, _ string) error {
+	return nil
+}
+
 func (m *mockContainerManager) ListNetworks(_ context.Context, _ map[string]string) ([]model.NetworkInfo, error) {
 	return nil, nil
 }

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -85,6 +85,20 @@ type DockerConfig struct {
 	// CallbackBaseURL is the base URL agent containers use to call back to the API
 	// (e.g., "http://api:8080"). Set via CALLBACK_BASE_URL env var.
 	CallbackBaseURL string `yaml:"callback_base_url"`
+	// IsolateRuns opts into East-West run isolation: the agent leaves the shared
+	// AgentNetwork and is single-homed on its own per-run network instead, so two
+	// agents from different runs/projects can no longer reach each other on a
+	// shared L2 segment. The API container is attached to each per-run network so
+	// the callback (http://api:8080) keeps working; Internet egress stays open.
+	// Defaults to false: with it off, behaviour is byte-identical to today (the
+	// shared AgentNetwork remains the agent's primary network). Set via the
+	// DOCKER_ISOLATE_RUNS env var.
+	IsolateRuns bool `yaml:"isolate_runs"`
+	// APIContainerName is the name (or id) of the platform API container, used to
+	// attach/detach it to per-run networks when IsolateRuns is enabled. Defaults to
+	// "hopeitworks-api" (the compose service container name). Set via the
+	// DOCKER_API_CONTAINER env var.
+	APIContainerName string `yaml:"api_container_name"`
 }
 
 // LogConfig holds logging settings.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     container_name: hopeitworks-socket-proxy
     environment:
       CONTAINERS: 1   # allow container create/start/stop/inspect
-      NETWORKS: 1     # allow network connect (agent-network)
+      NETWORKS: 1     # allow network create/connect/disconnect (per-run nets + East-West API attach)
       POST: 1         # required for create/start operations
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -63,6 +63,16 @@ services:
       DOCKER_HOST: tcp://socket-proxy:2375
       # Compose names this network "<project>_agent-network" (project = compose dir, "deploy").
       DOCKER_AGENT_NETWORK: ${DOCKER_AGENT_NETWORK:-deploy_agent-network}
+      # --- East-West run isolation (opt-in, OFF by default) ---
+      # When DOCKER_ISOLATE_RUNS=true the agent leaves the shared agent-network and is
+      # single-homed on its own per-run network (hopeitworks-run-<id>); the API container
+      # (DOCKER_API_CONTAINER) is attached to each per-run network so the callback below
+      # (http://api:8080) keeps working, while Internet egress stays open. Two agents from
+      # different runs can then no longer reach each other on a shared L2 segment. Default
+      # off = today's behaviour exactly (agent dual-homed via agent-network). agent-network
+      # is kept (transition) and CALLBACK_BASE_URL is unchanged under this mode (Option A).
+      DOCKER_ISOLATE_RUNS: ${DOCKER_ISOLATE_RUNS:-false}
+      DOCKER_API_CONTAINER: ${DOCKER_API_CONTAINER:-hopeitworks-api}
       AGENT_IMAGE: ${AGENT_IMAGE:-hopeitworks/agent-go-node:latest}
       CLAUDE_MD_PATH: ${CLAUDE_MD_PATH:-agent/claude-md}
       # --- agent tokens (required for pipeline execution) ---


### PR DESCRIPTION
## Problème
Tous les conteneurs agents (tous projets/runs) partagent le réseau Docker `agent-network` → sous parallélisme, agent-projet-X et agent-projet-Y sont sur le **même segment L2** et peuvent se joindre directement (East-West / cross-projet). Les sidecars sont déjà isolés par-run ; la **seule fuite** = ce réseau partagé entre agents.

## Fix (Option A — opt-in `DOCKER_ISOLATE_RUNS`, défaut `false`)
En mode isolé : l'agent n'est **QUE** sur son réseau par-run `hopeitworks-run-<uuid>` (retiré de `agent-network`), et le conteneur **API est attaché à chaque réseau par-run** (alias `api`) → callback `http://api:8080` **inchangé**, agents **non co-résidents**. L'**egress Internet reste ouvert** (recherche web préservée — ce design ne ferme que l'East-West, pas le North-South).

- `DOCKER_ISOLATE_RUNS=false` par défaut → **byte-identique** (oracle golden vert).
- Toujours créer un réseau par-run en mode isolé (même sans sidecars).
- API connectée **avant** le start agent ; **détachée avant `RemoveNetwork`** (rollback / Cleanup / GC), idempotent.
- Nouveau port `DisconnectContainer` (+ `ConnectContainer` rendu idempotent).
- Mappe **1:1 sur K8s** (NetworkPolicy : agent → ses sidecars + API + Internet, deny le reste).

## Vérification
- build / vet / **golangci-lint exit 0** ✓
- golden byte-identical (flag off) ✓ + suite `-short` **21 pkg ok** ✓
- tests d'isolation : runtime (primary par-run, shared absent) + sidecar (always-create, connect API, détach avant remove, 2 runs distincts, rollback) + **legacy** + idempotence connect ✓
- **revue adversariale Opus** : *sûr à merger*, l'isolation tient sur les **2 chemins** (pas de faille partielle) ; 2 points relevés (test chemin legacy + `ConnectContainer` idempotent) → **corrigés** (commit `cc1753f`).

## Note
Défaut `false` = zéro impact prod ; bascule défaut→`true` dans un commit séparé après e2e callback. Défense **East-West** Docker (dev/CI) ; l'isolation forte contre du code non-fiable reste **microVM** (hors scope, trusted aujourd'hui). Back-only justifié (durcissement réseau infra, aucune surface user/API/front).

🤖 Generated with [Claude Code](https://claude.com/claude-code)